### PR TITLE
Add ubisys J1 calibration and switch configuration.

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -2956,6 +2956,24 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             QStringList supportedModes({"momentary", "rocker"});
             item = sensor.addItem(DataTypeString, RConfigMode);
 
+            bool isWindowCovering = sensor.modelId().startsWith(QLatin1String("J1"));
+            ResourceItem *itemWindowCovering = 0;
+            if (isWindowCovering)
+            {
+            	itemWindowCovering = sensor.addItem(DataTypeUInt8, RConfigWindowCoveringType);
+            }
+
+            if (configCol >= 0)
+            {
+            	sensor.jsonToConfig(QLatin1String(colval[configCol])); // needed again otherwise item isEmpty
+            }
+
+            if (isWindowCovering)
+            {
+            	int val = itemWindowCovering->toNumber(); // prevent null value
+            	itemWindowCovering->setValue(val);
+            }
+
             if (item->toString().isEmpty() || !supportedModes.contains(item->toString()))
             {
                 item->setValue(supportedModes.first());

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -490,6 +490,10 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
             handleTimeClusterIndication(ind, zclFrame);
             break;
 
+        case WINDOW_COVERING_CLUSTER_ID:
+        	handleWindowCoveringClusterIndication(ind, zclFrame);
+            break;
+
         default:
         {
         }
@@ -2109,56 +2113,6 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
                     }
                 }
             }
-            else if (ic->id() == WINDOW_COVERING_CLUSTER_ID && (event.clusterId() == WINDOW_COVERING_CLUSTER_ID))
-            { // FIXME ubisys J1 begin
-                std::vector<deCONZ::ZclAttribute>::const_iterator ia = ic->attributes().begin();
-                std::vector<deCONZ::ZclAttribute>::const_iterator enda = ic->attributes().end();
-                for (;ia != enda; ++ia)
-                {
-                    if (ia->id() == 0x0008) // current CurrentPositionLiftPercentage 0-100
-                    {
-                        uint8_t level = ia->numericValue().u8 * 255 / 100;
-                        ResourceItem *item = lightNode->item(RStateBri);
-                        if (item && item->toNumber() != level)
-                        {
-                            DBG_Printf(DBG_INFO, "0x%016llX level %u --> %u\n", lightNode->address().ext(), (uint)item->toNumber(), level);
-                            lightNode->clearRead(READ_LEVEL);
-                            item->setValue(level);
-                            Event e(RLights, RStateBri, lightNode->id(), item);
-                            enqueueEvent(e);
-                            updated = true;
-
-                            // also change on-state if bri changes to/from 0
-                            bool on = (ia->numericValue().u8 > 0 ? true : false) ;
-                            ResourceItem *itemOn = lightNode->item(RStateOn);
-                            if (itemOn && itemOn->toBool() != on)
-                            {
-                                DBG_Printf(DBG_INFO, "0x%016llX onOff %u --> %u\n", lightNode->address().ext(), (uint)item->toNumber(), on);
-                                itemOn->setValue(on);
-                                Event e(RLights, RStateOn, lightNode->id(), itemOn);
-                                enqueueEvent(e);
-                                updated = true;
-                            }
-
-                        }
-                        lightNode->setZclValue(updateType, event.clusterId(), 0x0008, ia->numericValue());
-                        break;
-                    }
-                    else if (ia->id() == 0x0009) // current CurrentPositionTiltPercentage 0-100
-                    {
-                        uint8_t sat = ia->numericValue().u8 * 255 / 100;
-                        ResourceItem *item = lightNode->item(RStateSat);
-                        if (item && item->toNumber() != sat)
-                        {
-                            item->setValue(sat);
-                            Event e(RLights, RStateSat, lightNode->id(), item);
-                            enqueueEvent(e);
-                            updated = true;
-                        }
-                    }
-                }
-                break;
-            } // FIXME ubisys J1 end
         }
 
         break;
@@ -3271,6 +3225,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                 case ONOFF_CLUSTER_ID:
                 case LEVEL_CLUSTER_ID:
                 case SCENE_CLUSTER_ID:
