### PR TITLE
Fix sensor event timestamps

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -1719,6 +1719,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             item->setValue(0);
             item = sensor.addItem(DataTypeBool, RStateDark);
             item->setValue(true);
+            item->setTimeStamps(QDateTime::currentDateTime().addSecs(-120));
             item = sensor.addItem(DataTypeBool, RStateDaylight);
             item->setValue(false);
             item = sensor.addItem(DataTypeUInt16, RConfigTholdDark);

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1370,6 +1370,7 @@ void DeRestPluginPrivate::handleSensorEvent(const Event &e)
                 {
                     const char *key = item->descriptor().suffix + 6;
 
+                    // if (item->lastSet().isValid() && item->lastChanged().isValid() && item->lastChanged() >= sensor->lastStatePush)
                     if (item->lastSet().isValid())
                     {
                         state[key] = item->toVariant();
@@ -1413,6 +1414,7 @@ void DeRestPluginPrivate::handleSensorEvent(const Event &e)
                 {
                     const char *key = item->descriptor().suffix + 7;
 
+                    // if (item->lastSet().isValid() && item->lastChanged().isValid() && item->lastChanged() >= sensor->lastConfigPush)
                     if (item->lastSet().isValid())
                     {
                         config[key] = item->toVariant();

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -370,6 +370,10 @@ Sensor::Sensor() :
     m_buttonMap(0),
     m_rxCounter(0)
 {
+    QDateTime now = QDateTime::currentDateTime();
+    lastStatePush = now;
+    lastConfigPush = now;
+
     // common sensor items
     addItem(DataTypeBool, RConfigOn);
     addItem(DataTypeBool, RConfigReachable);
@@ -643,6 +647,7 @@ void Sensor::jsonToConfig(const QString &json)
         return;
     }
     QVariantMap map = var.toMap();
+    QDateTime dt = QDateTime::currentDateTime().addSecs(-120);
 
     for (int i = 0; i < itemCount(); i++)
     {
@@ -664,6 +669,7 @@ void Sensor::jsonToConfig(const QString &json)
             if (map.contains(QLatin1String(key)))
             {
                 item->setValue(map[key]);
+                item->setTimeStamps(dt);
             }
         }
     }


### PR DESCRIPTION
I've been playing around a bit more with web socket notifications, changing the code from 8308384da6f49aa8f958e2fda569002f8f60d0fc to include only the attributes that have actually changed in the web socket notification, just for the feel of it.  For now, I have commented out the code for this change in this PR.  Basically it's just changing the checks for the attributes to be included in the notification from
```c++
if (item->lastSet().isValid())
```
to
```c++
if (item->lastSet().isValid() && item->lastChanged().isValid() && item->lastChanged() >= sensor->lastStatePush)
```
and
```c++
if (item->lastSet().isValid() && item->lastChanged().isValid() && item->lastChanged() >= sensor->lastConfigPush)
```

The change does what I expected, but I found some funny behaviour after restarting deCONZ.  The CLIP sensor state attributes are initialised to 0, as expected, and the config is restored from the database, also as expected.  When setting `state.lightlevel` to 0, I would expect a web socket notification with only `state.lastupdated`, but `state.dark` is included as well, yet `state.daylight` isn't.  When updating `config.tholddark` for the first time, all config attributes are included in the notification, instead of only `config.tholddark`.

I traced these issues to improper initialisation of `item->lastSet()`, `item->lastUpdated()`, `sensor->lastStatePush()` and `sensor->lastConfigPush()`.  This PR fixes this, pending the discussion whether the web socket notification should include all attributes or only the changed attributes.