### PR TITLE
Cleanup

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -2091,7 +2091,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             {
                 clusterId = ANALOG_INPUT_CLUSTER_ID;
             }
-            item = sensor.addItem(DataTypeInt64, RStateConsumption);
+            item = sensor.addItem(DataTypeUInt64, RStateConsumption);
             item->setValue(0);
         }
         else if (sensor.type().endsWith(QLatin1String("Power")))

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -3332,13 +3332,13 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
         if (sensorNode.fingerPrint().hasInCluster(METERING_CLUSTER_ID))
         {
             clusterId = METERING_CLUSTER_ID;
-            item = sensorNode.addItem(DataTypeInt64, RStateConsumption);
+            item = sensorNode.addItem(DataTypeUInt64, RStateConsumption);
             item = sensorNode.addItem(DataTypeInt16, RStatePower);
         }
         else if (sensorNode.fingerPrint().hasInCluster(ANALOG_INPUT_CLUSTER_ID))
         {
             clusterId = ANALOG_INPUT_CLUSTER_ID;
-            item = sensorNode.addItem(DataTypeInt64, RStateConsumption);
+            item = sensorNode.addItem(DataTypeUInt64, RStateConsumption);
         }
     }
     else if (sensorNode.type().endsWith(QLatin1String("Power")))
@@ -4535,11 +4535,6 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
 
                                 updateSensorEtag(&*i);
                             }
-                            else if (ia->id() == 0xff01) // Xiaomi magic
-                            {
-                                QByteArray arr = ia->toString().toLatin1();
-                                DBG_Printf(DBG_INFO_L2, ">>>>> 0x%016llX: Xiaomi magic: %s\n", event.node()->address().ext(), qPrintable(arr.toHex()));
-                            }
                         }
                     }
                     else if (event.clusterId() == ANALOG_INPUT_CLUSTER_ID)
@@ -4672,7 +4667,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     i->setZclValue(updateType, event.clusterId(), ia->id(), ia->numericValue());
                                 }
 
-                                qint64 consumption = ia->numericValue().s64;
+                                quint64 consumption = ia->numericValue().u64;
                                 ResourceItem *item = i->item(RStateConsumption);
 
                                 if (i->modelId() == QLatin1String("SmartPlug")) // Heiman
@@ -4680,7 +4675,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     consumption += 5; consumption /= 10; // 0.1 Wh -> Wh
                                 }
 
-                                if (item && (item->toNumber() != consumption || updateType == NodeValue::UpdateByZclReport))
+                                if (item && ((quint64) item->toNumber() != consumption || updateType == NodeValue::UpdateByZclReport))
                                 {
                                     item->setValue(consumption); // in Wh (0.001 kWh)
                                     enqueueEvent(Event(RSensors, RStateConsumption, i->id(), item));

--- a/resource.cpp
+++ b/resource.cpp
@@ -119,7 +119,7 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeInt32, RStateButtonEvent));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, RStateCarbonMonoxide));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RStateColorMode));
-    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeInt64, RStateConsumption, 0, 0xffffffffffff));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt64, RStateConsumption));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RStateCurrent));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RStateCt));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, RStateDark));

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -275,7 +275,7 @@ int DeRestPluginPrivate::createSensor(const ApiRequest &req, ApiResponse &rsp)
 
         if      (type == QLatin1String("CLIPAlarm")) { item = sensor.addItem(DataTypeBool, RStateAlarm); item->setValue(false); }
         else if (type == QLatin1String("CLIPCarbonMonoxide")) { item = sensor.addItem(DataTypeBool, RStateCarbonMonoxide); item->setValue(false); }
-        else if (type == QLatin1String("CLIPConsumption")) { item = sensor.addItem(DataTypeInt64, RStateConsumption); item->setValue(0); }
+        else if (type == QLatin1String("CLIPConsumption")) { item = sensor.addItem(DataTypeUInt64, RStateConsumption); item->setValue(0); }
         else if (type == QLatin1String("CLIPFire")) { item = sensor.addItem(DataTypeBool, RStateFire); item->setValue(false); }
         else if (type == QLatin1String("CLIPGenericFlag")) { item = sensor.addItem(DataTypeBool, RStateFlag); item->setValue(false); }
         else if (type == QLatin1String("CLIPGenericStatus")) { item = sensor.addItem(DataTypeInt32, RStateStatus); item->setValue(0); }


### PR DESCRIPTION
- _Current Summation Delivered_ is unsigned (`u48`), so
`RStateConsumption` should also be unsigned;
- Remove debug info message for Xiaomi 0xff01 attribute as it’s handled
elsewhere.