### PR TITLE
window_covering updating bri and adding sat for move to tilt

### DIFF
--- a/light_node.cpp
+++ b/light_node.cpp
@@ -475,7 +475,7 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
             for (; i != end; ++i)
             {
 
-                if (i->id() == LEVEL_CLUSTER_ID || i->id() == WINDOW_COVERING_CLUSTER_ID /*FIXME ubisys J1*/)
+                if (i->id() == LEVEL_CLUSTER_ID)
                 {
                     addItem(DataTypeUInt8, RStateBri);
                 }
@@ -523,6 +523,11 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
                     default:
                         break;
                     }
+                }
+                else if (i->id() == WINDOW_COVERING_CLUSTER_ID /*FIXME ubisys J1*/)
+                {
+                	addItem(DataTypeUInt8, RStateBri);
+                	addItem(DataTypeUInt8, RStateSat);
                 }
             }
         }

--- a/light_node.cpp
+++ b/light_node.cpp
@@ -526,8 +526,41 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
                 }
                 else if (i->id() == WINDOW_COVERING_CLUSTER_ID /*FIXME ubisys J1*/)
                 {
-                	addItem(DataTypeUInt8, RStateBri);
-                	addItem(DataTypeUInt8, RStateSat);
+                	QList<deCONZ::ZclCluster>::const_iterator ic = haEndpoint().inClusters().constBegin();
+                	std::vector<deCONZ::ZclAttribute>::const_iterator ia = ic->attributes().begin();
+                	std::vector<deCONZ::ZclAttribute>::const_iterator enda = ic->attributes().end();
+                	bool hasLift = true; // set default to lift
+                	bool hasTilt = false;
+                	for (;ia != enda; ++ia)
+                	{
+                		if (ia->id() == 0x0000)  // WindowCoveringType
+                		{
+                			/*
+                			 * Value 	Type 					Capabilities
+                			 * 0  	Roller Shade 				= Lift only
+                			 * 1  	Roller Shade two motors		= Lift only
+                			 * 2 	Roller Shade exterior		= Lift only
+                			 * 3 	Roller Shade two motors ext = Lift only
+                			 * 4 	Drapery						= Lift only
+                			 * 5 	Awning						= Lift only
+                			 * 6 	Shutter 					= Tilt only
+                			 * 7 	Tilt Blind Lift only		= Tilt only
+                			 * 8 	Tilt Blind lift & tilt 		= Lift & Tilt
+                			 * 9 	Projector Screen 			= Lift only
+                			 */
+                			uint8_t coveringType = ia->numericValue().u8;
+                			if (coveringType == 8 ) {
+                				hasTilt = true;
+                			}
+                			else if (coveringType == 6 || coveringType == 7)
+                			{
+                				hasTilt = true;
+                				hasLift = false;
+                			}
+                		}
+                	}
+                	if (hasLift) { addItem(DataTypeUInt8, RStateBri);}
+                	if (hasTilt) { addItem(DataTypeUInt8, RStateSat);}
                 }
             }
         }

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -493,6 +493,13 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         }
     }
 
+    // FIXME temporary workaround to support window_covering
+    bool isWindowCoveringDevice = false;
+    if (taskRef.lightNode->type() == QLatin1String("Window covering device"))
+    {
+    	isWindowCoveringDevice = true;
+    }
+
     // on/off
     if (hasOn)
     {
@@ -510,9 +517,8 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
 
             TaskItem task;
             copyTaskReq(taskRef, task);
-            //FIXME workaround ubisys J1 is not a light
-            if ((taskRef.lightNode->modelId().startsWith(QLatin1String("J1"))
-            		|| taskRef.lightNode->modelId().startsWith(QLatin1String("lumi.curtain")))
+            //FIXME workaround window_convering
+            if (isWindowCoveringDevice
             		&& addTaskWindowCovering(task, isOn ? 0x01 /*down*/ : 0x00 /*up*/, 0, 0))
             {
 				QVariantMap rspItem;
@@ -521,7 +527,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
 				rspItem["success"] = rspItemState;
 				rsp.list.append(rspItem);
 				taskToLocalData(task);
-            } // FIXME end workaround ubisys J1
+            } // FIXME end workaround window_covering
             else if (hasBri ||
                 // map.contains("transitiontime") || // FIXME: use bri if transitionTime is given
                 addTaskSetOnOff(task, isOn ? ONOFF_COMMAND_ON : ONOFF_COMMAND_OFF, 0)) // onOff task only if no bri or transitionTime is given
@@ -563,9 +569,8 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
             }
         }
 
