### PR TITLE
Attribute reporting for Hue motion sensor config

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -560,11 +560,11 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt, Configu
         stream << rq.minInterval;
         stream << rq.maxInterval;
 
-        if (rq.reportableChange16bit)
+        if (rq.reportableChange16bit != 0xFFFF)
         {
             stream << rq.reportableChange16bit;
         }
-        else if (rq.reportableChange8bit)
+        else if (rq.reportableChange8bit != 0xFF)
         {
             stream << rq.reportableChange8bit;
         }
@@ -621,7 +621,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         if (sendConfigureReportingRequest(bt, rq))
         {
             rq = ConfigureReportingRequest();
-            rq.dataType = deCONZ::ZclBoolean;
+            rq.dataType = deCONZ::Zcl8BitUint;
             rq.attributeId = 0x0030; // sensitivity
             rq.minInterval = 5;      // value used by Hue bridge
             rq.maxInterval = 7200;   // value used by Hue bridge
@@ -674,13 +674,15 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq.attributeId = 0x0021;   // battery percentage remaining
         if (sensor && sensor->modelId() == QLatin1String("SML001")) // Hue motion sensor
         {
-            rq.minInterval = 7200;     // value used by Hue bridge
-            rq.maxInterval = 7200;     // value used by Hue bridge
+            rq.minInterval = 7200;        // value used by Hue bridge
+            rq.maxInterval = 7200;        // value used by Hue bridge
+            rq.reportableChange8bit = 0;  // value used by Hue bridge
         }
         else if (sensor && sensor->modelId().startsWith(QLatin1String("RWL02"))) // Hue dimmer switch
         {
-            rq.minInterval = 300;     // value used by Hue bridge
-            rq.maxInterval = 300;     // value used by Hue bridge
+            rq.minInterval = 300;         // value used by Hue bridge
+            rq.maxInterval = 300;         // value used by Hue bridge
+            rq.reportableChange8bit = 0;  // value used by Hue bridge
         }
         else
         {

--- a/bindings.h
+++ b/bindings.h
@@ -84,5 +84,25 @@ public:
     deCONZ::ApsDataRequest apsReq; //!< The APS request to match APS confirm.id
 };
 
-#endif // BINDINGS_H
+class ConfigureReportingRequest
+{
+public:
+    ConfigureReportingRequest() :
+        direction(0x00),
+        reportableChange8bit(0),
+        reportableChange16bit(0),
+        manufacturerCode(0)
+    {
+    }
 
+    quint8 direction;
+    quint8 dataType;
+    quint16 attributeId;
+    quint16 minInterval;
+    quint16 maxInterval;
+    quint8 reportableChange8bit;
+    quint16 reportableChange16bit;
+    quint16 manufacturerCode;
+};
+
+#endif // BINDINGS_H

--- a/bindings.h
+++ b/bindings.h
@@ -89,8 +89,8 @@ class ConfigureReportingRequest
 public:
     ConfigureReportingRequest() :
         direction(0x00),
-        reportableChange8bit(0),
-        reportableChange16bit(0),
+        reportableChange8bit(0xFF),
+        reportableChange16bit(0xFFFF),
         manufacturerCode(0)
     {
     }

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -765,6 +765,7 @@ public Q_SLOTS:
     void saveDatabaseTimerFired();
     void userActivity();
     bool sendBindRequest(BindingTask &bt);
+    bool sendConfigureReportingRequest(BindingTask &bt, ConfigureReportingRequest &rq);
     bool sendConfigureReportingRequest(BindingTask &bt);
     void checkLightBindingsForAttributeReporting(LightNode *lightNode);
     void checkSensorBindingsForAttributeReporting(Sensor *sensor);


### PR DESCRIPTION
Still trying to get `config.sensitivity`, `config.senstivitymax`, `config.usertest` and `config.ledindication` to work.  This is as far as I got this weekend.

- Added the attributes to `updateSensorNode()`;
- Read them in `delayedFastEnddeviceProbe()` - not sure if this is a good idea: they're read multiple times (as in many) on device discovery;
- Added the _Basic_ cluster to `checkSensorBindingsForAttributeReporting()`, but somehow the binding isn't configured.  Don't know why not;
- Refactored `sendConfigureReportingRequest` to allow for:
  - Reporting config for multiple attributes per cluster;
  - a reportableChange of 0 (as issued by the Hue bridge);
  - manufacturer-specific attributes;
- Double-checked the used parameters against what Philips Hue bridge uses, notably _Battery Percentage_ (0x0001/0x0021).

I'm running production with this change now, it doesn't seem to have broken anything (although I only deleted / repaired a single motion sensor).
