### PR TITLE
web socket notification enhancements

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -639,9 +639,10 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             {
                 rq = ConfigureReportingRequest();
                 rq.dataType = deCONZ::Zcl8BitUint;
-                rq.attributeId = 0x0030; // sensitivity
-                rq.minInterval = 5;      // value used by Hue bridge
-                rq.maxInterval = 7200;   // value used by Hue bridge
+                rq.attributeId = 0x0030;      // sensitivity
+                rq.minInterval = 5;           // value used by Hue bridge
+                rq.maxInterval = 7200;        // value used by Hue bridge
+                rq.reportableChange8bit = 1;  // value used by Hue bridge
                 rq.manufacturerCode = VENDOR_PHILIPS;
                 return sendConfigureReportingRequest(bt, rq);
             }

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -963,8 +963,14 @@ void DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         }
         else if (*i == OCCUPANCY_SENSING_CLUSTER_ID)
         {
-            val = sensor->getZclValue(*i, 0x0000); // occupied state
-            // val = sensor->getZclValue(*i, 0x0030); // sensitivity
+            if (sensor->modelId() == QLatin1String("SML001")) // Hue motion sensor
+            {
+                val = sensor->getZclValue(*i, 0x0030); // sensitivity
+            }
+            else
+            {
+                val = sensor->getZclValue(*i, 0x0000); // occupied state
+            }
         }
         else if (*i == POWER_CONFIGURATION_CLUSTER_ID)
         {

--- a/database.cpp
+++ b/database.cpp
@@ -1824,6 +1824,11 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
         }
         else if (sensor.modelId() == QLatin1String("SML001")) // Hue motion sensor
         {
+            if (!sensor.fingerPrint().hasInCluster(BASIC_CLUSTER_ID))
+            {
+                sensor.fingerPrint().inClusters.push_back(BASIC_CLUSTER_ID);
+                sensor.setNeedSaveDatabase(true);
+            }
             if (!sensor.fingerPrint().hasInCluster(POWER_CONFIGURATION_CLUSTER_ID))
             {
                 sensor.fingerPrint().inClusters.push_back(POWER_CONFIGURATION_CLUSTER_ID);

--- a/database.cpp
+++ b/database.cpp
@@ -543,6 +543,15 @@ static int sqliteLoadConfigCallback(void *user, int ncols, char **colval , char 
           d->gwBridgeId = val;
       }
     }
+    else if (strcmp(colval[0], "websocketnotifyall") == 0)
+    {
+      if (!val.isEmpty())
+      {
+          bool notifyAll = val == "true";
+          d->gwConfig["websocketnotifyall"] = notifyAll;
+          d->gwWebSocketNotifyAll = notifyAll;
+      }
+    }
     return 0;
 }
 
@@ -2366,6 +2375,7 @@ void DeRestPluginPrivate::saveDb()
         gwConfig["wifichannel"] = gwWifiChannel;
         gwConfig["wifiip"] = gwWifiIp;
         gwConfig["bridgeid"] = gwBridgeId;
+        gwConfig["websocketnotifyall"] = gwWebSocketNotifyAll;
 
         QVariantMap::iterator i = gwConfig.begin();
         QVariantMap::iterator end = gwConfig.end();

--- a/de_web.pro
+++ b/de_web.pro
@@ -58,7 +58,7 @@ GIT_COMMIT = $$system("git rev-list HEAD --max-count=1")
 # Version Major.Minor.Build
 # Important: don't change the format of this line since it's parsed by scripts!
 DEFINES += GW_SW_VERSION=\\\"2.04.77\\\"
-DEFINES += GW_API_VERSION=\\\"1.0.3\\\"
+DEFINES += GW_API_VERSION=\\\"1.0.4\\\"
 DEFINES += GIT_COMMMIT=\\\"$$GIT_COMMIT\\\" \
 
 # Minimum version of the RaspBee firmware

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4912,7 +4912,7 @@ bool DeRestPluginPrivate::processZclAttributes(Sensor *sensorNode)
         DBG_Printf(DBG_INFO_L2, "handle pending sensitivity for 0x%016llX\n", sensorNode->address().ext());
         if (item)
         {
-            bool sensitivity = item->toNumber();
+            quint64 sensitivity = item->toNumber();
             // sensitivity
             deCONZ::ZclAttribute attr(0x0030, deCONZ::Zcl8BitUint, "sensitivity", deCONZ::ZclReadWrite, true);
             attr.setValue(sensitivity);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -3484,7 +3484,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 }
                                 updateSensorEtag(&*i);
                             }