-        //FIXME workaround ubisys J1
-        if (taskRef.lightNode->modelId().startsWith(QLatin1String("J1"))
-        		|| taskRef.lightNode->modelId().startsWith(QLatin1String("lumi.curtain")))
+        //FIXME workaround window_covering
+        if (isWindowCoveringDevice)
         {
         	if ((map["bri"].type() == QVariant::String) && map["bri"].toString() == "stop")
         	{
@@ -605,7 +610,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         			rsp.list.append(errorToMap(ERR_INTERNAL_ERROR, QString("/lights/%1").arg(id), QString("Internal error, %1").arg(ERR_BRIDGE_BUSY)));
         		}
         	}
-        } // FIXME end workaround ubisys J1
+        } // FIXME end workaround window_covering
         else if (!isOn && !hasOn)
         {
             rsp.list.append(errorToMap(ERR_DEVICE_OFF, QString("/lights/%1").arg(id), QString("parameter, /lights/%1/bri, is not modifiable. Device is set to off.").arg(id)));
@@ -805,9 +810,8 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
     {
         uint sat2 = map["sat"].toUInt(&ok);
 
-        //FIXME workaround ubisys J1
-        if (taskRef.lightNode->modelId().startsWith(QLatin1String("J1"))
-        		|| taskRef.lightNode->modelId().startsWith(QLatin1String("lumi.curtain")))
+        //FIXME workaround window_covering
+        if (isWindowCoveringDevice)
         {
         	if (ok && (map["sat"].type() == QVariant::Double) && (sat2 < 256))
         	{
@@ -828,7 +832,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         			rsp.list.append(errorToMap(ERR_INTERNAL_ERROR, QString("/lights/%1").arg(id), QString("Internal error, %1").arg(ERR_BRIDGE_BUSY)));
         		}
         	}
-        } //FIXME workaround ubisys J1 end
+        } //FIXME workaround window_covering
         else if (!isOn)
         {
             rsp.list.append(errorToMap(ERR_DEVICE_OFF, QString("/lights/%1").arg(id), QString("parameter, /lights/%1/sat, is not modifiable. Device is set to off.").arg(id)));
@@ -960,9 +964,8 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         {
             rsp.list.append(errorToMap(ERR_PARAMETER_NOT_AVAILABLE, QString("/lights/%1").arg(id), QString("parameter, /lights/%1/bri_inc, is not available.").arg(id)));
         }
-        //FIXME workaround ubisys J1
-        else if (taskRef.lightNode->modelId().startsWith(QLatin1String("J1"))
-        		|| taskRef.lightNode->modelId().startsWith(QLatin1String("lumi.curtain")))
+        //FIXME workaround window_covering
+        else if (isWindowCoveringDevice)
         {
         	if (ok && (map["bri_inc"].type() == QVariant::Double) && (briIinc == 0))
         	{
@@ -982,7 +985,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         			rsp.list.append(errorToMap(ERR_INTERNAL_ERROR, QString("/lights/%1").arg(id), QString("Internal error, %1").arg(ERR_BRIDGE_BUSY)));
         		}
         	}
-        } // FIXME end workaround ubisys J1
+        } // FIXME end workaround window_covering
         else if (!isOn)
         {
             rsp.list.append(errorToMap(ERR_DEVICE_OFF, QString("/lights/%1").arg(id), QString("parameter, /lights/%1/bri, is not modifiable. Device is set to off.").arg(id)));


### PR DESCRIPTION
Add window_covering cluster updating `bri` value with lift percentage during moving. The update happens in realtime. This requires that reporting has been configured. The updateLightNode will map WINDOW_COVERING cluster attributes lift/tilt percentage to bri/sat on lightnode. 

Add move to tilt percentage for PUT `{ "sat" : value }`. 

Add modelId `lumi.curtain` in rest_lights.cpp setLightState, see issue #593.

The ubisys J1 now shows up in `/lights` with:
```
  "state": {
    "alert": "none",
    "bri": 165,
    "on": true,
    "reachable": true,
    "sat": 0
  },
```
This PR is a follow up on PR #727 and issue #534 

@ebaauw the `dc_eventlog` is now showing output while moving.

Summary: These commands are implemented.

ubisys J1 command | put command
-------- | -----------------------
move down/up | `{"on" : true/false }`
stop | `{"bri_inc" : 0 }`
move to lift pct | `{"bri" : <pct * 255 / 100> }`
move to tilt pct | `{"sat" : <pct * 255 / 100> }`
