### PR TITLE
Fix automatic resetting of `state.presence` to `false`

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -1780,7 +1780,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             item = sensor.addItem(DataTypeBool, RStatePresence);
             item->setValue(false);
             item = sensor.addItem(DataTypeUInt16, RConfigDuration);
-            item->setValue(60);
+            item->setValue(0);
             if (sensor.modelId() == QLatin1String("SML001")) // Hue motion sensor
             {
                 item->setValue(0);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2131,15 +2131,18 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                 if (item)
                 {
                     item->setValue(true);
-                    if (item->lastSet() == item->lastChanged())
-                    {
-                        Event e(RSensors, RStatePresence, sensor->id(), item);
-                        enqueueEvent(e);
-                    }
+                    Event e(RSensors, RStatePresence, sensor->id(), item);
+                    enqueueEvent(e);
                     updateSensorEtag(sensor);
                     sensor->updateStateTimestamp();
                     sensor->setNeedSaveDatabase(true);
                     enqueueEvent(Event(RSensors, RStateLastUpdated, sensor->id()));
+
+                    ResourceItem *item2 = sensor->item(RConfigDuration);
+                    if (item2 && item2->toNumber() > 0)
+                    {
+                        sensor->durationDue = QDateTime::currentDateTime().addSecs(item2->toNumber());
+                    }
                 }
                 break;
             }
@@ -7886,6 +7889,11 @@ void DeRestPluginPrivate::handleOnOffClusterIndication(TaskItem &task, const deC
                     Event e(RSensors, RStatePresence, s.id(), item);
                     enqueueEvent(e);
                     enqueueEvent(Event(RSensors, RStateLastUpdated, s.id()));
+                }
+                item = s.item(RConfigDuration);
+                if (item && item->toNumber() > 0)
+                {
+                    s.durationDue = QDateTime::currentDateTime().addSecs(item->toNumber());
                 }
             }
         }

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1318,7 +1318,6 @@ public:
     size_t sensorIter;
     size_t lightAttrIter;
     size_t sensorAttrIter;
-    size_t sensorCheckIter;
     std::vector<Group> groups;
     std::vector<LightNode> nodes;
     std::vector<Rule> rules;

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -391,6 +391,7 @@ Sensor::Sensor() :
     QDateTime now = QDateTime::currentDateTime();
     lastStatePush = now;
     lastConfigPush = now;
+    durationDue = QDateTime();
 
     // common sensor items
     addItem(DataTypeBool, RConfigOn);

--- a/sensor.h
+++ b/sensor.h
@@ -129,6 +129,7 @@ public:
     uint8_t previousDirection;
     QDateTime lastStatePush;
     QDateTime lastConfigPush;
+    QDateTime durationDue;
 
 private:
     DeletedState m_deletedstate;


### PR DESCRIPTION
Fix automatic resetting of `state.presence` to `false`:
- Now the reset of `state.presence` to `false` takes place `config.duration` seconds (+/- 1 for rounding errors) after `state.presence` was last set to `true`;
- To disable automatic resetting, set `config.duration` to 0;
- Don’t reset `state.presence` automatically for motion sensors that do attribute reporting on the Occupancy Sensing cluster (like the Hue motion sensor), under the assumption that they’ll issue a message when motion is no longer detected;
- Also reset `state.presence` automatically for CLIPPresence sensors (when `config.duration` > 0);
- `config.duration` initialised to `0` instead of `60`.

Refactored the logic:
- Loop over all sensor resources in `checkSensorStateTimerFired()` instead of just checking one sensor per second;
- Added `sensor->durationDue` so loop only needs to do simple check per sensor;
- Set `sensor->durationDue` when setting `state.presence` (only for sensors where `state.presence` needs to be reset automatically).

Fixed a segmentation fault when setting `config.duration` of a CLIPPresence sensor through the REST API.