### PR TITLE
Add ubisys J1 to lights with states on and bri. 

### DIFF
--- a/de_web.pro
+++ b/de_web.pro
@@ -147,6 +147,7 @@ SOURCES  = authentification.cpp \
            reset_device.cpp \
            rest_userparameter.cpp \
            zcl_tasks.cpp \
+           window_covering.cpp \
            websocket_server.cpp
 
 win32 {

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1073,6 +1073,7 @@ public:
     bool addTaskAddEmptyScene(TaskItem &task, quint16 groupId, quint8 sceneId, quint16 transitionTime);
     bool addTaskAddScene(TaskItem &task, uint16_t groupId, uint8_t sceneId, const QString &lightId);
     bool addTaskRemoveScene(TaskItem &task, uint16_t groupId, uint8_t sceneId);
+    bool addTaskWindowCovering(TaskItem &task, uint8_t cmdId, uint16_t pos, uint8_t pct);
     void handleGroupClusterIndication(TaskItem &task, const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleSceneClusterIndication(TaskItem &task, const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleOnOffClusterIndication(TaskItem &task, const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);

--- a/light_node.cpp
+++ b/light_node.cpp
@@ -475,7 +475,7 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
             for (; i != end; ++i)
             {
 
-                if (i->id() == LEVEL_CLUSTER_ID)
+                if (i->id() == LEVEL_CLUSTER_ID || i->id() == WINDOW_COVERING_CLUSTER_ID /*FIXME ubisys J1*/)
                 {
                     addItem(DataTypeUInt8, RStateBri);
                 }

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -510,7 +510,18 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
 
             TaskItem task;
             copyTaskReq(taskRef, task);
-            if (hasBri ||
+            //FIXME workaround ubisys J1 is not a light
+            if (taskRef.lightNode->modelId().startsWith(QLatin1String("J1")) &&
+            		addTaskWindowCovering(task, isOn ? 0x01 /*down*/ : 0x00 /*up*/, 0, 0))
+            {
+				QVariantMap rspItem;
+				QVariantMap rspItemState;
+				rspItemState[QString("/lights/%1/state/on").arg(id)] = isOn;
+				rspItem["success"] = rspItemState;
+				rsp.list.append(rspItem);
+				taskToLocalData(task);
+            } // FIXME end workaround ubisys J1
+            else if (hasBri ||
                 // map.contains("transitiontime") || // FIXME: use bri if transitionTime is given
                 addTaskSetOnOff(task, isOn ? ONOFF_COMMAND_ON : ONOFF_COMMAND_OFF, 0)) // onOff task only if no bri or transitionTime is given
             {
@@ -551,7 +562,49 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
             }
         }
 
-        if (!isOn && !hasOn)
+        //FIXME workaround ubisys J1
+        if (taskRef.lightNode->modelId().startsWith(QLatin1String("J1")))
+        {
+        	if ((map["bri"].type() == QVariant::String) && map["bri"].toString() == "stop")
+        	{
+        		TaskItem task;
+        		copyTaskReq(taskRef, task);
+        		if (addTaskWindowCovering(task, 0x02 /*stop motion*/, 0, 0))
+        		{
+        			QVariantMap rspItem;
+        			QVariantMap rspItemState;
+        			rspItemState[QString("/groups/%1/action/bri").arg(id)] = map["bri"];
+        			rspItem["success"] = rspItemState;
+        			rsp.list.append(rspItem);
+        			taskToLocalData(task);
+        		}
+        		else
+        		{
+        			rsp.list.append(errorToMap(ERR_INTERNAL_ERROR, QString("/lights/%1").arg(id), QString("Internal error, %1").arg(ERR_BRIDGE_BUSY)));
+        		}
+        	}
+        	else if (ok && (map["bri"].type() == QVariant::Double) && (bri < 256))
+        	{
+        		TaskItem task;
+        		copyTaskReq(taskRef, task);
+        		uint8_t moveToPct = 0x00;
+        		moveToPct = bri * 100 / 255;  // Percent 0 - 100 (0x00 - 0x64)
+        		if (addTaskWindowCovering(task, 0x05 /*move to Lift Percent*/, 0, moveToPct))
+        		{
+        			QVariantMap rspItem;
+        			QVariantMap rspItemState;
+        			rspItemState[QString("/lights/%1/state/bri").arg(id)] = map["bri"];
+        			rspItem["success"] = rspItemState;
+        			rsp.list.append(rspItem);
+        			taskToLocalData(task);
+        		}
+        		else
+        		{
+        			rsp.list.append(errorToMap(ERR_INTERNAL_ERROR, QString("/lights/%1").arg(id), QString("Internal error, %1").arg(ERR_BRIDGE_BUSY)));
+        		}
+        	}
+        } // FIXME end workaround ubisys J1
+        else if (!isOn && !hasOn)
         {
             rsp.list.append(errorToMap(ERR_DEVICE_OFF, QString("/lights/%1").arg(id), QString("parameter, /lights/%1/bri, is not modifiable. Device is set to off.").arg(id)));
         }


### PR DESCRIPTION
Add ubisys J1 to `/lights` with states _on_ and _bri_. Sending `PUT { "on": true/false }` triggers J1 to moveDown/Up. Sending `PUT { "bri": "stop" }` triggers a stop. Sending `PUT { "bri": <value> }` triggers move to lift percentage. The moving to lift percentage only works for calibrated J1. Moving up/down/stop always works.

The J1 is a shuttering device (window covering). Adding the J1 device to lights is just a temporary workaroud and will be fixed later when generic endpoint devices becomes available.