### PR TITLE
Refactor MAC checks, add new IKEA prefixes

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -123,10 +123,10 @@ bool DeRestPluginPrivate::readBindingTable(RestNodeBase *node, quint8 startIndex
     Resource *r = dynamic_cast<Resource*>(node);
 
     // whitelist
-    if ((node->address().ext() & macPrefixMask) == deMacPrefix)
+    if (checkMacVendor(node->address(), VENDOR_DDEL))
     {
     }
-    else if ((node->address().ext() & macPrefixMask) == ubisysMacPrefix)
+    else if (checkMacVendor(node->address(), VENDOR_UBISYS))
     {
     }
     else if (r && r->item(RAttrModelId)->toString().startsWith(QLatin1String("FLS-")))
@@ -964,12 +964,12 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq.dataType = deCONZ::ZclBoolean;
         rq.attributeId = 0x0000; // on/off
 
-        if ((bt.restNode->address().ext() & macPrefixMask) == deMacPrefix)
+        if (checkMacVendor(bt.restNode->address(), VENDOR_DDEL))
         {
             rq.minInterval = 5;
             rq.maxInterval = 180;
         }
-        else if ((bt.restNode->address().ext() & macPrefixMask) == xalMacPrefix ||
+        else if (checkMacVendor(bt.restNode->address(), VENDOR_XAL) ||
                  bt.restNode->node()->nodeDescriptor().manufacturerCode() == VENDOR_XAL)
         {
             rq.minInterval = 5;
@@ -1072,7 +1072,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq.dataType = deCONZ::Zcl8BitUint;
         rq.attributeId = 0x0000; // current level
 
-        if ((bt.restNode->address().ext() & macPrefixMask) == deMacPrefix)
+        if (checkMacVendor(bt.restNode->address(), VENDOR_DDEL))
         {
             rq.minInterval = 5;
             rq.maxInterval = 180;
@@ -1116,8 +1116,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
 
         return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4});
     }
-    else if (bt.binding.clusterId == BASIC_CLUSTER_ID &&
-            (bt.restNode->address().ext() & macPrefixMask) == philipsMacPrefix)
+    else if (bt.binding.clusterId == BASIC_CLUSTER_ID && checkMacVendor(bt.restNode->address(), VENDOR_PHILIPS))
     {
         Sensor *sensor = dynamic_cast<Sensor*>(bt.restNode);
         if (!sensor)
@@ -1316,7 +1315,7 @@ void DeRestPluginPrivate::checkLightBindingsForAttributeReporting(LightNode *lig
             }
 
             BindingTask bt;
-            if ((lightNode->address().ext() & macPrefixMask) == deMacPrefix)
+            if (checkMacVendor(lightNode->address(), VENDOR_DDEL))
             {
                 bt.state = BindingTask::StateCheck;
             }
@@ -1361,8 +1360,7 @@ void DeRestPluginPrivate::checkLightBindingsForAttributeReporting(LightNode *lig
         return;
     }
 
-    if ((lightNode->address().ext() & macPrefixMask) == deMacPrefix ||
-         lightNode->manufacturerCode() == VENDOR_XAL)
+    if (checkMacVendor(lightNode->address(), VENDOR_DDEL) || lightNode->manufacturerCode() == VENDOR_XAL)
     {
         lightNode->enableRead(READ_BINDING_TABLE);
         lightNode->setNextReadTime(READ_BINDING_TABLE, queryTime);
@@ -2598,7 +2596,7 @@ void DeRestPluginPrivate::bindingToRuleTimerFired()
 
             for (const deCONZ::ZclCluster &cl : sd.outClusters())
             {
-                if (cl.id() == ILLUMINANCE_MEASUREMENT_CLUSTER_ID && (node->address().ext() & macPrefixMask) == deMacPrefix)
+                if (cl.id() == ILLUMINANCE_MEASUREMENT_CLUSTER_ID && checkMacVendor(node->address(), VENDOR_DDEL))
                 {
                     continue; // ignore, binding only allowed for server cluster
                 }
@@ -2678,7 +2676,7 @@ void DeRestPluginPrivate::bindingToRuleTimerFired()
             continue;
         }
 
-        if ((bnd.srcAddress & macPrefixMask) == ubisysMacPrefix)
+        if (checkMacVendor(bnd.srcAddress, VENDOR_UBISYS))
         {
             processUbisysBinding(&*i, bnd);
             return;

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -247,6 +247,7 @@
 #define VENDOR_LGE          0x102E
 #define VENDOR_JENNIC       0x1037 // Used by Xiaomi, Trust
 #define VENDOR_CENTRALITE   0x104E
+#define VENDOR_SI_LABS      0x1049
 #define VENDOR_BITRON       0x1071
 #define VENDOR_NYCE         0x10B9
 #define VENDOR_UBISYS       0x10F2
@@ -343,6 +344,7 @@ extern const quint64 macPrefixMask;
 extern const quint64 bjeMacPrefix;
 extern const quint64 deMacPrefix;
 extern const quint64 emberMacPrefix;
+extern const quint64 energyMiMacPrefix;
 extern const quint64 heimanMacPrefix;
 extern const quint64 ikeaMacPrefix;
 extern const quint64 silabsMacPrefix;
@@ -358,6 +360,76 @@ extern const quint64 stMacPrefix;
 extern const quint64 tiMacPrefix;
 extern const quint64 ubisysMacPrefix;
 extern const quint64 xalMacPrefix;
+
+inline bool checkMacVendor(quint64 addr, quint16 vendor)
+{
+    quint64 prefix = addr & macPrefixMask;
+    switch (vendor) {
+        case VENDOR_115F:
+            return prefix == jennicMacPrefix;
+        case VENDOR_120B:
+            return prefix == emberMacPrefix;
+        case VENDOR_1224:
+            return prefix == emberMacPrefix;
+        case VENDOR_BITRON:
+            return prefix == tiMacPrefix;
+        case VENDOR_BOSCH:
+            return prefix == boschMacPrefix;
+        case VENDOR_BUSCH_JAEGER:
+            return prefix == bjeMacPrefix;
+        case VENDOR_CENTRALITE:
+            return prefix == emberMacPrefix;
+        case VENDOR_EMBER:
+            return prefix == emberMacPrefix;
+        case VENDOR_DDEL:
+            return prefix == deMacPrefix;
+        case VENDOR_IKEA:
+            return prefix == ikeaMacPrefix ||
+                   prefix == silabsMacPrefix ||
+                   prefix == energyMiMacPrefix ||
+                   prefix == emberMacPrefix;
+        case VENDOR_INNR:
+        case VENDOR_INNR2:
+            return prefix == jennicMacPrefix;
+        case VENDOR_INSTA:
+            return prefix == instaMacPrefix;
+        case VENDOR_JENNIC:
+            return prefix == jennicMacPrefix;
+        case VENDOR_KEEN_HOME:
+            return prefix == keenhomeMacPrefix;
+        case VENDOR_LGE:
+            return prefix == emberMacPrefix;
+        case VENDOR_LUTRON:
+            return prefix == lutronMacPrefix;
+        case VENDOR_NYCE:
+            return prefix == emberMacPrefix;
+        case VENDOR_OSRAM:
+        case VENDOR_OSRAM_STACK:
+            return prefix == osramMacPrefix ||
+                   prefix == heimanMacPrefix;
+        case VENDOR_PHILIPS:
+            return prefix == philipsMacPrefix;
+        case VENDOR_PHYSICAL:
+            return stMacPrefix;
+        case VENDOR_SI_LABS:
+            return prefix == silabsMacPrefix ||
+                   prefix == energyMiMacPrefix ||
+                   prefix == ikeaMacPrefix; // belongs to SiLabs
+        case VENDOR_UBISYS:
+            return prefix == ubisysMacPrefix;
+        case VENDOR_VISONIC:
+            return prefix == emberMacPrefix;
+        case VENDOR_XAL:
+            return prefix == xalMacPrefix;
+        default:
+            return false;
+    }
+}
+
+inline bool checkMacVendor(const deCONZ::Address &addr, quint16 vendor)
+{
+    return checkMacVendor(addr.ext(), vendor);
+}
 
 // HTTP status codes
 extern const char *HttpStatusOk;

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -2364,7 +2364,7 @@ void DeRestPluginPrivate::checkSensorStateTimerFired()
  */
 void DeRestPluginPrivate::checkInstaModelId(Sensor *sensor)
 {
-    if (sensor && (sensor->address().ext() & macPrefixMask) == instaMacPrefix)
+    if (sensor && checkMacVendor(sensor->address(), VENDOR_INSTA))
     {
         if (!sensor->modelId().endsWith(QLatin1String("_1")))
         {   // extract model identifier from mac address 6th byte
@@ -2420,13 +2420,13 @@ void DeRestPluginPrivate::handleIndicationSearchSensors(const deCONZ::ApsDataInd
         // filter supported devices
 
         // Busch-Jaeger
-        if ((ext & macPrefixMask) == bjeMacPrefix)
+        if (checkMacVendor(ext, VENDOR_BUSCH_JAEGER))
         {
         }
-        else if ((ext & macPrefixMask) == ubisysMacPrefix)
+        else if (checkMacVendor(ext, VENDOR_UBISYS))
         {
         }
-        else if ((ext & macPrefixMask) == boschMacPrefix)
+        else if (checkMacVendor(ext, VENDOR_BOSCH))
         { // macCapabilities == 0
         }
         else if (macCapabilities & deCONZ::MacDeviceIsFFD)
@@ -2683,7 +2683,7 @@ void DeRestPluginPrivate::handleIndicationSearchSensors(const deCONZ::ApsDataInd
     }
 
     // check for dresden elektronik devices
-    if ((sc->address.ext() & macPrefixMask) == deMacPrefix)
+    if (checkMacVendor(sc->address, VENDOR_DDEL))
     {
         if (sc->macCapabilities & deCONZ::MacDeviceIsFFD) // end-devices only
             return;
@@ -2983,7 +2983,7 @@ void DeRestPluginPrivate::handleIndicationSearchSensors(const deCONZ::ApsDataInd
             }
         }
     }
-    else if ((sc->address.ext() & macPrefixMask) == ikeaMacPrefix)
+    else if (checkMacVendor(sc->address, VENDOR_IKEA))
     {
         if (sc->macCapabilities & deCONZ::MacDeviceIsFFD) // end-devices only
             return;


### PR DESCRIPTION
Multiple MAC prefixes have been seen in the wild for IKEA devices.
Because of this, existing checks looking for specific MAC prefixes are fragile.
Therefore, this PR changes existing MAC checks to invoke a new `checkMacVendor()` function that supports multiple prefixes per vendor. In addition, IKEA check has been amended to support the 4 different prefixes seen in the wild.

---

As discussed in https://github.com/dresden-elektronik/deconz-rest-plugin/pull/700