### PR TITLE
CLIPConsumption, CLIPPower, and config.delay

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -2013,15 +2013,19 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             }
             item = sensor.addItem(DataTypeBool, RStatePresence);
             item->setValue(false);
-            item = sensor.addItem(DataTypeUInt16, RConfigDuration);
-            item->setValue(60); // presence should be reasonable for physical sensors
             if (sensor.modelId() == QLatin1String("SML001")) // Hue motion sensor
             {
+                item = sensor.addItem(DataTypeUInt16, RConfigDelay);
                 item->setValue(0);
                 item = sensor.addItem(DataTypeUInt8, RConfigSensitivity);
                 item->setValue(0);
                 item = sensor.addItem(DataTypeUInt8, RConfigSensitivityMax);
                 item->setValue(R_SENSITIVITY_MAX_DEFAULT);
+            }
+            else
+            {
+                item = sensor.addItem(DataTypeUInt16, RConfigDuration);
+                item->setValue(60); // presence should be reasonable for physical sensors
             }
         }
         else if (sensor.type().endsWith(QLatin1String("Flag")))

--- a/database.cpp
+++ b/database.cpp
@@ -2088,35 +2088,37 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             if (sensor.fingerPrint().hasInCluster(METERING_CLUSTER_ID))
             {
                 clusterId = METERING_CLUSTER_ID;
-                item = sensor.addItem(DataTypeInt64, RStateConsumption);
-                item->setValue(0);
             }
             else if (sensor.fingerPrint().hasInCluster(ANALOG_INPUT_CLUSTER_ID))
             {
                 clusterId = ANALOG_INPUT_CLUSTER_ID;
-                item = sensor.addItem(DataTypeInt64, RStateConsumption);
-                item->setValue(0);
             }
+            item = sensor.addItem(DataTypeInt64, RStateConsumption);
+            item->setValue(0);
         }
         else if (sensor.type().endsWith(QLatin1String("Power")))
         {
+            bool hasVoltage = true;
             if (sensor.fingerPrint().hasInCluster(ELECTRICAL_MEASUREMENT_CLUSTER_ID))
             {
                 clusterId = ELECTRICAL_MEASUREMENT_CLUSTER_ID;
-                item = sensor.addItem(DataTypeInt16, RStatePower);
-                item->setValue(0);
-                if (!sensor.modelId().startsWith(QLatin1String("Plug"))) // OSRAM
+                if (sensor.modelId().startsWith(QLatin1String("Plug"))) // OSRAM
                 {
-                    item = sensor.addItem(DataTypeUInt16, RStateVoltage);
-                    item->setValue(0);
-                    item = sensor.addItem(DataTypeUInt16, RStateCurrent);
-                    item->setValue(0);
+                    hasVoltage = false;
                 }
             }
             else if (sensor.fingerPrint().hasInCluster(ANALOG_INPUT_CLUSTER_ID))
             {
                 clusterId = ANALOG_INPUT_CLUSTER_ID;
-                item = sensor.addItem(DataTypeInt16, RStatePower);
+                hasVoltage = false;
+            }
+            item = sensor.addItem(DataTypeInt16, RStatePower);
+            item->setValue(0);
+            if (hasVoltage)
+            {
+                item = sensor.addItem(DataTypeUInt16, RStateVoltage);
+                item->setValue(0);
+                item = sensor.addItem(DataTypeUInt16, RStateCurrent);
                 item->setValue(0);
             }
         }

--- a/database.cpp
+++ b/database.cpp
@@ -2092,6 +2092,8 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             if (sensor.fingerPrint().hasInCluster(METERING_CLUSTER_ID))
             {
                 clusterId = METERING_CLUSTER_ID;
+                item = sensor.addItem(DataTypeInt16, RStatePower);
+                item->setValue(0);
             }
             else if (sensor.fingerPrint().hasInCluster(ANALOG_INPUT_CLUSTER_ID))
             {

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -210,7 +210,7 @@
 
 // write flags
 #define WRITE_OCCUPANCY_CONFIG  (1 << 11)
-#define WRITE_DURATION          (1 << 13)
+#define WRITE_DELAY             (1 << 13)
 #define WRITE_LEDINDICATION     (1 << 14)
 #define WRITE_SENSITIVITY       (1 << 15)
 #define WRITE_USERTEST          (1 << 16)

--- a/resource.cpp
+++ b/resource.cpp
@@ -74,6 +74,7 @@ const char *RConfigColorCapabilities = "config/colorcapabilities";
 const char *RConfigCtMin = "config/ctmin";
 const char *RConfigCtMax = "config/ctmax";
 const char *RConfigConfigured = "config/configured";
+const char *RConfigDelay = "config/delay";
 const char *RConfigDuration = "config/duration";
 const char *RConfigGroup = "config/group";
 const char *RConfigLat = "config/lat";
@@ -153,6 +154,7 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigCtMin));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigCtMax));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, RConfigConfigured));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigDelay));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigDuration));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RConfigGroup));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RConfigLat));

