### PR TITLE
Split out network info and refactor/clean config map generation 

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -12089,7 +12089,7 @@ void DeRestPlugin::idleTimerFired()
     {
         d->gwDeviceAddress.setExt(d->apsCtrl->getParameter(deCONZ::ParamMacAddress));
         d->gwDeviceAddress.setNwk(d->apsCtrl->getParameter(deCONZ::ParamNwkAddress));
-        if (d->gwDeviceAddress.hasExt())
+        if (!(d->gwLANBridgeId) && d->gwDeviceAddress.hasExt())
         {
             d->gwBridgeId.sprintf("%016llX", (quint64)d->gwDeviceAddress.ext());
             if (!d->gwConfig.contains("bridgeid") || d->gwConfig["bridgeid"] != d->gwBridgeId)

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -305,8 +305,6 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
     group.setName("All");
     groups.push_back(group);
 
-    initUpnpDiscovery();
-
     connect(apsCtrl, SIGNAL(apsdeDataConfirm(const deCONZ::ApsDataConfirm&)),
             this, SLOT(apsdeDataConfirm(const deCONZ::ApsDataConfirm&)));
 
@@ -392,6 +390,9 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
     quint16 wsPort = deCONZ::appArgumentNumeric(QLatin1String("--ws-port"), gwConfig["websocketport"].toUInt());
     webSocketServer = new WebSocketServer(this, wsPort);
     gwConfig["websocketport"] = webSocketServer->port();
+
+    initNetworkInfo();
+    initUpnpDiscovery();
 
     initAuthentification();
     initInternetDicovery();

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -863,6 +863,7 @@ public Q_SLOTS:
     void processGroupTasks();
     void nodeEvent(const deCONZ::NodeEvent &event);
     void initTimezone();
+    void initNetworkInfo();
     void initWiFi();
     void internetDiscoveryTimerFired();
     void internetDiscoveryFinishedRequest(QNetworkReply *reply);
@@ -1235,11 +1236,14 @@ public:
     quint16 gwProxyPort;
     QString gwTimezone;
     QString gwTimeFormat;
-    QString gwIpAddress;
+    QString gwMAC;
+    QString gwIPAddress;
     uint16_t gwPort;
+    QString gwNetMask;
     QString gwHomebridge;
     QString gwHomebridgePin;
     QString gwName;
+    QString gwBridgeId;
     QString gwUuid;
     QString gwUpdateVersion;
     QString gwSwUpdateState;
@@ -1264,7 +1268,6 @@ public:
     QVariantMap gwUserParameter;
     std::vector<QString> gwUserParameterToDelete;
     deCONZ::Address gwDeviceAddress;
-    QString gwBridgeId;
     QString gwSdImageVersion;
     QString gwDeviceName;
     QDateTime globalLastMotion; // last time any physical PIR has detected motion

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1243,6 +1243,7 @@ public:
     QString gwHomebridge;
     QString gwHomebridgePin;
     QString gwName;
+    bool gwLANBridgeId;
     QString gwBridgeId;
     QString gwUuid;
     QString gwUpdateVersion;

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -40,7 +40,7 @@ ApiConfig::ApiConfig() :
 {
 }
 
-/*! Intit the configuration. */
+/*! Init the configuration. */
 void DeRestPluginPrivate::initConfig()
 {
     QString dataPath = deCONZ::getStorageLocation(deCONZ::ApplicationsDataLocation);
@@ -81,6 +81,10 @@ void DeRestPluginPrivate::initConfig()
     gwFirmwareNeedUpdate = false;
     gwFirmwareVersion = "0x00000000"; // query later
     gwFirmwareVersionUpdate = "";
+    gwMAC = "38:60:77:7c:53:18";
+    gwIPAddress = "127.0.0.1";
+    gwPort = (apsCtrl ? apsCtrl->getParameter(deCONZ::ParamHttpPort) : deCONZ::appArgumentNumeric("--http-port", 80));
+    gwNetMask = "255.0.0.0";
     gwBridgeId = "0000000000000000";
     gwConfig["websocketport"] = 443;
     fwUpdateState = FW_Idle;
@@ -251,6 +255,86 @@ void DeRestPluginPrivate::initTimezone()
     daylighTimer->start(10000);
 
     daylightTimerFired();
+}
+
+/*! Init the network info. */
+void DeRestPluginPrivate::initNetworkInfo()
+{
+    bool ok = false;
+    bool retry = false;
+
+    QList<QNetworkInterface> ifaces = QNetworkInterface::allInterfaces();
+    QList<QNetworkInterface>::Iterator i = ifaces.begin();
+    QList<QNetworkInterface>::Iterator end = ifaces.end();
+
+    // optimistic approach chose the first available ethernet interface
+    for (; !ok && i != end; ++i)
+    {
+        if (i->name() == QLatin1String("tun0"))
+        {
+            continue;
+        }
+
+        retry = true;
+        if ((i->flags() & QNetworkInterface::IsUp) &&
+            (i->flags() & QNetworkInterface::IsRunning) &&
+            !(i->flags() & QNetworkInterface::IsLoopBack))
+        {
+            //DBG_Printf(DBG_INFO, "%s (%s)\n", qPrintable(i->name()), qPrintable(i->humanReadableName()));
+
+            QList<QNetworkAddressEntry> addresses = i->addressEntries();
+
+            if (ok || addresses.isEmpty())
+            {
+                continue;
+            }
+
+            QList<QNetworkAddressEntry>::Iterator a = addresses.begin();
+            QList<QNetworkAddressEntry>::Iterator aend = addresses.end();
+
+            for (; a != aend; ++a)
+            {
+                if (a->ip().protocol() != QAbstractSocket::IPv4Protocol)
+                {
+                    continue;
+                }
+
+                quint32 ipv4 = a->ip().toIPv4Address();
+                if ((ipv4 & 0xff000000UL) == 0x7f000000UL)
+                {
+                    // 127.x.x.x
+                    continue;
+                }
+
+                if ((ipv4 & 0x80000000UL) != 0x00000000UL && // class A 0xxx xxxx
+                    (ipv4 & 0xc0000000UL) != 0x80000000UL && // class B 10xx xxxx
+                    (ipv4 & 0xe0000000UL) != 0xc0000000UL)   // class C 110x xxxx
+                {
+                    // unsupported network
+                    continue;
+                }
+
+                QString mac = i->hardwareAddress().toLower();
+                gwMAC = mac;
+                gwIPAddress = a->ip().toString();
+                gwConfig["ipaddress"] = gwIPAddress;
+                gwNetMask = a->netmask().toString();
+                ok = true;
+                retry = false;
+                break;
+            }
+        }
+    }
+
+    if (!ok)
+    {
+        DBG_Printf(DBG_ERROR, "No valid ethernet interface found\n");
+    }
+
+    if (retry)
+    {
+        QTimer::singleShot(10000, this, SLOT(initNetworkInfo()));
+    }
 }
 
 /*! Init WiFi parameters if necessary. */
@@ -599,7 +683,6 @@ int DeRestPluginPrivate::createUser(const ApiRequest &req, ApiResponse &rsp)
  */
 void DeRestPluginPrivate::configToMap(const ApiRequest &req, QVariantMap &map)
 {
-    bool ok = false;
     QVariantMap whitelist;
     QVariantMap swupdate;
     QVariantMap swupdate2;
@@ -612,73 +695,17 @@ void DeRestPluginPrivate::configToMap(const ApiRequest &req, QVariantMap &map)
     QDateTime datetime = QDateTime::currentDateTimeUtc();
     QDateTime localtime = QDateTime::currentDateTime();
 
+    basicConfigToMap(map);
+    map["ipaddress"] = gwIPAddress;
+    map["netmask"] = gwNetMask;
+    if (gwDeviceName.isEmpty())
     {
-        QList<QNetworkInterface> ifaces = QNetworkInterface::allInterfaces();
-        QList<QNetworkInterface>::Iterator i = ifaces.begin();
-        QList<QNetworkInterface>::Iterator end = ifaces.end();
-
-        // optimistic approach chose the first available ethernet interface
-        for (; !ok && i != end; ++i)
-        {
-            if (i->name() == QLatin1String("tun0"))
-            {
-                continue;
-            }
-
-            if ((i->flags() & QNetworkInterface::IsUp) &&
-                (i->flags() & QNetworkInterface::IsRunning) &&
-                !(i->flags() & QNetworkInterface::IsLoopBack))
-            {
-                //DBG_Printf(DBG_INFO, "%s (%s)\n", qPrintable(i->name()), qPrintable(i->humanReadableName()));
-
-                QList<QNetworkAddressEntry> addresses = i->addressEntries();
-
-                if (ok || addresses.isEmpty())
-                {
-                    continue;
-                }
-
-                QList<QNetworkAddressEntry>::Iterator a = addresses.begin();
-                QList<QNetworkAddressEntry>::Iterator aend = addresses.end();
-
-                for (; a != aend; ++a)
-                {
-                    if (a->ip().protocol() != QAbstractSocket::IPv4Protocol)
-                    {
-                        continue;
-                    }
-
-                    quint32 ipv4 = a->ip().toIPv4Address();
-                    if ((ipv4 & 0xff000000UL) == 0x7f000000UL)
-                    {
-                        // 127.x.x.x
-                        continue;
-                    }
-
-                    if ((ipv4 & 0x80000000UL) != 0x00000000UL && // class A 0xxx xxxx
-                        (ipv4 & 0xc0000000UL) != 0x80000000UL && // class B 10xx xxxx
-                        (ipv4 & 0xe0000000UL) != 0xc0000000UL)   // class C 110x xxxx
-                    {
-                        // unsupported network
-                        continue;
-                    }
-
-                    map["ipaddress"] = a->ip().toString();
-                    map["netmask"] = a->netmask().toString();
-                    map["mac"] = i->hardwareAddress().toLower();
-                    ok = true;
-                    break;
-                }
-            }
-        }
+        gwDeviceName = apsCtrl->getParameter(deCONZ::ParamDeviceName);
     }
 
-    if (!ok)
+    if (!gwDeviceName.isEmpty())
     {
-        map["mac"] = "38:60:77:7c:53:18";
-        map["ipaddress"] = "127.0.0.1";
-        map["netmask"] = "255.0.0.0";
-        DBG_Printf(DBG_ERROR, "No valid ethernet interface found\n");
+        map["devicename"] = gwDeviceName;
     }
 
     std::vector<ApiAuth>::const_iterator i = apiAuths.begin();
@@ -694,8 +721,6 @@ void DeRestPluginPrivate::configToMap(const ApiRequest &req, QVariantMap &map)
             whitelist[i->apikey] = au;
         }
     }
-
-    map["modelid"] = QLatin1String("deCONZ");
 
     if (req.apiVersion() == ApiVersion_1_DDEL)
     {
@@ -735,7 +760,7 @@ void DeRestPluginPrivate::configToMap(const ApiRequest &req, QVariantMap &map)
         swupdate["text"] = "";
         swupdate["notify"] = false;
         map["swupdate"] = swupdate;
-        map["port"] = (double)(apsCtrl ? apsCtrl->getParameter(deCONZ::ParamHttpPort) : 80);
+        map["port"] = gwPort;
         // since api version 1.2.1
         map["apiversion"] = QLatin1String(GW_SW_VERSION);
         map["system"] = "other";
@@ -769,14 +794,6 @@ void DeRestPluginPrivate::configToMap(const ApiRequest &req, QVariantMap &map)
             map["apiversion"] = QLatin1String("1.20.0");
             map["modelid"] = QLatin1String("BSB002");
         }
-        else
-        {
-            QStringList versions = QString(GW_SW_VERSION).split('.');
-            QString swversion;
-            swversion.sprintf("%d.%d.%d", versions[0].toInt(), versions[1].toInt(), versions[2].toInt());
-            map["swversion"] = swversion;
-            map["apiversion"] = QString(GW_API_VERSION);
-        }
         devicetypes["bridge"] = false;
         devicetypes["lights"] = QVariantList();
         devicetypes["sensors"] = QVariantList();
@@ -797,11 +814,7 @@ void DeRestPluginPrivate::configToMap(const ApiRequest &req, QVariantMap &map)
         backup["status"] = QLatin1String("idle");
         backup["errorcode"] = 0;
         map["backup"] = backup;
-        map["factorynew"] = false;
-        map["replacesbridgeid"] = QVariant();
-        map["datastoreversion"] = QLatin1String("60");
         map["swupdate"] = swupdate;
-        map["starterkitid"] = QLatin1String("");
     }
 
     bridge["state"] = gwSwUpdateState;
