### PR TITLE
Gateway Discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+Makefile
+Makefile.Debug
+Makefile.Release
+release
+ui_de_web_widget.h

--- a/de_web.pro
+++ b/de_web.pro
@@ -57,7 +57,7 @@ GIT_COMMIT = $$system("git rev-list HEAD --max-count=1")
 
 # Version Major.Minor.Build
 # Important: don't change the format of this line since it's parsed by scripts!
-DEFINES += GW_SW_VERSION=\\\"2.04.42\\\"
+DEFINES += GW_SW_VERSION=\\\"2.04.43\\\"
 DEFINES += GIT_COMMMIT=\\\"$$GIT_COMMIT\\\" \
 
 # Minimum version of the RaspBee firmware

--- a/de_web.pro
+++ b/de_web.pro
@@ -58,6 +58,7 @@ GIT_COMMIT = $$system("git rev-list HEAD --max-count=1")
 # Version Major.Minor.Build
 # Important: don't change the format of this line since it's parsed by scripts!
 DEFINES += GW_SW_VERSION=\\\"2.04.43\\\"
+DEFINES += GW_API_VERSION=\\\"1.0.1\\\"
 DEFINES += GIT_COMMMIT=\\\"$$GIT_COMMIT\\\" \
 
 # Minimum version of the RaspBee firmware

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -7892,6 +7892,7 @@ void DeRestPlugin::idleTimerFired()
         d->gwDeviceAddress.setExt(d->apsCtrl->getParameter(deCONZ::ParamMacAddress));
         d->gwDeviceAddress.setNwk(d->apsCtrl->getParameter(deCONZ::ParamNwkAddress));
         d->gwBridgeId.sprintf("%016llX", (quint64)d->gwDeviceAddress.ext());
+        d->initDescriptionXml();
     }
 
     if (!pluginActive())

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -3290,7 +3290,7 @@ bool DeRestPluginPrivate::deleteOldGroupOfSwitch(Sensor *sensor, quint16 newGrou
                                                       sensor->id()))
         {
             DBG_Printf(DBG_INFO, "delete old switch group 0x%04X of sensor %s\n", i->address(), qPrintable(sensor->name()));
-            //found            
+            //found
             i->setState(Group::StateDeleted);
         }
     }
@@ -6056,7 +6056,7 @@ void DeRestPluginPrivate::handleSceneClusterIndication(TaskItem &task, const deC
         }
     }
     else if (zclFrame.commandId() == 0x02) // Remove scene response
