### PR TITLE
Windows Covering: Allow Configuration of ubisys J1 Specific Attributes

### DIFF
--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1091,6 +1091,7 @@ public:
     bool addTaskAddScene(TaskItem &task, uint16_t groupId, uint8_t sceneId, const QString &lightId);
     bool addTaskRemoveScene(TaskItem &task, uint16_t groupId, uint8_t sceneId);
     bool addTaskWindowCovering(TaskItem &task, uint8_t cmdId, uint16_t pos, uint8_t pct);
+    bool addTaskWindowCoveringSetAttr(TaskItem &task, uint16_t mfrCode, uint16_t attrId, uint8_t attrType, uint16_t attrValue);
     bool addTaskWindowCoveringCalibrate(TaskItem &task, int WindowCoveringType);
     bool addTaskUbisysJ1ConfigureSwitch(TaskItem &taskRef);
     void handleGroupClusterIndication(TaskItem &task, const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);

--- a/resource.cpp
+++ b/resource.cpp
@@ -105,6 +105,21 @@ const char *RConfigTholdOffset = "config/tholdoffset";
 const char *RConfigUrl = "config/url";
 const char *RConfigUsertest = "config/usertest";
 const char *RConfigWindowCoveringType = "config/windowcoveringtype";
+const char *RConfigUbisysJ1Mode = "config/ubisys_j1_mode";
+const char *RConfigUbisysJ1WindowCoveringType = "config/ubisys_j1_windowcoveringtype";
+const char *RConfigUbisysJ1ConfigurationAndStatus = "config/ubisys_j1_configurationandstatus";
+const char *RConfigUbisysJ1InstalledOpenLimitLift = "config/ubisys_j1_installedopenlimitlift";
+const char *RConfigUbisysJ1InstalledClosedLimitLift = "config/ubisys_j1_installedclosedlimitlift";
+const char *RConfigUbisysJ1InstalledOpenLimitTilt = "config/ubisys_j1_installedopenlimittilt";
+const char *RConfigUbisysJ1InstalledClosedLimitTilt = "config/ubisys_j1_installedclosedlimittilt";
+const char *RConfigUbisysJ1TurnaroundGuardTime = "config/ubisys_j1_turnaroundguardtime";
+const char *RConfigUbisysJ1LiftToTiltTransitionSteps = "config/ubisys_j1_lifttotilttransitionsteps";
+const char *RConfigUbisysJ1TotalSteps = "config/ubisys_j1_totalsteps";
+const char *RConfigUbisysJ1LiftToTiltTransitionSteps2 = "config/ubisys_j1_lifttotilttransitionsteps2";
+const char *RConfigUbisysJ1TotalSteps2 = "config/ubisys_j1_totalsteps2";
+const char *RConfigUbisysJ1AdditionalSteps = "config/ubisys_j1_additionalsteps";
+const char *RConfigUbisysJ1InactivePowerThreshold = "config/ubisys_j1_inactivepowerthreshold";
+const char *RConfigUbisysJ1StartupSteps = "config/ubisys_j1_startupsteps";
 
 static std::vector<const char*> rPrefixes;
 static std::vector<ResourceItemDescriptor> rItemDescriptors;
@@ -194,6 +209,21 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RConfigUrl));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, RConfigUsertest));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, RConfigWindowCoveringType));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, RConfigUbisysJ1Mode));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, RConfigUbisysJ1WindowCoveringType));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, RConfigUbisysJ1ConfigurationAndStatus));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigUbisysJ1InstalledOpenLimitLift));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigUbisysJ1InstalledClosedLimitLift));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigUbisysJ1InstalledOpenLimitTilt));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigUbisysJ1InstalledClosedLimitTilt));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, RConfigUbisysJ1TurnaroundGuardTime));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigUbisysJ1LiftToTiltTransitionSteps));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigUbisysJ1TotalSteps));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigUbisysJ1LiftToTiltTransitionSteps2));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigUbisysJ1TotalSteps2));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, RConfigUbisysJ1AdditionalSteps));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigUbisysJ1InactivePowerThreshold));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigUbisysJ1StartupSteps));
 }
 
 const char *getResourcePrefix(const QString &str)

--- a/resource.h
+++ b/resource.h
@@ -120,6 +120,21 @@ extern const char *RConfigTholdOffset;
 extern const char *RConfigUrl;
 extern const char *RConfigUsertest;
 extern const char *RConfigWindowCoveringType;
