### PR TITLE
Make Samsung devices visible in rest

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -82,7 +82,7 @@ const quint64 osramMacPrefix      = 0x8418260000000000ULL;
 const quint64 bjeMacPrefix        = 0xd85def0000000000ULL;
 const quint64 xalMacPrefix        = 0xf8f0050000000000ULL;
 const quint64 lutronMacPrefix     = 0xffff000000000000ULL;
-const quint64 samjinMacPrefix     = 0xffff000000000000ULL;
+const quint64 samjinMacPrefix     = 0x286d000000000000ULL;
 
 struct SupportedDevice {
     quint16 vendorId;

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -82,6 +82,7 @@ const quint64 osramMacPrefix      = 0x8418260000000000ULL;
 const quint64 bjeMacPrefix        = 0xd85def0000000000ULL;
 const quint64 xalMacPrefix        = 0xf8f0050000000000ULL;
 const quint64 lutronMacPrefix     = 0xffff000000000000ULL;
+const quint64 samjinMacPrefix     = 0xffff000000000000ULL;
 
 struct SupportedDevice {
     quint16 vendorId;
@@ -170,6 +171,8 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_JENNIC, "ZYCT-202", jennicMacPrefix }, // Trust remote control ZYCT-202
     { VENDOR_INNR, "RC 110", jennicMacPrefix }, // innr remote RC 110
     { VENDOR_VISONIC, "MCT-340", emberMacPrefix }, // Visonic MCT-340 E temperature/motion
+    { VENDOR_SAMJIN, "button", samjinMacPrefix }, // Samsung SmartThings Button
+    { VENDOR_SAMJIN, "water", samjinMacPrefix }, // Samsung Leak Sensor
     { 0, nullptr, 0 }
 };
 


### PR DESCRIPTION
Button triggers websocket notifications in rest api, but single, double and hold still aren’t distinguishable from each other.
https://github.com/dresden-elektronik/deconz-rest-plugin/issues/993
https://github.com/dresden-elektronik/deconz-rest-plugin/issues/946