-    {       
+    {
         if (zclFrame.payload().size() < 4)
         {
             DBG_Printf(DBG_INFO, "remove scene response payload size too small %d\n", zclFrame.payload().size());
@@ -6182,7 +6182,7 @@ void DeRestPluginPrivate::handleSceneClusterIndication(TaskItem &task, const deC
         }
     }
     else if (zclFrame.commandId() == 0x01) // View scene response
-    {       
+    {
         if (zclFrame.payload().size() < 4)
         {
             DBG_Printf(DBG_INFO, "view scene response payload size too small %d\n", zclFrame.payload().size());
@@ -7891,6 +7891,7 @@ void DeRestPlugin::idleTimerFired()
     {
         d->gwDeviceAddress.setExt(d->apsCtrl->getParameter(deCONZ::ParamMacAddress));
         d->gwDeviceAddress.setNwk(d->apsCtrl->getParameter(deCONZ::ParamNwkAddress));
+        d->gwBridgeId.sprintf("%016llX", (quint64)d->gwDeviceAddress.ext());
     }
 
     if (!pluginActive())
@@ -8965,7 +8966,7 @@ bool DeRestPluginPrivate::exportConfiguration()
                 file.close();
             }
 
-            //create .tar           
+            //create .tar
             if (!archProcess)
             {
                 archProcess = new QProcess(this);
@@ -9031,7 +9032,7 @@ bool DeRestPluginPrivate::exportConfiguration()
                 file2.remove();
             }
             return success;
-        }        
+        }
     }
     else
     {
@@ -9142,7 +9143,7 @@ bool DeRestPluginPrivate::importConfiguration()
                 }
                 apsCtrl->setParameter(deCONZ::ParamMacAddress, macAddress);
                 apsCtrl->setParameter(deCONZ::ParamStaticNwkAddress, staticNwkAddress);
-                apsCtrl->setParameter(deCONZ::ParamNwkAddress, nwkAddress);               
+                apsCtrl->setParameter(deCONZ::ParamNwkAddress, nwkAddress);
                 apsCtrl->setParameter(deCONZ::ParamApsAck, apsAck);
                 // channelMask
                 apsCtrl->setParameter(deCONZ::ParamCurrentChannel, curChannel);

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1001,6 +1001,7 @@ public:
     bool groupDeviceMembershipChecked;
     QVariantMap gwUserParameter;
     deCONZ::Address gwDeviceAddress;
+    QString gwBridgeId;
 
     // firmware update
     enum FW_UpdateState {

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -535,6 +535,7 @@ public:
     int createUser(const ApiRequest &req, ApiResponse &rsp);
     int getFullState(const ApiRequest &req, ApiResponse &rsp);
     int getConfig(const ApiRequest &req, ApiResponse &rsp);
+    int getBasicConfig(const ApiRequest &req, ApiResponse &rsp);
     int modifyConfig(const ApiRequest &req, ApiResponse &rsp);
     int deleteUser(const ApiRequest &req, ApiResponse &rsp);
     int updateSoftware(const ApiRequest &req, ApiResponse &rsp);
@@ -548,6 +549,7 @@ public:
     int restoreWifiConfig(const ApiRequest &req, ApiResponse &rsp);
 
     void configToMap(const ApiRequest &req, QVariantMap &map);
+    void basicConfigToMap(QVariantMap &map);
 
     // REST API userparameter
     int handleUserparameterApi(const ApiRequest &req, ApiResponse &rsp);

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -652,6 +652,7 @@ public:
 
     // UPNP discovery
     void initUpnpDiscovery();
+    void initDescriptionXml();
     // Internet discovery
     void initInternetDicovery();
     bool setInternetDiscoveryInterval(int minutes);

--- a/discovery.cpp
+++ b/discovery.cpp
@@ -197,9 +197,14 @@ void DeRestPluginPrivate::internetDiscoveryTimerFired()
 {
     if (gwAnnounceInterval > 0)
     {
+        if (gwBridgeId.isEmpty())
+        {
+          // Don't announce before bridgeid has been set.
+          return;
+        }
         QString str = QString("{ \"name\": \"%1\", \"mac\": \"%2\", \"internal_ip\":\"%3\", \"internal_port\":%4, \"interval\":%5, \"swversion\":\"%6\", \"fwversion\":\"%7\", \"nodecount\":%8, \"uptime\":%9, \"updatechannel\":\"%10\"")
                 .arg(gwName)
-                .arg(gwConfig["mac"].toString())
+                .arg(gwBridgeId)
                 .arg(gwConfig["ipaddress"].toString())
                 .arg(gwConfig["port"].toDouble())
                 .arg(gwAnnounceInterval)

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -291,15 +291,10 @@ void DeRestPluginPrivate::configToMap(const ApiRequest &req, QVariantMap &map)
         }
 
         map["mac"] = eth.hardwareAddress().toLower();
-        if (gwDeviceAddress.hasExt())
+        if (!gwBridgeId.isEmpty())
         {
-            QString bridgeId;
-            bridgeId.sprintf("%016llX", (quint64)gwDeviceAddress.ext());
-            map["bridgeid"] = bridgeId;
-        }
-        else
-        {
-            map["bridgeid"] = eth.hardwareAddress().remove(':').insert(6,"FFFE");
+            // Only expose bridgeid after it's been set.
+            map["bridgeid"] = gwBridgeId;
         }
     }
 
@@ -959,7 +954,7 @@ int DeRestPluginPrivate::modifyConfig(const ApiRequest &req, ApiResponse &rsp)
 */
 #endif
 #endif
-        }       
+        }
         else if ((gwWifi == "not-running" && wifi == "running") ||
                  (gwWifi == "running" && wifi == "not-running"))
         {

--- a/upnp.cpp
+++ b/upnp.cpp
@@ -79,6 +79,8 @@ void DeRestPluginPrivate::announceUpnp()
 {
     quint16 port = 1900;
     QHostAddress host;
+    QString bridgeId;
+    bridgeId.sprintf("%016llX", (quint64)gwDeviceAddress.ext());
     QByteArray datagram = QString(QLatin1String(
     "NOTIFY * HTTP/1.1\r\n"
     "HOST: 239.255.255.250:1900\r\n"
@@ -88,12 +90,12 @@ void DeRestPluginPrivate::announceUpnp()
     "NTS: ssdp:alive\r\n"
     "NT: upnp:rootdevice\r\n"
     "USN: uuid:%3::upnp:rootdevice\r\n"
-    "GWID.phoscon.de:%4\r\n"
+    "GWID.phoscon.de: %4\r\n"
     "\r\n"))
             .arg(gwConfig["ipaddress"].toString())
             .arg(gwConfig["port"].toDouble())
             .arg(gwConfig["uuid"].toString())
-            .arg(gwDeviceAddress.toStringExt()).toLocal8Bit();
+            .arg(bridgeId).toLocal8Bit();
 
     host.setAddress(QLatin1String("239.255.255.250"));
 
@@ -110,6 +112,8 @@ void DeRestPluginPrivate::upnpReadyRead()
     {
         quint16 port;
         QHostAddress host;
+        QString bridgeId;
+        bridgeId.sprintf("%016llX", (quint64)gwDeviceAddress.ext());
         QByteArray datagram;
         datagram.resize(udpSock->pendingDatagramSize());
         udpSock->readDatagram(datagram.data(), datagram.size(), &host, &port);
@@ -126,9 +130,9 @@ void DeRestPluginPrivate::upnpReadyRead()
                             .arg(gwConfig["ipaddress"].toString())
                             .arg(gwConfig["port"].toDouble()).toLocal8Bit());
             datagram.append("SERVER: FreeRTOS/7.4.2, UPnP/1.0, IpBridge/1.8.0\r\n");
-            datagram.append("ST: urn:schemas-upnp-org:device:basic:1\r\n");
+            datagram.append("ST: upnp:rootdevice\r\n");
             datagram.append(QString("USN: uuid:%1::upnp:rootdevice\r\n").arg(gwUuid));
-            datagram.append(QString("GWID.phoscon.de:%1\r\n").arg(gwDeviceAddress.toStringExt()));
+            datagram.append(QString("GWID.phoscon.de: %1\r\n").arg(bridgeId));
             datagram.append("\r\n");
 
             if (udpSockOut->writeDatagram(datagram.data(), datagram.size(), host, port) == -1)

--- a/upnp.cpp
+++ b/upnp.cpp
@@ -65,6 +65,7 @@ void DeRestPluginPrivate::initUpnpDiscovery()
                    line.replace(QString("{{IPADDRESS}}"), qPrintable(gwIpAddress));
                    line.replace(QString("{{UUID}}"), qPrintable(gwUuid));
                    line.replace(QString("{{GWNAME}}"), qPrintable(gwName));
+                   line.replace(Qstring("{{BRIDGEID}}"), qPrintable(gwBridgeId));
                    descriptionXml.append(line);
 
                    DBG_Printf(DBG_INFO_L2, "%s", line.constData());

--- a/upnp.cpp
+++ b/upnp.cpp
@@ -43,9 +43,11 @@ void DeRestPluginPrivate::initUpnpDiscovery()
     connect(timer, SIGNAL(timeout()),
             this, SLOT(announceUpnp()));
     timer->start(20 * 1000);
+}
 
-    // replace description_in.xml template with dynamic content
-
+/*! Replaces description_in.xml template with dynamic content. */
+void DeRestPluginPrivate::initDescriptionXml()
+{
     deCONZ::ApsController *apsCtrl = deCONZ::ApsController::instance();
     QString serverRoot = apsCtrl->getParameter(deCONZ::ParamHttpRoot);
 

--- a/upnp.cpp
+++ b/upnp.cpp
@@ -65,7 +65,7 @@ void DeRestPluginPrivate::initUpnpDiscovery()
                    line.replace(QString("{{IPADDRESS}}"), qPrintable(gwIpAddress));
                    line.replace(QString("{{UUID}}"), qPrintable(gwUuid));
                    line.replace(QString("{{GWNAME}}"), qPrintable(gwName));
-                   line.replace(Qstring("{{BRIDGEID}}"), qPrintable(gwBridgeId));
+                   line.replace(QString("{{BRIDGEID}}"), qPrintable(gwBridgeId));
                    descriptionXml.append(line);
 
                    DBG_Printf(DBG_INFO_L2, "%s", line.constData());


### PR DESCRIPTION
See issues #19, #41.

Versions:
- Bumped gateway version to 2.04.43;
- Bumped API version to 1.0.1;
- API version in `de_web.pro` instead of hard coded.

Bridge ID:
- Added variable `gwBridgeId` for consistent use in `config.bridgeid`, UPnP discovery, appspot discovery, and `description.xml`.
-  `gwBridgeId` is set to the gateway device’s ZIgBee address, after this device has been discovered.

UPnP discovery:
- Fixed issue #19 (space after `GWID.phoscon.de:` and `upnp:rootdevice`);
- Don’t respond to M-SEARCH and don’t announce before `gwBridgeId` has been set.

appspot discovery:
- Don’t announce before `gwBridgeId` has been set;
- Note that deCONZ only sends `mac` to appspot, which exposes this value as both `macaddress` and `id`.  I think `macaddress` should be dropped (the meethue portal only exposes `id` and `internalipaddress`).

`description.xml`:
- Added `{{BRIDGEID}}` placeholder for `description_in.xml`;
- `descriptionXml` created after `gwBridgeId` has been set;
- `description_in.xml` needs to be updated, but is not included with the REST API plugin development package:
```xml
<?xml version="1.0"?>
<root xmlns="urn:schemas-upnp-org:device-1-0">
  <specVersion>
    <major>1</major>
    <minor>0</minor>
  </specVersion>
  <URLBase>http://{{IPADDRESS}}:{{PORT}}/</URLBase>
  <device>
    <deviceType>urn:schemas-upnp-org:device:Basic:1</deviceType>
    <friendlyName>{{GWNAME}} ({{IPADDRESS}})</friendlyName>
    <manufacturer>dresden elektronik</manufacturer>
    <manufacturerURL>https://www.dresden-elektronik.de/?L=1</manufacturerURL>
    <modelDescription>dresden elektronik Wireless Light Control</modelDescription>
    <modelName>Wireless Light Control</modelName>
    <modelNumber>deCONZ</modelNumber>
    <modelURL>https://www.dresden-elektronik.de/funktechnik/solutions/wireless-light-control/webapp/?L=1</modelURL>
    <serialNumber>{{BRIDGEID}}</serialNumber>
    <UDN>uuid:{{UUID}}</UDN>
    <gatewayName>{{GWNAME}}</gatewayName>
    <presentationURL>index.html</presentationURL>
    <iconList>
      <icon>
        <mimetype>image/png</mimetype>
        <height>48</height>
        <width>48</width>
        <depth>24</depth>
        <url>hue_logo_0.png</url>
      </icon>
      <icon>
        <mimetype>image/png</mimetype>
        <height>120</height>
        <width>120</width>
        <depth>24</depth>
        <url>hue_logo_3.png</url>
      </icon>
    </iconList>
  </device>
</root>
```

GET `/api/<apikey>/config`:
- Only include `bridgeid` in response after `gwBridgeId` has been set;
- `swversion` returns full semver gateway version (incl. dots);
- Added `starterkitid` (Hue API v1.18.0);

GET `/api/config`:
- Added unauthenticated request for basic configuration:
```json
{
  "apiversion": "1.0.1",
  "bridgeid": "00212EFFFFxxxxxx",
  "datastoreversion": "60",
  "factorynew": false,
  "mac": "b8:27:eb:xx:xx:xx",
  "modelid": "deCONZ",
  "name": "pi",
  "replacesbridgeid": null,
  "starterkitid": "",
  "swversion": "2.04.43"
}
```
- Only include `bridgeid` in response after `gwBridgeId` has been set.