-                            else if (i->modelId() != QLatin1String("SML001") && ia->id() == 0x0010) // occupied to unoccupied delay
+                            else if (i->modelId().startsWith(QLatin1String("FLS-NB")) && ia->id() == 0x0010) // occupied to unoccupied delay
                             {
                                 quint16 duration = ia->numericValue().u16;
                                 ResourceItem *item = i->item(RConfigDuration);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -172,6 +172,7 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
     supportColorModeXyForGroups = false;
     groupDeviceMembershipChecked = false;
     gwLinkButton = false;
+    gwWebSocketNotifyAll = true;
 
     // preallocate memory to get consistent pointers
     nodes.reserve(150);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -3540,7 +3540,6 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 if (item && item->toNumber() != duration)
                                 {
                                     item->setValue(duration);
-                                    i->updateStateTimestamp();
                                     i->setNeedSaveDatabase(true);
                                     Event e(RSensors, RConfigDuration, i->id(), item);
                                     enqueueEvent(e);
@@ -3561,7 +3560,6 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 if (item && item->toNumber() != sensitivity)
                                 {
                                     item->setValue(sensitivity);
-                                    i->updateStateTimestamp();
                                     i->setNeedSaveDatabase(true);
                                     Event e(RSensors, RConfigSensitivity, i->id(), item);
                                     enqueueEvent(e);
@@ -3582,7 +3580,6 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 if (item && item->toNumber() != sensitivitymax)
                                 {
                                     item->setValue(sensitivitymax);
-                                    i->updateStateTimestamp();
                                     i->setNeedSaveDatabase(true);
                                     Event e(RSensors, RConfigSensitivityMax, i->id(), item);
                                     enqueueEvent(e);
@@ -3748,7 +3745,6 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 if (item && item->toNumber() != usertest)
                                 {
                                     item->setValue(usertest);
-                                    i->updateStateTimestamp();
                                     i->setNeedSaveDatabase(true);
                                     Event e(RSensors, RConfigUsertest, i->id(), item);
                                     enqueueEvent(e);
@@ -3769,7 +3765,6 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 if (item && item->toNumber() != ledindication)
                                 {
                                     item->setValue(ledindication);
-                                    i->updateStateTimestamp();
                                     i->setNeedSaveDatabase(true);
                                     Event e(RSensors, RConfigLedIndication, i->id(), item);
                                     enqueueEvent(e);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4857,6 +4857,7 @@ bool DeRestPluginPrivate::processZclAttributes(Sensor *sensorNode)
     {
         ResourceItem *item = sensorNode->item(RConfigDuration);
 
+        DBG_Printf(DBG_INFO_L2, "handle pending duration for 0x%016llX\n", sensorNode->address().ext());
         if (item)
         {
             quint64 duration = item->toNumber();
@@ -4870,16 +4871,21 @@ bool DeRestPluginPrivate::processZclAttributes(Sensor *sensorNode)
                 uint8_t mask = item->toNumber();
                 mask &= ~R_PENDING_DURATION;
                 item->setValue(mask);
+                sensorNode->clearRead(WRITE_DURATION);
                 processed++;
             }
         }
-        sensorNode->clearRead(WRITE_DURATION);
+        else
+        {
+            sensorNode->clearRead(WRITE_DURATION);
+        }
     }
 
     if (sensorNode->mustRead(WRITE_LEDINDICATION) && tNow > sensorNode->nextReadTime(WRITE_LEDINDICATION))
     {
         ResourceItem *item = sensorNode->item(RConfigLedIndication);
 
+        DBG_Printf(DBG_INFO_L2, "handle pending ledindication for 0x%016llX\n", sensorNode->address().ext());
         if (item)
         {
             bool ledindication = (item->toNumber() != 0);
@@ -4893,16 +4899,21 @@ bool DeRestPluginPrivate::processZclAttributes(Sensor *sensorNode)
                 uint8_t mask = item->toNumber();
                 mask &= ~R_PENDING_LEDINDICATION;
                 item->setValue(mask);
+                sensorNode->clearRead(WRITE_LEDINDICATION);
                 processed++;
             }
         }
-        sensorNode->clearRead(WRITE_LEDINDICATION);
+        else
+        {
+            sensorNode->clearRead(WRITE_LEDINDICATION);
+        }
     }
 
     if (sensorNode->mustRead(WRITE_SENSITIVITY) && tNow > sensorNode->nextReadTime(WRITE_SENSITIVITY))
     {
         ResourceItem *item = sensorNode->item(RConfigSensitivity);
 
+        DBG_Printf(DBG_INFO_L2, "handle pending sensitivity for 0x%016llX\n", sensorNode->address().ext());
         if (item)
         {
             bool sensitivity = item->toNumber();
@@ -4916,16 +4927,21 @@ bool DeRestPluginPrivate::processZclAttributes(Sensor *sensorNode)
                 uint8_t mask = item->toNumber();
                 mask &= ~R_PENDING_SENSITIVITY;
                 item->setValue(mask);
+                sensorNode->clearRead(WRITE_SENSITIVITY);
                 processed++;
             }
         }
-        sensorNode->clearRead(WRITE_SENSITIVITY);
+        else
+        {
+            sensorNode->clearRead(WRITE_SENSITIVITY);
+        }
     }
 
     if (sensorNode->mustRead(WRITE_USERTEST) && tNow > sensorNode->nextReadTime(WRITE_USERTEST))
     {
         ResourceItem *item = sensorNode->item(RConfigUsertest);
 
+        DBG_Printf(DBG_INFO_L2, "handle pending usertest for 0x%016llX\n", sensorNode->address().ext());
         if (item)
         {
             bool usertest = (item->toNumber() != 0);
@@ -4939,10 +4955,14 @@ bool DeRestPluginPrivate::processZclAttributes(Sensor *sensorNode)
                 uint8_t mask = item->toNumber();
                 mask &= ~R_PENDING_USERTEST;
                 item->setValue(mask);
+                sensorNode->clearRead(WRITE_USERTEST);
                 processed++;
             }
         }
-        sensorNode->clearRead(WRITE_USERTEST);
+        else
+        {
+            sensorNode->clearRead(WRITE_USERTEST);
+        }
     }
 
     return (processed > 0);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2320,6 +2320,12 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node)
                     }
 
                     fpSwitch.inClusters.push_back(ci->id());
