### PR TITLE
Return complete group information on collection

### DIFF
--- a/rest_groups.cpp
+++ b/rest_groups.cpp
@@ -1385,6 +1385,7 @@ bool DeRestPluginPrivate::groupToMap(const Group *group, QVariantMap &map)
     etag.remove('"'); // no quotes allowed in string
     map["etag"] = etag;
     map["action"] = action;
+    map["type"] = "LightGroup"; // TODO
 
     QStringList multis;
     std::vector<QString>::const_iterator m = group->m_multiDeviceIds.begin();


### PR DESCRIPTION
- returns complete group information on group collections ( /api/xxx/groups and /api/xxx )
- refactored duplicated code

The method getGroupAttributes and groupToMap shared huge amount of duplicated code in different order but functional almost equivalent. I combined the two methods and used groupToMap  