### PR TITLE
ZHALightLevel and more...

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1488,7 +1488,7 @@ void DeRestPluginPrivate::bindingToRuleTimerFired()
 
                 case ILLUMINANCE_MEASUREMENT_CLUSTER_ID:
                 {
-                    if (i->type() == "ZHALight")
+                    if (i->type() == "ZHALightLevel")
                     {
                         sensor = &(*i);
                     }

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -595,6 +595,14 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             reportableChange8bit = 1;
         }
     }
+    else if (bt.binding.clusterId == COLOR_CLUSTER_ID)
+    {
+        dataType = deCONZ::Zcl16BitUint;
+        attributeId = 0x0007; // color temperature
+        minInterval = 1;
+        maxInterval = 300;
+        reportableChange16bit = 1;
+    }
     else
     {
         return false;
@@ -709,6 +717,7 @@ void DeRestPluginPrivate::checkLightBindingsForAttributeReporting(LightNode *lig
         {
         case ONOFF_CLUSTER_ID:
         case LEVEL_CLUSTER_ID:
+        case COLOR_CLUSTER_ID:
         {
             DBG_Printf(DBG_INFO_L2, "create binding for attribute reporting of cluster 0x%04X\n", i->id());
 
@@ -988,6 +997,13 @@ void DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
         {
             clusters.push_back(SCENE_CLUSTER_ID);
         }
+    }
+    // IKEA Trådfri remote
+    else if (sensor->modelId().startsWith(QLatin1String("TRADFRI")))
+    {
+        clusters.push_back(ONOFF_CLUSTER_ID);
+        clusters.push_back(LEVEL_CLUSTER_ID);
+        clusters.push_back(SCENE_CLUSTER_ID);
     }
     else
     {

--- a/database.cpp
+++ b/database.cpp
@@ -1580,6 +1580,11 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             }
             else if (strcmp(colname[i], "type") == 0)
             {
+                if (val == QLatin1String("ZHALight"))
+                {
+                    val = QLatin1String("ZHALightLevel");
+                    sensor.setNeedSaveDatabase(true);
+                }
                 sensor.setType(val);
             }
             else if (strcmp(colname[i], "modelid") == 0)
@@ -1694,7 +1699,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             item = sensor.addItem(DataTypeInt32, RStateButtonEvent);
             item->setValue(0);
         }
-        else if (sensor.type().endsWith(QLatin1String("Light")) || sensor.type().endsWith(QLatin1String("LightLevel")))
+        else if (sensor.type().endsWith(QLatin1String("LightLevel")))
         {
             if (sensor.fingerPrint().hasInCluster(ILLUMINANCE_MEASUREMENT_CLUSTER_ID))
             {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1941,6 +1941,7 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                     // zclFrame.payload().at(1) and zclFrame.payload().at(0) seem to hold the duration of the button hold
                     if (zclFrame.payload().size() >= 1 && buttonMap->zclParam0 == sensor->previousButton)
                     {
+                        sensor->previousButton = 0xFF;
                         ok = true;
                     }
                 }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -3049,10 +3049,10 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                         item->setValue(bat);
                                         i->setNeedSaveDatabase(true);
                                         queSaveDb(DB_SENSORS, DB_HUGE_SAVE_DELAY);
-
-                                        Event e(RSensors, RConfigBattery, i->id());
-                                        enqueueEvent(e);
                                     }
+
+                                    Event e(RSensors, RConfigBattery, i->id());
+                                    enqueueEvent(e);
                                 }
 
                                 updateSensorEtag(&*i);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2349,17 +2349,17 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node)
             }
         }
 