+                    if (node->nodeDescriptor().manufacturerCode() == VENDOR_PHILIPS)
+                    {
+                        fpPresenceSensor.inClusters.push_back(ci->id());
+                        fpLightSensor.inClusters.push_back(ci->id());
+                        fpTemperatureSensor.inClusters.push_back(ci->id());
+                    }
                 }
                     break;
 

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1040,6 +1040,7 @@ public:
 
     // configuration
     bool gwLinkButton;
+    bool gwWebSocketNotifyAll;  // include all attributes in websocket notification
     bool gwRfConnectedExpected;  // the state which should be hold
     bool gwRfConnected;  // to detect changes
     int gwAnnounceInterval; // used by internet discovery [minutes]

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -476,6 +476,7 @@ void DeRestPluginPrivate::configToMap(const ApiRequest &req, QVariantMap &map)
     map["linkbutton"] = gwLinkButton;
     map["portalservices"] = false;
     map["websocketport"] = (double)webSocketServer->port();
+    map["websocketnotifyall"] = gwWebSocketNotifyAll;
 
     gwIpAddress = map["ipaddress"].toString(); // cache
 
@@ -1673,6 +1674,23 @@ int DeRestPluginPrivate::modifyConfig(const ApiRequest &req, ApiResponse &rsp)
         QVariantMap rspItem;
         QVariantMap rspItemState;
         rspItemState["/config/timeformat"] = timeFormat;
