### PR TITLE
Api handling

### DIFF
--- a/authentification.cpp
+++ b/authentification.cpp
@@ -209,7 +209,7 @@ bool DeRestPluginPrivate::checkApikeyAuthentification(const ApiRequest &req, Api
 #endif
 
     rsp.httpStatus = HttpStatusForbidden;
-    rsp.list.append(errorToMap(ERR_UNAUTHORIZED_USER, req.path.join("/"), "unauthorized user"));
+    rsp.list.append(errorToMap(ERR_UNAUTHORIZED_USER, "/" + req.path.mid(2).join("/"), "unauthorized user"));
 
     if (req.sock)
     {

--- a/de_web.pro
+++ b/de_web.pro
@@ -140,6 +140,9 @@ SOURCES  = authentification.cpp \
            rest_sensors.cpp \
            rest_schedules.cpp \
            rest_touchlink.cpp \
+           rest_scenes.cpp \
+           rest_info.cpp \
+           rest_capabilities.cpp \
            rule.cpp \
            upnp.cpp \
            permitJoin.cpp \

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -815,13 +815,15 @@ public:
     bool checkConditions(QVariantList conditionsList, ApiResponse &rsp);
 
     // REST API scenes
-    int handleScenesApi(ApiRequest &req, ApiResponse &rsp);
+    int handleScenesApi(const ApiRequest &req, ApiResponse &rsp);
 
     // REST API info
-    int handleInfoApi(ApiRequest &req, ApiResponse &rsp);
+    int handleInfoApi(const ApiRequest &req, ApiResponse &rsp);
+    int getInfoTimezones(const ApiRequest &req, ApiResponse &rsp);
 
     // REST API capabilities
-    int handleCapabilitiesApi(ApiRequest &req, ApiResponse &rsp);
+    int handleCapabilitiesApi(const ApiRequest &req, ApiResponse &rsp);
+    int getCapabilities(const ApiRequest &req, ApiResponse &rsp);
 
     // REST API common
     QVariantMap errorToMap(int id, const QString &ressource, const QString &description);
@@ -855,7 +857,8 @@ public:
     void initResetDeviceApi();
 
     //Timezone
-    std::string getTimezone();
+    // std::string getTimezone();
+    QVariantList getTimezones();
 
     //Export/Import/Reset Configuration
     bool exportConfiguration();

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -814,6 +814,15 @@ public:
     bool checkActions(QVariantList actionsList, ApiResponse &rsp);
     bool checkConditions(QVariantList conditionsList, ApiResponse &rsp);
 
+    // REST API scenes
+    int handleScenesApi(ApiRequest &req, ApiResponse &rsp);
+
+    // REST API info
+    int handleInfoApi(ApiRequest &req, ApiResponse &rsp);
+
+    // REST API capabilities
+    int handleCapabilitiesApi(ApiRequest &req, ApiResponse &rsp);
+
     // REST API common
     QVariantMap errorToMap(int id, const QString &ressource, const QString &description);
 

--- a/rest_capabilities.cpp
+++ b/rest_capabilities.cpp
@@ -17,9 +17,29 @@
     \return REQ_READY_SEND
             REQ_NOT_HANDLED
  */
-int DeRestPluginPrivate::handleCapabilitiesApi(ApiRequest &req, ApiResponse &rsp)
+int DeRestPluginPrivate::handleCapabilitiesApi(const ApiRequest &req, ApiResponse &rsp)
 {
+    // GET /api/<apikey>/capabilities
+    if ((req.path.size() == 3) && (req.hdr.method() == "GET"))
+    {
+        return getCapabilities(req, rsp);
+    }
+
+    return REQ_NOT_HANDLED;
+}
+
+/*! GET /api/<apikey>/info/timezones
+    \return REQ_READY_SEND
+            REQ_NOT_HANDLED
+ */
+int DeRestPluginPrivate::getCapabilities(const ApiRequest &req, ApiResponse &rsp)
+{
+    Q_UNUSED(req);
+
+    QVariantMap tzs;
+    tzs["values"] = getTimezones();
+    rsp.map["timezones"] = tzs;
+
     rsp.httpStatus = HttpStatusOk;
     return REQ_READY_SEND;
-    // return REQ_NOT_HANDLED;
 }

--- a/rest_capabilities.cpp
+++ b/rest_capabilities.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2018 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ */
+
+#include "de_web_plugin.h"
+#include "de_web_plugin_private.h"
+
+/*! Capabilities REST API broker.
+    \param req - request data
+    \param rsp - response data
+    \return REQ_READY_SEND
+            REQ_NOT_HANDLED
+ */
+int DeRestPluginPrivate::handleCapabilitiesApi(ApiRequest &req, ApiResponse &rsp)
+{
+    rsp.httpStatus = HttpStatusOk;
+    return REQ_READY_SEND;
+    // return REQ_NOT_HANDLED;
+}

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -951,11 +951,12 @@ int DeRestPluginPrivate::getFullState(const ApiRequest &req, ApiResponse &rsp)
 
     QVariantMap lightsMap;
     QVariantMap groupsMap;
-    QVariantMap configMap;
     QVariantMap schedulesMap;
+    QVariantMap scenesMap;
     QVariantMap sensorsMap;
-    QVariantMap resourcelinksMap;
     QVariantMap rulesMap;
+    QVariantMap configMap;
+    QVariantMap resourcelinksMap;
 
     // lights
     {
@@ -1069,15 +1070,20 @@ int DeRestPluginPrivate::getFullState(const ApiRequest &req, ApiResponse &rsp)
         }
     }
 
+    // scenes
+    {
+    }
+
     configToMap(req, configMap);
 
     rsp.map["lights"] = lightsMap;
     rsp.map["groups"] = groupsMap;
-    rsp.map["config"] = configMap;
     rsp.map["schedules"] = schedulesMap;
+    rsp.map["scenes"] = scenesMap;
     rsp.map["sensors"] = sensorsMap;
-    rsp.map["resourcelinks"] = resourcelinksMap;
     rsp.map["rules"] = rulesMap;
+    rsp.map["config"] = configMap;
+    rsp.map["resourcelinks"] = resourcelinksMap;
     rsp.etag = gwConfigEtag;
     rsp.httpStatus = HttpStatusOk;
     return REQ_READY_SEND;

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -2128,7 +2128,7 @@ int DeRestPluginPrivate::deletePassword(const ApiRequest &req, ApiResponse &rsp)
     if (!ok)
     {
         rsp.httpStatus = HttpStatusForbidden;
-        rsp.list.append(errorToMap(ERR_UNAUTHORIZED_USER, req.path.join("/"), "unauthorized user"));
+        rsp.list.append(errorToMap(ERR_UNAUTHORIZED_USER, "/" + req.path.join("/"), "unauthorized user"));
         return REQ_READY_SEND;
     }
 
@@ -2383,7 +2383,7 @@ int DeRestPluginPrivate::putWifiScanResult(const ApiRequest &req, ApiResponse &r
 
     if (req.sock->peerAddress() != localHost)
     {
-        rsp.list.append(errorToMap(ERR_UNAUTHORIZED_USER, req.path.join("/"), "unauthorized user"));
+        rsp.list.append(errorToMap(ERR_UNAUTHORIZED_USER, "/" + req.path.join("/"), "unauthorized user"));
         return REQ_READY_SEND;
     }
 
@@ -2410,7 +2410,7 @@ int DeRestPluginPrivate::putWifiUpdated(const ApiRequest &req, ApiResponse &rsp)
 
     if (req.sock->peerAddress() != localHost)
     {
-        rsp.list.append(errorToMap(ERR_UNAUTHORIZED_USER, req.path.join("/"), "unauthorized user"));
+        rsp.list.append(errorToMap(ERR_UNAUTHORIZED_USER, "/" + req.path.join("/"), "unauthorized user"));
         return REQ_READY_SEND;
     }
 

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -483,31 +483,8 @@ void DeRestPluginPrivate::configurationChanged()
  */
 int DeRestPluginPrivate::handleConfigurationApi(const ApiRequest &req, ApiResponse &rsp)
 {
-    // POST /api
-    if ((req.path.size() == 1) && (req.hdr.method() == "POST"))
-    {
-        return createUser(req, rsp);
-    }
-    else if ((req.path.size() == 2) && (req.hdr.method() == "GET"))
-    {
-        // GET /api/config
-        if (req.path[1] == "config")
-        {
-          return getBasicConfig(req, rsp);
-        }
-        // GET /api/challenge
-        else if (req.path[1] == "challenge")
-        {
-          return getChallenge(req, rsp);
-        }
-        // GET /api/<apikey>
-        else
-        {
-          return getFullState(req, rsp);
-        }
-    }
     // GET /api/<apikey>/config
-    else if ((req.path.size() == 3) && (req.hdr.method() == "GET") && (req.path[2] == "config"))
+    if ((req.path.size() == 3) && (req.hdr.method() == "GET") && (req.path[2] == "config"))
     {
         return getConfig(req, rsp);
     }
@@ -957,11 +934,6 @@ void DeRestPluginPrivate::basicConfigToMap(QVariantMap &map)
  */
 int DeRestPluginPrivate::getFullState(const ApiRequest &req, ApiResponse &rsp)
 {
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     checkRfConnectState();
 
     // handle ETag
@@ -1117,11 +1089,6 @@ int DeRestPluginPrivate::getFullState(const ApiRequest &req, ApiResponse &rsp)
  */
 int DeRestPluginPrivate::getConfig(const ApiRequest &req, ApiResponse &rsp)
 {
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return getBasicConfig(req, rsp);
-    }
-
     checkRfConnectState();
 
     // handle ETag
@@ -1237,11 +1204,6 @@ int DeRestPluginPrivate::getChallenge(const ApiRequest &req, ApiResponse &rsp)
  */
 int DeRestPluginPrivate::modifyConfig(const ApiRequest &req, ApiResponse &rsp)
 {
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     bool ok;
     bool changed = false;
     QVariant var = Json::parse(req.content, ok);
@@ -1751,11 +1713,6 @@ int DeRestPluginPrivate::modifyConfig(const ApiRequest &req, ApiResponse &rsp)
  */
 int DeRestPluginPrivate::deleteUser(const ApiRequest &req, ApiResponse &rsp)
 {
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     QString username2 = req.path[4];
 
     std::vector<ApiAuth>::iterator i = apiAuths.begin();
@@ -1789,11 +1746,6 @@ int DeRestPluginPrivate::deleteUser(const ApiRequest &req, ApiResponse &rsp)
  */
 int DeRestPluginPrivate::updateSoftware(const ApiRequest &req, ApiResponse &rsp)
 {
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     rsp.httpStatus = HttpStatusOk;
     QVariantMap rspItem;
     QVariantMap rspItemState;
@@ -1820,11 +1772,6 @@ int DeRestPluginPrivate::updateSoftware(const ApiRequest &req, ApiResponse &rsp)
  */
 int DeRestPluginPrivate::restartGateway(const ApiRequest &req, ApiResponse &rsp)
 {
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     rsp.httpStatus = HttpStatusOk;
     QVariantMap rspItem;
     QVariantMap rspItemState;
@@ -1853,11 +1800,6 @@ int DeRestPluginPrivate::restartGateway(const ApiRequest &req, ApiResponse &rsp)
  */
 int DeRestPluginPrivate::restartApp(const ApiRequest &req, ApiResponse &rsp)
 {
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     rsp.httpStatus = HttpStatusOk;
     QVariantMap rspItem;
     QVariantMap rspItemState;
@@ -1884,11 +1826,6 @@ int DeRestPluginPrivate::restartApp(const ApiRequest &req, ApiResponse &rsp)
  */
 int DeRestPluginPrivate::shutDownGateway(const ApiRequest &req, ApiResponse &rsp)
 {
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     rsp.httpStatus = HttpStatusOk;
     QVariantMap rspItem;
     QVariantMap rspItemState;
@@ -1917,11 +1854,6 @@ int DeRestPluginPrivate::shutDownGateway(const ApiRequest &req, ApiResponse &rsp
  */
 int DeRestPluginPrivate::updateFirmware(const ApiRequest &req, ApiResponse &rsp)
 {
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     if (startUpdateFirmware())
     {
         rsp.httpStatus = HttpStatusOk;
@@ -1945,11 +1877,6 @@ int DeRestPluginPrivate::updateFirmware(const ApiRequest &req, ApiResponse &rsp)
  */
 int DeRestPluginPrivate::exportConfig(const ApiRequest &req, ApiResponse &rsp)
 {
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     if (exportConfiguration())
     {
         rsp.httpStatus = HttpStatusOk;
@@ -1973,11 +1900,6 @@ int DeRestPluginPrivate::exportConfig(const ApiRequest &req, ApiResponse &rsp)
  */
 int DeRestPluginPrivate::importConfig(const ApiRequest &req, ApiResponse &rsp)
 {
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     if (importConfiguration())
     {
         rsp.httpStatus = HttpStatusOk;
@@ -2009,11 +1931,6 @@ int DeRestPluginPrivate::importConfig(const ApiRequest &req, ApiResponse &rsp)
  */
 int DeRestPluginPrivate::resetConfig(const ApiRequest &req, ApiResponse &rsp)
 {
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     bool resetGW = false;
     bool deleteDB = false;
     bool ok;
@@ -2108,11 +2025,6 @@ int DeRestPluginPrivate::resetConfig(const ApiRequest &req, ApiResponse &rsp)
  */
 int DeRestPluginPrivate::changePassword(const ApiRequest &req, ApiResponse &rsp)
 {
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     bool ok;
     QVariant var = Json::parse(req.content, ok);
     QVariantMap map = var.toMap();
@@ -2322,11 +2234,6 @@ int DeRestPluginPrivate::getWifiState(const ApiRequest &req, ApiResponse &rsp)
  */
 int DeRestPluginPrivate::configureWifi(const ApiRequest &req, ApiResponse &rsp)
 {
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     bool ok;
     QVariant var = Json::parse(req.content, ok);
     QVariantMap map = var.toMap();
@@ -2896,11 +2803,6 @@ int DeRestPluginPrivate::scanWifiNetworks(const ApiRequest &req, ApiResponse &rs
 int DeRestPluginPrivate::resetHomebridge(const ApiRequest &req, ApiResponse &rsp)
 {
     Q_UNUSED(req);
-
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
 
     rsp.httpStatus = HttpStatusOk;
 #ifdef ARCH_ARM

--- a/rest_gateways.cpp
+++ b/rest_gateways.cpp
@@ -28,16 +28,6 @@
  */
 int DeRestPluginPrivate::handleGatewaysApi(const ApiRequest &req, ApiResponse &rsp)
 {
-    if (req.path[2] != QLatin1String("gateways"))
-    {
-        return REQ_NOT_HANDLED;
-    }
-
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     // GET /api/<apikey>/gateways
     if ((req.path.size() == 3) && (req.hdr.method() == QLatin1String("GET")))
     {

--- a/rest_groups.cpp
+++ b/rest_groups.cpp
@@ -25,16 +25,6 @@
  */
 int DeRestPluginPrivate::handleGroupsApi(ApiRequest &req, ApiResponse &rsp)
 {
-    if (req.path[2] != QLatin1String("groups"))
-    {
-        return REQ_NOT_HANDLED;
-    }
-
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     // GET /api/<apikey>/groups
     if ((req.path.size() == 3) && (req.hdr.method() == "GET"))
     {

--- a/rest_info.cpp
+++ b/rest_info.cpp
@@ -17,9 +17,32 @@
     \return REQ_READY_SEND
             REQ_NOT_HANDLED
  */
-int DeRestPluginPrivate::handleInfoApi(ApiRequest &req, ApiResponse &rsp)
+int DeRestPluginPrivate::handleInfoApi(const ApiRequest &req, ApiResponse &rsp)
 {
+    // GET /api/<apikey>/info/timezones
+    if ((req.path.size() == 4) && (req.hdr.method() == "GET") && (req.path[3] == "timezones"))
+    {
+        return getInfoTimezones(req, rsp);
+    }
+
+    return REQ_NOT_HANDLED;
+}
+
+/*! GET /api/<apikey>/info/timezones
+    \return REQ_READY_SEND
+            REQ_NOT_HANDLED
+ */
+int DeRestPluginPrivate::getInfoTimezones(const ApiRequest &req, ApiResponse &rsp)
+{
+    Q_UNUSED(req);
+
+    // QByteArrayList tzs = getTimezones();
+    // foreach (QByteArray tz, tzs)
+    // {
+    //     rsp.list.append(QVariant(tz));
+    // }
+    rsp.list = getTimezones();
+
     rsp.httpStatus = HttpStatusOk;
     return REQ_READY_SEND;
-    // return REQ_NOT_HANDLED;
 }

--- a/rest_info.cpp
+++ b/rest_info.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2018 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ */
+
+#include "de_web_plugin.h"
+#include "de_web_plugin_private.h"
+
+/*! Info REST API broker.
+    \param req - request data
+    \param rsp - response data
+    \return REQ_READY_SEND
+            REQ_NOT_HANDLED
+ */
+int DeRestPluginPrivate::handleInfoApi(ApiRequest &req, ApiResponse &rsp)
+{
+    rsp.httpStatus = HttpStatusOk;
+    return REQ_READY_SEND;
+    // return REQ_NOT_HANDLED;
+}

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -26,16 +26,6 @@
  */
 int DeRestPluginPrivate::handleLightsApi(ApiRequest &req, ApiResponse &rsp)
 {
-    if (req.path[2] != QLatin1String("lights"))
-    {
-        return REQ_NOT_HANDLED;
-    }
-
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     // GET /api/<apikey>/lights
     if ((req.path.size() == 3) && (req.hdr.method() == "GET"))
     {

--- a/rest_resourcelinks.cpp
+++ b/rest_resourcelinks.cpp
@@ -24,16 +24,6 @@
  */
 int DeRestPluginPrivate::handleResourcelinksApi(ApiRequest &req, ApiResponse &rsp)
 {
-    if (req.path[2] != QLatin1String("resourcelinks"))
-    {
-        return REQ_NOT_HANDLED;
-    }
-
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     // GET /api/<apikey>/resourcelinks
     if ((req.path.size() == 3) && (req.hdr.method() == "GET"))
     {

--- a/rest_rules.cpp
+++ b/rest_rules.cpp
@@ -28,11 +28,6 @@
  */
 int DeRestPluginPrivate::handleRulesApi(const ApiRequest &req, ApiResponse &rsp)
 {
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     // GET /api/<apikey>/rules
     if ((req.path.size() == 3) && (req.hdr.method() == "GET")  && (req.path[2] == "rules"))
     {

--- a/rest_scenes.cpp
+++ b/rest_scenes.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2018 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ */
+
+#include "de_web_plugin.h"
+#include "de_web_plugin_private.h"
+
+/*! Scenes REST API broker.
+    \param req - request data
+    \param rsp - response data
+    \return REQ_READY_SEND
+            REQ_NOT_HANDLED
+ */
+int DeRestPluginPrivate::handleScenesApi(ApiRequest &req, ApiResponse &rsp)
+{
+    rsp.httpStatus = HttpStatusOk;
+    return REQ_READY_SEND;
+    // return REQ_NOT_HANDLED;
+}

--- a/rest_scenes.cpp
+++ b/rest_scenes.cpp
@@ -17,8 +17,12 @@
     \return REQ_READY_SEND
             REQ_NOT_HANDLED
  */
-int DeRestPluginPrivate::handleScenesApi(ApiRequest &req, ApiResponse &rsp)
+int DeRestPluginPrivate::handleScenesApi(const ApiRequest &req, ApiResponse &rsp)
 {
+    if (rsp.map.isEmpty())
+    {
+        rsp.str = "{}"; // return empty object
+    }
     rsp.httpStatus = HttpStatusOk;
     return REQ_READY_SEND;
     // return REQ_NOT_HANDLED;

--- a/rest_schedules.cpp
+++ b/rest_schedules.cpp
@@ -35,11 +35,6 @@ void DeRestPluginPrivate::initSchedules()
  */
 int DeRestPluginPrivate::handleSchedulesApi(ApiRequest &req, ApiResponse &rsp)
 {
-    if (req.path[2] != "schedules")
-    {
-        return REQ_NOT_HANDLED;
-    }
-
     // GET /api/<apikey>/schedules
     if ((req.path.size() == 3) && (req.hdr.method() == "GET"))
     {

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -30,16 +30,6 @@ const int MaxOnTimeWithoutPresence = 60 * 6;
  */
 int DeRestPluginPrivate::handleSensorsApi(ApiRequest &req, ApiResponse &rsp)
 {
-    if (req.path[2] != QLatin1String("sensors"))
-    {
-        return REQ_NOT_HANDLED;
-    }
-
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     // GET /api/<apikey>/sensors
     if ((req.path.size() == 3) && (req.hdr.method() == "GET"))
     {

--- a/rest_touchlink.cpp
+++ b/rest_touchlink.cpp
@@ -79,16 +79,6 @@ void DeRestPluginPrivate::initTouchlinkApi()
  */
 int DeRestPluginPrivate::handleTouchlinkApi(ApiRequest &req, ApiResponse &rsp)
 {
-    if (req.path[2] != "touchlink")
-    {
-        return REQ_NOT_HANDLED;
-    }
-
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     // POST /api/<apikey>/touchlink/scan
     if ((req.path.size() == 4) && (req.hdr.method() == "POST") && (req.path[3] == "scan"))
     {

--- a/rest_userparameter.cpp
+++ b/rest_userparameter.cpp
@@ -71,11 +71,6 @@ int DeRestPluginPrivate::handleUserparameterApi(const ApiRequest &req, ApiRespon
  */
 int DeRestPluginPrivate::createUserParameter(const ApiRequest &req, ApiResponse &rsp)
 {
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     if (req.content.isEmpty())
     {
         rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/userparameter"), QString("invalid value for userparameter")));
@@ -112,11 +107,6 @@ int DeRestPluginPrivate::createUserParameter(const ApiRequest &req, ApiResponse 
  */
 int DeRestPluginPrivate::addUserParameter(const ApiRequest &req, ApiResponse &rsp)
 {
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     DBG_Assert(req.path.size() == 4);
 
     if (req.path.size() != 4)
@@ -155,11 +145,6 @@ int DeRestPluginPrivate::addUserParameter(const ApiRequest &req, ApiResponse &rs
  */
 int DeRestPluginPrivate::modifyUserParameter(const ApiRequest &req, ApiResponse &rsp)
 {
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     DBG_Assert(req.path.size() == 4);
 
     if (req.path.size() != 4)
@@ -210,11 +195,6 @@ int DeRestPluginPrivate::getAllUserParameter(const ApiRequest &req, ApiResponse 
 {
     Q_UNUSED(req);
 
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     rsp.httpStatus = HttpStatusOk;
 
     QVariantMap::const_iterator k = gwUserParameter.begin();
@@ -240,11 +220,6 @@ int DeRestPluginPrivate::getAllUserParameter(const ApiRequest &req, ApiResponse 
 int DeRestPluginPrivate::getUserParameter(const ApiRequest &req, ApiResponse &rsp)
 {
     Q_UNUSED(req);
-
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
 
     DBG_Assert(req.path.size() == 4);
 
@@ -280,11 +255,6 @@ int DeRestPluginPrivate::getUserParameter(const ApiRequest &req, ApiResponse &rs
  */
 int DeRestPluginPrivate::deleteUserParameter(const ApiRequest &req, ApiResponse &rsp)
 {
-    if(!checkApikeyAuthentification(req, rsp))
-    {
-        return REQ_READY_SEND;
-    }
-
     DBG_Assert(req.path.size() == 4);
 
     if (req.path.size() != 4)

--- a/time.cpp
+++ b/time.cpp
@@ -218,3 +218,17 @@ void DeRestPluginPrivate::sendTimeClusterResponse(const deCONZ::ApsDataIndicatio
     }
 
 }
+
+/*! Get all available timezone ids
+ */
+QVariantList DeRestPluginPrivate::getTimezones()
+{
+    // return QTimeZone::availableTimeZoneIds();
+    QByteArrayList tzs = QTimeZone::availableTimeZoneIds();
+    QVariantList list;
+    foreach (QByteArray tz, tzs)
+    {
+        list.append(QVariant(tz));
+    }
+	return list;
+}


### PR DESCRIPTION
This PR adds the scenes, info, and capabilities nodes to the api. Furthermore it:
- adds the timezones of the system to the info and capabilities nodes, the rest of the capabilities node and the scenes node is empty for now
- centralise the apikey check so it isn't missed anywhere, e.g. schedules
- update the error messages and handle everything under /api

The aim is still to slowly work towards better support for the hue-api/Hue app (#663)