### PR TITLE
Implement config.alert for sensors

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -1808,8 +1808,6 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 sensor.fingerPrint().inClusters.push_back(VENDOR_CLUSTER_ID);
                 sensor.setNeedSaveDatabase(true);
             }
-            item = sensor.addItem(DataTypeString, RConfigAlert);
-            item->setValue(R_ALERT_DEFAULT);
         }
         else if (sensor.modelId() == QLatin1String("SML001")) // Hue motion sensor
         {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2741,9 +2741,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
     {
         sensorNode.setManufacturer(QLatin1String("Philips"));
 
-        item = sensorNode.addItem(DataTypeString, RConfigAlert);
-        item->setValue(R_ALERT_DEFAULT);
-
         if (modelId.startsWith(QLatin1String("RWL02"))) // Hue dimmer switch
         {
             sensorNode.fingerPrint().endpoint = 2;
@@ -2777,6 +2774,8 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             item->setValue(false);
             item = sensorNode.addItem(DataTypeBool, RConfigUsertest);
             item->setValue(false);
+            item = sensorNode.addItem(DataTypeString, RConfigAlert);
+            item->setValue(R_ALERT_DEFAULT);
         }
     }
     else if (node->nodeDescriptor().manufacturerCode() == VENDOR_BEGA)

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -916,11 +916,11 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         }
         else if (alert == "select")
         {
-            task.identifyTime = 1;
+            task.identifyTime = 2;    // Hue lights don't react to 1.
         }
         else if (alert == "lselect")
         {
-            task.identifyTime = 30;
+            task.identifyTime = 15;   // Default for Philips Hue bridge
         }
         else
         {


### PR DESCRIPTION
Implement `config.alert` for sensors:
- Hue motion sensor;
- TRÅDFRI motion sensor;
- TRÅDFRI remote.

Remove `config.alert` from Hue dimmer switch, as it doesn’t support _Identify_ (even though it has a 0x0003 server cluster).

Change timings for light `state.alert` to match Hue bridge:
- `select`: 2s (Hue lights don’t respond when set to 1s);
- `lselect`: 15s.