### PR TITLE
Update Hue motion sensor config attributes through config.duration

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -1829,12 +1829,14 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 sensor.fingerPrint().inClusters.push_back(POWER_CONFIGURATION_CLUSTER_ID);
                 sensor.setNeedSaveDatabase(true);
             }
-            item = sensor.addItem(DataTypeBool, RConfigLedIndication);
-            item->setValue(false);
-            item = sensor.addItem(DataTypeBool, RConfigUsertest);
-            item->setValue(false);
             item = sensor.addItem(DataTypeString, RConfigAlert);
             item->setValue(R_ALERT_DEFAULT);
+            item = sensor.addItem(DataTypeBool, RConfigLedIndication);
+            item->setValue(false);
+            item = sensor.addItem(DataTypeUInt8, RConfigPending);
+            item->setValue(0);
+            item = sensor.addItem(DataTypeBool, RConfigUsertest);
+            item->setValue(false);
         } else if (sensor.modelId().startsWith(QLatin1String("TRADFRI")))
         {
             // support power configuration cluster for IKEA devices

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -174,6 +174,10 @@
 
 // write flags
 #define WRITE_OCCUPANCY_CONFIG  (1 << 11)
+#define WRITE_DURATION          (1 << 13)
+#define WRITE_LEDINDICATION     (1 << 14)
+#define WRITE_SENSITIVITY       (1 << 15)
+#define WRITE_USERTEST          (1 << 16)
 
 // manufacturer codes
 #define VENDOR_ATMEL    0x1014

--- a/resource.cpp
+++ b/resource.cpp
@@ -63,6 +63,7 @@ const char *RConfigLedIndication = "config/ledindication";
 const char *RConfigLocalTime = "config/localtime";
 const char *RConfigLong = "config/long";
 const char *RConfigOn = "config/on";
+const char *RConfigPending = "config/pending";
 const char *RConfigReachable = "config/reachable";
 const char *RConfigSensitivity = "config/sensitivity";
 const char *RConfigSensitivityMax = "config/sensitivitymax";
@@ -120,6 +121,7 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeTime, RConfigLocalTime));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RConfigLong));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, RConfigOn));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, RConfigPending));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, RConfigReachable));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, RConfigSensitivity));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, RConfigSensitivityMax));

--- a/resource.h
+++ b/resource.h
@@ -75,6 +75,7 @@ extern const char *RConfigLedIndication;
 extern const char *RConfigLocalTime;
 extern const char *RConfigLong;
 extern const char *RConfigOn;
+extern const char *RConfigPending;
 extern const char *RConfigReachable;
 extern const char *RConfigSensitivity;
 extern const char *RConfigSensitivityMax;
@@ -89,6 +90,11 @@ extern const char *RConfigUsertest;
 #define R_SENSITIVITY_MAX_DEFAULT   2
 #define R_THOLDDARK_DEFAULT         12000
 #define R_THOLDOFFSET_DEFAULT       7000
+
+#define R_PENDING_DURATION          (1 << 0)
+#define R_PENDING_LEDINDICATION     (1 << 1)
+#define R_PENDING_SENSITIVITY       (1 << 2)
+#define R_PENDING_USERTEST          (1 << 3)
 
 class  ResourceItemDescriptor
 {


### PR DESCRIPTION
Added `config.duration` attribute for Hue motion sensor.  It's value is just a bitmap - the array is only created when GETting the sensor resource;

When changing `config.duration`, `config.ledindication`, `config.sensitivity`, or `config.usertest` from the API, the following happens:
- The cached attribute is updated immediately, and a websocket notification is issued accordingly;
- The attribute name is added to `config.pending`;
- A `mustRead()` flag is set for the attribute;
- On the next communication with the sensor, the attribute is written, the attribute name is deleted from `config.pending` and the `mustRead()` flag is cleared - no websocket notification is issued at this time.

I disabled the old `config.duration` logic for the Hue motion sensor.  It prevented setting duration back to 0 from the GUI.  I thought this was an issue with the Motion sensor, but it was actually the REST API overwriting the new value with the old value, immediately after the change.

There's still a few issues.  @manup, I would appreciate your input on these:
1. When restoring `config.pending` from the database, the `mustRead()` flag isn't set.  I'm not sure what should be the correct behaviour: setting the flag, or just clearing `config.pending` (or rather: not persisting `config.pending` to the database in the first place).
2. The setup of attribute reporting for `config.sensitivity` (Occupancy Sensing cluster) and for `config.ledindication` and `config.usertest` is not working (reliably or at all?).  In particular, `config.usertest` isn't reset when the user test ends after 2 minutes.
3. The values of `config.ledindication` and `config.usertest` are not updated in the other two resources.  I need to test how the Hue bridge handles this: whether it updates `config.pending` on all three resources, and whether the other two resources are updated on PUT or on actually writing the attribute (and clearing `config.pending`).  I'm hoping all three resources will be updated once attribute reporting works.  Alternatively, we could only expose these attributes in the ZHAPresence resource (which makes sense, as they apply to this functionality).
