### PR TITLE
Whitelist newer model Heiman gas sensor

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -163,7 +163,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_OSRAM_STACK, "CO_", heimanMacPrefix }, // Heiman CO sensor
     { VENDOR_OSRAM_STACK, "DOOR_", heimanMacPrefix }, // Heiman door/window sensor
     { VENDOR_OSRAM_STACK, "PIR_", heimanMacPrefix }, // Heiman motion sensor
-    { VENDOR_OSRAM_STACK, "GAS_", heimanMacPrefix }, // Heiman gas sensor
+    { VENDOR_OSRAM_STACK, "GAS_", heimanMacPrefix }, // Heiman gas sensor - older model
     { VENDOR_OSRAM_STACK, "TH-H_", heimanMacPrefix }, // Heiman temperature/humidity sensor
     { VENDOR_OSRAM_STACK, "TH-T_", heimanMacPrefix }, // Heiman temperature/humidity sensor
     { VENDOR_OSRAM_STACK, "SMOK_", heimanMacPrefix }, // Heiman fire sensor - older model
@@ -171,6 +171,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_LGE, "LG IP65 HMS", emberMacPrefix },
     { VENDOR_EMBER, "SmartPlug", emberMacPrefix }, // Heiman smart plug
     { VENDOR_120B, "SmartPlug", emberMacPrefix }, // Heiman smart plug
+    { VENDOR_120B, "GAS", emberMacPrefix }, // Heiman gas sensor - newer model
     { VENDOR_120B, "Smoke", emberMacPrefix }, // Heiman fire sensor - newer model
     { VENDOR_120B, "WarningDevice", emberMacPrefix }, // Heiman siren
     { VENDOR_LUTRON, "LZL4BWHL01", lutronMacPrefix }, // Lutron LZL-4B-WH-L01 Connected Bulb Remote


### PR DESCRIPTION
I’ve bought a new Heiman HC1CG-E gas sensor. They use a new manufacturer code and model ID: `GASSensor-EM`.

I followed 059af72001a13eb1afc2bf238fa071e5e4bd7f8d and added the new prefix. (I haven’t compiled nor tested this change.)

![F2EACF39-072D-4EE1-B82F-61FA63B2E773](https://user-images.githubusercontent.com/1612377/54116204-8c803280-43ee-11e9-8f82-bc55925a1a7f.jpeg)