### PR TITLE
Various smaller enhancements

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -2435,6 +2435,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
     }
 
     Sensor sensor;
+    QDateTime startTime = QDateTime::currentDateTimeUtc();
     DeRestPluginPrivate *d = static_cast<DeRestPluginPrivate*>(user);
 
     int configCol = -1;
@@ -2706,11 +2707,15 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
         {
             item = sensor.addItem(DataTypeBool, RStateFlag);
             item->setValue(false);
+            item = sensor.item(RStateLastUpdated);
+            item->setValue(startTime);
         }
         else if (sensor.type().endsWith(QLatin1String("Status")))
         {
             item = sensor.addItem(DataTypeInt32, RStateStatus);
             item->setValue(0);
+            item = sensor.item(RStateLastUpdated);
+            item->setValue(startTime);
         }
         else if (sensor.type().endsWith(QLatin1String("OpenClose")))
         {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5528,17 +5528,17 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 {
                                     if (i->modelId() == QLatin1String("SP 120")) // innr
                                     {
-                                        current += 50; current /= 100; // 0.001A -> 0.1A
+                                        // already in mA
                                     }
                                     else if (i->modelId() == QLatin1String("SmartPlug")) // Heiman
                                     {
-                                        current += 5; current /= 10; // 0.01A -> 0.1A
+                                        current *= 100; // 0.01A -> mA
                                     }
                                     else
                                     {
-                                        current *= 10; // A -> 0.1A
+                                        current *= 1000; // A -> mA
                                     }
-                                    item->setValue(current); // in 0.1A
+                                    item->setValue(current); // in mA
                                     enqueueEvent(Event(RSensors, RStateCurrent, i->id(), item));
                                     updated = true;
                                 }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -3192,13 +3192,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                             fpConsumptionSensor.inClusters.push_back(ci->id());
                         }
                     }
-                    else if (modelId.startsWith(QLatin1String("lumi.ctrl_neutral")))
-                    {
-                        if (i->endpoint() == 0x08)
-                        {
-                            fpConsumptionSensor.inClusters.push_back(ci->id());
-                        }
-                    }
                 }
                     break;
 

--- a/general.xml
+++ b/general.xml
@@ -145,6 +145,7 @@
 				<value name="Mains (single phase) with battery backup" value="0x81"></value>
 			</attribute>
 			<attribute id="0x4000" name="SW Build ID" type="cstring" access="r" required="o" range="0,16"></attribute>
+			<attribute id="0xff0d" name="Xiaomi Sensitivity" type="u8" access="rw" required="o" mfcode="0x11f5"></attribute>
 		</attribute-set>
 		<attribute-set id="001" description="Basic Device Settings">
 			<attribute id="0010" name="Location Description" type="cstring" range="0,16" access="rw" required="o"></attribute>
@@ -171,7 +172,6 @@
 			<attribute id="0x0032" name="Usertest" type="bool" default="0" access="rw" required="o" mfcode="0x100b"></attribute>
 			<attribute id="0x0033" name="LED Indication" type="bool" default="0" access="rw" required="o" mfcode="0x100b"></attribute>
 		</attribute-set>
-
 		<command id="00" dir="recv" name="Reset to Factory Defaults" required="o"></command>
 		</server>
 		<client>

--- a/general.xml
+++ b/general.xml
@@ -772,24 +772,25 @@ various characteristics of that measurement.</description>
         </client>
 	<!-- TODO -->
 	</cluster>
-	<cluster id="000d" name="Analog Output (Basic)">
-	   <description>The Analog Output (Basic) cluster provides an interface for setting the value of an analog output (typically to the environment) and accessing various characteristics of that value.</description>
-     <server>
-       <attribute id="0x001c" type="cstring" name="Description" required="o" access="rw"></attribute>
-       <attribute id="0x0041" type="float" name="Max Present Value" required="o" access="rw"></attribute>
-       <attribute id="0x0045" type="float" name="Min Present Value" required="o" access="rw"></attribute>
-       <attribute id="0x0051" type="bool" name="Out of service" required="m" access="rw" default="0"></attribute>
-       <attribute id="0x0055" type="float" name="Present value" required="m" access="rw" default="0"></attribute>
-       <attribute id="0x006f" type="bmp8" name="Status flags" required="m" access="r" default="0">
- 				<value name="In Alarm" value="0x01"></value>
- 				<value name="Fault" value="0x02"></value>
- 				<value name="Overidden" value="0x04"></value>
- 				<value name="Out of Service" value="0x08"></value>
- 			</attribute>
+  <cluster id="0x000d" name="Analog Output (Basic)">
+    <description>The Analog Output (Basic) cluster provides an interface for setting the value of an analog output (typically to the environment) and accessing various characteristics of that value.</description>
+    <server>
+      <attribute id="0x001c" type="cstring" name="Description" required="o" access="rw"></attribute>
+      <attribute id="0x0041" type="float" name="Max Present Value" required="o" access="rw"></attribute>
+      <attribute id="0x0045" type="float" name="Min Present Value" required="o" access="rw"></attribute>
+      <attribute id="0x0051" type="bool" name="Out of service" required="m" access="rw" default="0"></attribute>
+      <attribute id="0x0055" type="float" name="Present value" required="m" access="rw" default="0"></attribute>
+      <attribute id="0x006f" type="bmp8" name="Status flags" required="m" access="r" default="0">
+        <value name="In Alarm" value="0x01"></value>
+        <value name="Fault" value="0x02"></value>
+        <value name="Overidden" value="0x04"></value>
+        <value name="Out of Service" value="0x08"></value>
+      </attribute>
+      <attribute id="0xf000" type="u32" name="Xiaomi 0xf000" required="o" access="r"></attribute>
      </server>
      <client>
      </client>
-	</cluster>
+   </cluster>
 	<cluster id="000e" name="Analog Value (Basic)">
 	<description>An interface for setting an analog value, typically used as a control system parameter, and accessing various characteristics of that value.</description>
 	<!-- TODO -->

--- a/rest_groups.cpp
+++ b/rest_groups.cpp
@@ -1773,17 +1773,18 @@ bool DeRestPluginPrivate::groupToMap(const ApiRequest &req, const Group *group, 
         }
 
         map["lightsequence"] = lightsequence;
-
-        QStringList deviceIds;
-        auto d = group->m_deviceMemberships.begin();
-        auto dend = group->m_deviceMemberships.end();
-
-        for ( ;d != dend; ++d)
-        {
-            deviceIds.append(*d);
-        }
-        map["devicemembership"] = deviceIds;
     }
+
+    QStringList deviceIds;
+    auto d = group->m_deviceMemberships.begin();
+    auto dend = group->m_deviceMemberships.end();
+
+    for ( ;d != dend; ++d)
+    {
+        deviceIds.append(*d);
+    }
+
+    map["devicemembership"] = deviceIds;
 
     // append lights which are known members in this group
     QVariantList lights;


### PR DESCRIPTION
- Another Xiaomi special attribute.
On the _Analog Output_ cluster of the `lumi.curtain`.  It cannot be read, but is included in the attribute report for this cluster.
Not sure what it means, yet; it always seems to hold the same value.
- Initialise `state.lastupdated` of CLIPGenericFlag and CLIPGenericStatus to startup time on startup.
- Bring back `devicemembership` attribute of `/groups` resources, see #856.
- Report ZHAPower sensor `state.current` in mA (instead of 0.1A), see #820.
- Suppress creation of ZHAConsumption sensor for `lumi.ctrl_neutral` switches.  The switch doesn't report consumption, to the value of `state.consumption` remains `0`.