### PR TITLE
Implement searching for new lights based on the searching for sensors code.

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1288,7 +1288,7 @@ void DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         return;
     }
 
-    if (findSensorsState != FindSensorsActive &&
+    if (searchSensorsState != SearchSensorsActive &&
         idleTotalCounter < (IDLE_READ_LIMIT + 120)) // wait for some input before fire bindings
     {
         return;
@@ -1567,7 +1567,7 @@ void DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
         return;
     }
 
-    if (findSensorsState != FindSensorsActive &&
+    if (searchSensorsState != SearchSensorsActive &&
         idleTotalCounter < (IDLE_READ_LIMIT + 60)) // wait for some input before fire bindings
     {
         return;

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -710,7 +710,7 @@ public:
     // REST API lights
     int handleLightsApi(ApiRequest &req, ApiResponse &rsp);
     int getAllLights(const ApiRequest &req, ApiResponse &rsp);
-    int searchLights(const ApiRequest &req, ApiResponse &rsp);
+    int searchNewLights(const ApiRequest &req, ApiResponse &rsp);
     int getNewLights(const ApiRequest &req, ApiResponse &rsp);
     int getLightState(const ApiRequest &req, ApiResponse &rsp);
     int setLightState(const ApiRequest &req, ApiResponse &rsp);
@@ -769,7 +769,7 @@ public:
     int getAllSensors(const ApiRequest &req, ApiResponse &rsp);
     int getSensor(const ApiRequest &req, ApiResponse &rsp);
     int getSensorData(const ApiRequest &req, ApiResponse &rsp);
-    int findNewSensors(const ApiRequest &req, ApiResponse &rsp);
+    int searchNewSensors(const ApiRequest &req, ApiResponse &rsp);
     int getNewSensors(const ApiRequest &req, ApiResponse &rsp);
     int updateSensor(const ApiRequest &req, ApiResponse &rsp);
     int deleteSensor(const ApiRequest &req, ApiResponse &rsp);
@@ -941,9 +941,13 @@ public Q_SLOTS:
     void checkResetState();
     void resetDeviceSendConfirm(bool success);
 
+    // lights
+    void startSearchLights();
+    void searchLightsTimerFired();
+    
     // sensors
-    void startFindSensors();
-    void findSensorsTimerFired();
+    void startSearchSensors();
+    void searchSensorsTimerFired();
     void checkInstaModelId(Sensor *sensor);
     void delayedFastEnddeviceProbe();
     void checkSensorStateTimerFired();
@@ -1074,7 +1078,7 @@ public:
     void handleClusterIndicationGateways(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleIasZoneClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void sendIasZoneEnrollResponse(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
-    void handleIndicationFindSensors(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
+    void handleIndicationSearchSensors(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleCommissioningClusterIndication(TaskItem &task, const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleZdpIndication(const deCONZ::ApsDataIndication &ind);
     bool handleMgmtBindRspConfirm(const deCONZ::ApsDataConfirm &conf);
@@ -1408,12 +1412,20 @@ public:
     uint64_t lastNodeAddressExt;
     uint8_t resetDeviceApsRequestId;
 
-    // sensors
-    enum FindSensorsState
+    // lights
+    enum SearchLightsState
     {
-        FindSensorsIdle,
-        FindSensorsActive,
-        FindSensorsDone,
+        SearchLightsIdle,
+        SearchLightsActive,
+        SearchLightsDone,
+    };
+
+    // sensors
+    enum SearchSensorsState
+    {
+        SearchSensorsIdle,
+        SearchSensorsActive,
+        SearchSensorsDone,
     };
 
     int sensorIndIdleTotalCounter;
@@ -1452,13 +1464,18 @@ public:
         std::vector<SensorCommand> rxCommands;
     };
 
-    FindSensorsState findSensorsState;
+    SearchLightsState searchLightsState;
+    QVariantMap searchLightsResult;
+    int searchLightsTimeout;
+    QString lastLightsScan;
+
+    SearchSensorsState searchSensorsState;
     deCONZ::Address fastProbeAddr;
-    QVariantMap findSensorResult;
+    QVariantMap searchSensorsResult;
     QTimer *fastProbeTimer;
-    int findSensorsTimeout;
+    int searchSensorsTimeout;
     QString lastSensorsScan;
-    std::vector<SensorCandidate> findSensorCandidates;
+    std::vector<SensorCandidate> searchSensorsCandidates;
 
     class RecoverOnOff
     {

--- a/ias_zone.cpp
+++ b/ias_zone.cpp
@@ -52,7 +52,7 @@ void DeRestPluginPrivate::handleIasZoneClusterIndication(const deCONZ::ApsDataIn
     {
         // during setup the IAS Zone type will be read
         // start to proceed discovery here
-        if (findSensorsState == FindSensorsActive)
+        if (searchSensorsState == SearchSensorsActive)
         {
             if (!fastProbeTimer->isActive())
             {

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -1365,7 +1365,8 @@ int DeRestPluginPrivate::modifyConfig(const ApiRequest &req, ApiResponse &rsp)
 
         if (seconds > 0)
         {
-            startFindSensors();
+            startSearchLights();
+            startSearchSensors();
         }
 
         QVariantMap rspItem;
@@ -2564,47 +2565,6 @@ int DeRestPluginPrivate::scanWifiNetworks(const ApiRequest &req, ApiResponse &rs
     rsp.map["cells"] = cells;
     rsp.httpStatus = HttpStatusOk;
     return REQ_READY_SEND;
-}
-
-/*! Check if permitJoin is > 60 seconds then resend permitjoin with 60 seconds
- */
-void DeRestPluginPrivate::resendPermitJoinTimerFired()
-{
-    resendPermitJoinTimer->stop();
-    if (gwPermitJoinDuration <= 1)
-    {
-        if (gwPermitJoinResend > 0)
-        {
-
-            if (gwPermitJoinResend >= 60)
-            {
-                setPermitJoinDuration(60);
-            }
-            else
-            {
-                setPermitJoinDuration(gwPermitJoinResend);
-            }
-            gwPermitJoinResend -= 60;
-            updateEtag(gwConfigEtag);
-            if (gwPermitJoinResend <= 0)
-            {
-                gwPermitJoinResend = 0;
-                return;
-            }
-
-        }
-        else if (gwPermitJoinResend == 0)
-        {
-            setPermitJoinDuration(0);
-            return;
-        }
-    }
-    else if (gwPermitJoinResend == 0)
-    {
-        setPermitJoinDuration(0);
-        return;
-    }
-    resendPermitJoinTimer->start(1000);
 }
 
 /* Check daylight state */


### PR DESCRIPTION
This implements searching for new lights through "GET /api/<apikey>/lights/new" and reporting them in a way that works with the Hue app. Hopefully this fixes ~~#29~~ #28. Also see #663.

I've basically copied the code for searching for new sensors. However, the sensors code seems to be quite a bit more involved. In order to track what is going on, and for consistency I renamed the sensor code from "find" to "search". Then I left out what didn't seem to apply to light nodes. It would be good for someone more knowledgeable to double check this though. One more change is that I moved the resendPermitJoinTimer to where the permitJoinTimer code is, that seemed more sensible.

Obviously this works for me, but some more testing is probably a good idea. Hope this helps.