### PR TITLE
Hue motion sensor config - continued

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -963,8 +963,14 @@ void DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         }
         else if (*i == OCCUPANCY_SENSING_CLUSTER_ID)
         {
-            val = sensor->getZclValue(*i, 0x0000); // occupied state
-            // val = sensor->getZclValue(*i, 0x0030); // sensitivity
+            if (sensor->modelId() == QLatin1String("SML001")) // Hue motion sensor
+            {
+                val = sensor->getZclValue(*i, 0x0030); // sensitivity
+            }
+            else
+            {
+                val = sensor->getZclValue(*i, 0x0000); // occupied state
+            }
         }
         else if (*i == POWER_CONFIGURATION_CLUSTER_ID)
         {

--- a/database.cpp
+++ b/database.cpp
@@ -1824,6 +1824,11 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
         }
         else if (sensor.modelId() == QLatin1String("SML001")) // Hue motion sensor
         {
+            if (!sensor.fingerPrint().hasInCluster(BASIC_CLUSTER_ID))
+            {
+                sensor.fingerPrint().inClusters.push_back(BASIC_CLUSTER_ID);
+                sensor.setNeedSaveDatabase(true);
+            }
             if (!sensor.fingerPrint().hasInCluster(POWER_CONFIGURATION_CLUSTER_ID))
             {
                 sensor.fingerPrint().inClusters.push_back(POWER_CONFIGURATION_CLUSTER_ID);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -3484,7 +3484,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 }
                                 updateSensorEtag(&*i);
                             }
-                            else if (i->modelId() != QLatin1String("SML001") && ia->id() == 0x0010) // occupied to unoccupied delay
+                            else if (i->modelId().startsWith(QLatin1String("FLS-NB")) && ia->id() == 0x0010) // occupied to unoccupied delay
                             {
                                 quint16 duration = ia->numericValue().u16;
                                 ResourceItem *item = i->item(RConfigDuration);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2320,6 +2320,12 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node)
                     }
 
                     fpSwitch.inClusters.push_back(ci->id());
+                    if (node->nodeDescriptor().manufacturerCode() == VENDOR_PHILIPS)
+                    {
+                        fpPresenceSensor.inClusters.push_back(ci->id());
+                        fpLightSensor.inClusters.push_back(ci->id());
+                        fpTemperatureSensor.inClusters.push_back(ci->id());
+                    }
                 }
                     break;
 


### PR DESCRIPTION
Add Basic cluster to Hue motion sensor fingerprint, so attribute reporting for ledindication and usertest will be setup.

Once attribute reporting has been setup, `config.ledindication` and `config.usertest` are indeed updated in all three resources (as I hoped).

For the Hue motion sensor, check attribute reporting for Occupancy Sensing cluster on sensitivity instead of occupied state (in the hope that attribute reporting for sensitivity is more likely to be setup).