### PR TITLE
Add upnp specification required messages and update to v2 bridge comp…

### DIFF
--- a/description_in.xml
+++ b/description_in.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root xmlns="urn:schemas-upnp-org:device-1-0">
+  <specVersion>
+    <major>1</major>
+    <minor>0</minor>
+  </specVersion>
+  <URLBase>http://{{IPADDRESS}}:{{PORT}}/</URLBase>
+  <device>
+    <deviceType>urn:schemas-upnp-org:device:Basic:1</deviceType>
+    <friendlyName>{{GWNAME}} ({{IPADDRESS}})</friendlyName>
+    <manufacturer>dresden elektronik</manufacturer>
+    <manufacturerURL>http://www.dresden-elektronik.de</manufacturerURL>
+    <modelDescription>Philips hue compatible Personal Wireless Lighting</modelDescription>
+    <modelName>Philips hue bridge 2015</modelName>
+    <modelNumber>BSB002</modelNumber>
+    <modelURL>http://www.dresden-elektronik.de</modelURL>
+    <serialNumber>{{SERIAL}}</serialNumber>
+    <UDN>uuid:{{UUID}}</UDN>
+    <presentationURL>index.html</presentationURL>
+    <iconList>
+      <icon>
+        <mimetype>image/png</mimetype>
+        <height>48</height>
+        <width>48</width>
+        <depth>24</depth>
+        <url>hue_logo_0.png</url>
+      </icon>
+    </iconList>
+  </device>
+</root>


### PR DESCRIPTION
The upnp specification requires three specific messages to be sent when notifying and requires a specific reply if there is an search request for a specific device. While I was at it, I've also updated the description_in.xml (I've added this as it's not currently in the repository) to what the v2 bridge uses. In particular the serialNumber is the 48-bit version of the bridge-id, not the full extended 64-bit. Note that the Hue bridge uses an ethernet mac-based serial, bridge-id and uuid, but I don't think it matters.