--- a/resource.h
+++ b/resource.h
@@ -89,6 +89,7 @@ extern const char *RConfigColorCapabilities;
 extern const char *RConfigCtMin;
 extern const char *RConfigCtMax;
 extern const char *RConfigConfigured;
+extern const char *RConfigDelay;
 extern const char *RConfigDuration;
 extern const char *RConfigGroup;
 extern const char *RConfigLat;
@@ -114,7 +115,7 @@ extern const char *RConfigUsertest;
 #define R_THOLDDARK_DEFAULT         12000
 #define R_THOLDOFFSET_DEFAULT       7000
 
-#define R_PENDING_DURATION          (1 << 0)
+#define R_PENDING_DELAY             (1 << 0)
 #define R_PENDING_LEDINDICATION     (1 << 1)
 #define R_PENDING_SENSITIVITY       (1 << 2)
 #define R_PENDING_USERTEST          (1 << 3)

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -275,6 +275,7 @@ int DeRestPluginPrivate::createSensor(const ApiRequest &req, ApiResponse &rsp)
 
         if      (type == QLatin1String("CLIPAlarm")) { item = sensor.addItem(DataTypeBool, RStateAlarm); item->setValue(false); }
         else if (type == QLatin1String("CLIPCarbonMonoxide")) { item = sensor.addItem(DataTypeBool, RStateCarbonMonoxide); item->setValue(false); }
+        else if (type == QLatin1String("CLIPConsumption")) { item = sensor.addItem(DataTypeInt64, RStateConsumption); item->setValue(0); }
         else if (type == QLatin1String("CLIPFire")) { item = sensor.addItem(DataTypeBool, RStateFire); item->setValue(false); }
         else if (type == QLatin1String("CLIPGenericFlag")) { item = sensor.addItem(DataTypeBool, RStateFlag); item->setValue(false); }
         else if (type == QLatin1String("CLIPGenericStatus")) { item = sensor.addItem(DataTypeInt32, RStateStatus); item->setValue(0); }
@@ -286,6 +287,9 @@ int DeRestPluginPrivate::createSensor(const ApiRequest &req, ApiResponse &rsp)
                                                             item = sensor.addItem(DataTypeUInt16, RConfigTholdDark); item->setValue(R_THOLDDARK_DEFAULT);
                                                             item = sensor.addItem(DataTypeUInt16, RConfigTholdOffset); item->setValue(R_THOLDOFFSET_DEFAULT); }
         else if (type == QLatin1String("CLIPOpenClose")) { item = sensor.addItem(DataTypeBool, RStateOpen); item->setValue(false); }
+        else if (type == QLatin1String("CLIPPower")) { item = sensor.addItem(DataTypeInt16, RStatePower); item->setValue(0);
+                                                       item = sensor.addItem(DataTypeUInt16, RStateVoltage); item->setValue(0);
+                                                       item = sensor.addItem(DataTypeUInt16, RStateCurrent); item->setValue(0); }
         else if (type == QLatin1String("CLIPPresence")) { item = sensor.addItem(DataTypeBool, RStatePresence); item->setValue(false);
                                                           item = sensor.addItem(DataTypeUInt16, RConfigDuration); item->setValue(0); }
         else if (type == QLatin1String("CLIPPressure")) { item = sensor.addItem(DataTypeInt16, RStatePressure); item->setValue(0); }
