### PR TITLE
Update general.xml

### DIFF
--- a/general.xml
+++ b/general.xml
@@ -499,6 +499,11 @@
 							</attribute>
 							<attribute id="0x4002" name="OffWaitTime" type="u16" access="r" default="0" required="o">
 							</attribute>
+							<attribute id="0x4003" name="PowerOn OnOff" type="enum8" access="rw" default="0x01" required="o">
+                <value name="Off" value="0x00"></value>
+                <value name="On" value="0x01"></value>
+                <value name="Previous" value="0xff"></value>
+							</attribute>
 						</attribute-set>
 
 			<command id="00" dir="recv" name="Off" required="m">
@@ -618,6 +623,8 @@
 			<attribute id = "0011" name="On Level" type="u8" range="0x00,0xfe" access="rw" required="o" default="0xfe">
 				<description>The OnLevel attribute determines the value that the CurrentLevel attribute is set to when the OnOff attribute of an On/Off cluster on the same endpoint is set to On. If the OnLevel attribute is not implemented, or is set to 0xff, it has no effect.</description>
 			</attribute>
+			<attribute id="0x4000" name="PowerOn Level" type="u8" access="rw" required="o">
+      </attribute>
 			<command id="0x00" dir="recv" name="Move to Level" required="m">
 				<description></description>
 				<payload>
@@ -1416,6 +1423,9 @@ Data Request rate.</description>
 				</attribute>
 				<attribute id="0x400b" name="Color temperature min" type="u16" access="r" range="0x0000,0xffff" default="0" required="m"></attribute>
 				<attribute id="0x400c" name="Color temperature max" type="u16" access="r" range="0x0000,0xffff" default="0xffff" required="m"></attribute>
+				<attribute id="0x4010" name="PowerOn Color Temperature" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
+        <attribute id="0x0003" mfcode="0x100b" name="PowerOn Current X" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
+        <attribute id="0x0004" mfcode="0x100b" name="PowerOn Current Y" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
 				<attribute id="0xde01" name="Active channels" type="u8" access="r" range="0x00,0xff" default="0x00" required="m"></attribute>
 			</attribute-set>
 			<command id="0x00" dir="recv" name="Move to hue" required="o">

--- a/general.xml
+++ b/general.xml
@@ -1424,8 +1424,8 @@ Data Request rate.</description>
 				<attribute id="0x400b" name="Color temperature min" type="u16" access="r" range="0x0000,0xffff" default="0" required="m"></attribute>
 				<attribute id="0x400c" name="Color temperature max" type="u16" access="r" range="0x0000,0xffff" default="0xffff" required="m"></attribute>
 				<attribute id="0x4010" name="PowerOn Color Temperature" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
-        <attribute id="0x0003" mfcode="0x100b" name="PowerOn Current X" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
-        <attribute id="0x0004" mfcode="0x100b" name="PowerOn Current Y" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
+        <attribute id="0x0003" mfcode="0x100b" name="PowerOn X" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
+        <attribute id="0x0004" mfcode="0x100b" name="PowerOn Y" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
 				<attribute id="0xde01" name="Active channels" type="u8" access="r" range="0x00,0xff" default="0x00" required="m"></attribute>
 			</attribute-set>
 			<command id="0x00" dir="recv" name="Move to hue" required="o">


### PR DESCRIPTION
PowerOn attributes for Philips Hue lights with Dec 2018 firmware.

Note that there's two bugs in the deCONZ GUI, see #1014:
- You cannot set _PowerOn OnOff_ to _Previous_ - the GUI generates an invalid command where the value is missing;
- You cannot set _PowerOn X_ or _PowerOn Y_ unless you comment the attribute definitions for the standard _Current X_ and _Current Y_ attributes.