### PR TITLE
Sensor Polling and Keen Home Vent

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1088,6 +1088,9 @@ void DeRestPluginPrivate::checkLightBindingsForAttributeReporting(LightNode *lig
         else if (lightNode->manufacturerCode() == VENDOR_EMBER)
         {
         }
+        else if (lightNode->manufacturerCode() == VENDOR_KEEN_HOME)
+        {
+        }
         else
         {
             return;

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4692,7 +4692,8 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 qint32 power = ia->numericValue().s32;
                                 ResourceItem *item = i->item(RStatePower);
 
-                                if (i->modelId() == QLatin1String("SmartPlug")) // Heiman
+                                if (i->modelId() == QLatin1String("SmartPlug") || // Heiman
+                                    i->modelId() == QLatin1String("902010/25")) // Bitron
                                 {
                                     power += 5; power /= 10; // 0.1 W -> W
                                 }
@@ -11215,7 +11216,7 @@ void DeRestPlugin::idleTimerFired()
                     continue;
                 }
 
-                if (sensorNode->type().startsWith(QLatin1String("CLIP")))
+                if (!sensorNode->type().startsWith(QLatin1String("Z"))) // Exclude CLIP and Daylight sensors
                 {
                     continue;
                 }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -75,6 +75,7 @@ const quint64 ubisysMacPrefix     = 0x001fee0000000000ULL;
 const quint64 netvoxMacPrefix     = 0x00137a0000000000ULL;
 const quint64 heimanMacPrefix     = 0x0050430000000000ULL;
 const quint64 lutronMacPrefix     = 0xffff000000000000ULL;
+const quint64 keenhomeMacPrefix   = 0x0022a30000000000ULL;
 
 struct SupportedDevice {
     quint16 vendorId;
@@ -139,6 +140,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_EMBER, "SmartPlug", emberMacPrefix }, // Heiman smart plug
     { VENDOR_120B, "WarningDevice", emberMacPrefix }, // Heiman siren
     { VENDOR_LUTRON, "LZL4BWHL01", lutronMacPrefix }, // Lutron LZL-4B-WH-L01 Connected Bulb Remote
+    { VENDOR_KEEN_HOME , "SV01-610-MP", keenhomeMacPrefix}, // Keen Home Vent
     { 0, 0, 0 }
 };
 
@@ -1049,7 +1051,11 @@ qint64 DeRestPluginPrivate::getUptime()
 void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
 {
     DBG_Assert(node != 0);
-    if (!node || !node->nodeDescriptor().receiverOnWhenIdle())
+    if (node && node->nodeDescriptor().manufacturerCode() == VENDOR_KEEN_HOME)
+    {
+        // exception for Keen Home Vent
+    }
+    else if (!node || !node->nodeDescriptor().receiverOnWhenIdle())
     {
         return;
     }
@@ -1147,6 +1153,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
                 case DEV_ID_MAINS_POWER_OUTLET:
                 case DEV_ID_HA_ONOFF_LIGHT:
                 case DEV_ID_ONOFF_OUTPUT:
+                case DEV_ID_LEVEL_CONTROLLABLE_OUTPUT:
                 case DEV_ID_HA_DIMMABLE_LIGHT:
                 case DEV_ID_HA_COLOR_DIMMABLE_LIGHT:
                 case DEV_ID_SMART_PLUG:
@@ -1522,6 +1529,7 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
             case DEV_ID_Z30_DIMMABLE_PLUGIN_UNIT:
             case DEV_ID_HA_ONOFF_LIGHT:
             case DEV_ID_ONOFF_OUTPUT:
+            case DEV_ID_LEVEL_CONTROLLABLE_OUTPUT:
             case DEV_ID_ZLL_ONOFF_LIGHT:
             case DEV_ID_ZLL_ONOFF_PLUGIN_UNIT:
             case DEV_ID_Z30_ONOFF_PLUGIN_UNIT:
@@ -3519,6 +3527,10 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
         {
             sensorNode.setMode(Sensor::ModeDimmer);
         }
+    }
+    else if (node->nodeDescriptor().manufacturerCode() == VENDOR_KEEN_HOME)
+    {
+        sensorNode.setManufacturer("Keen Home Inc");
     }
 
     if (sensorNode.manufacturer().isEmpty() && !manufacturer.isEmpty())

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4675,7 +4675,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     consumption += 5; consumption /= 10; // 0.1 Wh -> Wh
                                 }
 
-                                if (item && ((quint64) item->toNumber() != consumption || updateType == NodeValue::UpdateByZclReport))
+                                if (item)
                                 {
                                     item->setValue(consumption); // in Wh (0.001 kWh)
                                     enqueueEvent(Event(RSensors, RStateConsumption, i->id(), item));
@@ -4698,7 +4698,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     power += 5; power /= 10; // 0.1 W -> W
                                 }
 
