### PR TITLE
Add support for Trådfri on/off switch

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1719,6 +1719,12 @@ void DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
         clusters.push_back(SCENE_CLUSTER_ID);
         srcEndpoints.push_back(sensor->fingerPrint().endpoint);
     }
+    // IKEA Trådfri on/off switch
+    else if (sensor->modelId().startsWith(QLatin1String("TRADFRI on/off switch")))
+    {
+        clusters.push_back(ONOFF_CLUSTER_ID);
+        srcEndpoints.push_back(sensor->fingerPrint().endpoint);
+    }
     else if (sensor->modelId().startsWith(QLatin1String("D1")))
     {
         clusters.push_back(ONOFF_CLUSTER_ID);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -109,6 +109,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_IKEA, "TRADFRI remote control", ikeaMacPrefix },
     { VENDOR_IKEA, "TRADFRI motion sensor", ikeaMacPrefix },
     { VENDOR_IKEA, "TRADFRI wireless dimmer", ikeaMacPrefix },
+    { VENDOR_IKEA, "TRADFRI on/off switch", ikeaMacPrefix },
     { VENDOR_INSTA, "Remote", instaMacPrefix },
     { VENDOR_INSTA, "HS_4f_GJ_1", instaMacPrefix },
     { VENDOR_INSTA, "WS_4f_J_1", instaMacPrefix },
@@ -2522,6 +2523,10 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
         {
             sensor->setMode(Sensor::ModeDimmer);
         }
+    }
+    else if (sensor->modelId() == QLatin1String("TRADFRI on/off switch"))
+    {
+        checkReporting = true;
     }
     else if (sensor->modelId() == QLatin1String("TRADFRI motion sensor"))
     {

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -131,6 +131,12 @@ static const Sensor::ButtonMap philipsDimmerSwitchMap[] = {
     { Sensor::ModeNone,             0x00, 0x0000, 0x00, 0,    0,                                           0 }
 };
 
+static const Sensor::ButtonMap ikeaOnOffMap[] = {
+//    mode                          ep    cluster cmd   param button                                       name
+    { Sensor::ModeScenes,           0x01, 0x0006, 0x01, 0,    S_BUTTON_1 + S_BUTTON_ACTION_SHORT_RELEASED, "On" },
+    { Sensor::ModeScenes,           0x01, 0x0006, 0x00, 0,    S_BUTTON_2 + S_BUTTON_ACTION_SHORT_RELEASED, "Off" },
+};
+
 static const Sensor::ButtonMap ikeaRemoteMap[] = {
 //    mode                          ep    cluster cmd   param button                                       name
     // big button
@@ -893,6 +899,7 @@ const Sensor::ButtonMap *Sensor::buttonMap()
             if      (modelid.contains(QLatin1String("remote"))) { m_buttonMap = ikeaRemoteMap; }
             else if (modelid.contains(QLatin1String("motion"))) { m_buttonMap = ikeaMotionSensorMap; }
             else if (modelid.contains(QLatin1String("dimmer"))) { m_buttonMap = ikeaDimmerMap; }
+            else if (modelid.contains(QLatin1String("on/off"))) { m_buttonMap = ikeaOnOffMap; }
         }
         else if (m_manufacturer == QLatin1String("ubisys"))
         {

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -135,6 +135,10 @@ static const Sensor::ButtonMap ikeaOnOffMap[] = {
 //    mode                          ep    cluster cmd   param button                                       name
     { Sensor::ModeScenes,           0x01, 0x0006, 0x01, 0,    S_BUTTON_1 + S_BUTTON_ACTION_SHORT_RELEASED, "On" },
     { Sensor::ModeScenes,           0x01, 0x0006, 0x00, 0,    S_BUTTON_2 + S_BUTTON_ACTION_SHORT_RELEASED, "Off" },
+    { Sensor::ModeScenes,           0x01, 0x0008, 0x05, 0,    S_BUTTON_1 + S_BUTTON_ACTION_HOLD, "Move up (with on/off)" },
+    { Sensor::ModeScenes,           0x01, 0x0008, 0x01, 1,    S_BUTTON_2 + S_BUTTON_ACTION_HOLD, "Move down" },
+    { Sensor::ModeScenes,           0x01, 0x0008, 0x07, 0,    S_BUTTON_1 + S_BUTTON_ACTION_LONG_RELEASED,  "Stop (with on/off)" },
+    { Sensor::ModeScenes,           0x01, 0x0008, 0x07, 1,    S_BUTTON_2 + S_BUTTON_ACTION_LONG_RELEASED,  "Stop" },
 };
 
 static const Sensor::ButtonMap ikeaRemoteMap[] = {


### PR DESCRIPTION
This PR adds basic support for the Trådfri on/off switch (bundled with the IKEA plug, see #779).

With these changes the button emits 1001/1002/1003, 2001/2002/2003 button events.


@manup My remote has a different mac address then `ikeaMacPrefix` (it starts with 0xd0cf5e), maybe something needs to change there as well?