### PR TITLE
Xiaomi wall switches, Climax Siren

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -2155,7 +2155,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
         }
         else if (sensor.modelId().startsWith(QLatin1String("lumi.")))
         {
-            if (!sensor.modelId().startsWith(QLatin1String("lumi.ctrl_ln2")))
+            if (!sensor.modelId().startsWith(QLatin1String("lumi.ctrl_")))
             {
                 item = sensor.addItem(DataTypeUInt8, RConfigBattery);
                 //item->setValue(100); // wait for report

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -94,6 +94,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_NONE, "LMHT_", tiMacPrefix },
     { VENDOR_NONE, "IR_", tiMacPrefix },
     { VENDOR_NONE, "DC_", tiMacPrefix },
+    { VENDOR_NONE, "BX_", tiMacPrefix }, // Climax siren
     { VENDOR_NONE, "OJB-IR715-Z", tiMacPrefix },
     { VENDOR_NONE, "902010/21A", tiMacPrefix }, // Bitron: door/window sensor
     { VENDOR_NONE, "902010/25", tiMacPrefix }, // Bitron: smart plug
@@ -1089,9 +1090,10 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
         return;
     }
     if (node->nodeDescriptor().manufacturerCode() == VENDOR_KEEN_HOME ||
-        node->nodeDescriptor().manufacturerCode() == VENDOR_JENNIC)
+        node->nodeDescriptor().manufacturerCode() == VENDOR_JENNIC ||
+        node->nodeDescriptor().manufacturerCode() == VENDOR_NONE)
     {
-        // exception for Keen Home Vent and Xiaomi wall switches lumi.ctrl_neutral1, lumi.ctrl_neutral2
+        // exception for Keen Home Vent and Xiaomi wall switches lumi.ctrl_neutral1, lumi.ctrl_neutral2; and Climax siren
     }
     else if (!node->nodeDescriptor().receiverOnWhenIdle())
     {

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -738,6 +738,8 @@ void Sensor::jsonToState(const QString &json)
         {
             dt = lu;
         }
+        lu.setTimeSpec(Qt::UTC);
+        map["lastupdated"] = lu;
     }
 
     for (int i = 0; i < itemCount(); i++)


### PR DESCRIPTION
Xiaomi wall switches, #356:
- Don't create `config.battery` for Xiaomi wall switches;
- Don't create light resources for `On/Off Switch` endpoints for lumi.ctrl_neutral1, lumi.ctrl_neutral2;
- Fix Xiaomi magic for lumi.ctrl_ln2.aq1, so now `config.temperature` is updated.

Climax Siren, #404:
- Whitelist Climax Siren as end-device light;
- Whitelist Climax Siren as sensor.

TODO:
- Suppress light resource for endpoint 03 for lumi.ctrl_neutral1;
- Update light states on Xiaomi magic;
- Check Xiaomi magic for lumi.ctrl_ln1.aq1, lumi.ctrl_neutral1, lumi.ctrl_neutral2;
- Check whether lumi.ctrl_neutral1 and lumi.ctrl_neutral2 switches actually report consumption on endpoint 08.