-                                if (item && (item->toNumber() != power || updateType == NodeValue::UpdateByZclReport))
+                                if (item)
                                 {
                                     item->setValue((qint16) power); // in W
                                     enqueueEvent(Event(RSensors, RStatePower, i->id(), item));
@@ -4729,7 +4729,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 qint16 power = ia->numericValue().s16;
                                 ResourceItem *item = i->item(RStatePower);
 
-                                if (power != -32768)
+                                if (item && power != -32768)
                                 {
                                     if (i->modelId() == QLatin1String("SmartPlug")) // Heiman
                                     {
@@ -4739,12 +4739,9 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     {
                                         power = power == 28000 ? 0 : power / 10;
                                     }
-                                    if (item && (item->toNumber() != power || updateType == NodeValue::UpdateByZclReport))
-                                    {
-                                        item->setValue(power); // in W
-                                        enqueueEvent(Event(RSensors, RStatePower, i->id(), item));
-                                        updated = true;
-                                    }
+                                    item->setValue(power); // in W
+                                    enqueueEvent(Event(RSensors, RStatePower, i->id(), item));
+                                    updated = true;
                                 }
                             }
                             else if (ia->id() == 0x0505) // RMS Voltage
@@ -4757,18 +4754,15 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 quint16 voltage = ia->numericValue().u16;
                                 ResourceItem *item = i->item(RStateVoltage);
 
-                                if (voltage != 65535)
+                                if (item && voltage != 65535)
                                 {
                                     if (i->modelId() == QLatin1String("SmartPlug")) // Heiman
                                     {
                                         voltage += 50; voltage /= 100; // 0.01V -> V
                                     }
-                                    if (item && (item->toNumber() != voltage || updateType == NodeValue::UpdateByZclReport))
-                                    {
-                                        item->setValue(voltage); // in V
-                                        enqueueEvent(Event(RSensors, RStateVoltage, i->id(), item));
-                                        updated = true;
-                                    }
+                                    item->setValue(voltage); // in V
+                                    enqueueEvent(Event(RSensors, RStateVoltage, i->id(), item));
+                                    updated = true;
                                 }
                             }
                             else if (ia->id() == 0x0508) // RMS Current
@@ -4781,18 +4775,15 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 quint16 current = ia->numericValue().u16;
                                 ResourceItem *item = i->item(RStateCurrent);
 
-                                if (current != 65535)
+                                if (item && current != 65535)
                                 {
                                     if (i->modelId() != QLatin1String("SmartPlug")) // Heiman
                                     {
                                         current *= 10; // A -> 0.1A
                                     }
-                                    if (item && (item->toNumber() != current || updateType == NodeValue::UpdateByZclReport))
-                                    {
-                                        item->setValue(current); // in 0.1A
-                                        enqueueEvent(Event(RSensors, RStateCurrent, i->id(), item));
-                                        updated = true;
-                                    }
+                                    item->setValue(current); // in 0.1A
+                                    enqueueEvent(Event(RSensors, RStateCurrent, i->id(), item));
+                                    updated = true;
                                 }
                             }
                         }

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -90,6 +90,7 @@
 #define DEV_ID_ONOFF_SWITCH                 0x0000 // On/Off switch
 #define DEV_ID_LEVEL_CONTROL_SWITCH         0x0001 // Level control switch
 #define DEV_ID_ONOFF_OUTPUT                 0x0002 // On/Off output
+#define DEV_ID_LEVEL_CONTROLLABLE_OUTPUT    0x0003 // Level controllable output
 #define DEV_ID_RANGE_EXTENDER               0x0008 // Range extender
 #define DEV_ID_MAINS_POWER_OUTLET           0x0009 // Mains power outlet
 #define DEV_ID_SMART_PLUG                   0x0051 // Smart plug
@@ -229,6 +230,7 @@
 #define VENDOR_OSRAM        0x110C
 #define VENDOR_DDEL         0x1135
 #define VENDOR_LUTRON       0x1144
+#define VENDOR_KEEN_HOME    0x115B
 #define VENDOR_115F         0x115F    // Used by Xiaomi
 #define VENDOR_INNR         0x1166
 #define VENDOR_INNR2        0x1168
@@ -318,6 +320,7 @@ extern const quint64 ubisysMacPrefix;
 extern const quint64 netvoxMacPrefix;
 extern const quint64 heimanMacPrefix;
 extern const quint64 lutronMacPrefix;
+extern const quint64 keenhomeMacPrefix;
 
 // HTTP status codes
 extern const char *HttpStatusOk;

--- a/light_node.cpp
+++ b/light_node.cpp
@@ -104,6 +104,7 @@ void LightNode::setManufacturerCode(uint16_t code)
         case VENDOR_BUSCH_JAEGER:  m_manufacturer = QLatin1String("Busch-Jaeger"); break;
         case VENDOR_EMBER:   // fall through
         case VENDOR_120B:    m_manufacturer = QLatin1String("Heiman"); break;
+        case VENDOR_KEEN_HOME: m_manufacturer = QLatin1String("Keen Home Inc"); break;
         default:
             m_manufacturer = QLatin1String("Unknown");
             break;
@@ -550,6 +551,7 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
             }
                 break;
             case DEV_ID_ONOFF_OUTPUT:             ltype = QLatin1String("On/Off output"); break;
+            case DEV_ID_LEVEL_CONTROLLABLE_OUTPUT:   ltype = QLatin1String("Level controllable output"); break;
             case DEV_ID_Z30_ONOFF_PLUGIN_UNIT:    ltype = QLatin1String("On/Off plug-in unit"); break;
             case DEV_ID_ZLL_ONOFF_PLUGIN_UNIT:    ltype = QLatin1String("On/Off plug-in unit"); break;
             case DEV_ID_ZLL_DIMMABLE_PLUGIN_UNIT: ltype = QLatin1String("Dimmable plug-in unit"); break;


### PR DESCRIPTION
- Also poll _Instantaneous Demand_;
- Don’t poll Daylight sensor;
- Check sensor type for polling `state.power`;
- Additional debug messages.