### PR TITLE
Add support for Bitron smoke detector 902010/24

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -3151,7 +3151,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     }
                     else if (modelId.startsWith(QLatin1String("GAS_")) ||             // Heiman gas sensor
                              modelId.startsWith(QLatin1String("SMOK_")) ||            // Heiman fire sensor
-							 modelId.startsWith(QLatin1String("902010/24")) ||        // Bitron smoke detector
+                             modelId.startsWith(QLatin1String("902010/24")) ||        // Bitron smoke detector
                              modelId.startsWith(QLatin1String("lumi.sensor_smoke")))  // Xiaomi Mi smoke sensor
                     {
                         // Gas sensor detects combustable gas, so fire is more appropriate than CO.

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -104,7 +104,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_NONE, "BX_", tiMacPrefix }, // Climax siren
     { VENDOR_NONE, "PSMD_", tiMacPrefix }, // Climax smart plug
     { VENDOR_NONE, "OJB-IR715-Z", tiMacPrefix },
-    { VENDOR_NONE, "902010/21A", tiMacPrefix }, // Bitron: door/window sensor
+    { VENDOR_NONE, "902010/21", tiMacPrefix }, // Bitron: door/window sensor
     { VENDOR_NONE, "902010/24", tiMacPrefix }, // Bitron: smoke detector
     { VENDOR_NONE, "902010/25", tiMacPrefix }, // Bitron: smart plug
     { VENDOR_BITRON, "902010/32", emberMacPrefix }, // Bitron: thermostat

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -3151,6 +3151,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     }
                     else if (modelId.startsWith(QLatin1String("GAS_")) ||             // Heiman gas sensor
                              modelId.startsWith(QLatin1String("SMOK_")) ||            // Heiman fire sensor
+							 modelId.startsWith(QLatin1String("902010/24")) ||        // Bitron smoke detector
                              modelId.startsWith(QLatin1String("lumi.sensor_smoke")))  // Xiaomi Mi smoke sensor
                     {
                         // Gas sensor detects combustable gas, so fire is more appropriate than CO.

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -105,6 +105,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_NONE, "PSMD_", tiMacPrefix }, // Climax smart plug
     { VENDOR_NONE, "OJB-IR715-Z", tiMacPrefix },
     { VENDOR_NONE, "902010/21A", tiMacPrefix }, // Bitron: door/window sensor
+    { VENDOR_NONE, "902010/24", tiMacPrefix }, // Bitron: smoke detector
     { VENDOR_NONE, "902010/25", tiMacPrefix }, // Bitron: smart plug
     { VENDOR_BITRON, "902010/32", emberMacPrefix }, // Bitron: thermostat
     { VENDOR_DDEL, "Lighting Switch", deMacPrefix },

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -105,6 +105,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_NONE, "PSMD_", tiMacPrefix }, // Climax smart plug
     { VENDOR_NONE, "OJB-IR715-Z", tiMacPrefix },
     { VENDOR_NONE, "902010/21", tiMacPrefix }, // Bitron: door/window sensor
+    { VENDOR_NONE, "902010/22", tiMacPrefix }, // Bitron: motion sensor
     { VENDOR_NONE, "902010/24", tiMacPrefix }, // Bitron: smoke detector
     { VENDOR_NONE, "902010/25", tiMacPrefix }, // Bitron: smart plug
     { VENDOR_BITRON, "902010/32", emberMacPrefix }, // Bitron: thermostat
@@ -3145,7 +3146,8 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     {
                         fpOpenCloseSensor.inClusters.push_back(ci->id());
                     }
-                    else if (modelId.startsWith(QLatin1String("PIR_")))               // Heiman motion sensor
+                    else if (modelId.startsWith(QLatin1String("PIR_")) ||             // Heiman motion sensor
+                             modelId.startsWith(QLatin1String("902010/22")))          // Bitron motion sensor
                     {
                         fpPresenceSensor.inClusters.push_back(ci->id());
                     }


### PR DESCRIPTION
Add Bitron smoke detector 902010/24

```
{
        "config": {
            "on": true,
            "reachable": true
        },
        "ep": 1,
        "etag": "90f0140d0c8eaa982b3e7675ec28ab14",
        "manufacturername": "Bitron Home",
        "modelid": "902010/24",
        "name": "Alarm 18",
        "state": {
            "alarm": false,
            "lastupdated": "none",
            "lowbattery": false,
            "tampered": false
        },
        "type": "ZHAAlarm",
        "uniqueid": "00:12:4b:00:07:7f:13:44-01-0500"
    },
```