### PR TITLE
Detect IKEA light by manufacturer code in additon to MAC prefix

### DIFF
--- a/zcl_tasks.cpp
+++ b/zcl_tasks.cpp
@@ -369,7 +369,7 @@ bool DeRestPluginPrivate::addTaskSetColorTemperature(TaskItem &task, uint16_t ct
         // workaround IKEA move to color temperature is broken and won't update x,y values
         // which results in broken scenes
         // instead transform into a move to color x,y task
-        if ((task.lightNode->address().ext() & macPrefixMask) == ikeaMacPrefix)
+        if (task.lightNode->manufacturerCode() == VENDOR_IKEA || (task.lightNode->address().ext() & macPrefixMask) == ikeaMacPrefix)
         {
             quint16 x;
             quint16 y;


### PR DESCRIPTION
Recent light/firmware combos have a different MAC prefix (`0x90fd9f`) compared
to the hardcoded `ikeaMacPrefix` (`0x000b57`), so use the manufacturer code
as an additional criteria to detect IKEA lights.

---

Background:

I'm using this PR to start a conversation/brainsorm. I have a number of recently-purchased IKEA lights (E27, E14, GU10) which were shipped with the latest available firmware from the factory. I control them via the REST plugin and the `deconz`component of Home Assistant. I noticed that the IKEA E27 colored lights do not support setting `ct`, only `xy`, and I was exploring the possibility of emulating that feature by internally converting any incoming commands containing `ct` into `xy` and sending that to the lamp instead.

By examining the source code I realized that by coincidence this feature is already implemented, introduced in https://github.com/dresden-elektronik/deconz-rest-plugin/commit/4a43cb9193f0ab262bb8d6bb0f462f854e1da87c to work around a firmware bug in IKEA lamps. However, it was not triggering for my lights and after some investigation I realized that the MAC prefix of all my IKEA lamps and remotes start with `0x90fd9ffffe` and not `0x000b57` which is the `ikeaMacPrefix` in the source code (however, the motion sensors I purchased do have the latter prefix).

I have then added a check for the manufacturer code and verified that this now works for my intended use case: the light does change color in response to `ct` change commands, both when sending it directly to the light or to a group the light is in. But I'm unsure if that's the indented behaviour of the original commit, since it mentions that the workaround should kick in for unicast messages only.

It looks to me that this code could further be modified from being an IKEA workaround to a more generic emulation of "ct" for lamps that have no such capability but support "xy": all that is necessary is to check if either the lamp lacks "ct" (it does not have the corresponding cluster), or it's an IKEA lamp. Would that make sense? What are your thoughts about this?

---

Regarding the different IKEA MAC prefixes:

As I have mentioned, all my IKEA devices apart from the motion sensors have MAC addresses starting with `0x90fd9ffffe` instead of the `0x000b57` prefix assigned to `ikeaMacPrefix`. Do new devices start using a different prefix? And it's also very strange that I cannot find any matching vendor on http://standards-oui.ieee.org/oui/oui.txt. 

Apart from the workaround above, this is another place I found that checks for the IKEA prefix:

https://github.com/dresden-elektronik/deconz-rest-plugin/blob/5d2b1da9be3091e5ec0da88d3f15a9e22170aebe/rest_sensors.cpp#L2627

Maybe it should be changed to check for the manufacturer instead, or alternatively a new prefix added to the source code and the existing checks amended to look for either one. If you want I can add it to this PR, just let me know what's your preferred approach.