### PR TITLE
Fix cluster when loading ZHAPresence sensor

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -2657,17 +2657,17 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     sensor.setLastRead(READ_OCCUPANCY_CONFIG, 0);
                 }
             }
-            else if (sensor.fingerPrint().hasInCluster(BINARY_INPUT_CLUSTER_ID))
-            {
-                clusterId = BINARY_INPUT_CLUSTER_ID;
-            }
             else if (sensor.fingerPrint().hasInCluster(IAS_ZONE_CLUSTER_ID))
             {
                 clusterId = IAS_ZONE_CLUSTER_ID;
             }
-            else if (sensor.fingerPrint().hasInCluster(COMMISSIONING_CLUSTER_ID))
+            else if (sensor.fingerPrint().hasInCluster(BINARY_INPUT_CLUSTER_ID))
             {
-                clusterId = COMMISSIONING_CLUSTER_ID;
+                clusterId = BINARY_INPUT_CLUSTER_ID;
+            }
+            else if (sensor.fingerPrint().hasInCluster(ONOFF_CLUSTER_ID))
+            {
+                clusterId = ONOFF_CLUSTER_ID;
             }
             item = sensor.addItem(DataTypeBool, RStatePresence);
             item->setValue(false);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -150,10 +150,11 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_OSRAM_STACK, "GAS_", heimanMacPrefix }, // Heiman gas sensor
     { VENDOR_OSRAM_STACK, "TH-H_", heimanMacPrefix }, // Heiman temperature/humidity sensor
     { VENDOR_OSRAM_STACK, "TH-T_", heimanMacPrefix }, // Heiman temperature/humidity sensor
-    { VENDOR_OSRAM_STACK, "SMOK_", heimanMacPrefix }, // Heiman fire sensor
+    { VENDOR_OSRAM_STACK, "SMOK_", heimanMacPrefix }, // Heiman fire sensor - older model
     { VENDOR_OSRAM_STACK, "WATER_", heimanMacPrefix }, // Heiman water sensor
     { VENDOR_LGE, "LG IP65 HMS", emberMacPrefix },
     { VENDOR_EMBER, "SmartPlug", emberMacPrefix }, // Heiman smart plug
+    { VENDOR_120B, "Smoke", emberMacPrefix }, // Heiman fire sensor - newer model
     { VENDOR_120B, "WarningDevice", emberMacPrefix }, // Heiman siren
     { VENDOR_LUTRON, "LZL4BWHL01", lutronMacPrefix }, // Lutron LZL-4B-WH-L01 Connected Bulb Remote
     { VENDOR_KEEN_HOME , "SV01-", keenhomeMacPrefix}, // Keen Home Vent


### PR DESCRIPTION
See #692.

Removed _Commissioning_ cluster and added _On/Off_ cluster.

Changed the order to match creating the sensor:
- _Occupancy Sensing_,
- _IAS Zone_,
- _Binary Input_,
- _On/Off_.