### PR TITLE
lumi.curtain and lumi.ctrl_neutral

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -132,7 +132,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_JENNIC, "lumi.sensor_smoke", jennicMacPrefix },
     { VENDOR_115F, "lumi.plug", jennicMacPrefix }, // Xiaomi smart plug (router)
     { VENDOR_115F, "lumi.ctrl_ln", jennicMacPrefix}, // Xiaomi Wall Switch (router)
-    { VENDOR_115F, "lumi.curtain", jennicMacPrefix}, // Xiaomi curtain controller (router)
+    // { VENDOR_115F, "lumi.curtain", jennicMacPrefix}, // Xiaomi curtain controller (router) - exposed only as light
     { VENDOR_UBISYS, "D1", ubisysMacPrefix },
     { VENDOR_UBISYS, "C4", ubisysMacPrefix },
     { VENDOR_UBISYS, "S2", ubisysMacPrefix },
@@ -493,7 +493,7 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
             break;
 
         case WINDOW_COVERING_CLUSTER_ID:
-        	handleWindowCoveringClusterIndication(ind, zclFrame);
+            handleWindowCoveringClusterIndication(ind, zclFrame);
             break;
 
         default:

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2018,6 +2018,10 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
             }
             else if (ic->id() == ONOFF_CLUSTER_ID && (event.clusterId() == ONOFF_CLUSTER_ID))
             {
+                if (lightNode->modelId().startsWith(QLatin1String("lumi.curtain")))
+                {
+                    continue; // ignore OnOff cluster
+                }
                 std::vector<deCONZ::ZclAttribute>::const_iterator ia = ic->attributes().begin();
                 std::vector<deCONZ::ZclAttribute>::const_iterator enda = ic->attributes().end();
                 for (;ia != enda; ++ia)
@@ -4018,7 +4022,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
         sensorNode.setManufacturer("LUMI");
         if (!sensorNode.modelId().startsWith(QLatin1String("lumi.ctrl_")) &&
             sensorNode.modelId() != QLatin1String("lumi.plug") &&
-            sensorNode.modelId() != QLatin1String("lumi.curtain"))
+            !sensorNode.modelId().startsWith(QLatin1String("lumi.curtain")))
         {
             sensorNode.addItem(DataTypeUInt8, RConfigBattery);
         }

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -596,6 +596,10 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         		copyTaskReq(taskRef, task);
         		uint8_t moveToPct = 0x00;
         		moveToPct = bri * 100 / 255;  // Percent 0 - 100 (0x00 - 0x64)
+                if (taskRef.lightNode->modelId().startsWith(QLatin1String("lumi.curtain")))
+                {
+                    moveToPct = 100 - moveToPct;
+                }
         		if (addTaskWindowCovering(task, 0x05 /*move to Lift Percent*/, 0, moveToPct))
         		{
         			QVariantMap rspItem;

--- a/window_covering.cpp
+++ b/window_covering.cpp
@@ -95,11 +95,11 @@ void DeRestPluginPrivate::handleWindowCoveringClusterIndication(const deCONZ::Ap
     }
 
     bool updated = false;
-	deCONZ::NumericUnion numericValue;
-	quint16 attrid = 0x0000;
-	quint8 attrTypeId = 0x00;
-	quint8 attrValue = 0x00;
-	quint8 status = 0x00;
+    deCONZ::NumericUnion numericValue;
+    quint16 attrid = 0x0000;
+    quint8 attrTypeId = 0x00;
+    quint8 attrValue = 0x00;
+    quint8 status = 0x00;
 
     QDataStream stream(zclFrame.payload());
     stream.setByteOrder(QDataStream::LittleEndian);
@@ -150,7 +150,11 @@ void DeRestPluginPrivate::handleWindowCoveringClusterIndication(const deCONZ::Ap
 
     	if (attrid == 0x0008) // current CurrentPositionLiftPercentage 0-100
     	{
-    		uint8_t level = attrValue * 255 / 100;
+            if (lightNode->modelId().startsWith(QLatin1String("lumi.curtain")))
+            {
+                attrValue = 100 - attrValue;
+            }
+        	uint8_t level = attrValue * 255 / 100;
     		numericValue.u8 = level;
     		ResourceItem *item = lightNode->item(RStateBri);
     		if (item && item->toNumber() != level)
@@ -785,4 +789,3 @@ void DeRestPluginPrivate::calibrateWindowCoveringNextStep()
 	break;
 	}
 }
-


### PR DESCRIPTION
- Invert _CurrentPositionLiftPercentage_ so that 0% is _Open_ and 100% is _Closed_, in line with ZCL spec, see #746;
- Ignore _OnOff_ cluster;
- Suppress creating non-operational ZHASwitch and ZHAPresence sensors.
- Handle Xiaomi special attribute for `lumi.curtain` - update `state.bri` and `state.on` of the `/lights` resource;
- Handle Xiaomi special attribute for `lumi.ctrl_neutral` and `lumi.ctrl_ln` - update `state.on` of the `/lights` resource.
- Set node's `rx()` on receiving Xiaomi special attribute - this solves the `lumi.ctrl_neutral` being unavailable after restart, see #798.