### PR TITLE
Fix for newer Aqara single button switches (lumi.remote.b1acn01)

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5293,7 +5293,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     else if (rawValue & 0x0100)  { buttonevent = side * 1000; }                // push
                                     else if (rawValue & 0x0200)  { buttonevent = side * 1000 + side; }         // double tap
                                 }
-                                else if (i->modelId() == QLatin1String("lumi.sensor_switch.aq3") || i->modelId() == QLatin1String("lumi.remote.b1acn01"))
+                                else if (i->modelId() == QLatin1String("lumi.sensor_switch.aq3"))
                                 {
                                     switch (rawValue)
                                     {
@@ -5302,6 +5302,17 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                         case 16: buttonevent = S_BUTTON_1 + S_BUTTON_ACTION_HOLD;           break;
                                         case 17: buttonevent = S_BUTTON_1 + S_BUTTON_ACTION_LONG_RELEASED;  break;
                                         case 18: buttonevent = S_BUTTON_1 + S_BUTTON_ACTION_SHAKE;          break;
+                                        default: break;
+                                    }
+                                }
+                                else if (i->modelId() == QLatin1String("lumi.remote.b1acn01"))
+                                {
+                                    switch (rawValue)
+                                    {
+                                        case   1: buttonevent = S_BUTTON_1 + S_BUTTON_ACTION_SHORT_RELEASED; break;
+                                        case   2: buttonevent = S_BUTTON_1 + S_BUTTON_ACTION_DOUBLE_PRESS;   break;
+                                        case   0: buttonevent = S_BUTTON_1 + S_BUTTON_ACTION_HOLD;           break;
+                                        case 255: buttonevent = S_BUTTON_1 + S_BUTTON_ACTION_LONG_RELEASED;  break;
                                         default: break;
                                     }
                                 }


### PR DESCRIPTION
This makes the newer Aqara single button switches work with normal press, long press and double press.