### PR TITLE
Extend strict API mode

### DIFF
--- a/authorisation.cpp
+++ b/authorisation.cpp
@@ -35,9 +35,9 @@ void ApiAuth::setDeviceType(const QString &devtype)
     devicetype = devtype;
 }
 
-/*! Init authentification and security.
+/*! Init authentication.
  */
-void DeRestPluginPrivate::initAuthentification()
+void DeRestPluginPrivate::initAuthentication()
 {
     bool ok = false;
 
@@ -62,7 +62,7 @@ void DeRestPluginPrivate::initAuthentification()
 
         // combine username:password
         QString comb = QString("%1:%2").arg(gwAdminUserName).arg(gwAdminPasswordHash);
-        // create base64 encoded version as used in HTTP basic authentification
+        // create base64 encoded version as used in HTTP basic authentication
         QString hash = comb.toLocal8Bit().toBase64();
 
         gwAdminPasswordHash = encryptString(hash);
@@ -72,7 +72,7 @@ void DeRestPluginPrivate::initAuthentification()
 
 }
 
-/*! Use HTTP basic authentification or HMAC token to check if the request
+/*! Use HTTP basic authentication or HMAC token to check if the request
     has valid credentials to create API key.
  */
 bool DeRestPluginPrivate::allowedToCreateApikey(const ApiRequest &req, ApiResponse &rsp, QVariantMap &map)
@@ -125,11 +125,11 @@ bool DeRestPluginPrivate::allowedToCreateApikey(const ApiRequest &req, ApiRespon
     return false;
 }
 
-/*! Checks if the request is authenticated to access the API.
-    \retval true if authenticated
-    \retval false if not authenticated and the rsp http status is set to 403 Forbidden and JSON error is appended
+/*! Checks if the request is authorised to access the API.
+    \retval true if authorised
+    \retval false if not authorised and the rsp http status is set to 403 Forbidden and JSON error is appended
  */
-bool DeRestPluginPrivate::checkAuthentification(ApiRequest &req, ApiResponse &rsp)
+bool DeRestPluginPrivate::checkAuthorisation(ApiRequest &req, ApiResponse &rsp)
 {
     Q_UNUSED(rsp);
 

--- a/database.cpp
+++ b/database.cpp
@@ -734,7 +734,7 @@ void DeRestPluginPrivate::readDb()
     loadAllGatewaysFromDb();
 }
 
