### PR TITLE
Make allowing localhost to create an api key optional

### DIFF
--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1237,6 +1237,7 @@ public:
     QString gwTimeFormat;
     QString gwIpAddress;
     uint16_t gwPort;
+    bool gwAllowLocal;
     QString gwHomebridge;
     QString gwHomebridgePin;
     QString gwName;

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -82,6 +82,7 @@ void DeRestPluginPrivate::initConfig()
     gwFirmwareVersion = "0x00000000"; // query later
     gwFirmwareVersionUpdate = "";
     gwBridgeId = "0000000000000000";
+    gwAllowLocal = (deCONZ::appArgumentNumeric("--allow-local", 1) == 1);
     gwConfig["websocketport"] = 443;
     fwUpdateState = FW_Idle;
 
@@ -485,7 +486,7 @@ int DeRestPluginPrivate::createUser(const ApiRequest &req, ApiResponse &rsp)
 
     if (!gwLinkButton)
     {
-        if (req.sock->peerAddress() == localHost)
+        if (gwAllowLocal && req.sock->peerAddress() == localHost)
         {
             // proceed
         }


### PR DESCRIPTION
Commit https://github.com/dresden-elektronik/deconz-rest-plugin/commit/59a7811a7c3d9fd6dcdb447e5e2ffe61402eb77b automatically allows localhost. However, with the pass-through server that I set up for the Hue app (https://github.com/KodeCR/hue-pass) this automatically allows all users. This makes it optional with a comment-line parameter (default is still to allow). 