### PR TITLE
SmartThings Arrival sensor, take 2

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -863,12 +863,12 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq.maxInterval = 1800;
             rq.reportableChange8bit = 0xFF;
         }
-        else if (sensor && sensor->modelId() == QLatin1String("tagv4"))
+        else if (sensor && sensor->modelId().startsWith(QLatin1String("tagv4")))
         {
             rq.attributeId = 0x0020;   // battery voltage
             rq.minInterval = 3600;
             rq.maxInterval = 3600;
-            rq.reportableChange8bit = 1;
+            rq.reportableChange8bit = 0;
         }
         else
         {
@@ -1327,7 +1327,7 @@ void DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         // Nimbus
         sensor->modelId().startsWith(QLatin1String("FLS-NB")) ||
         // SmartThings
-        sensor->modelId() == QLatin1String("tagv4"))
+        sensor->modelId().startsWith(QLatin1String("tagv4")))
     {
         deviceSupported = true;
         if (!sensor->node()->nodeDescriptor().receiverOnWhenIdle())
@@ -1453,6 +1453,10 @@ void DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         {
             val = sensor->getZclValue(*i, 0x050b); // Active power
         }
+        else if (*i == BINARY_INPUT_CLUSTER_ID)
+        {
+            val = sensor->getZclValue(*i, 0x0055); // Present value
+        }
 
         quint16 maxInterval = (val.maxInterval > 0) ? (val.maxInterval * 1.5) : (60 * 45);
 
@@ -1500,6 +1504,7 @@ void DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         case ELECTRICAL_MEASUREMENT_CLUSTER_ID:
         case VENDOR_CLUSTER_ID:
         case BASIC_CLUSTER_ID:
+        case BINARY_INPUT_CLUSTER_ID:
         {
             DBG_Printf(DBG_INFO_L2, "0x%016llX (%s) create binding for attribute reporting of cluster 0x%04X on endpoint 0x%02X\n",
                        sensor->address().ext(), qPrintable(sensor->modelId()), (*i), srcEndpoint);

--- a/database.cpp
+++ b/database.cpp
@@ -2196,7 +2196,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             else
             {
                 item = sensor.addItem(DataTypeUInt16, RConfigDuration);
-                if (sensor.modelId() == QLatin1String("tagv4")) // SmartThings Arrival sensor
+                if (sensor.modelId().startsWith(QLatin1String("tagv4"))) // SmartThings Arrival sensor
                 {
                     item->setValue(310);
                 }
@@ -2394,7 +2394,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 //item->setValue(0);
             }
         }
-        else if (sensor.modelId() == QLatin1String("tagv4")) // SmartThings Arrival sensor
+        else if (sensor.modelId().startsWith(QLatin1String("tagv4"))) // SmartThings Arrival sensor
         {
             item = sensor.addItem(DataTypeString, RConfigAlert);
             item->setValue(R_ALERT_DEFAULT);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -3497,7 +3497,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
         item = sensorNode.addItem(DataTypeBool, RStatePresence);
         item->setValue(false);
         item = sensorNode.addItem(DataTypeUInt16, RConfigDuration);
-        if (modelId == QLatin1String("tagv4")) // SmartThings Arrival sensor
+        if (modelId.startsWith(QLatin1String("tagv4"))) // SmartThings Arrival sensor
         {
             item->setValue(310); // Sensor will be configured to report every 5 minutes
         }
@@ -4335,7 +4335,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                             }
                             else if (ia->id() == 0x0020) // battery voltage
                             {
-                                if (i->modelId() != QLatin1String("tagv4")) // SmartThings Arrival sensor
+                                if (!i->modelId().startsWith(QLatin1String("tagv4"))) // SmartThings Arrival sensor
                                 {
                                     continue;
                                 }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2998,7 +2998,10 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
 
                 case BINARY_INPUT_CLUSTER_ID:
                 {
-                    fpPresenceSensor.inClusters.push_back(ci->id());
+                    if (modelId.startsWith(QLatin1String("tagv4"))) // SmartThings Arrival sensor
+                    {
+                        fpPresenceSensor.inClusters.push_back(ci->id());
+                    }
                 }
                     break;
 


### PR DESCRIPTION
- Only handle _Binary Input_ for SmartThings Arrival sensor, see #655;
- Fix attribute reporting for SmartThings Arrival sensor, see #427;
- Consistently use `modelId.startsWith(QLatin1String("tagv4"))` to recognise the sensor.