-/*! Sqlite callback to load authentification data.
+/*! Sqlite callback to load authorisation data.
  */
 static int sqliteLoadAuthCallback(void *user, int ncols, char **colval , char **colname)
 {
@@ -793,7 +793,7 @@ static int sqliteLoadAuthCallback(void *user, int ncols, char **colval , char **
     return 0;
 }
 
-/*! Loads all authentification data from database.
+/*! Loads all authorisation data from database.
  */
 void DeRestPluginPrivate::loadAuthFromDb()
 {
@@ -3649,7 +3649,7 @@ void DeRestPluginPrivate::saveDb()
 
     DBG_Printf(DBG_INFO, "DB save zll database items 0x%08X\n", saveDatabaseItems);
 
-    // dump authentification
+    // dump authorisation data
     if (saveDatabaseItems & DB_AUTH)
     {
         std::vector<ApiAuth>::iterator i = apiAuths.begin();

--- a/de_web.pro
+++ b/de_web.pro
@@ -106,7 +106,7 @@ HEADERS  = bindings.h \
            sensor.h \
            websocket_server.h
 
-SOURCES  = authentification.cpp \
+SOURCES  = authorisation.cpp \
            atmel_wsndemo_sensor.cpp \
            bindings.cpp \
            change_channel.cpp \

--- a/de_web.pro
+++ b/de_web.pro
@@ -61,10 +61,12 @@ INCLUDEPATH    += ../.. \
                   ../../common
 
 GIT_COMMIT = $$system("git rev-list HEAD --max-count=1")
+GIT_COMMIT_DATE = $$system("git show -s --format=%cI HEAD")
 
 # Version Major.Minor.Build
 # Important: don't change the format of this line since it's parsed by scripts!
 DEFINES += GW_SW_VERSION=\\\"2.05.50\\\"
+DEFINES += GW_SW_DATE=\\\"$$GIT_COMMIT_DATE\\\"
 DEFINES += GW_API_VERSION=\\\"1.16.0\\\"
 DEFINES += GIT_COMMMIT=\\\"$$GIT_COMMIT\\\" \
 

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -191,7 +191,7 @@ ApiRequest::ApiRequest(const QHttpRequestHeader &h, const QStringList &p, QTcpSo
  */
 QString ApiRequest::apikey() const
 {
-    if (path.length() > 1 && path[0] == "api")
+    if (path.length() > 1 && path[0] == QLatin1String("api"))
     {
         return path.at(1);
     }
@@ -13337,6 +13337,7 @@ int DeRestPlugin::handleHttpRequest(const QHttpRequestHeader &hdr, QTcpSocket *s
     QString content;
     QTextStream stream(sock);
     QHttpRequestHeader hdrmod(hdr);
+    QHostAddress localHost(QHostAddress::LocalHost);
 
     stream.setCodec(QTextCodec::codecForName("UTF-8"));
     d->pushClientForClose(sock, 10, hdr);
@@ -13524,7 +13525,7 @@ int DeRestPlugin::handleHttpRequest(const QHttpRequestHeader &hdr, QTcpSocket *s
             ret = d->deletePassword(req, rsp);
         }
         // GET api/<apikey>/config/wifi
-        else if ((req.path.size() == 4) && (req.hdr.method() == "GET") && (req.path[2] == "config") && (req.path[3] == "wifi"))
+        else if ((req.path.size() == 4) && (req.hdr.method() == "GET") && (req.path[2] == "config") && (req.path[3] == "wifi") && (req.sock->peerAddress() == localHost || auth))
         {
             ret = d->getWifiState(req, rsp);
         }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -402,7 +402,7 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
     initNetworkInfo();
     initUpnpDiscovery();
 
-    initAuthentification();
+    initAuthentication();
     initInternetDicovery();
     initSchedules();
     initPermitJoin();
@@ -13216,7 +13216,7 @@ int DeRestPlugin::handleHttpRequest(const QHttpRequestHeader &hdr, QTcpSocket *s
 
     int ret = REQ_NOT_HANDLED;
 
-    bool auth = d->checkAuthentification(req, rsp);
+    bool auth = d->checkAuthorisation(req, rsp);
 
      // general response to a OPTIONS HTTP method
     if (req.hdr.method() == QLatin1String("OPTIONS"))

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -569,7 +569,7 @@ private:
 
 /*! \class ApiAuth
 
-    Helper to combine serval authentification parameters.
+    Helper to combine serval authorisation parameters.
  */
 class ApiAuth
 {
@@ -677,10 +677,10 @@ public:
     DeRestPluginPrivate(QObject *parent = 0);
     ~DeRestPluginPrivate();
 
-    // REST API authentification
-    void initAuthentification();
+    // REST API authorisation
+    void initAuthentication();
     bool allowedToCreateApikey(const ApiRequest &req, ApiResponse &rsp, QVariantMap &map);
-    bool checkAuthentification(ApiRequest &req, ApiResponse &rsp);
+    bool checkAuthorisation(ApiRequest &req, ApiResponse &rsp);
     QString encryptString(const QString &str);
 
     // REST API gateways
@@ -1230,7 +1230,7 @@ public:
     std::vector<Gateway*> gateways;
     GatewayScanner *gwScanner;
 
-    // authentification
+    // authorisation
     QTime apiAuthSaveDatabaseTime;
     size_t apiAuthCurrent;
     std::vector<ApiAuth> apiAuths;

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -583,7 +583,6 @@ public:
     ApiAuth();
     void setDeviceType(const QString &devtype);
 
-    bool strict;
     bool needSaveDatabase;
     State state;
     QString apikey; // also called username (10..32 chars)
@@ -597,6 +596,14 @@ enum ApiVersion
 {
     ApiVersion_1,      //!< common version 1.0
     ApiVersion_1_DDEL  //!< version 1.0, "Accept: application/vnd.ddel.v1"
+};
+
+enum ApiMode
+{
+    ApiModeNormal,
+    ApiModeStrict,
+    ApiModeEcho,
+    ApiModeHue
 };
 
 /*! \class ApiRequest
@@ -615,7 +622,7 @@ public:
     QTcpSocket *sock;
     QString content;
     ApiVersion version;
-    bool strict;
+    ApiMode mode;
 };
 
 /*! \class ApiResponse
@@ -673,7 +680,7 @@ public:
     // REST API authentification
     void initAuthentification();
     bool allowedToCreateApikey(const ApiRequest &req, ApiResponse &rsp, QVariantMap &map);
-    bool checkApikeyAuthentification(const ApiRequest &req, ApiResponse &rsp);
+    bool checkAuthentification(ApiRequest &req, ApiResponse &rsp);
     QString encryptString(const QString &str);
 
     // REST API gateways
@@ -724,7 +731,7 @@ public:
     int deleteUserParameter(const ApiRequest &req, ApiResponse &rsp);
 
     // REST API lights
-    int handleLightsApi(ApiRequest &req, ApiResponse &rsp);
+    int handleLightsApi(const ApiRequest &req, ApiResponse &rsp);
     int getAllLights(const ApiRequest &req, ApiResponse &rsp);
     int searchNewLights(const ApiRequest &req, ApiResponse &rsp);
     int getNewLights(const ApiRequest &req, ApiResponse &rsp);
@@ -741,7 +748,7 @@ public:
     bool lightToMap(const ApiRequest &req, const LightNode *webNode, QVariantMap &map);
 
     // REST API groups
-    int handleGroupsApi(ApiRequest &req, ApiResponse &rsp);
+    int handleGroupsApi(const ApiRequest &req, ApiResponse &rsp);
     int getAllGroups(const ApiRequest &req, ApiResponse &rsp);
     int createGroup(const ApiRequest &req, ApiResponse &rsp);
     int getGroupAttributes(const ApiRequest &req, ApiResponse &rsp);
@@ -765,7 +772,7 @@ public:
 
     // REST API schedules
     void initSchedules();
-    int handleSchedulesApi(ApiRequest &req, ApiResponse &rsp);
+    int handleSchedulesApi(const ApiRequest &req, ApiResponse &rsp);
     int getAllSchedules(const ApiRequest &req, ApiResponse &rsp);
     int createSchedule(const ApiRequest &req, ApiResponse &rsp);
     int getScheduleAttributes(const ApiRequest &req, ApiResponse &rsp);
@@ -775,14 +782,14 @@ public:
 
     // REST API touchlink
     void initTouchlinkApi();
-    int handleTouchlinkApi(ApiRequest &req, ApiResponse &rsp);
-    int touchlinkScan(ApiRequest &req, ApiResponse &rsp);
-    int getTouchlinkScanResults(ApiRequest &req, ApiResponse &rsp);
-    int identifyLight(ApiRequest &req, ApiResponse &rsp);
-    int resetLight(ApiRequest &req, ApiResponse &rsp);
+    int handleTouchlinkApi(const ApiRequest &req, ApiResponse &rsp);
+    int touchlinkScan(const ApiRequest &req, ApiResponse &rsp);
+    int getTouchlinkScanResults(const ApiRequest &req, ApiResponse &rsp);
+    int identifyLight(const ApiRequest &req, ApiResponse &rsp);
+    int resetLight(const ApiRequest &req, ApiResponse &rsp);
 
     // REST API sensors
-    int handleSensorsApi(ApiRequest &req, ApiResponse &rsp);
+    int handleSensorsApi(const ApiRequest &req, ApiResponse &rsp);
     int getAllSensors(const ApiRequest &req, ApiResponse &rsp);
     int getSensor(const ApiRequest &req, ApiResponse &rsp);
     int getSensorData(const ApiRequest &req, ApiResponse &rsp);
@@ -795,16 +802,16 @@ public:
     int createSensor(const ApiRequest &req, ApiResponse &rsp);
     int getGroupIdentifiers(const ApiRequest &req, ApiResponse &rsp);
     int recoverSensor(const ApiRequest &req, ApiResponse &rsp);
-    bool sensorToMap(const Sensor *sensor, QVariantMap &map, bool strictMode);
+    bool sensorToMap(const Sensor *sensor, QVariantMap &map, const ApiMode mode);
     void handleSensorEvent(const Event &e);
 
     // REST API resourcelinks
-    int handleResourcelinksApi(ApiRequest &req, ApiResponse &rsp);
-    int getAllResourcelinks(ApiRequest &req, ApiResponse &rsp);
-    int getResourcelinks(ApiRequest &req, ApiResponse &rsp);
-    int createResourcelinks(ApiRequest &req, ApiResponse &rsp);
-    int updateResourcelinks(ApiRequest &req, ApiResponse &rsp);
-    int deleteResourcelinks(ApiRequest &req, ApiResponse &rsp);
+    int handleResourcelinksApi(const ApiRequest &req, ApiResponse &rsp);
+    int getAllResourcelinks(const ApiRequest &req, ApiResponse &rsp);
+    int getResourcelinks(const ApiRequest &req, ApiResponse &rsp);
+    int createResourcelinks(const ApiRequest &req, ApiResponse &rsp);
+    int updateResourcelinks(const ApiRequest &req, ApiResponse &rsp);
+    int deleteResourcelinks(const ApiRequest &req, ApiResponse &rsp);
 
     // REST API rules
     int handleRulesApi(const ApiRequest &req, ApiResponse &rsp);
@@ -1290,6 +1297,7 @@ public:
     QString gwBridgeId;
     QString gwUuid;
     QString gwUpdateVersion;
+    QString gwUpdateDate;
     QString gwSwUpdateState;
     QString gwRgbwDisplay;
     QString gwFirmwareVersion;

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -599,6 +599,14 @@ enum ApiVersion
     ApiVersion_1_DDEL  //!< version 1.0, "Accept: application/vnd.ddel.v1"
 };
 
+enum ApiAuthorisation
+{
+    ApiAuthNone,
+    ApiAuthLocal,
+    ApiAuthInternal,
+    ApiAuthFull
+};
+
 enum ApiMode
 {
     ApiModeNormal,
@@ -623,6 +631,7 @@ public:
     QTcpSocket *sock;
     QString content;
     ApiVersion version;
+    ApiAuthorisation auth;
     ApiMode mode;
 };
 
@@ -681,7 +690,7 @@ public:
     // REST API authorisation
     void initAuthentication();
     bool allowedToCreateApikey(const ApiRequest &req, ApiResponse &rsp, QVariantMap &map);
-    bool checkAuthorisation(ApiRequest &req, ApiResponse &rsp);
+    void authorise(ApiRequest &req, ApiResponse &rsp);
     QString encryptString(const QString &str);
 
     // REST API gateways
@@ -695,7 +704,9 @@ public:
 
     // REST API configuration
     void initConfig();
-    int handleConfigurationApi(const ApiRequest &req, ApiResponse &rsp);
+    int handleConfigBasicApi(const ApiRequest &req, ApiResponse &rsp);
+    int handleConfigLocalApi(const ApiRequest &req, ApiResponse &rsp);
+    int handleConfigFullApi(const ApiRequest &req, ApiResponse &rsp);
     int createUser(const ApiRequest &req, ApiResponse &rsp);
     int getFullState(const ApiRequest &req, ApiResponse &rsp);
     int getConfig(const ApiRequest &req, ApiResponse &rsp);

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -1168,7 +1168,7 @@ int DeRestPluginPrivate::getBasicConfig(const ApiRequest &req, ApiResponse &rsp)
 }
 
 /*! GET /api/challenge
-    Creates a new authentification challenge which should be used as HMAC-Sha256(challenge, install code).
+    Creates a new authentication challenge which should be used as HMAC-Sha256(challenge, install code).
     \return REQ_READY_SEND
             REQ_NOT_HANDLED
  */
@@ -2139,7 +2139,7 @@ int DeRestPluginPrivate::deletePassword(const ApiRequest &req, ApiResponse &rsp)
     gwConfig.remove("gwusername");
     gwConfig.remove("gwpassword");
 
-    initAuthentification();
+    initAuthentication();
 
     rsp.httpStatus = HttpStatusOk;
     return REQ_READY_SEND;

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -492,12 +492,81 @@ void DeRestPluginPrivate::configurationChanged()
     \return REQ_READY_SEND
             REQ_NOT_HANDLED
  */
-int DeRestPluginPrivate::handleConfigurationApi(const ApiRequest &req, ApiResponse &rsp)
+int DeRestPluginPrivate::handleConfigBasicApi(const ApiRequest &req, ApiResponse &rsp)
+{
+    // POST /api
+    if ((req.path.size() == 1) && (req.hdr.method() == QLatin1String("POST")))
+    {
+        return createUser(req, rsp);
+    }
+    // GET /api/challenge
+    else if ((req.path.size() == 2) && (req.hdr.method() == QLatin1String("GET")) && (req.path[1] == QLatin1String("challenge")))
+    {
+        return getChallenge(req, rsp);
+    }
+    // GET /api/config
+    else if ((req.path.size() == 2) && (req.hdr.method() == QLatin1String("GET")) && (req.path[1] == QLatin1String("config")))
+    {
+        return getBasicConfig(req, rsp);
+    }
+    // DELETE /api/config/password
+    else if ((req.path.size() == 3) && (req.hdr.method() == QLatin1String("DELETE")) && (req.path[1] == QLatin1String("config")) && (req.path[2] == QLatin1String("password")))
+    {
+        return deletePassword(req, rsp);
+    }
+    // GET /api/<nouser>/config
+    else if ((req.path.size() == 3) && (req.hdr.method() == QLatin1String("GET")) && (req.path[2] == QLatin1String("config")))
+    {
+        return getBasicConfig(req, rsp);
+    }
+
+    return REQ_NOT_HANDLED;
+}
+
+/*! Configuration REST API broker.
+    \param req - request data
+    \param rsp - response data
+    \return REQ_READY_SEND
+            REQ_NOT_HANDLED
+ */
+int DeRestPluginPrivate::handleConfigLocalApi(const ApiRequest &req, ApiResponse &rsp)
+{
+    // GET api/<localuser>/config/wifi
+    if ((req.path.size() == 4) && (req.hdr.method() == QLatin1String("GET")) && (req.path[2] == QLatin1String("config")) && (req.path[3] == QLatin1String("wifi")))
+    {
+        return getWifiState(req, rsp);
+    }
+    // PUT /api/<localuser>/config/wifi/updated
+    else if ((req.path.size() == 5) && (req.hdr.method() == QLatin1String("PUT")) && (req.path[2] == QLatin1String("config")) && (req.path[3] == QLatin1String("wifi")) && (req.path[4] == QLatin1String("updated")))
+    {
+        return putWifiUpdated(req, rsp);
+    }
+    // PUT /api/<localuser>/config/wifi/scanresult
+    else if ((req.path.size() == 5) && (req.hdr.method() == QLatin1String("PUT")) && (req.path[2] == QLatin1String("config")) && (req.path[3] == QLatin1String("wifi")) && (req.path[4] == QLatin1String("scanresult")))
+    {
+        return putWifiScanResult(req, rsp);
+    }
+
+    return REQ_NOT_HANDLED;
+}
+
+/*! Configuration REST API broker.
+    \param req - request data
+    \param rsp - response data
+    \return REQ_READY_SEND
+            REQ_NOT_HANDLED
+ */
+int DeRestPluginPrivate::handleConfigFullApi(const ApiRequest &req, ApiResponse &rsp)
 {
     // GET /api/<apikey>/config
     if ((req.path.size() == 3) && (req.hdr.method() == "GET") && (req.path[2] == "config"))
     {
         return getConfig(req, rsp);
+    }
+    // GET api/<apikey>/config/wifi
+    else if ((req.path.size() == 4) && (req.hdr.method() == "GET") && (req.path[2] == "config") && (req.path[3] == "wifi"))
+    {
+        return getWifiState(req, rsp);
     }
     // PUT /api/<apikey>/config/wifi
     else if ((req.path.size() == 4) && (req.hdr.method() == "PUT") && (req.path[2] == "config") && (req.path[3] == "wifi"))

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -499,11 +499,6 @@ int DeRestPluginPrivate::handleConfigurationApi(const ApiRequest &req, ApiRespon
     {
         return getConfig(req, rsp);
     }
-    // GET /api/<apikey>/config/wifi
-    else if ((req.path.size() == 4) && (req.hdr.method() == "GET") && (req.path[2] == "config") && (req.path[3] == "wifi"))
-    {
-        return getWifiState(req, rsp);
-    }
     // PUT /api/<apikey>/config/wifi
     else if ((req.path.size() == 4) && (req.hdr.method() == "PUT") && (req.path[2] == "config") && (req.path[3] == "wifi"))
     {
@@ -2210,16 +2205,6 @@ void DeRestPluginPrivate::checkRfConnectState()
 int DeRestPluginPrivate::getWifiState(const ApiRequest &req, ApiResponse &rsp)
 {
     Q_UNUSED(req);
-
-    QHostAddress localHost(QHostAddress::LocalHost);
-    if (req.sock->peerAddress() == localHost || checkApikeyAuthentification(req, rsp))
-    {
-        // continue
-    }
-    else
-    {
-        return REQ_READY_SEND;
-    }
 
     rsp.map["wifi"] = gwWifi;
     rsp.map["wifitype"] = gwWifiType;

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -76,6 +76,7 @@ void DeRestPluginPrivate::initConfig()
     gwZigbeeChannel = 0;
     gwName = GW_DEFAULT_NAME;
     gwUpdateVersion = GW_SW_VERSION; // will be replaced by discovery handler
+    gwUpdateDate = GW_SW_DATE;
     gwSwUpdateState = swUpdateState.noUpdate;
     gwUpdateChannel = "stable";
     gwReportingEnabled = (deCONZ::appArgumentNumeric("--reporting", 1) == 1) ? true : false;
@@ -816,10 +817,10 @@ void DeRestPluginPrivate::configToMap(const ApiRequest &req, QVariantMap &map)
     }
     else
     {
-        if (req.strict)
+        if (req.mode != ApiModeNormal)
         {
-            map["swversion"] = QLatin1String("01038802");
-            map["apiversion"] = QLatin1String("1.20.0");
+            map["swversion"] = QLatin1String("1810251352");
+            map["apiversion"] = QLatin1String("1.28.0");
             map["modelid"] = QLatin1String("BSB002");
         }
         devicetypes["bridge"] = false;
@@ -846,7 +847,7 @@ void DeRestPluginPrivate::configToMap(const ApiRequest &req, QVariantMap &map)
     }
 
     bridge["state"] = gwSwUpdateState;
-    bridge["lastinstall"] = "";
+    bridge["lastinstall"] = gwUpdateDate;
     swupdate2["bridge"] = bridge;
     swupdate2["checkforupdate"] = false;
     swupdate2["state"] = gwSwUpdateState;
@@ -1024,7 +1025,7 @@ int DeRestPluginPrivate::getFullState(const ApiRequest &req, ApiResponse &rsp)
                 continue;
             }
             QVariantMap map;
-            if (sensorToMap(&(*i), map, req.strict))
+            if (sensorToMap(&(*i), map, req.mode))
             {
                 sensorsMap[i->id()] = map;
             }
@@ -1747,6 +1748,7 @@ int DeRestPluginPrivate::deleteUser(const ApiRequest &req, ApiResponse &rsp)
  */
 int DeRestPluginPrivate::updateSoftware(const ApiRequest &req, ApiResponse &rsp)
 {
+    Q_UNUSED(req);
     rsp.httpStatus = HttpStatusOk;
     QVariantMap rspItem;
     QVariantMap rspItemState;
@@ -1773,6 +1775,7 @@ int DeRestPluginPrivate::updateSoftware(const ApiRequest &req, ApiResponse &rsp)
  */
 int DeRestPluginPrivate::restartGateway(const ApiRequest &req, ApiResponse &rsp)
 {
+    Q_UNUSED(req);
     rsp.httpStatus = HttpStatusOk;
     QVariantMap rspItem;
     QVariantMap rspItemState;
@@ -1801,6 +1804,7 @@ int DeRestPluginPrivate::restartGateway(const ApiRequest &req, ApiResponse &rsp)
  */
 int DeRestPluginPrivate::restartApp(const ApiRequest &req, ApiResponse &rsp)
 {
+    Q_UNUSED(req);
     rsp.httpStatus = HttpStatusOk;
     QVariantMap rspItem;
     QVariantMap rspItemState;
@@ -1827,6 +1831,7 @@ int DeRestPluginPrivate::restartApp(const ApiRequest &req, ApiResponse &rsp)
  */
 int DeRestPluginPrivate::shutDownGateway(const ApiRequest &req, ApiResponse &rsp)
 {
+    Q_UNUSED(req);
     rsp.httpStatus = HttpStatusOk;
     QVariantMap rspItem;
     QVariantMap rspItemState;
@@ -1855,6 +1860,7 @@ int DeRestPluginPrivate::shutDownGateway(const ApiRequest &req, ApiResponse &rsp
  */
 int DeRestPluginPrivate::updateFirmware(const ApiRequest &req, ApiResponse &rsp)
 {
+    Q_UNUSED(req);
     if (startUpdateFirmware())
     {
         rsp.httpStatus = HttpStatusOk;
@@ -1878,6 +1884,7 @@ int DeRestPluginPrivate::updateFirmware(const ApiRequest &req, ApiResponse &rsp)
  */
 int DeRestPluginPrivate::exportConfig(const ApiRequest &req, ApiResponse &rsp)
 {
+    Q_UNUSED(req);
     if (exportConfiguration())
     {
         rsp.httpStatus = HttpStatusOk;
@@ -1901,6 +1908,7 @@ int DeRestPluginPrivate::exportConfig(const ApiRequest &req, ApiResponse &rsp)
  */
 int DeRestPluginPrivate::importConfig(const ApiRequest &req, ApiResponse &rsp)
 {
+    Q_UNUSED(req);
     if (importConfiguration())
     {
         rsp.httpStatus = HttpStatusOk;

--- a/rest_groups.cpp
+++ b/rest_groups.cpp
@@ -1772,7 +1772,7 @@ bool DeRestPluginPrivate::groupToMap(const ApiRequest &req, const Group *group, 
         else if (item->descriptor().suffix == RAttrClass) { map["class"] = item->toString(); }
         else if (item->descriptor().suffix == RAttrUniqueId) { map["uniqueid"] = item->toString(); }
     }
-    if (map["type"] == "LightGroup")
+    if (map["type"] != QLatin1String("Room"))
     {
         map.remove("class");
     }

--- a/rest_groups.cpp
+++ b/rest_groups.cpp
@@ -23,7 +23,7 @@
     \return REQ_READY_SEND
             REQ_NOT_HANDLED
  */
-int DeRestPluginPrivate::handleGroupsApi(ApiRequest &req, ApiResponse &rsp)
+int DeRestPluginPrivate::handleGroupsApi(const ApiRequest &req, ApiResponse &rsp)
 {
     if (req.path[2] != QLatin1String("groups"))
     {
@@ -158,7 +158,6 @@ int DeRestPluginPrivate::getAllGroups(const ApiRequest &req, ApiResponse &rsp)
 /*! POST /api/<apikey>/groups
     \return REQ_READY_SEND
             REQ_NOT_HANDLED
-    \note currently not in Philips API 1.0
  */
 int DeRestPluginPrivate::createGroup(const ApiRequest &req, ApiResponse &rsp)
 {
@@ -211,7 +210,7 @@ int DeRestPluginPrivate::createGroup(const ApiRequest &req, ApiResponse &rsp)
     }
 
     // class
-    if (map.contains("class"))
+    if (type == "Room" && map.contains("class"))
     {
         ok = false;
         QString gclass = map["class"].toString();
@@ -1772,6 +1771,10 @@ bool DeRestPluginPrivate::groupToMap(const ApiRequest &req, const Group *group, 
         //else if (item->descriptor().suffix == RAttrModelId) { map["modelid"] = item->toString(); }; // not supported yet
         else if (item->descriptor().suffix == RAttrClass) { map["class"] = item->toString(); }
         else if (item->descriptor().suffix == RAttrUniqueId) { map["uniqueid"] = item->toString(); }
+    }
+    if (map["type"] == "LightGroup")
+    {
+        map.remove("class");
     }
 
     map["id"] = group->id();

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -25,7 +25,7 @@
     \return REQ_READY_SEND
             REQ_NOT_HANDLED
  */
-int DeRestPluginPrivate::handleLightsApi(ApiRequest &req, ApiResponse &rsp)
+int DeRestPluginPrivate::handleLightsApi(const ApiRequest &req, ApiResponse &rsp)
 {
     if (req.path[2] != QLatin1String("lights"))
     {
@@ -220,13 +220,6 @@ bool DeRestPluginPrivate::lightToMap(const ApiRequest &req, const LightNode *lig
         return false;
     }
 
-    if (apiAuthCurrent >= apiAuths.size())
-    {
-        return false;
-    }
-
-    const ApiAuth &auth = apiAuths[apiAuthCurrent];
-
     QVariantMap state;
     const ResourceItem *ix = 0;
     const ResourceItem *iy = 0;
@@ -284,7 +277,7 @@ bool DeRestPluginPrivate::lightToMap(const ApiRequest &req, const LightNode *lig
     map["modelid"] = lightNode->modelId(); // real model id
     map["manufacturername"] = lightNode->manufacturer();
 
-    if (!auth.strict)
+    if (req.mode != ApiModeEcho)
     {
         map["hascolor"] = lightNode->hasColor();
     }
@@ -292,7 +285,7 @@ bool DeRestPluginPrivate::lightToMap(const ApiRequest &req, const LightNode *lig
     map["type"] = lightNode->type();
 
     // Amazon Echo quirks mode
-    if (auth.strict && auth.devicetype.startsWith(QLatin1String("Echo")))
+    if (req.mode == ApiModeEcho)
     {
         // OSRAM plug + Ubisys S1/S2
         if (lightNode->type().startsWith(QLatin1String("On/Off")))

--- a/rest_resourcelinks.cpp
+++ b/rest_resourcelinks.cpp
@@ -22,7 +22,7 @@
     \return REQ_READY_SEND
             REQ_NOT_HANDLED
  */
-int DeRestPluginPrivate::handleResourcelinksApi(ApiRequest &req, ApiResponse &rsp)
+int DeRestPluginPrivate::handleResourcelinksApi(const ApiRequest &req, ApiResponse &rsp)
 {
     if (req.path[2] != QLatin1String("resourcelinks"))
     {
@@ -64,7 +64,7 @@ int DeRestPluginPrivate::handleResourcelinksApi(ApiRequest &req, ApiResponse &rs
     \return REQ_READY_SEND
             REQ_NOT_HANDLED
  */
-int DeRestPluginPrivate::getAllResourcelinks(ApiRequest &req, ApiResponse &rsp)
+int DeRestPluginPrivate::getAllResourcelinks(const ApiRequest &req, ApiResponse &rsp)
 {
     Q_UNUSED(req);
     for (const Resourcelinks &rl : resourcelinks)
@@ -91,7 +91,7 @@ int DeRestPluginPrivate::getAllResourcelinks(ApiRequest &req, ApiResponse &rsp)
     \return REQ_READY_SEND
             REQ_NOT_HANDLED
  */
-int DeRestPluginPrivate::getResourcelinks(ApiRequest &req, ApiResponse &rsp)
+int DeRestPluginPrivate::getResourcelinks(const ApiRequest &req, ApiResponse &rsp)
 {
     DBG_Assert(req.path.size() == 4);
     const QString &id = req.path[3];
@@ -117,7 +117,7 @@ int DeRestPluginPrivate::getResourcelinks(ApiRequest &req, ApiResponse &rsp)
     \return REQ_READY_SEND
             REQ_NOT_HANDLED
  */
-int DeRestPluginPrivate::createResourcelinks(ApiRequest &req, ApiResponse &rsp)
+int DeRestPluginPrivate::createResourcelinks(const ApiRequest &req, ApiResponse &rsp)
 {
     rsp.httpStatus = HttpStatusOk;
 
@@ -234,7 +234,7 @@ int DeRestPluginPrivate::createResourcelinks(ApiRequest &req, ApiResponse &rsp)
     \return REQ_READY_SEND
             REQ_NOT_HANDLED
  */
-int DeRestPluginPrivate::updateResourcelinks(ApiRequest &req, ApiResponse &rsp)
+int DeRestPluginPrivate::updateResourcelinks(const ApiRequest &req, ApiResponse &rsp)
 {
     bool ok;
     int errors = 0;
@@ -330,7 +330,7 @@ int DeRestPluginPrivate::updateResourcelinks(ApiRequest &req, ApiResponse &rsp)
     \return REQ_READY_SEND
             REQ_NOT_HANDLED
  */
-int DeRestPluginPrivate::deleteResourcelinks(ApiRequest &req, ApiResponse &rsp)
+int DeRestPluginPrivate::deleteResourcelinks(const ApiRequest &req, ApiResponse &rsp)
 {
     DBG_Assert(req.path.size() == 4);
     const QString &id = req.path[3];

--- a/rest_rules.cpp
+++ b/rest_rules.cpp
@@ -1548,7 +1548,7 @@ void DeRestPluginPrivate::triggerRule(Rule &rule)
         }
         else if (path[2] == QLatin1String("config"))
         {
-            if (handleConfigurationApi(req, rsp) == REQ_NOT_HANDLED)
+            if (handleConfigFullApi(req, rsp) == REQ_NOT_HANDLED)
             {
                 return;
             }

--- a/rest_scenes.cpp
+++ b/rest_scenes.cpp
@@ -19,6 +19,7 @@
  */
 int DeRestPluginPrivate::handleScenesApi(const ApiRequest &req, ApiResponse &rsp)
 {
+    Q_UNUSED(req);
     if (rsp.map.isEmpty())
     {
         rsp.str = "{}"; // return empty object

--- a/rest_schedules.cpp
+++ b/rest_schedules.cpp
@@ -33,7 +33,7 @@ void DeRestPluginPrivate::initSchedules()
     \return REQ_READY_SEND
             REQ_NOT_HANDLED
  */
-int DeRestPluginPrivate::handleSchedulesApi(ApiRequest &req, ApiResponse &rsp)
+int DeRestPluginPrivate::handleSchedulesApi(const ApiRequest &req, ApiResponse &rsp)
 {
     if (req.path[2] != "schedules")
     {

--- a/rest_touchlink.cpp
+++ b/rest_touchlink.cpp
@@ -77,7 +77,7 @@ void DeRestPluginPrivate::initTouchlinkApi()
     \return REQ_READY_SEND
             REQ_NOT_HANDLED
  */
-int DeRestPluginPrivate::handleTouchlinkApi(ApiRequest &req, ApiResponse &rsp)
+int DeRestPluginPrivate::handleTouchlinkApi(const ApiRequest &req, ApiResponse &rsp)
 {
     if (req.path[2] != "touchlink")
     {
@@ -114,7 +114,7 @@ int DeRestPluginPrivate::handleTouchlinkApi(ApiRequest &req, ApiResponse &rsp)
     \return REQ_READY_SEND
             REQ_NOT_HANDLED
  */
-int DeRestPluginPrivate::touchlinkScan(ApiRequest &req, ApiResponse &rsp)
+int DeRestPluginPrivate::touchlinkScan(const ApiRequest &req, ApiResponse &rsp)
 {
     Q_UNUSED(req);
 
@@ -151,7 +151,7 @@ int DeRestPluginPrivate::touchlinkScan(ApiRequest &req, ApiResponse &rsp)
     \return REQ_READY_SEND
             REQ_NOT_HANDLED
  */
-int DeRestPluginPrivate::getTouchlinkScanResults(ApiRequest &req, ApiResponse &rsp)
+int DeRestPluginPrivate::getTouchlinkScanResults(const ApiRequest &req, ApiResponse &rsp)
 {
     Q_UNUSED(req);
     rsp.httpStatus = HttpStatusOk;
@@ -194,7 +194,7 @@ int DeRestPluginPrivate::getTouchlinkScanResults(ApiRequest &req, ApiResponse &r
     \return REQ_READY_SEND
             REQ_NOT_HANDLED
  */
-int DeRestPluginPrivate::identifyLight(ApiRequest &req, ApiResponse &rsp)
+int DeRestPluginPrivate::identifyLight(const ApiRequest &req, ApiResponse &rsp)
 {
     /*
      * - disconnect
@@ -258,7 +258,7 @@ int DeRestPluginPrivate::identifyLight(ApiRequest &req, ApiResponse &rsp)
     \return REQ_READY_SEND
             REQ_NOT_HANDLED
  */
-int DeRestPluginPrivate::resetLight(ApiRequest &req, ApiResponse &rsp)
+int DeRestPluginPrivate::resetLight(const ApiRequest &req, ApiResponse &rsp)
 {
     /*
      * - disconnect


### PR DESCRIPTION
Extend strict api mode to: normal, strict, amazon echo, philips hue app
Whitelist supported sensors for the Hue app (some such as ZHAAlarm crash the app), this fixes #663, nr 1
Only rooms can have classes (LightGroups with a class breaks Hue app)
Some consistency changes and warning fixes
Update Hue version and add software date
Mimic hue dimmer switches for some compatible other switches
Terminology

