### PR TITLE
Whitelist Keen Home vent for attribute reporting

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1220,6 +1220,8 @@ void DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId().startsWith(QLatin1String("D1")) ||
         // IKEA
         sensor->modelId().startsWith(QLatin1String("TRADFRI")) ||
+        // Keen Home
+        sensor->modelId().startsWith(QLatin1String("SV01-610-MP")) ||
         // Heiman
         sensor->modelId().startsWith(QLatin1String("SmartPlug")) ||
         sensor->modelId().startsWith(QLatin1String("CO_")) ||


### PR DESCRIPTION
One more change, @manup.  I hope you can still include it.