-        // ZHALight
+        // ZHALightLevel
         if (fpLightSensor.hasInCluster(ILLUMINANCE_MEASUREMENT_CLUSTER_ID))
         {
             fpLightSensor.endpoint = i->endpoint();
             fpLightSensor.deviceId = i->deviceId();
             fpLightSensor.profileId = i->profileId();
 
-            sensor = getSensorNodeForFingerPrint(node->address().ext(), fpLightSensor, "ZHALight");
+            sensor = getSensorNodeForFingerPrint(node->address().ext(), fpLightSensor, "ZHALightLevel");
             if (!sensor || sensor->deletedState() != Sensor::StateNormal)
             {
-                addSensorNode(node, fpLightSensor, "ZHALight", modelId);
+                addSensorNode(node, fpLightSensor, "ZHALightLevel", modelId);
             }
             else
             {
@@ -2531,7 +2531,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
         }
         sensorNode.addItem(DataTypeInt32, RStateButtonEvent);
     }
-    else if (sensorNode.type().endsWith(QLatin1String("Light")) || sensorNode.type().endsWith(QLatin1String("LightLevel")))
+    else if (sensorNode.type().endsWith(QLatin1String("LightLevel")))
     {
         if (sensorNode.fingerPrint().hasInCluster(ILLUMINANCE_MEASUREMENT_CLUSTER_ID))
         {
@@ -2843,9 +2843,9 @@ void DeRestPluginPrivate::checkUpdatedFingerPrint(const deCONZ::Node *node, quin
                 continue;
             }
 
-            if      (i->type().endsWith(QLatin1String("Switch")))   { clusterId = ONOFF_CLUSTER_ID; }
-            else if (i->type().endsWith(QLatin1String("Light")))    { clusterId = ILLUMINANCE_MEASUREMENT_CLUSTER_ID; }
-            else if (i->type().endsWith(QLatin1String("Presence"))) { clusterId = OCCUPANCY_SENSING_CLUSTER_ID; }
+            if      (i->type().endsWith(QLatin1String("Switch")))     { clusterId = ONOFF_CLUSTER_ID; }
+            else if (i->type().endsWith(QLatin1String("LightLevel"))) { clusterId = ILLUMINANCE_MEASUREMENT_CLUSTER_ID; }
+            else if (i->type().endsWith(QLatin1String("Presence")))   { clusterId = OCCUPANCY_SENSING_CLUSTER_ID; }
 
             DBG_Printf(DBG_INFO, "change 0x%016llX finger print ep: 0x%02X --> 0x%02X\n", i->address().ext(), fp.endpoint, endpoint);
 
@@ -3891,7 +3891,7 @@ void DeRestPluginPrivate::changeRuleStatusofGroup(QString groupId, bool enabled)
         }
 
         // disable or enable rule depending of group action
-        if (sensorType == "ZHALight" && !sensorModelId.startsWith("FLS-NB") && sensorModelId != "")
+        if (sensorType == "ZHALightLevel" && !sensorModelId.startsWith("FLS-NB") && sensorModelId != "")
         {
             std::vector<RuleAction>::const_iterator a = ri->actions().begin();
             std::vector<RuleAction>::const_iterator aend = ri->actions().end();

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -236,7 +236,7 @@ bool DeRestPluginPrivate::lightToMap(const ApiRequest &req, const LightNode *lig
     map["hascolor"] = lightNode->hasColor();
     map["type"] = lightNode->type();
     map["swversion"] = lightNode->swBuildId();
-    map["manufacturer"] = lightNode->manufacturer();
+    map["manufacturername"] = lightNode->manufacturer();
     /*
     QVariantMap pointsymbol;
     map["pointsymbol"] = pointsymbol; // dummy

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1476,7 +1476,7 @@ void DeRestPluginPrivate::checkSensorStateTimerFired()
  */
 void DeRestPluginPrivate::checkInstaModelId(Sensor *sensor)
 {
-    if (sensor && (sensor->address().ext() & instaMacPrefix) == instaMacPrefix)
+    if (sensor && (sensor->address().ext() & macPrefixMask) == instaMacPrefix)
     {
         if (!sensor->modelId().endsWith(QLatin1String("_1")))
         {   // extract model identifier from mac address 6th byte
@@ -1523,7 +1523,7 @@ void DeRestPluginPrivate::handleIndicationFindSensors(const deCONZ::ApsDataIndic
         // filter supported devices
 
         // Busch-Jaeger
-        if ((ext & bjeMacPrefix) == bjeMacPrefix)
+        if ((ext & macPrefixMask) == bjeMacPrefix)
         {
         }
         else if (macCapabilities == 0 || (macCapabilities & deCONZ::MacDeviceIsFFD))
@@ -1735,7 +1735,7 @@ void DeRestPluginPrivate::handleIndicationFindSensors(const deCONZ::ApsDataIndic
     }
 
     // check for dresden elektronik devices
-    if ((sc->address.ext() & deMacPrefix) == deMacPrefix)
+    if ((sc->address.ext() & macPrefixMask) == deMacPrefix)
     {
         if (sc->macCapabilities & deCONZ::MacDeviceIsFFD) // end-devices only
             return;
@@ -2035,7 +2035,7 @@ void DeRestPluginPrivate::handleIndicationFindSensors(const deCONZ::ApsDataIndic
             }
         }
     }
-    else if ((sc->address.ext() & ikeaMacPrefix) == ikeaMacPrefix)
+    else if ((sc->address.ext() & macPrefixMask) == ikeaMacPrefix)
     {
         if (sc->macCapabilities & deCONZ::MacDeviceIsFFD) // end-devices only
             return;
@@ -2136,10 +2136,10 @@ void DeRestPluginPrivate::handleIndicationFindSensors(const deCONZ::ApsDataIndic
                     continue;
                 }
 
-                if (ri->status() != QLatin1String("enabled"))
-                {
-                    continue;
-                }
+                // if (ri->status() != QLatin1String("enabled"))
+                // {
+                //     continue;
+                // }
 
                 std::vector<RuleCondition>::const_iterator ci = ri->conditions().begin();
                 std::vector<RuleCondition>::const_iterator cend = ri->conditions().end();

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1258,6 +1258,26 @@ void DeRestPluginPrivate::handleSensorEvent(const Event &e)
             webSocketServer->broadcastTextMessage(Json::serialize(map));
         }
     }
+    else if (strncmp(e.what(), "config/", 7) == 0)
+    {
+        ResourceItem *item = sensor->item(e.what());
+        if (item)
+        {
+            // checkRulesForResource(sensor);
+
+            QVariantMap map;
+            map["t"] = QLatin1String("event");
+            map["e"] = QLatin1String("changed");
+            map["r"] = QLatin1String("sensors");
+            map["id"] = e.id();
+            QVariantMap config;
+            config[e.what() + 7] = item->toVariant();
+
+            map["config"] = config;
+
+            webSocketServer->broadcastTextMessage(Json::serialize(map));
+        }
+    }
     else if (e.what() == REventAdded)
     {
         checkSensorGroup(sensor);

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -365,6 +365,8 @@ Sensor::Sensor() :
     addItem(DataTypeBool, RConfigOn);
     addItem(DataTypeBool, RConfigReachable);
     addItem(DataTypeTime, RStateLastUpdated);
+
+    previousButton = 0xFF;
 }
 
 /*! Returns the sensor deleted state.


### PR DESCRIPTION
- Use sensor `type` ZHALightLevel instead of ZHALight.
- Also issue web socket notification for `config.battery` on read/report, when value hasn’t changed.
- Setup attribute reporting for color temperature 0x0300/0x0007 of lights and binding for Trådfri remote (commit 471679a - sorry wrong comment, but I can't seem to change it).  The color temperature works: I see dbg-info level 2 messages and the expected settings can be read back from the deCONZ GUI.  I'm not too sure about the Trådfri remote bindings - I don't see any info message for binding of cluster 0x0005.
- Bug fixes for mac address mask; Don't re-create IKEA remote rules when rules exist, but disabled.
- Change light `manufacturer` attribute to `manufacturername` (issue #30, item 7).