### PR TITLE
lumi.curtain

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2206,6 +2206,45 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
                     }
                 }
             }
+            else if (ic->id() == ANALOG_OUTPUT_CLUSTER_ID && (event.clusterId() == ANALOG_OUTPUT_CLUSTER_ID))
+            {
+                if (!(lightNode->modelId().startsWith(QLatin1String("lumi.curtain"))))
+                {
+                    continue; // ignore except for lumi.curtain
+                }
+
+                std::vector<deCONZ::ZclAttribute>::const_iterator ia = ic->attributes().begin();
+                std::vector<deCONZ::ZclAttribute>::const_iterator enda = ic->attributes().end();
+                for (;ia != enda; ++ia)
+                {
+                    if (ia->id() == 0x0055) // Present Value
+                    {
+                        uint8_t level = 255 * (100 - ia->numericValue().real) / 100;
+                        ResourceItem *item = lightNode->item(RStateBri);
+                        if (item && item->toNumber() != level)
+                        {
+                            DBG_Printf(DBG_INFO, "0x%016llX level %u --> %u\n", lightNode->address().ext(), (uint)item->toNumber(), level);
+                            item->setValue(level);
+                            Event e(RLights, RStateBri, lightNode->id(), item);
+                            enqueueEvent(e);
+                            updated = true;
+                        }
+                        bool on = level > 0;
+                        item = lightNode->item(RStateOn);
+                        if (item && item->toBool() != on)
+                        {
+                            DBG_Printf(DBG_INFO, "0x%016llX onOff %u --> %u\n", lightNode->address().ext(), (uint)item->toNumber(), on);
+                            item->setValue(on);
+                            Event e(RLights, RStateOn, lightNode->id(), item);
+                            enqueueEvent(e);
+                            updated = true;
+                        }
+                        lightNode->setZclValue(updateType, event.clusterId(), 0x0055, ia->numericValue());
+                        pushZclValueDb(event.node()->address().ext(), event.endpoint(), event.clusterId(), ia->id(), ia->numericValue().real);
+                        break;
+                    }
+                }
+            }
         }
 
         break;
@@ -9353,6 +9392,7 @@ void DeRestPluginPrivate::nodeEvent(const deCONZ::NodeEvent &event)
         case GROUP_CLUSTER_ID:
         case SCENE_CLUSTER_ID:
         case COLOR_CLUSTER_ID:
+        case ANALOG_OUTPUT_CLUSTER_ID: // lumi.curtain
         case WINDOW_COVERING_CLUSTER_ID:  // FIXME ubisys J1 is not a light
             {
                 updateLightNode(event);

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -158,6 +158,7 @@
 #define LEVEL_CLUSTER_ID                      0x0008
 #define TIME_CLUSTER_ID                       0x000A
 #define ANALOG_INPUT_CLUSTER_ID               0x000C
+#define ANALOG_OUTPUT_CLUSTER_ID              0x000D
 #define BINARY_INPUT_CLUSTER_ID               0x000F
 #define MULTISTATE_INPUT_CLUSTER_ID           0x0012
 #define OTAU_CLUSTER_ID                       0x0019


### PR DESCRIPTION
Use reports for _Analog Output_ cluster to set `state.bri` and `state.on` as a backup in case _Window Covering_ reports fails.