@@ -819,29 +832,15 @@ void DeRestPluginPrivate::configToMap(const ApiRequest &req, QVariantMap &map)
 
     map["fwversion"] = gwFirmwareVersion;
     map["rfconnected"] = gwRfConnected;
-    map["name"] = gwName;
     map["uuid"] = gwUuid;
-    map["bridgeid"] = gwBridgeId;
     if (apsCtrl)
     {
         map["zigbeechannel"] = apsCtrl->getParameter(deCONZ::ParamCurrentChannel);
         map["panid"] = apsCtrl->getParameter(deCONZ::ParamPANID);
-        gwPort = apsCtrl->getParameter(deCONZ::ParamHttpPort); // cache
     }
     else
     {
         map["zigbeechannel"] = (double)gwZigbeeChannel;
-        gwPort = deCONZ::appArgumentNumeric("--http-port", 80); // cache
-    }
-
-    if (gwDeviceName.isEmpty())
-    {
-        gwDeviceName = apsCtrl->getParameter(deCONZ::ParamDeviceName);
-    }
-
-    if (!gwDeviceName.isEmpty())
-    {
-        map["devicename"] = gwDeviceName;
     }
 
     if (gwConfig.contains(QLatin1String("ntp")))
@@ -863,10 +862,7 @@ void DeRestPluginPrivate::configToMap(const ApiRequest &req, QVariantMap &map)
     map["websocketport"] = (double)gwConfig["websocketport"].toUInt();
     map["websocketnotifyall"] = gwWebSocketNotifyAll;
 
