### PR TITLE
Fix for new Trådfri remote firmware

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1941,6 +1941,7 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                     // zclFrame.payload().at(1) and zclFrame.payload().at(0) seem to hold the duration of the button hold
                     if (zclFrame.payload().size() >= 1 && buttonMap->zclParam0 == sensor->previousButton)
                     {
+                        sensor->previousButton = 0xFF;
                         ok = true;
                     }
                 }

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -365,6 +365,8 @@ Sensor::Sensor() :
     addItem(DataTypeBool, RConfigOn);
     addItem(DataTypeBool, RConfigReachable);
     addItem(DataTypeTime, RStateLastUpdated);
+
+    previousButton = 0xFF;
 }
 
 /*! Returns the sensor deleted state.


### PR DESCRIPTION
Suppress superfluous 4003 and 5003 buttonevents for the new Trådfri remote firmware (see https://github.com/dresden-elektronik/deconz-rest-plugin/issues/96#issuecomment-321982500)