+                case WINDOW_COVERING_CLUSTER_ID:
                 {
                     if (modelId == QLatin1String("ZYCT-202"))
                     {
@@ -3288,6 +3243,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     else if (node->nodeDescriptor().manufacturerCode() == VENDOR_UBISYS)
                     {
                         if ((modelId.startsWith(QLatin1String("D1")) && i->endpoint() == 0x02) ||
+                            (modelId.startsWith(QLatin1String("J1")) && i->endpoint() == 0x02) ||
                             (modelId.startsWith(QLatin1String("C4")) && i->endpoint() == 0x01) ||
                             (modelId.startsWith(QLatin1String("S2")) && i->endpoint() == 0x03))
                         {
@@ -3907,6 +3863,12 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             sensorNode.addItem(DataTypeString, RConfigGroup);
             item = sensorNode.addItem(DataTypeString, RConfigMode);
             item->setValue(QString("momentary"));
+
+            if (sensorNode.modelId().startsWith(QLatin1String("J1")))
+            {
+            	item = sensorNode.addItem(DataTypeUInt8, RConfigWindowCoveringType);
+            	item->setValue(0);
+            }
         }
     }
     else if (node->nodeDescriptor().manufacturerCode() == VENDOR_BUSCH_JAEGER)
@@ -8762,6 +8724,7 @@ void DeRestPluginPrivate::nodeEvent(const deCONZ::NodeEvent &event)
         case METERING_CLUSTER_ID:
         case ELECTRICAL_MEASUREMENT_CLUSTER_ID:
         case VENDOR_CLUSTER_ID:
+        case WINDOW_COVERING_CLUSTER_ID:
             {
                 addSensorNode(event.node(), &event);
                 updateSensorNode(event);

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -497,7 +497,8 @@ enum TaskType
     TaskViewGroup = 32,
     TaskTriggerEffect = 33,
     TaskWarning = 34,
-    TaskIncBrightness = 35
+    TaskIncBrightness = 35,
+    TaskWindowCovering = 36
 };
 
 struct TaskItem
@@ -983,6 +984,9 @@ public Q_SLOTS:
     // gateways
     void foundGateway(const QHostAddress &host, quint16 port, const QString &uuid, const QString &name);
 
+    // window covering
+    void calibrateWindowCoveringNextStep();
+
 public:
     void checkRfConnectState();
     bool isInNetwork();
@@ -1080,6 +1084,8 @@ public:
     bool addTaskAddScene(TaskItem &task, uint16_t groupId, uint8_t sceneId, const QString &lightId);
     bool addTaskRemoveScene(TaskItem &task, uint16_t groupId, uint8_t sceneId);
     bool addTaskWindowCovering(TaskItem &task, uint8_t cmdId, uint16_t pos, uint8_t pct);
+    bool addTaskWindowCoveringCalibrate(TaskItem &task, int WindowCoveringType);
+    bool addTaskUbisysJ1ConfigureSwitch(TaskItem &taskRef);
     void handleGroupClusterIndication(TaskItem &task, const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleSceneClusterIndication(TaskItem &task, const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleOnOffClusterIndication(TaskItem &task, const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);

--- a/resource.cpp
+++ b/resource.cpp
@@ -104,7 +104,7 @@ const char *RConfigTholdDark = "config/tholddark";
 const char *RConfigTholdOffset = "config/tholdoffset";
 const char *RConfigUrl = "config/url";
 const char *RConfigUsertest = "config/usertest";
-
+const char *RConfigWindowCoveringType = "config/windowcoveringtype";
 
 static std::vector<const char*> rPrefixes;
 static std::vector<ResourceItemDescriptor> rItemDescriptors;
@@ -193,6 +193,7 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigTholdOffset, 1, 0xfffe));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RConfigUrl));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, RConfigUsertest));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, RConfigWindowCoveringType));
 }
 
 const char *getResourcePrefix(const QString &str)

--- a/resource.h
+++ b/resource.h
@@ -119,6 +119,7 @@ extern const char *RConfigTholdDark;
 extern const char *RConfigTholdOffset;
 extern const char *RConfigUrl;
 extern const char *RConfigUsertest;
+extern const char *RConfigWindowCoveringType;
 
 #define R_ALERT_DEFAULT             QVariant(QLatin1String("none"))
 #define R_SENSITIVITY_MAX_DEFAULT   2

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1173,6 +1173,42 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                         }
                     }
 
