### PR TITLE
Support more switches

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1264,6 +1264,9 @@ void DeRestPluginPrivate::checkLightBindingsForAttributeReporting(LightNode *lig
         else if (lightNode->modelId() == QLatin1String("NL08-0800")) // Nanoleaf Ivy
         {
         }
+        else if (lightNode->modelId() == QLatin1String("ICZB-IW11D")) // iCasa Dimmer
+        {
+        }
         else
         {
             return;
@@ -1410,8 +1413,9 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId() == QLatin1String("SML001") ||
         sensor->modelId().startsWith(QLatin1String("RWL02")) ||
         // ubisys
-        sensor->modelId().startsWith(QLatin1String("D1")) ||
         sensor->modelId().startsWith(QLatin1String("C4")) ||
+        sensor->modelId().startsWith(QLatin1String("D1")) ||
+        sensor->modelId().startsWith(QLatin1String("S1")) ||
         sensor->modelId().startsWith(QLatin1String("S2")) ||
         // IKEA
         sensor->modelId().startsWith(QLatin1String("TRADFRI")) ||
@@ -1811,6 +1815,17 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
         srcEndpoints.push_back(0x03);
         sensor->setMgmtBindSupported(true);
     }
+    else if (sensor->modelId().startsWith(QLatin1String("S1")))
+    {
+        clusters.push_back(ONOFF_CLUSTER_ID);
+        clusters.push_back(LEVEL_CLUSTER_ID);
+        srcEndpoints.push_back(0x02);
+        if (sensor->modelId().startsWith(QLatin1String("S1-R")))
+        {
+            srcEndpoints.push_back(0x03);
+        }
+        sensor->setMgmtBindSupported(true);
+    }
     else if (sensor->modelId().startsWith(QLatin1String("S2")))
     {
         clusters.push_back(ONOFF_CLUSTER_ID);
@@ -2182,6 +2197,13 @@ void DeRestPluginPrivate::processUbisysBinding(Sensor *sensor, const Binding &bn
             if       (bnd.srcEndpoint == 0x02) { pos = 0; }
             else if  (bnd.srcEndpoint == 0x03) { pos = 1; }
 
+        }
+        else if (sensor->modelId().startsWith(QLatin1String("S1")))
+        {
+            DBG_Assert(sensor->fingerPrint().endpoint == 0x02);
+
+            if       (bnd.srcEndpoint == 0x02) { pos = 0; }
+            else if  (bnd.srcEndpoint == 0x03) { pos = 1; } // S1-R only
         }
         else if (sensor->modelId().startsWith(QLatin1String("S2")))
         {

--- a/database.cpp
+++ b/database.cpp
@@ -3250,6 +3250,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
 
 //            int n = 0;
 //            if      (sensor.modelId().startsWith(QLatin1String("D1"))) { n = 2; }
+//            else if (sensor.modelId().startsWith(QLatin1String("S1-R"))) { n = 2; }
 //            else if (sensor.modelId().startsWith(QLatin1String("S1"))) { n = 1; }
 //            else if (sensor.modelId().startsWith(QLatin1String("S2"))) { n = 2; }
 //            else if (sensor.modelId().startsWith(QLatin1String("C4"))) { n = 4; }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -66,7 +66,6 @@ static uint MaxGroupTasks = 4;
 const quint64 macPrefixMask       = 0xffffff0000000000ULL;
 
 const quint64 ikeaMacPrefix       = 0x000b570000000000ULL;
-const quint64 silabsMacPrefix     = 0x90fd9f0000000000ULL;
 const quint64 emberMacPrefix      = 0x000d6f0000000000ULL;
 const quint64 instaMacPrefix      = 0x000f170000000000ULL;
 const quint64 tiMacPrefix         = 0x00124b0000000000ULL;
@@ -80,6 +79,7 @@ const quint64 keenhomeMacPrefix   = 0x0022a30000000000ULL;
 const quint64 heimanMacPrefix     = 0x0050430000000000ULL;
 const quint64 stMacPrefix         = 0x24fd5b0000000000ULL;
 const quint64 osramMacPrefix      = 0x8418260000000000ULL;
+const quint64 silabsMacPrefix     = 0x90fd9f0000000000ULL;
 const quint64 bjeMacPrefix        = 0xd85def0000000000ULL;
 const quint64 xalMacPrefix        = 0xf8f0050000000000ULL;
 const quint64 lutronMacPrefix     = 0xffff000000000000ULL;
@@ -145,10 +145,11 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_115F, "lumi.plug", jennicMacPrefix }, // Xiaomi smart plug (router)
     { VENDOR_115F, "lumi.ctrl_ln", jennicMacPrefix}, // Xiaomi Wall Switch (router)
     // { VENDOR_115F, "lumi.curtain", jennicMacPrefix}, // Xiaomi curtain controller (router) - exposed only as light
-    { VENDOR_UBISYS, "D1", ubisysMacPrefix },
     { VENDOR_UBISYS, "C4", ubisysMacPrefix },
-    { VENDOR_UBISYS, "S2", ubisysMacPrefix },
+    { VENDOR_UBISYS, "D1", ubisysMacPrefix },
     { VENDOR_UBISYS, "J1", ubisysMacPrefix },
+    { VENDOR_UBISYS, "S1", ubisysMacPrefix },
+    { VENDOR_UBISYS, "S2", ubisysMacPrefix },
     { VENDOR_NONE, "Z716A", netvoxMacPrefix },
     // { VENDOR_OSRAM_STACK, "Plug", osramMacPrefix }, // OSRAM plug - exposed only as light
     { VENDOR_OSRAM_STACK, "CO_", heimanMacPrefix }, // Heiman CO sensor
@@ -171,6 +172,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_JENNIC, "ZYCT-202", jennicMacPrefix }, // Trust remote control ZYCT-202
     { VENDOR_INNR, "RC 110", jennicMacPrefix }, // innr remote RC 110
     { VENDOR_VISONIC, "MCT-340", emberMacPrefix }, // Visonic MCT-340 E temperature/motion
+    { VENDOR_1224, "ICZB-KPD1", emberMacPrefix }, // iCasa keypad
     { 0, nullptr, 0 }
 };
 