@@ -525,7 +529,7 @@ int DeRestPluginPrivate::createSensor(const ApiRequest &req, ApiResponse &rsp)
             }
             if (state.contains("water"))
             {
-                item = sensor.item(RStatePressure);
+                item = sensor.item(RStateWater);
                 if (!item)
                 {
                     rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/sensors"), QString("parameter, water, not available")));
@@ -556,6 +560,74 @@ int DeRestPluginPrivate::createSensor(const ApiRequest &req, ApiResponse &rsp)
                 if (!item->setValue(state["tampered"]))
                 {
                     rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/sensors/state"), QString("invalid value, %1, for parameter tampered").arg(state["tampered"].toString())));
+                    rsp.httpStatus = HttpStatusBadRequest;
+                    return REQ_READY_SEND;
+                }
+            }
+            if (state.contains("consumption"))
+            {
+                item = sensor.item(RStateConsumption);
+                if (!item)
+                {
+                    rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/sensors"), QString("parameter, consumption, not available")));
+                    rsp.httpStatus = HttpStatusBadRequest;
+                    return REQ_READY_SEND;
+                }
+
+                if (!item->setValue(state["consumption"]))
+                {
+                    rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/sensors/state"), QString("invalid value, %1, for parameter consumption").arg(state["consumption"].toString())));
+                    rsp.httpStatus = HttpStatusBadRequest;
+                    return REQ_READY_SEND;
+                }
+            }
+            if (state.contains("power"))
+            {
+                item = sensor.item(RStatePower);
+                if (!item)
+                {
+                    rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/sensors"), QString("parameter, power, not available")));
+                    rsp.httpStatus = HttpStatusBadRequest;
+                    return REQ_READY_SEND;
+                }
+
+                if (!item->setValue(state["power"]))
+                {
+                    rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/sensors/state"), QString("invalid value, %1, for parameter power").arg(state["power"].toString())));
+                    rsp.httpStatus = HttpStatusBadRequest;
+                    return REQ_READY_SEND;
+                }
+            }
+            if (state.contains("voltage"))
+            {
+                item = sensor.item(RStateVoltage);
+                if (!item)
+                {
+                    rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/sensors"), QString("parameter, voltage, not available")));
+                    rsp.httpStatus = HttpStatusBadRequest;
+                    return REQ_READY_SEND;
+                }
+
+                if (!item->setValue(state["voltage"]))
+                {
+                    rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/sensors/state"), QString("invalid value, %1, for parameter voltage").arg(state["voltage"].toString())));
+                    rsp.httpStatus = HttpStatusBadRequest;
+                    return REQ_READY_SEND;
+                }
+            }
+            if (state.contains("current"))
+            {
+                item = sensor.item(RStateCurrent);
+                if (!item)
+                {
+                    rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/sensors"), QString("parameter, current, not available")));
+                    rsp.httpStatus = HttpStatusBadRequest;
+                    return REQ_READY_SEND;
+                }
+
+                if (!item->setValue(state["current"]))
+                {
+                    rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/sensors/state"), QString("invalid value, %1, for parameter current").arg(state["current"].toString())));
                     rsp.httpStatus = HttpStatusBadRequest;
                     return REQ_READY_SEND;
                 }


### PR DESCRIPTION
Added support for CLIPConsumption and CLIPPower sensors.

Introduced `config.delay`, as discussed in https://github.com/dresden-elektronik/deconz-rest-plugin/issues/404#issuecomment-369028276.  Tested on Hue motion, Heiman motion, IKEA Trådfri motion, and CLIPPresence sensors.
- I didn't dare touching the FLS-NB sensors, so they still have `config.duration`;
- Also I didn't touch the logic to reset presence to false when no reports are received;
- The API allows setting `config.delay` for the Trådfri, but this doesn't do anything - the value is overwritten on the next motion is detection.
- I didn't implement the part where a presence is false report is ignored when `config.duration` > 0.  I feel it would mess up the code too much.

Also busy trying to add support for the Bitron smart plug, see #482.  @manup, could you please add to general.xml the _Instantaneous Demand_ attribute of the _Metering_ cluster:
```
<attribute id="0400" name="Instantaneous Demand" type="s24" access="r" required="o"></attribute>
```
It looks like deCONZ GUI won't display the s24 value, though (just like it wouldn't display the u48 value for _Current Summation Delivered_).  I do see a non-zero value in WireShark, but the GUI keeps displaying 0.  I don't get any value in the REST API either, but I assume that's due to the same cause?