+                    if (rid.suffix == RConfigMode)
+                    {
+                    	if (sensor->modelId().startsWith(QLatin1String("J1")))
+                    	{
+                    		if (addTaskUbisysJ1ConfigureSwitch(task))
+                    		{
+                    			rspItemState[QString("successfully updated %1").arg(sensor->modelId())] = val;
+                    		}
+                    		else
+                    		{
+                    			rspItemState[QString("error %1").arg(sensor->modelId())] = val;
+                    		}
+                    		rspItem["success"] = rspItemState;
+                    	}
+                    }
+
+                    if (rid.suffix == RConfigWindowCoveringType)
+                    {
+                    	if (sensor->modelId().startsWith(QLatin1String("J1")))
+                    	{
+                    		bool ok;
+                    		int WindowCoveringType = val.toUInt(&ok);
+
+                    		if (ok && addTaskWindowCoveringCalibrate(task, WindowCoveringType))
+                    		{
+                    			rspItemState[QString("started calibration %1").arg(sensor->modelId())] = val;
+                    		}
+                    		else
+                    		{
+                    			rspItemState[QString("error calibration %1").arg(sensor->modelId())] = val;
+                    		}
+                    		rspItem["success"] = rspItemState;
+                    	}
+                    }
+
+
                     if (rid.suffix == RConfigGroup)
                     {
                         checkSensorBindingsForClientClusters(sensor);

--- a/window_covering.cpp
+++ b/window_covering.cpp
@@ -74,6 +74,10 @@
 #include "de_web_plugin.h"
 #include "de_web_plugin_private.h"
 
+int calibrationStep = 0;
+int operationalStatus = 0;
+TaskItem calibrationTask;
+
 /*! Handle packets related to the ZCL Window Covering cluster.
     \param ind the APS level data indication containing the ZCL packet
     \param zclFrame the actual ZCL frame which holds the Window Covering command or attribute
@@ -82,17 +86,142 @@ void DeRestPluginPrivate::handleWindowCoveringClusterIndication(const deCONZ::Ap
 {
     Q_UNUSED(ind);
 
+    LightNode *lightNode = getLightNodeForAddress(ind.srcAddress(), ind.srcEndpoint());
+
+    if (!lightNode)
+    {
+        // was no relevant node
+        return;
+    }
+
+    bool updated = false;
+	deCONZ::NumericUnion numericValue;
+	quint16 attrid = 0x0000;
+	quint8 attrTypeId = 0x00;
+	quint8 attrValue = 0x00;
+	quint8 status = 0x00;
+
     QDataStream stream(zclFrame.payload());
     stream.setByteOrder(QDataStream::LittleEndian);
 
-    // Read ZCL reporting
+    bool isReadAttr = false;
+    bool isReporting = false;
     if (zclFrame.isProfileWideCommand() && zclFrame.commandId() == deCONZ::ZclReadAttributesResponseId)
     {
-
-
+    	isReadAttr = true;
+    }
+    if (zclFrame.isProfileWideCommand() && zclFrame.commandId() == deCONZ::ZclReportAttributesId)
+    {
+    	isReporting = true;
     }
 
-    // More to do ...
+    // Read ZCL reporting and ZCL Read Attributes Response
+    if (isReadAttr || isReporting)
+    {
+    	while(!stream.atEnd())
+    	{
+
+    		stream >> attrid;
+    		if (isReadAttr)
+    		{
+    			stream >> status;  // Read Attribute Response status
+    			if (status != 0)
+    			{
+    				return;
+    			}
+    		}
+    		stream >> attrTypeId;
+    		// only read 8-bit values, i.e. attrTypeId 0x10,0x20,0x30,0x08,0x18,0x28
+    		if ( ((attrTypeId >> 4) <= 0x03 && (attrTypeId & 0x0F) == 0x00) || // 0x10,0x20,0x30
+    			 ((attrTypeId >> 4) <= 0x02 && (attrTypeId & 0x0F) == 0x08))   // 0x08,0x18,0x28
+    		{
+    			stream >> attrValue;
+    		}
+    		else
+    		{
+    			return;
+    		}
+
+
+    		break;
+    	}
+
+    	NodeValue::UpdateType updateType = NodeValue::UpdateByZclReport;
+
+    	if (attrid == 0x0008) // current CurrentPositionLiftPercentage 0-100
+    	{
+    		uint8_t level = attrValue * 255 / 100;
+    		numericValue.u8 = level;
+    		ResourceItem *item = lightNode->item(RStateBri);
+    		if (item && item->toNumber() != level)
+    		{
+    			DBG_Printf(DBG_INFO, "0x%016llX level %u --> %u\n", lightNode->address().ext(), (uint)item->toNumber(), level);
+    			lightNode->clearRead(READ_LEVEL);
+    			item->setValue(level);
+    			Event e(RLights, RStateBri, lightNode->id(), item);
+    			enqueueEvent(e);
+    			updated = true;
+
+    			// also change on-state if bri changes to/from 0
+    			bool on = (attrValue > 0 ? true : false) ;
+    			ResourceItem *itemOn = lightNode->item(RStateOn);
+    			if (itemOn && itemOn->toBool() != on)
+    			{
+    				DBG_Printf(DBG_INFO, "0x%016llX onOff %u --> %u\n", lightNode->address().ext(), (uint)item->toNumber(), on);
+    				itemOn->setValue(on);
+    				Event e(RLights, RStateOn, lightNode->id(), itemOn);
+    				enqueueEvent(e);
+    				updated = true;
+    			}
+    		}
+    		lightNode->setZclValue(updateType, WINDOW_COVERING_CLUSTER_ID, 0x0008, numericValue);
+    	}
+    	else if (attrid == 0x0009) // current CurrentPositionTiltPercentage 0-100
+    	{
+    		uint8_t sat = attrValue * 255 / 100;
+    		numericValue.u8 = sat;
+    		ResourceItem *item = lightNode->item(RStateSat);
+    		if (item && item->toNumber() != sat)
+    		{
+    			item->setValue(sat);
+    			Event e(RLights, RStateSat, lightNode->id(), item);
+    			enqueueEvent(e);
+    			updated = true;
+    		}
+    		lightNode->setZclValue(updateType, WINDOW_COVERING_CLUSTER_ID, 0x0009, numericValue);
+    	}
+    	else if (attrid == 0x000A)  // read attribute 0x000A OperationalStatus
+    	{
+    		if (calibrationStep != 0 && ind.srcAddress().ext() == calibrationTask.req.dstAddress().ext())
+    		{
+    			operationalStatus = attrValue;
+    		}
+    	}
+    	else if (attrid == 0x0000)  // read attribute 0x0000 WindowConveringType
+    	{
+    		Sensor *sensor = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), 0x02);
+    		if (sensor)
+    		{
+    			ResourceItem *item = 0;
+
+    			item = sensor->item(RConfigWindowCoveringType);
+    			if (item)
+    			{
+    				item->setValue(attrValue);
+    		        sensor->setNeedSaveDatabase(true);
+    		        queSaveDb(DB_SENSORS, DB_SHORT_SAVE_DELAY);
+    			}
+    		}
+    	}
+
+    	if (updated)
+    	{
+    		updateEtag(lightNode->etag);
+    		updateEtag(gwConfigEtag);
+    		lightNode->setNeedSaveDatabase(true);
+    		saveDatabaseItems |= DB_LIGHTS;
+    	}
+    }
 }
 
 /*! Adds a window covering task to the queue.
@@ -106,7 +235,7 @@ void DeRestPluginPrivate::handleWindowCoveringClusterIndication(const deCONZ::Ap
  */
 bool DeRestPluginPrivate::addTaskWindowCovering(TaskItem &task, uint8_t cmd, uint16_t pos, uint8_t pct)
 {
-    task.taskType = TaskStoreScene;
+    task.taskType = TaskWindowCovering;
 
     task.req.setClusterId(WINDOW_COVERING_CLUSTER_ID);
     task.req.setProfileId(HA_PROFILE_ID);
@@ -142,3 +271,518 @@ bool DeRestPluginPrivate::addTaskWindowCovering(TaskItem &task, uint8_t cmd, uin
 
     return addTask(task);
 }
+
+/*! Helper to generate a new task with new task and req id based on a reference */
+static void copyTaskReq(TaskItem &a, TaskItem &b)
+{
+    b.req.dstAddress() = a.req.dstAddress();
+    b.req.setDstAddressMode(a.req.dstAddressMode());
+    b.req.setSrcEndpoint(a.req.srcEndpoint());
+    b.req.setDstEndpoint(a.req.dstEndpoint());
+    b.req.setRadius(a.req.radius());
+    b.req.setTxOptions(a.req.txOptions());
+    b.req.setSendDelay(a.req.sendDelay());
+    b.transitionTime = a.transitionTime;
+    b.lightNode = a.lightNode;
+    b.taskType = TaskWindowCovering;
+    b.req.setClusterId(WINDOW_COVERING_CLUSTER_ID);
+    b.req.setProfileId(HA_PROFILE_ID);
+    b.zclFrame.payload().clear();
+}
+
+/*! Configures window covering cluster.
+ * Creates Binding from Target Device Endpoint to Coordinator Endpoint
+ * and configures Reporting on Cluster 0x0102 Attributes 0x0008, 0x0009, 0x000A.
+ * and starts calibration on ubisys J1
+ *
+ * Value 	WindowCoveringType      Capabilities
+ * 0    Roller Shade                = Lift only
+ * 1    Roller Shade two motors     = Lift only
+ * 2    Roller Shade exterior       = Lift only
+ * 3    Roller Shade two motors ext = Lift only
+ * 4    Drapery                     = Lift only
+ * 5    Awning                      = Lift only
+ * 6    Shutter                     = Tilt only
+ * 7    Tilt Blind Lift only        = Tilt only
+ * 8    Tilt Blind lift & tilt      = Lift & Tilt
+ * 9    Projector Screen            = Lift only
+
+   \param task - the task item
+   \parma deviceType - WindowCoveringType 0-9
+   \return true - on success
+           false - on error
+ */
+bool DeRestPluginPrivate::addTaskWindowCoveringCalibrate(TaskItem &taskRef, int WindowCoveringType)
+{
+	Sensor *sensor = getSensorNodeForAddressAndEndpoint(taskRef.req.dstAddress(), 0x02); // Endpoint 0x02
+
+	if (!sensor || !sensor->modelId().startsWith(QLatin1String("J1")))
+	{
+		return false;
+	}
+
+	taskRef.req.setDstEndpoint(0x01);  // Window_Covering Server Cluster is on Endpoint 0x01
+
+	TaskItem task;
+	copyTaskReq(taskRef, task);
+	copyTaskReq(taskRef, calibrationTask);
+
+	// Create Binding
+	BindingTask bt;
+
+	bt.state = BindingTask::StateIdle;
+	bt.action = BindingTask::ActionBind;
+	bt.restNode = sensor; //task.lightNode;
+	Binding &bnd = bt.binding;
+	bnd.srcAddress = task.req.dstAddress().ext();
+	bnd.dstAddrMode = deCONZ::ApsExtAddress;
+	bnd.srcEndpoint = task.req.srcEndpoint();
+	bnd.clusterId = WINDOW_COVERING_CLUSTER_ID;
+	bnd.dstAddress.ext = apsCtrl->getParameter(deCONZ::ParamMacAddress);
+	bnd.dstEndpoint = endpoint();
+
+	if (bnd.dstEndpoint > 0) // valid gateway endpoint?
+	{
+		DBG_Printf(DBG_INFO_L2, "create binding for attribute reporting of cluster 0x%04X\n", WINDOW_COVERING_CLUSTER_ID);
+		queueBindingTask(bt);
+	}
+	else
+	{
+		return false;
+	}
+
+	if (!bindingTimer->isActive())
+	{
+		bindingTimer->start();
+	}
+
+	// Configure Reporting on Cluster 0x0102 Attributes 0x0008, 0x0009, 0x000A
+    ConfigureReportingRequest rq;
+
+    rq.zclSeqNum = zclSeq++; // to match in configure reporting response handler
+    rq.dataType = deCONZ::Zcl8BitUint;
+    rq.attributeId = 0x0008; // CurrentPositionLiftPercentage
+    rq.minInterval = 1;
+    rq.maxInterval = 600;
+    rq.reportableChange8bit = 1;
+
+    ConfigureReportingRequest rq2;
+    rq2.dataType = deCONZ::Zcl8BitUint;
+    rq2.attributeId = 0x0009; // CurrentPositionTiltPercentage
+    rq2.minInterval = 1;
+    rq2.maxInterval = 600;
+    rq2.reportableChange8bit = 1;
+
+    ConfigureReportingRequest rq3;
+    rq3.dataType = deCONZ::Zcl8BitBitMap;
+    rq3.attributeId = 0x000A; // OperationalStatus
+    rq3.minInterval = 1;
+    rq3.maxInterval = 600;
+
+    std::vector<ConfigureReportingRequest> out = {rq, rq2, rq3};
+
+    DBG_Printf(DBG_INFO, "ubisys addTaskWindowCoveringCalibrate task4 deviceType = %d\n", WindowCoveringType);
+
+    TaskItem task2;
+    copyTaskReq(taskRef, task2);
+
+    // ZDP Header
+    task2.zclFrame.setSequenceNumber(zclSeq++);
+    task2.zclFrame.setCommandId(deCONZ::ZclConfigureReportingId);
+    task2.zclFrame.setFrameControl(deCONZ::ZclFCProfileCommand |
+    		deCONZ::ZclFCDirectionClientToServer |
+			deCONZ::ZclFCDisableDefaultResponse);
+
+    { // payload
+        QDataStream stream(&task2.zclFrame.payload(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+
+        for (const ConfigureReportingRequest &rq : out)
+        {
+            stream << rq.direction;
+            stream << rq.attributeId;
+            stream << rq.dataType;
+            stream << rq.minInterval;
+            stream << rq.maxInterval;
+
+            if (rq.reportableChange16bit != 0xFFFF)
+            {
+                stream << rq.reportableChange16bit;
+            }
+            else if (rq.reportableChange8bit != 0xFF)
+            {
+                stream << rq.reportableChange8bit;
+            }
+            else if (rq.reportableChange24bit != 0xFFFFFF)
+            {
+                stream << (qint8) (rq.reportableChange24bit & 0xFF);
+                stream << (qint8) ((rq.reportableChange24bit >> 8) & 0xFF);
+                stream << (qint8) ((rq.reportableChange24bit >> 16) & 0xFF);
+            }
+            else if (rq.reportableChange48bit != 0xFFFFFFFF)
+            {
+                stream << (qint8) (rq.reportableChange48bit & 0xFF);
+                stream << (qint8) ((rq.reportableChange48bit >> 8) & 0xFF);
+                stream << (qint8) ((rq.reportableChange48bit >> 16) & 0xFF);
+                stream << (qint8) ((rq.reportableChange48bit >> 24) & 0xFF);
+                stream << (qint8) 0x00;
+                stream << (qint8) 0x00;
+            }
+            DBG_Printf(DBG_INFO_L2, "configure reporting for 0x%016llX, attribute 0x%04X/0x%04X\n", bt.restNode->address().ext(), bt.binding.clusterId, rq.attributeId);
+        }
+    }
+
+    { // ZCL frame
+    	task2.req.asdu().clear(); // cleanup old request data if there is any
+        QDataStream stream(&task2.req.asdu(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+        task2.zclFrame.writeToStream(stream);
+    }
+
+    if (!addTask(task2))
+    {
+    	return false;
+    }
+
+	// Calibration Step 1 and Step 2
+    TaskItem task3;
+    copyTaskReq(taskRef, task3);
+
+    task3.zclFrame.setSequenceNumber(zclSeq++);
+    task3.zclFrame.setCommandId(deCONZ::ZclWriteAttributesId);
+    task3.zclFrame.setFrameControl(deCONZ::ZclFCProfileCommand |
+                             deCONZ::ZclFCManufacturerSpecific |
+                             deCONZ::ZclFCDirectionClientToServer |
+                             deCONZ::ZclFCDisableDefaultResponse);
+    task3.zclFrame.setManufacturerCode(0x10F2);  // Manufacturer code 0x10F2
+
+    { // payload
+        QDataStream stream(&task3.zclFrame.payload(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+        quint8 attrTypeId = deCONZ::Zcl16BitUint; // type-id 0x21 = unsigned16
+
+        stream << (quint16) 0x0000;
+        stream << (quint8) deCONZ::Zcl8BitEnum;
+        stream << (quint8) WindowCoveringType; // WindowCoveringType attribute 0x0000
+
+        stream << (quint16) 0x0010;
+        stream << attrTypeId;
+        stream << (quint16) 0x0000;  // Write attribute 0x10F2:0x0010 as 0x0000 = 0cm, typeid = 0x21
+
+        stream << (quint16) 0x0011;
+        stream << attrTypeId;
+        stream << (quint16) 0x00F0;  // Write attribute 0x10F2:0x0011 as 0x00F0 = 240cm, typeid = 0x21
+
+        stream << (quint16) 0x0012;
+        stream << attrTypeId;
+        stream << (quint16) 0x0000;  // Write attribute 0x10F2:0x0012 as 0x0000 = 0°, typeid = 0x21
+
+        stream << (quint16) 0x0013;
+        stream << attrTypeId;
+        stream << (quint16) 0x0384;  // Write attribute 0x10F2:0x0013 as 0x0384 = 90.0°, typeid = 0x21
+
+        stream << (quint16) 0x1001;
+        stream << attrTypeId;
+        stream << (quint16) 0xFFFF;  // Write attribute 0x10F2:0x1001 as 0xFFFF = invalid, typeid = 0x21
+
+        stream << (quint16) 0x1002;
+        stream << attrTypeId;
+        stream << (quint16) 0xFFFF;  // Write attribute 0x10F2:0x1002 as 0xFFFF = invalid, typeid = 0x21
+
+        stream << (quint16) 0x1003;
+        stream << attrTypeId;
+        stream << (quint16) 0xFFFF;  // Write attribute 0x10F2:0x1003 as 0xFFFF = invalid, typeid = 0x21
+
+        stream << (quint16) 0x1004;
+        stream << attrTypeId;
+        stream << (quint16) 0xFFFF;  // Write attribute 0x10F2:0x1004 as 0xFFFF = invalid, typeid = 0x21
+     }
+
+    { // ZCL frame
+        task3.req.asdu().clear(); // cleanup old request data if there is any
+        QDataStream stream(&task3.req.asdu(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+        task3.zclFrame.writeToStream(stream);
+    }
+
+    if (!addTask(task3))
+    {
+    	return false;
+    }
+
+	// Calibration Step 3
+    TaskItem task4;
+    copyTaskReq(taskRef, task4);
+
+    task4.zclFrame.setSequenceNumber(zclSeq++);
+    task4.zclFrame.setCommandId(deCONZ::ZclWriteAttributesId);
+    task4.zclFrame.setFrameControl(deCONZ::ZclFCProfileCommand |
+                             deCONZ::ZclFCDirectionClientToServer |
+                             deCONZ::ZclFCDisableDefaultResponse);
+
+    { // payload
+        QDataStream stream(&task4.zclFrame.payload(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+
+        stream << (quint16) 0x0017;
+        stream << (quint8) deCONZ::Zcl8BitBitMap;
+        stream << (quint8) 0x02; // Write attribute Mode 0x0017 as 0x02, typeid = 0x18
+    }
+
+    { // ZCL frame
+        task4.req.asdu().clear(); // cleanup old request data if there is any
+        QDataStream stream(&task4.req.asdu(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+        task4.zclFrame.writeToStream(stream);
+    }
+
+    if (!addTask(task4))
+    {
+    	return false;
+    }
+
+	// start timer for next step
+    calibrationStep = 3;
+    QTimer::singleShot(2000, this, SLOT(calibrateWindowCoveringNextStep()));
+
+	return true;
+}
+
+/*! Configures ubisys J1 switch.
+ * Using the device setup cluster 0xFC00 on endpoint 0xE8, you can configure endpoint 0x02
+ * either to be used with two push-buttons (momentary switches, one stable position)
+ * or two rocker switches (two stable positions).
+ *
+ * dual push-button operation (momentary, one stable position) default configuration:
+ *  - A short press will move up/down and stop when released,
+ *  - while a long press will move up/down without stopping
+ *
+ * two rocker switches (two stable positions):
+ *  - The blind moves as long as either switch is turned on.
+ *  - As soon as it is turned off, motion stops.
+ *
+ * http://www.ubisys.de/downloads/ubisys-j1-technical-reference.pdf
+ * 7.5.5.2. InputActions Attribute, Page 30
+
+   \param task - the task item
+   \return true - on success
+           false - on error
+ */
+bool DeRestPluginPrivate::addTaskUbisysJ1ConfigureSwitch(TaskItem &taskRef)
+{
+	TaskItem task;
+	copyTaskReq(taskRef, task);
+
+	Sensor *sensor = getSensorNodeForAddressAndEndpoint(task.req.dstAddress(), 0x02);
+
+	if (!sensor || !sensor->modelId().startsWith(QLatin1String("J1")))
+	{
+		return false;
+	}
+
+    ResourceItem *item = 0;
+
+    item = sensor->item(RConfigMode);
+    if (!item)
+    {
+        return false;
+    }
+
+    task.req.setClusterId(UBISYS_DEVICE_SETUP_CLUSTER_ID);
+    task.req.setDstEndpoint(0xE8);
+
+    task.zclFrame.setSequenceNumber(zclSeq++);
+    task.zclFrame.setCommandId(deCONZ::ZclWriteAttributesId);
+    task.zclFrame.setFrameControl(deCONZ::ZclFCProfileCommand |
+                             deCONZ::ZclFCDirectionClientToServer |
+                             deCONZ::ZclFCDisableDefaultResponse);
+
+    { // payload
+        QDataStream stream(&task.zclFrame.payload(), QIODevice::ReadWrite);
+        stream.setByteOrder(QDataStream::LittleEndian);
+
+        if (item->toString() == QLatin1String("momentary"))
+        {
+            stream << (quint16)0x0001; // attribute id InputActions
+            stream << (quint8)0x48;    // attribute type array
+
+            stream << (quint8)0x41;    // attribute datatype: octed string
+            stream << (quint16)0x0004; // element count: 0x0004 (4 entries)
+
+            stream << (quint8)0x06;    // element #1: length: 6
+            stream << (quint8)0x00;    // InputAndOptions: 0x00
+            stream << (quint8)0x0D;    // transition: released -> pressed
+            stream << (quint8)0x02;    // Source: Endpoint #2 (hosts window covering client cluster on J1)
+            stream << (quint16)0x0102; // Cluster ID: 0x0102 – window covering
+            stream << (quint8)0x00;    // ZCL command template: Move up/open
+
+            stream << (quint8)0x06;    // element #2
+            stream << (quint8)0x00;
+            stream << (quint8)0x07;    // transition: pressed -> released
+            stream << (quint8)0x02;
+            stream << (quint16)0x0102;
+            stream << (quint8)0x02;    // ZCL command template: Stop
+
+            stream << (quint8)0x06;    // element #3
+            stream << (quint8)0x01;    // InputAndOptions: 0x01
+            stream << (quint8)0x0D;    // transition: released -> pressed
+            stream << (quint8)0x02;
+            stream << (quint16)0x0102;
+            stream << (quint8)0x01;    // ZCL command template: Move down/close
+
+            stream << (quint8)0x06;    // element #4
+            stream << (quint8)0x01;
+            stream << (quint8)0x07;    // transition: pressed -> released
+            stream << (quint8)0x02;
+            stream << (quint16)0x0102;
+            stream << (quint8)0x02;    // ZCL command template: Stop
+
+        }
+        else if (item->toString() == QLatin1String("rocker"))
+        {
+            stream << (quint16)0x0001; // attribute id InputActions
+            stream << (quint8)0x48;    // attribute type array
+
+            stream << (quint8)0x41;    // attribute datatype: octed string
+            stream << (quint16)0x0004; // element count: 0x0004 (4 entries)
+
+            stream << (quint8)0x06;    // element #1: length 6
+            stream << (quint8)0x00;    // InputAndOptions: 0x00
+            stream << (quint8)0x0D;    // transition: released -> pressed
+            stream << (quint8)0x02;    // Source: Endpoint #2 (hosts window covering client cluster on J1)
+            stream << (quint16)0x0102; // Cluster ID: 0x0102 – window covering
+            stream << (quint8)0x00;    // ZCL command template: Move up/open
+
+            stream << (quint8)0x06;    // element #2
+            stream << (quint8)0x00;    // InputAndOptions: 0x00
+            stream << (quint8)0x03;    // transition: any state -> released
+            stream << (quint8)0x02;
+            stream << (quint16)0x0102;
+            stream << (quint8)0x02;    // ZCL command template: Stop
+
+            stream << (quint8)0x06;    // element #3
+            stream << (quint8)0x01;    // InputAndOptions: 0x01
+            stream << (quint8)0x0D;    // transition: released -> pressed
+            stream << (quint8)0x02;
+            stream << (quint16)0x0102;
+            stream << (quint8)0x01;    // ZCL command template: Move down/close
+
+            stream << (quint8)0x06;    // element #4
+            stream << (quint8)0x01;
+            stream << (quint8)0x03;    // transition: any state -> released
+            stream << (quint8)0x02;
+            stream << (quint16)0x0102;
+            stream << (quint8)0x02;    // ZCL command template: Stop
+
+        }
+        else
+        {
+        	return false;  // do nothing
+        }
+    }
+
+    { // ZCL frame
+        task.req.asdu().clear(); // cleanup old request data if there is any
+        QDataStream stream(&task.req.asdu(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+        task.zclFrame.writeToStream(stream);
+    }
+
+    if (!addTask(task))
+    {
+    	return false;
+    }
+
+	return true;
+}
+
+void DeRestPluginPrivate::calibrateWindowCoveringNextStep()
+{
+	TaskItem task;
+	copyTaskReq(calibrationTask, task);
+
+	DBG_Printf(DBG_INFO, "ubisys NextStep calibrationStep = %d, task=%s calibrationTask = %s \n",
+			calibrationStep,
+			qPrintable(task.req.dstAddress().toStringExt()),
+			qPrintable(calibrationTask.req.dstAddress().toStringExt()));
+
+	switch(calibrationStep)
+	{
+	case 3:
+	    calibrationStep = 4;
+	    QTimer::singleShot(2000, this, SLOT(calibrateWindowCoveringNextStep()));
+	    addTaskWindowCovering(task, 0x01 /*move down*/, 0, 0);
+	    break;
+
+	case 4:
+		calibrationStep = 5;
+		QTimer::singleShot(2000, this, SLOT(calibrateWindowCoveringNextStep()));
+		addTaskWindowCovering(task, 0x00 /*move up*/, 0, 0);
+		break;
+
+	case 5:
+		if (operationalStatus == 0)
+		{
+			calibrationStep = 6;
+			addTaskWindowCovering(task, 0x01 /*move down*/, 0, 0);
+		}
+		QTimer::singleShot(4000, this, SLOT(calibrateWindowCoveringNextStep()));
+		break;
+
+	case 6:
+		if (operationalStatus == 0)
+		{
+			calibrationStep = 7;
+			addTaskWindowCovering(task, 0x00 /*move up*/, 0, 0);
+		}
+		QTimer::singleShot(4000, this, SLOT(calibrateWindowCoveringNextStep()));
+		break;
+
+	case 7:
+		if (operationalStatus == 0)
+		{
+			calibrationStep = 8;
+		}
+		QTimer::singleShot(4000, this, SLOT(calibrateWindowCoveringNextStep()));
+		break;
+
+	case 8:
+		if (operationalStatus == 0)
+		{
+			calibrationStep = 0;
+
+			// leave calibration mode
+		    task.zclFrame.setSequenceNumber(zclSeq++);
+		    task.zclFrame.setCommandId(deCONZ::ZclWriteAttributesId);
+		    task.zclFrame.setFrameControl(deCONZ::ZclFCProfileCommand |
+		                             deCONZ::ZclFCDirectionClientToServer |
+		                             deCONZ::ZclFCDisableDefaultResponse);
+
+		    { // payload
+		        QDataStream stream(&task.zclFrame.payload(), QIODevice::WriteOnly);
+		        stream.setByteOrder(QDataStream::LittleEndian);
+
+		        stream << (quint16) 0x0017;
+		        stream << (quint8) deCONZ::Zcl8BitBitMap;
+		        stream << (quint8) 0x00; // Write attribute Mode 0x0017 as 0x00, typeid = 0x18
+		    }
+
+		    { // ZCL frame
+		    	task.req.asdu().clear(); // cleanup old request data if there is any
+		        QDataStream stream(&task.req.asdu(), QIODevice::WriteOnly);
+		        stream.setByteOrder(QDataStream::LittleEndian);
+		        task.zclFrame.writeToStream(stream);
+		    }
+
+		    addTask(task);
+
+		}
+		break;
+
+	default:
+	{
+	}
+	break;
+	}
+}
+


### PR DESCRIPTION
Sending  PUT /sensors/xx/config `{"windowcoveringtype" : 0}` starts calibration. 

Sending PUT /sensors/xx/config `{"mode":"momentary"}` or `{"mode":"rocker"}` to be used with two push-buttons (momentary switches, one stable position) or two rocker switches (two stable positions).

A sensor ZHASwitch has been created to implement the new functionality.


Calibration:
---
First binding and reporting is configured. Binding is created from device endpoint 0x01 and cluster 0x0102 window covering to deCONZ coordinator. Reporting is configured on attributes 0x0008 LiftPct, 0x0009 TiltPct, 0x000A OperationalStatus.

Then calibration steps 1-9 are started. The shutter/shade moves down and up during calibration. Details in ubisys J1 technical reference page 18-20.

The windowcoveringtype has values from 0-9. 

Value | Type | Lift and/or Tilt
--- | --- | ---
0 | Roller Shade | Lift only 
1 | Roller Shade two motors | Lift only 
2 | Roller Shade exterior  | Lift only 
3 | Roller Shade two motors ext | Lift only 
4 | Drapery   | Lift only 
5 | Awning    | Lift only 
6 |   Shutter   | Tilt only 
7 |   Tilt Blind Lift only        | Tilt only 
8 |   Tilt Blind lift [&](url) tilt      | Lift & Tilt 
9 |   Projector Screen            | Lift only 

Switch configuration:
---
Writes ZCL raw data to device setup cluster 0xFC00 / endpoint 232 (0xE8) / attribute 0x0001. Details in ubisys J1 technical reference page 30-31.

Fixed an issue in _database.cpp_:
---
Added `sensor.jsonToConfig()` after `sensor.addItem()` otherwise database value is ignored

https://github.com/ma-ca/deconz-rest-plugin/blob/edca49554f5ec5a323ec3c0370113a4c59b8eeaf/database.cpp#L2956-L2980