+extern const char *RConfigUbisysJ1Mode;
+extern const char *RConfigUbisysJ1WindowCoveringType;
+extern const char *RConfigUbisysJ1ConfigurationAndStatus;
+extern const char *RConfigUbisysJ1InstalledOpenLimitLift;
+extern const char *RConfigUbisysJ1InstalledClosedLimitLift;
+extern const char *RConfigUbisysJ1InstalledOpenLimitTilt;
+extern const char *RConfigUbisysJ1InstalledClosedLimitTilt;
+extern const char *RConfigUbisysJ1TurnaroundGuardTime;
+extern const char *RConfigUbisysJ1LiftToTiltTransitionSteps;
+extern const char *RConfigUbisysJ1TotalSteps;
+extern const char *RConfigUbisysJ1LiftToTiltTransitionSteps2;
+extern const char *RConfigUbisysJ1TotalSteps2;
+extern const char *RConfigUbisysJ1AdditionalSteps;
+extern const char *RConfigUbisysJ1InactivePowerThreshold;
+extern const char *RConfigUbisysJ1StartupSteps;
 
 #define R_ALERT_DEFAULT             QVariant(QLatin1String("none"))
 #define R_SENSITIVITY_MAX_DEFAULT   2

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1222,6 +1222,103 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                     return REQ_READY_SEND;
                 }
             }
+
+            if (QString(rid.suffix).startsWith("config/ubisys_j1_"))
+            {
+                uint16_t mfrCode = VENDOR_UBISYS;
+                uint16_t attrId;
+                uint8_t attrType = deCONZ::Zcl16BitUint;
+                if (rid.suffix == RConfigUbisysJ1Mode)
+                {
+                    mfrCode = 0x0000;
+                    attrId = 0x0017;
+                    attrType = deCONZ::Zcl8BitBitMap;
+                }
+                else if (rid.suffix == RConfigUbisysJ1WindowCoveringType)
+                {
+                    attrId = 0x0000;
+                    attrType = deCONZ::Zcl8BitEnum;
+                }
+                else if (rid.suffix == RConfigUbisysJ1ConfigurationAndStatus)
+                {
+                    attrId = 0x0007;
+                    attrType = deCONZ::Zcl8BitBitMap;
+                }
+                else if (rid.suffix == RConfigUbisysJ1InstalledOpenLimitLift)
+                {
+                    attrId = 0x0010;
+                }
+                else if (rid.suffix == RConfigUbisysJ1InstalledClosedLimitLift)
+                {
+                    attrId = 0x0011;
+                }
+                else if (rid.suffix == RConfigUbisysJ1InstalledOpenLimitTilt)
+                {
+                    attrId = 0x0012;
+                }
+                else if (rid.suffix == RConfigUbisysJ1InstalledClosedLimitTilt)
+                {
+                    attrId = 0x0013;
+                }
+                else if (rid.suffix == RConfigUbisysJ1TurnaroundGuardTime)
+                {
+                    attrId = 0x1000;
+                    attrType = deCONZ::Zcl8BitUint;
+                }
+                else if (rid.suffix == RConfigUbisysJ1LiftToTiltTransitionSteps)
+                {
+                    attrId = 0x1001;
+                }
+                else if (rid.suffix == RConfigUbisysJ1TotalSteps)
+                {
+                    attrId = 0x1002;
+                }
+                else if (rid.suffix == RConfigUbisysJ1LiftToTiltTransitionSteps2)
+                {
+                    attrId = 0x1003;
+                }
+                else if (rid.suffix == RConfigUbisysJ1TotalSteps2)
+                {
+                    attrId = 0x1004;
+                }
+                else if (rid.suffix == RConfigUbisysJ1AdditionalSteps)
+                {
+                    attrId = 0x1005;
+                    attrType = deCONZ::Zcl8BitUint;
+                }
+                else if (rid.suffix == RConfigUbisysJ1InactivePowerThreshold)
+                {
+                    attrId = 0x1006;
+                }
+                else if (rid.suffix == RConfigUbisysJ1StartupSteps)
+                {
+                    attrId = 0x1007;
+                }
+                else
+                {
+                    rsp.list.append(errorToMap(ERR_INTERNAL_ERROR, QString("/sensors/%1/%2").arg(id).arg(rid.suffix), QString("unknown attribute")));
+                    rsp.httpStatus = HttpStatusServiceUnavailable;
+                    return REQ_READY_SEND;
+                }
+
+                bool ok;
+                int attrValue = map[pi.key()].toUInt(&ok);
+
+                if (ok && addTaskWindowCoveringSetAttr(task, mfrCode, attrId, attrType, attrValue))
+                {
+                    rspItemState[QString("set attribute %1").arg(rid.suffix)] = attrValue;
+                    rspItem["success"] = rspItemState;
+                }
+                else
+                {
+                    rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/sensors/%1/%2").arg(id).arg(rid.suffix), QString("could not set attribute")));
+                    rsp.httpStatus = HttpStatusBadRequest;
+                    return REQ_READY_SEND;
+                }
+
+                rsp.list.append(rspItem);
+                return REQ_READY_SEND;
+            }
         }
 
         if (!item)


### PR DESCRIPTION
I have basically included all ubisys J1 attributes that can be written. Especially important are `LiftToTiltTransitionSteps` and `LiftToTiltTransitionSteps2`, as these need to be set manually for lift and tilt blinds and cannot be automatically detected by running a calibration cycle.

Please feel free to suggest changes or enhancements to the coding style - my cpp skills have been neglected in recent years, so they're fare from state of the art...