+        rspItem["success"] = rspItemState;
+        rsp.list.append(rspItem);
+    }
+
+    if (map.contains("websocketnotifyall")) // optional
+    {
+        bool notifyAll = map["websocketnotifyall"].toBool();
+
+        if (gwWebSocketNotifyAll != notifyAll)
+        {
+            gwWebSocketNotifyAll = notifyAll;
+            changed = true;
+            queSaveDb(DB_CONFIG, DB_SHORT_SAVE_DELAY);
+        }
+        QVariantMap rspItem;
+        QVariantMap rspItemState;
+        rspItemState["/config/websocketnotifyall"] = notifyAll;
         rspItem["success"] = rspItemState;
         rsp.list.append(rspItem);
     }

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1432,8 +1432,7 @@ void DeRestPluginPrivate::handleSensorEvent(const Event &e)
                 {
                     const char *key = item->descriptor().suffix + 6;
 
-                    // if (item->lastSet().isValid() && item->lastChanged().isValid() && item->lastChanged() >= sensor->lastStatePush)
-                    if (item->lastSet().isValid())
+                    if (item->lastSet().isValid() && (gwWebSocketNotifyAll || (item->lastChanged().isValid() && item->lastChanged() >= sensor->lastStatePush)))
                     {
                         state[key] = item->toVariant();
                     }
@@ -1480,8 +1479,7 @@ void DeRestPluginPrivate::handleSensorEvent(const Event &e)
                     {
                         continue;
                     }
-                    // if (item->lastSet().isValid() && item->lastChanged().isValid() && item->lastChanged() >= sensor->lastConfigPush)
-                    if (item->lastSet().isValid())
+                    if (item->lastSet().isValid() && (gwWebSocketNotifyAll || (item->lastChanged().isValid() && item->lastChanged() >= sensor->lastStatePush)))
                     {
                         config[key] = item->toVariant();
                     }

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1432,7 +1432,7 @@ void DeRestPluginPrivate::handleSensorEvent(const Event &e)
                 {
                     const char *key = item->descriptor().suffix + 6;
 
-                    if (item->lastSet().isValid() && (gwWebSocketNotifyAll || (item->lastChanged().isValid() && item->lastChanged() >= sensor->lastStatePush)))
+                    if (item->lastSet().isValid() && (gwWebSocketNotifyAll || rid.suffix == RStateButtonEvent || (item->lastChanged().isValid() && item->lastChanged() >= sensor->lastStatePush)))
                     {
                         state[key] = item->toVariant();
                     }

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -844,21 +844,25 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                         {
                             pendingMask |= R_PENDING_DURATION;
                             sensor->enableRead(WRITE_DURATION);
+                            sensor->setNextReadTime(WRITE_DURATION, QTime::currentTime());
                         }
                         else if (rid.suffix == RConfigLedIndication)
                         {
                             pendingMask |= R_PENDING_LEDINDICATION;
                             sensor->enableRead(WRITE_LEDINDICATION);
+                            sensor->setNextReadTime(WRITE_LEDINDICATION, QTime::currentTime());
                         }
                         else if (rid.suffix == RConfigSensitivity)
                         {
                             pendingMask |= R_PENDING_SENSITIVITY;
                             sensor->enableRead(WRITE_SENSITIVITY);
+                            sensor->setNextReadTime(WRITE_SENSITIVITY, QTime::currentTime());
                         }
                         else if (rid.suffix == RConfigUsertest)
                         {
                             pendingMask |= R_PENDING_USERTEST;
                             sensor->enableRead(WRITE_USERTEST);
+                            sensor->setNextReadTime(WRITE_USERTEST, QTime::currentTime());
                         }
                     }
                 }

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -680,7 +680,7 @@ void Sensor::jsonToConfig(const QString &json)
             continue;
         }
 
-        if (strncmp(rid.suffix, "config/", 7) == 0)
+        if (strncmp(rid.suffix, "config/", 7) == 0 && rid.suffix != RConfigPending)
         {
             const char *key = item->descriptor().suffix + 7;
 


### PR DESCRIPTION
Added new configuration setting, `/config/websocketnotifyall`, which defaults to `true`.  When set, all `state` or `config` attributes are included in the web socket notification; when set to `false` only the changed attributes are included.  See issue #194.

Updated API version to 1.0.4.

This PR also fixes that `state.lastupdated` was updated when `config.duration`, `config.ledindication`, `config.sensitivity`, `config.sensitivitymax`, or `config.usertest` was updated.  However, no event was issued for `state.lastupdated`, so the updated `state.lastupdate` wasn't reflected in the REST API.  I don't think this solves the duplicate web socket events from issue #194.