### PR TITLE
Poll battery percentage remaining for sensors.

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -13424,7 +13424,7 @@ void DeRestPlugin::idleTimerFired()
                         if (*ci == POWER_CONFIGURATION_CLUSTER_ID)
                         {
                             val = sensorNode->getZclValue(*ci, 0x0021); // battery percentage remaining
-                            if (!val.timestamp.isValid() || val.timestamp.secsTo(now) > 300)
+                            if (!val.timestamp.isValid() || val.timestamp.secsTo(now) > 1800)
                             {
                                 sensorNode->enableRead(READ_BATTERY);
                                 sensorNode->setLastRead(READ_BATTERY, d->idleTotalCounter);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -13423,14 +13423,17 @@ void DeRestPlugin::idleTimerFired()
 
                         if (*ci == POWER_CONFIGURATION_CLUSTER_ID)
                         {
-                            val = sensorNode->getZclValue(*ci, 0x0021); // battery percentage remaining
-                            if (!val.timestamp.isValid() || val.timestamp.secsTo(now) > 1800)
+                            if (sensorNode->modelId().startsWith(QLatin1String("ICZB-KPD1"))) // iCasa Pulse keypads
                             {
-                                sensorNode->enableRead(READ_BATTERY);
-                                sensorNode->setLastRead(READ_BATTERY, d->idleTotalCounter);
-                                sensorNode->setNextReadTime(READ_BATTERY, d->queryTime);
-                                d->queryTime = d->queryTime.addSecs(tSpacing);
-                                processSensors = true;
+                                val = sensorNode->getZclValue(*ci, 0x0021); // battery percentage remaining
+                                if (!val.timestamp.isValid() || val.timestamp.secsTo(now) > 1800)
+                                {
+                                    sensorNode->enableRead(READ_BATTERY);
+                                    sensorNode->setLastRead(READ_BATTERY, d->idleTotalCounter);
+                                    sensorNode->setNextReadTime(READ_BATTERY, d->queryTime);
+                                    d->queryTime = d->queryTime.addSecs(tSpacing);
+                                    processSensors = true;
+                                }
                             }
                         }
                     }

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -226,6 +226,7 @@
 #define READ_OCCUPANCY_CONFIG  (1 << 10)
 #define READ_GROUP_IDENTIFIERS (1 << 12)
 #define READ_THERMOSTAT_STATE  (1 << 17)
+#define READ_BATTERY           (1 << 18)
 
 #define READ_MODEL_ID_INTERVAL   (60 * 60) // s
 #define READ_SWBUILD_ID_INTERVAL (60 * 60) // s

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -531,6 +531,7 @@ struct TaskItem
         colorY = 0;
         colorTemperature = 0;
         transitionTime = DEFAULT_TRANSITION_TIME;
+        onTime = 0;
         sendTime = 0;
         ordered = false;
     }
@@ -562,6 +563,7 @@ struct TaskItem
     qint32 inc; // bri_inc, hue_inc, sat_inc, ct_inc
     QString etag;
     uint16_t transitionTime;
+    uint16_t onTime;
     QTcpSocket *client;
 
     bool autoMode; // true then this is a automode task

--- a/general.xml
+++ b/general.xml
@@ -629,6 +629,12 @@
 			<attribute id = "0011" name="On Level" type="u8" range="0x00,0xfe" access="rw" required="o" default="0xfe">
 				<description>The OnLevel attribute determines the value that the CurrentLevel attribute is set to when the OnOff attribute of an On/Off cluster on the same endpoint is set to On. If the OnLevel attribute is not implemented, or is set to 0xff, it has no effect.</description>
 			</attribute>
+      <attribute id = "0012" name="On Transition Time" type="u16" range="0x0000,0xfffe" access="rw" required="o">
+			</attribute>
+      <attribute id = "0013" name="Off Transition Time" type="u16" range="0x0000,0xfffe" access="rw" required="o">
+			</attribute>
+      <attribute id = "0014" name="Default Move Rate" type="u8" range="0x00,0xfe" access="rw" required="o">
+      </attribute>
 			<attribute id="0x4000" name="PowerOn Level" type="u8" access="rw" required="o">
       </attribute>
 			<command id="0x00" dir="recv" name="Move to Level" required="m">

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -2095,7 +2095,7 @@ void DeRestPluginPrivate::handleSensorEvent(const Event &e)
                     {
                         continue;
                     }
-                    if (item->lastSet().isValid() && (gwWebSocketNotifyAll || (item->lastChanged().isValid() && item->lastChanged() >= sensor->lastStatePush)))
+                    if (item->lastSet().isValid() && (gwWebSocketNotifyAll || (item->lastChanged().isValid() && item->lastChanged() >= sensor->lastConfigPush)))
                     {
                         config[key] = item->toVariant();
                     }


### PR DESCRIPTION
Poll battery percentage remaining (0x0001/0x0021) for `/sensors` resources  The change is for the iCasa Pulse keypads, which don't offer attribute reporting, see #1124.

@manup, please review.  This is working fine in my test network, but I worry about the potential performance implications, and battery usage implications for other devices, see https://github.com/dresden-elektronik/deconz-rest-plugin/issues/1124#issuecomment-456207910.