@@ -535,6 +537,10 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
                     else if (sensorNode->modelId().startsWith("C4"))
                     {
                         sensorNode = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), 0x01);
+                    }
+                    else if (sensorNode->modelId().startsWith("S1"))
+                    {
+                        sensorNode = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), 0x02);
                     }
                     else if (sensorNode->modelId().startsWith("S2"))
                     {
@@ -3498,6 +3504,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                         if ((modelId.startsWith(QLatin1String("D1")) && i->endpoint() == 0x02) ||
                             (modelId.startsWith(QLatin1String("J1")) && i->endpoint() == 0x02) ||
                             (modelId.startsWith(QLatin1String("C4")) && i->endpoint() == 0x01) ||
+                            (modelId.startsWith(QLatin1String("S1")) && i->endpoint() == 0x02) ||
                             (modelId.startsWith(QLatin1String("S2")) && i->endpoint() == 0x03))
                         {
                             // Combine multiple switch endpoints into a single ZHASwitch resource
@@ -4885,7 +4892,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 {
                                     int bat = ia->numericValue().u8 / 2;
 
-                                    if (i->modelId().startsWith("TRADFRI"))
+                                    if (i->modelId().startsWith("TRADFRI") || i->modelId().startsWith("ICZB-KPD1"))
                                     {
                                         bat = ia->numericValue().u8;
                                     }
@@ -14651,8 +14658,8 @@ void DeRestPluginPrivate::pushSensorInfoToCore(Sensor *sensor)
 
     if (sensor->modelId().startsWith(QLatin1String("FLS-NB")))
     { } // use name from light
-    else if (sensor->modelId().startsWith(QLatin1String("D1")) || sensor->modelId().startsWith(QLatin1String("S2")) ||
-             sensor->modelId().startsWith(QLatin1String("lumi.ctrl_")))
+    else if (sensor->modelId().startsWith(QLatin1String("D1")) || sensor->modelId().startsWith(QLatin1String("S1")) ||
+             sensor->modelId().startsWith(QLatin1String("S2")) ||sensor->modelId().startsWith(QLatin1String("lumi.ctrl_")))
     { } // use name from light
     else if (sensor->type() == QLatin1String("ZHAConsumption") || sensor->type() == QLatin1String("ZHAPower"))
     { } // use name from light

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -266,9 +266,10 @@
 #define VENDOR_BUSCH_JAEGER 0x112E
 #define VENDOR_PAULMANN     0x119D
 #define VENDOR_120B         0x120B // Used by Heiman
+#define VENDOR_1224         0x1224 // Used by iCasa keypads
 #define VENDOR_XAL          0x122A
-#define VENDOR_OSRAM_STACK  0xBBAA
 #define VENDOR_SAMJIN       0x1241
+#define VENDOR_OSRAM_STACK  0xBBAA
 
 #define ANNOUNCE_INTERVAL 10 // minutes default announce interval
 

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -466,6 +466,27 @@ static const Sensor::ButtonMap innrRC110Map[] = {
     { Sensor::ModeNone,             0x00, 0x0000, 0x00, 0,    0,                                           nullptr }
 };
 
+static const Sensor::ButtonMap icasaKeypadMap[] = {
+//    mode                          ep    cluster cmd   param button                                       name
+    // Off button
+    { Sensor::ModeScenes,           0x01, 0x0006, 0x00, 0,    S_BUTTON_1 + S_BUTTON_ACTION_SHORT_RELEASED, "Off" },
+    { Sensor::ModeScenes,           0x01, 0x0008, 0x05, 1,    S_BUTTON_1 + S_BUTTON_ACTION_HOLD, "Move down (with on/off)" },
+    { Sensor::ModeScenes,           0x01, 0x0008, 0x07, 1,    S_BUTTON_1 + S_BUTTON_ACTION_LONG_RELEASED, "Stop_ (with on/off)" },
+    // On button
+    { Sensor::ModeScenes,           0x01, 0x0006, 0x01, 0,    S_BUTTON_2 + S_BUTTON_ACTION_SHORT_RELEASED, "On" },
+    { Sensor::ModeScenes,           0x01, 0x0008, 0x05, 0,    S_BUTTON_2 + S_BUTTON_ACTION_HOLD, "Move up (with on/off)" },
+    { Sensor::ModeScenes,           0x01, 0x0008, 0x07, 0,    S_BUTTON_2 + S_BUTTON_ACTION_LONG_RELEASED, "Stop_ (with on/off)" },
+    // Scene buttons
+    { Sensor::ModeScenes,           0x01, 0x0005, 0x05, 1,    S_BUTTON_3 + S_BUTTON_ACTION_SHORT_RELEASED, "Recall scene 1" },
+    { Sensor::ModeScenes,           0x01, 0x0005, 0x05, 2,    S_BUTTON_4 + S_BUTTON_ACTION_SHORT_RELEASED, "Recall scene 2" },
+    { Sensor::ModeScenes,           0x01, 0x0005, 0x05, 3,    S_BUTTON_5 + S_BUTTON_ACTION_SHORT_RELEASED, "Recall scene 3" },
+    { Sensor::ModeScenes,           0x01, 0x0005, 0x05, 4,    S_BUTTON_6 + S_BUTTON_ACTION_SHORT_RELEASED, "Recall scene 4" },
+    { Sensor::ModeScenes,           0x01, 0x0005, 0x05, 5,    S_BUTTON_7 + S_BUTTON_ACTION_SHORT_RELEASED, "Recall scene 5" },
+    { Sensor::ModeScenes,           0x01, 0x0005, 0x05, 6,    S_BUTTON_8 + S_BUTTON_ACTION_SHORT_RELEASED, "Recall scene 6" },
+    // end
+    { Sensor::ModeNone,             0x00, 0x0000, 0x00, 0,    0,                                           nullptr }
+};
+
 /*! Returns a fingerprint as JSON string. */
 QString SensorFingerprint::toString() const
 {
@@ -989,6 +1010,7 @@ const Sensor::ButtonMap *Sensor::buttonMap()
         {
             if      (modelid.startsWith(QLatin1String("D1"))) { m_buttonMap = ubisysD1Map; }
             else if (modelid.startsWith(QLatin1String("C4"))) { m_buttonMap = ubisysC4Map; }
+            else if (modelid.startsWith(QLatin1String("S1"))) { m_buttonMap = ubisysD1Map; }
             else if (modelid.startsWith(QLatin1String("S2"))) { m_buttonMap = ubisysS2Map; }
         }
         else if (manufacturer == QLatin1String("LUMI"))
@@ -1008,6 +1030,10 @@ const Sensor::ButtonMap *Sensor::buttonMap()
         else if (manufacturer == QLatin1String("innr"))
         {
             if      (modelid.startsWith(QLatin1String("RC 110"))) { m_buttonMap = innrRC110Map; }
+        }
+        else if (manufacturer == QLatin1String("icasa"))
+        {
+            if      (modelid.startsWith(QLatin1String("ICZB-KPD1"))) { m_buttonMap = icasaKeypadMap; }
         }
     }
 


### PR DESCRIPTION
- ubisys S1, S1-R (untested), see #919;
- iCasa keypads, see #1124;
- iCasa dimmer, see #1124.

@manup there's still two loose ends:
- I cannot get deCONZ to create the binding and attribute reporting for the iCasa dimmer.  Don't know what's going on; I reset and re-paired my Trådfri colour bulb, but no bindings for that either.  deCONZ happily polls the lights.  Even after creating the binding manually, the report configuration isn't set.  After setting that manually as well, deCONZ stops polling the lights.  This is my test network (2.05.54, self compiled plugin from latest commits), with only two lights (the iCasa dimmer and the Trådfri).
- The iCasa keypads don't support attribute reporting for the battery, so deCONZ needs to poll them.  The good news: they seem to poll their parent at any button click.  The bad news: I'm lost were in the code to implement this - please help.