### PR TITLE
Add wrap option when sending bri_inc

### DIFF
--- a/rest_groups.cpp
+++ b/rest_groups.cpp
@@ -795,6 +795,7 @@ int DeRestPluginPrivate::setGroupState(const ApiRequest &req, ApiResponse &rsp)
     bool hasEffectColorLoop = false;
     bool hasAlert = map.contains("alert");
     bool hasToggle = map.contains("toggle");
+    bool hasWrap = map.contains("wrap");
 
     bool on = false;
     uint bri = 0;
@@ -1219,6 +1220,33 @@ int DeRestPluginPrivate::setGroupState(const ApiRequest &req, ApiResponse &rsp)
     {
 
         int briInc = map["bri_inc"].toInt(&ok);
+        if(hasWrap && map["wrap"].type() == QVariant::Bool && map["wrap"] == true) {
+            std::vector<LightNode>::iterator i = nodes.begin();
+            std::vector<LightNode>::iterator end = nodes.end();
+
+            // Find the highest and lowest brightness lights
+            int hiBri = -1, loBri = 255;
+            for (; i != end; ++i)
+            {
+                if (isLightNodeInGroup(&(*i), group->address()))
+                {
+                    if (i->isAvailable() && i->state() != LightNode::StateDeleted)
+                    {
+                        hiBri = (i->level() > hiBri) ? i->level() : hiBri;
+                        loBri = (i->level() < loBri) ? i->level() : loBri;
+                    }
+                }
+            }
+
+            // Check if we need to wrap around
+            if(hiBri >= 0 && loBri < 255) {
+                if(briInc < 0 && loBri + briInc <= -briInc) {
+                    briInc = 254;
+                } else if(briInc > 0 && hiBri + briInc >= 254) {
+                    briInc = -254;
+                }
+            }
+        }
 
         if (ok && (map["bri_inc"].type() == QVariant::Double) && (briInc >= -254 && briInc <= 254))
         {

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -470,6 +470,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
     bool hasEffect = map.contains("effect");
     bool hasEffectColorLoop = false;
     bool hasAlert = map.contains("alert");
+    bool hasWrap = map.contains("wrap");
 
     {
         ResourceItem *item = taskRef.lightNode->item(RStateOn);
@@ -963,6 +964,17 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         ResourceItem *item = taskRef.lightNode->item(RStateBri);
 
         int briIinc = map["bri_inc"].toInt(&ok);
+
+        if (hasWrap && map["wrap"].type() == QVariant::Bool && map["wrap"] == true) {
+            int lightLevel = taskRef.lightNode->level();
+            if(ok) {
+                if(briIinc < 0 && lightLevel + briIinc <= -briIinc) {
+                    briIinc = 254;
+                } else if(briIinc > 0 && lightLevel + briIinc >= 254) {
+                    briIinc = -254;
+                }
+            }
+        }
 
         if (!item)
         {


### PR DESCRIPTION
This adds an option to make the brightness wrap around when you send bri_inc, when it either reaches the maximum brightness (254), or 0 - depending on if bri_inc is negative or positive. I suppose it would be better if the deCONZ daemon could handle this instead, but since it's not possible for most people to change that I thought I would add the functionality to rest instead.

I don't know how useful this would be to people, but it is something I use myself - I have several aqara switches that only have the single-press and double-press actions, so I made the double-press dim down the lights by a fixed amount, but since there's no way of increasing it again, I added this option to make it wrap around back to the brightest again.

Do let me know if you want any changes done to it, or if this is something you're not really interested in.