### PR TITLE
Gateway DIscovery (2)

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -530,6 +530,14 @@ static int sqliteLoadConfigCallback(void *user, int ncols, char **colval , char 
             }
         }
     }
+    else if (strcmp(colval[0], "bridgeid") == 0)
+    {
+      if (!val.isEmpty())
+      {
+          d->gwConfig["bridgeid"] = val;
+          d->gwBridgeId = val;
+      }
+    }
     return 0;
 }
 
@@ -2126,6 +2134,7 @@ void DeRestPluginPrivate::saveDb()
         gwConfig["wifiname"] = gwWifiName;
         gwConfig["wifichannel"] = gwWifiChannel;
         gwConfig["wifiip"] = gwWifiIp;
+        gwConfig["bridgeid"] = gwBridgeId;
 
         QVariantMap::iterator i = gwConfig.begin();
         QVariantMap::iterator end = gwConfig.end();

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -205,6 +205,7 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
     gwFirmwareNeedUpdate = false;
     gwFirmwareVersion = "0x00000000"; // query later
     gwFirmwareVersionUpdate = "";
+    gwBridgeId = "0000000000000000";
 
     {
         QHttpRequestHeader hdr;
@@ -7892,7 +7893,13 @@ void DeRestPlugin::idleTimerFired()
         d->gwDeviceAddress.setExt(d->apsCtrl->getParameter(deCONZ::ParamMacAddress));
         d->gwDeviceAddress.setNwk(d->apsCtrl->getParameter(deCONZ::ParamNwkAddress));
         d->gwBridgeId.sprintf("%016llX", (quint64)d->gwDeviceAddress.ext());
-        d->initDescriptionXml();
+        if (!d->gwConfig.contains("bridgeid") || d->gwConfig["bridgeid"] != d->gwBridgeId)
+        {
+          DBG_Printf(DBG_INFO, "Set bridgeid to %s\n", qPrintable(d->gwBridgeId));
+          d->gwConfig["bridgeid"] = d->gwBridgeId;
+          d->queSaveDb(DB_CONFIG, DB_SHORT_SAVE_DELAY);
+          d->initDescriptionXml();
+        }
     }
 
     if (!pluginActive())

--- a/discovery.cpp
+++ b/discovery.cpp
@@ -197,11 +197,6 @@ void DeRestPluginPrivate::internetDiscoveryTimerFired()
 {
     if (gwAnnounceInterval > 0)
     {
-        if (gwBridgeId.isEmpty())
-        {
-          // Don't announce before bridgeid has been set.
-          return;
-        }
         QString str = QString("{ \"name\": \"%1\", \"mac\": \"%2\", \"internal_ip\":\"%3\", \"internal_port\":%4, \"interval\":%5, \"swversion\":\"%6\", \"fwversion\":\"%7\", \"nodecount\":%8, \"uptime\":%9, \"updatechannel\":\"%10\"")
                 .arg(gwName)
                 .arg(gwBridgeId)

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -308,12 +308,6 @@ void DeRestPluginPrivate::configToMap(const ApiRequest &req, QVariantMap &map)
         DBG_Printf(DBG_ERROR, "No valid ethernet interface found\n");
     }
 
-    if (!gwBridgeId.isEmpty())
-    {
-        // Only expose bridgeid after it's been set.
-        map["bridgeid"] = gwBridgeId;
-    }
-
     std::vector<ApiAuth>::const_iterator i = apiAuths.begin();
     std::vector<ApiAuth>::const_iterator end = apiAuths.end();
     for (; i != end; ++i)
@@ -407,6 +401,7 @@ void DeRestPluginPrivate::configToMap(const ApiRequest &req, QVariantMap &map)
         map["datastoreversion"] = QLatin1String("60");
         map["swupdate"] = swupdate;
         map["apiversion"] = QString(GW_API_VERSION);
+        map["bridgeid"] = gwBridgeId;
         map["starterkitid"] = QLatin1String("");
     }
 
@@ -495,12 +490,7 @@ void DeRestPluginPrivate::basicConfigToMap(QVariantMap &map)
         DBG_Printf(DBG_ERROR, "No valid ethernet interface found\n");
     }
 
-    if (!gwBridgeId.isEmpty())
-    {
-        // Only expose bridgeid after it's been set.
-        map["bridgeid"] = gwBridgeId;
-    }
-
+    map["bridgeid"] = gwBridgeId;
     map["swversion"] = QString(GW_SW_VERSION);
     map["modelid"] = QLatin1String("deCONZ");
     map["factorynew"] = false;

--- a/upnp.cpp
+++ b/upnp.cpp
@@ -43,6 +43,8 @@ void DeRestPluginPrivate::initUpnpDiscovery()
     connect(timer, SIGNAL(timeout()),
             this, SLOT(announceUpnp()));
     timer->start(20 * 1000);
+
+    initDescriptionXml();
 }
 
 /*! Replaces description_in.xml template with dynamic content. */
@@ -80,11 +82,6 @@ void DeRestPluginPrivate::initDescriptionXml()
 /*! Sends SSDP broadcast for announcement. */
 void DeRestPluginPrivate::announceUpnp()
 {
-    if (gwBridgeId.isEmpty())
-    {
-      // Don't announce before bridgeid has been set.
-      return;
-    }
     quint16 port = 1900;
     QHostAddress host;
     QByteArray datagram = QString(QLatin1String(
@@ -124,11 +121,6 @@ void DeRestPluginPrivate::upnpReadyRead()
 
         if (datagram.startsWith("M-SEARCH *"))
         {
-            if (gwBridgeId.isEmpty())
-            {
-              // Don't respond before bridgeid has been set.
-              return;
-            }
             DBG_Printf(DBG_HTTP, "UPNP %s:%u\n%s\n", qPrintable(host.toString()), port, datagram.data());
             datagram.clear();
 


### PR DESCRIPTION
Follow-up for #44.

> Preventing the internet announcement when gwBridgeId is not set is tricky, because the software update mechanism in the Web App depends on it (new versions are notified in the response). A missing gwBridgeId could happen for various reasons like: RaspBee firmware broken, no RaspBee or ConBee attached or a misconfigured UART. The update and discovery should not be blocked in these cases, therefore something like an fallback mechanism should be added. Maybe setting the gwBridgeId to the Raspberry mac address or the last known RaspBee or ConBee address.

`gwBridgeId` is now persisted in the database when the gateway device has been discovered.  It's initialised to `0000000000000000` on startup, but it should be restored before the REST API advertises itself or responds to commands.  Using the same logic for appspot, UPnP, GET `/api/<apikey>/config`, GET `/api/config`, and `description.xml`, all now use the value of `gwBridgeId` unconditionally.  This would only be `0000000000000000` after a new installation or gateway reset before the gateway has been discovered for the first time.
