### PR TITLE
Updated instructions for disabling deCONZ GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ $ sudo systemctl disable deconz-gui
 $ sudo systemctl stop deconz-gui
 ```
 
+On older versions of deCONZ this can be done by removing the X11 Autostart file.
+
+```bash
+$ rm -f /home/pi/.config/autostart/deCONZ.desktop
+```
+
+
 Software requirements
 ---------------------
 * Raspbian Jessie or Raspbian Stretch with Qt5

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ $ sudo systemctl enable deconz
 The dresden elektronik Raspbian sd-card image autostarts deCONZ GUI.
 
 ```bash
-$ sudo systemctl enable deconz-gui
+$ sudo systemctl disable deconz-gui
+$ sudo systemctl stop deconz-gui
 ```
 
 Software requirements

--- a/README.md
+++ b/README.md
@@ -97,12 +97,12 @@ The beta version contains a systemd script, which allows deCONZ to run without a
 $ sudo systemctl enable deconz
 ```
 
-2. Disable X11 deCONZ autostart script
+2. Disable deCONZ GUI Autostart
 
-The dresden elektronik Raspbian sd-card image contains a autostart script for X11 which should be removed.
+The dresden elektronik Raspbian sd-card image autostarts deCONZ GUI.
 
 ```bash
-$ rm -f /home/pi/.config/autostart/deCONZ.desktop
+$ sudo systemctl enable deconz-gui
 ```
 
 Software requirements


### PR DESCRIPTION
deCONZ GUI is started as a systemd service not an X11 autostart script