### PR TITLE
Fix GLEDOPTO bugs

### DIFF
--- a/light_node.cpp
+++ b/light_node.cpp
@@ -366,7 +366,14 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
                 }
                 else if (i->id() == COLOR_CLUSTER_ID)
                 {
-                    addItem(DataTypeString, RStateColorMode)->setValue(QVariant("hs"));
+                    if (manufacturerCode() == VENDOR_NONE && deviceId == DEV_ID_ZLL_DIMMABLE_LIGHT)
+                    {
+                        // GLEDOPTO GL-C-009 advertises non-functional color cluster
+                    }
+                    else
+                    {
+                        addItem(DataTypeString, RStateColorMode)->setValue(QVariant("hs"));
+                    }
 
                     if (modelId() == QLatin1String("lumi.light.aqcn02"))
                     {

--- a/light_node.cpp
+++ b/light_node.cpp
@@ -383,7 +383,7 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
                     {
                         addItem(DataTypeUInt16, RConfigColorCapabilities);
                         addItem(DataTypeUInt16, RConfigCtMin);
-                        addItem(DataTypeUInt16, RConfigCtMax);
+                        addItem(DataTypeUInt16, RConfigCtMax)->setValue(65535);
                         addItem(DataTypeUInt16, RStateCt);
 
                         if (deviceId == DEV_ID_Z30_COLOR_TEMPERATURE_LIGHT ||


### PR DESCRIPTION
See #1204, #1205.
- Set default `ctmax` value to 65535 instead of 0.
- Don't expose `state.colormode` for GL-C-009 _Dimmable Light_ endpoint, even though it advertises a non-functional _Color Control_ cluster.