### PR TITLE
Fix binding for attribute reporting for mains-powered sensors.

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -689,6 +689,12 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt, const s
             {
                 stream << rq.reportableChange8bit;
             }
+            else if (rq.reportableChange24bit != 0xFFFFFF)
+            {
+                stream << (qint8) (rq.reportableChange24bit & 0xFF);
+                stream << (qint8) ((rq.reportableChange24bit >> 8) & 0xFF);
+                stream << (qint8) ((rq.reportableChange24bit >> 16) & 0xFF);
+            }
             else if (rq.reportableChange48bit != 0xFFFFFFFF)
             {
                 stream << rq.reportableChange48bit;
@@ -888,7 +894,15 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq.minInterval = 1;
         rq.maxInterval = 300;
         rq.reportableChange48bit = 10; // 0.01 kWh
-        return sendConfigureReportingRequest(bt, {rq});
+
+        ConfigureReportingRequest rq2;
+        rq.dataType = deCONZ::Zcl24BitInt;
+        rq.attributeId = 0x0400; // Instantaneous Demand
+        rq.minInterval = 1;
+        rq.maxInterval = 300;
+        rq.reportableChange24bit = 10; // 1 W
+
+        return sendConfigureReportingRequest(bt, {rq, rq2});
     }
     else if (bt.binding.clusterId == ELECTRICAL_MEASUREMENT_CLUSTER_ID)
     {
@@ -897,7 +911,6 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq.minInterval = 1;
         rq.maxInterval = 300;
         rq.reportableChange16bit = 10; // 1 W
-        return sendConfigureReportingRequest(bt, {rq});
 
         ConfigureReportingRequest rq2;
         rq2.dataType = deCONZ::Zcl16BitUint;
@@ -912,6 +925,8 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq3.minInterval = 1;
         rq3.maxInterval = 300;
         rq3.reportableChange16bit = 1; // 0.1 A
+
+        return sendConfigureReportingRequest(bt, {rq, rq2, rq3});
     }
     else if (bt.binding.clusterId == LEVEL_CLUSTER_ID)
     {

--- a/bindings.h
+++ b/bindings.h
@@ -91,6 +91,7 @@ public:
         direction(0x00),
         reportableChange8bit(0xFF),
         reportableChange16bit(0xFFFF),
+        reportableChange24bit(0xFFFFFF),
         reportableChange48bit(0xFFFFFFFF),  // there's no quint48
         manufacturerCode(0)
     {
@@ -104,6 +105,7 @@ public:
     quint16 maxInterval;
     quint8 reportableChange8bit;
     quint16 reportableChange16bit;
+    quint32 reportableChange24bit;          // there's no quint24
     quint32 reportableChange48bit;          // there's no quint48
     quint16 manufacturerCode;
 };


### PR DESCRIPTION
@manup, hope you can still include this one in v2.05.14.

Somehow the binding request isn't sent unless `setMgmtBindSupported(false)` is issued.  Instead of checking for `receiverOnWhenIdle()`, I just whitelisted the plugs as `endDeviceSupported`.  I suppose if needed, the management binding will be created from the light node anyways.

I verified in WireShark that the right _Configure Reporting_ commands are generated for the u48 and s24 attributes of the _Simple Metering_ cluster and that the Heiman plug accepts these.  Apparently the Heiman has only room for 5 reporting configurations, where there's 6 attributes to be reported:
- _On/Off_ (0x0006/0x0000);
- _Current Summation Delivered_ (0x0702/0x0000);
- _Instantaneous Demand_ (0x0702/0x0400);
- _RMS Voltage_ (0x0B04/0x0505);
- _RMS Current_ (0x0B04/0x0508);
- _Active Power_ (0x0B04/0x050B).

_Active Power_ and _Instantaneous Demand_ seem to report the same value (except that the latter isn't received by deCONZ, probably due to the fact that it's an s24 value).