-    gwIpAddress = map["ipaddress"].toString(); // cache
-
-
-    QStringList ipv4 = gwIpAddress.split(".");
+    QStringList ipv4 = gwIPAddress.split(".");
 
     if (ipv4.size() == 4)
     {
@@ -884,62 +880,19 @@ void DeRestPluginPrivate::configToMap(const ApiRequest &req, QVariantMap &map)
  */
 void DeRestPluginPrivate::basicConfigToMap(QVariantMap &map)
 {
-    QNetworkInterface eth;
-
-    {
-        QList<QNetworkInterface> ifaces = QNetworkInterface::allInterfaces();
-        QList<QNetworkInterface>::Iterator i = ifaces.begin();
-        QList<QNetworkInterface>::Iterator end = ifaces.end();
-
-        // optimistic approach chose the first available ethernet interface
-        for (;i != end; ++i)
-        {
-            if ((i->flags() & QNetworkInterface::IsUp) &&
-                (i->flags() & QNetworkInterface::IsRunning) &&
-                !(i->flags() & QNetworkInterface::IsLoopBack))
-            {
-                QList<QNetworkAddressEntry> addresses = i->addressEntries();
-
-                if (!addresses.isEmpty())
-                {
-                    eth = *i;
-                    break;
-                }
-            }
-        }
-    }
-
-    if (eth.isValid() && !eth.addressEntries().isEmpty())
-    {
-        map["mac"] = eth.hardwareAddress().toLower();
-    }
-    else
-    {
-        DBG_Printf(DBG_ERROR, "No valid ethernet interface found\n");
-    }
-
-    map["bridgeid"] = gwBridgeId;
+    map["name"] = gwName;
+    map["datastoreversion"] = QLatin1String("60");
     QStringList versions = QString(GW_SW_VERSION).split('.');
     QString swversion;
     swversion.sprintf("%d.%d.%d", versions[0].toInt(), versions[1].toInt(), versions[2].toInt());
     map["swversion"] = swversion;
-    map["modelid"] = QLatin1String("deCONZ");
+    map["apiversion"] = QString(GW_API_VERSION);
+    map["mac"] = gwMAC;
+    map["bridgeid"] = gwBridgeId;
     map["factorynew"] = false;
     map["replacesbridgeid"] = QVariant();
-    map["datastoreversion"] = QLatin1String("60");
-    map["apiversion"] = QString(GW_API_VERSION);
-    map["name"] = gwName;
+    map["modelid"] = QLatin1String("deCONZ");
     map["starterkitid"] = QLatin1String("");
-
-    if (gwDeviceName.isEmpty())
-    {
-        gwDeviceName = apsCtrl->getParameter(deCONZ::ParamDeviceName);
-    }
-
-    if (!gwDeviceName.isEmpty())
-    {
-        map["devicename"] = gwDeviceName;
-    }
 }
 
 /*! GET /api/<apikey>

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -319,6 +319,7 @@ void DeRestPluginPrivate::initNetworkInfo()
                 gwIPAddress = a->ip().toString();
                 gwConfig["ipaddress"] = gwIPAddress;
                 gwNetMask = a->netmask().toString();
+                initDescriptionXml();
                 ok = true;
                 retry = false;
                 break;

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -85,6 +85,7 @@ void DeRestPluginPrivate::initConfig()
     gwIPAddress = "127.0.0.1";
     gwPort = (apsCtrl ? apsCtrl->getParameter(deCONZ::ParamHttpPort) : deCONZ::appArgumentNumeric("--http-port", 80));
     gwNetMask = "255.0.0.0";
+    gwLANBridgeId = (deCONZ::appArgumentNumeric("--lan-bridgeid", 0) == 1);
     gwBridgeId = "0000000000000000";
     gwConfig["websocketport"] = 443;
     fwUpdateState = FW_Idle;
@@ -316,6 +317,15 @@ void DeRestPluginPrivate::initNetworkInfo()
 
                 QString mac = i->hardwareAddress().toLower();
                 gwMAC = mac;
+                if (gwLANBridgeId) {
+                    gwBridgeId = mac.mid(0,2) + mac.mid(3,2) + mac.mid(6,2) + "fffe" + mac.mid(9,2) + mac.mid(12,2) + mac.mid(15,2);
+                    if (!gwConfig.contains("bridgeid") || gwConfig["bridgeid"] != gwBridgeId)
+                    {
+                        DBG_Printf(DBG_INFO, "Set bridgeid to %s\n", qPrintable(gwBridgeId));
+                        gwConfig["bridgeid"] = gwBridgeId;
+                        queSaveDb(DB_CONFIG, DB_SHORT_SAVE_DELAY);
+                    }
+                }
                 gwIPAddress = a->ip().toString();
                 gwConfig["ipaddress"] = gwIPAddress;
                 gwNetMask = a->netmask().toString();

--- a/upnp.cpp
+++ b/upnp.cpp
@@ -66,7 +66,7 @@ void DeRestPluginPrivate::initDescriptionXml()
                if (!line.isEmpty())
                {
                    line.replace(QString("{{PORT}}"), qPrintable(QString::number(gwPort)));
-                   line.replace(QString("{{IPADDRESS}}"), qPrintable(gwIpAddress));
+                   line.replace(QString("{{IPADDRESS}}"), qPrintable(gwIPAddress));
                    line.replace(QString("{{UUID}}"), qPrintable(gwUuid));
                    line.replace(QString("{{GWNAME}}"), qPrintable(gwName));
                    line.replace(QString("{{BRIDGEID}}"), qPrintable(gwBridgeId));


### PR DESCRIPTION
This refactors some of the code to remove code duplication in configToMap and basicConfigToMap by splitting out the network info code. It looks like description.xml wasn't updated with a found ip-adress before. The downside could be the config doesn't update the ip-address if it changes after initialisation, but I'm not sure if that really worked before? Probably best to look at 7c2cf2 for the changes because the line endings messed thing up for me.