### PR TITLE
Don't create ZHASwitch for lumi.vibration

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5932,7 +5932,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 ResourceItem *item = i->item(RStateConsumption);
 
                                 if (i->modelId() == QLatin1String("SmartPlug") || // Heiman
-                                    i->modelId().startsWith("PSMP5_")) // Climax
+                                    i->modelId().startsWith(QLatin1String("PSMP5_"))) // Climax
                                 {
                                     consumption += 5; consumption /= 10; // 0.1 Wh -> Wh
                                 }
@@ -5961,7 +5961,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
 
                                 if (i->modelId() == QLatin1String("SmartPlug") || // Heiman
                                     i->modelId() == QLatin1String("902010/25") || // Bitron
-                                    i->modelId().startsWith("PSMP5_")) // Climax
+                                    i->modelId().startsWith(QLatin1String("PSMP5_"))) // Climax
                                 {
                                     power += 5; power /= 10; // 0.1 W -> W
                                 }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5931,7 +5931,8 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 quint64 consumption = ia->numericValue().u64;
                                 ResourceItem *item = i->item(RStateConsumption);
 
-                                if (i->modelId() == QLatin1String("SmartPlug")) // Heiman
+                                if (i->modelId() == QLatin1String("SmartPlug") || // Heiman
+                                    i->modelId().startsWith("PSMP5_")) // Climax
                                 {
                                     consumption += 5; consumption /= 10; // 0.1 Wh -> Wh
                                 }
@@ -5959,7 +5960,8 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 ResourceItem *item = i->item(RStatePower);
 
                                 if (i->modelId() == QLatin1String("SmartPlug") || // Heiman
-                                    i->modelId() == QLatin1String("902010/25")) // Bitron
+                                    i->modelId() == QLatin1String("902010/25") || // Bitron
+                                    i->modelId().startsWith("PSMP5_")) // Climax
                                 {
                                     power += 5; power /= 10; // 0.1 W -> W
                                 }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -3527,7 +3527,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                 {
                     if (modelId.startsWith(QLatin1String("lumi.vibration"))) // lumi.vibration
                     {
-                        fpSwitch.inClusters.push_back(DOOR_LOCK_CLUSTER_ID);
+                        // fpSwitch.inClusters.push_back(DOOR_LOCK_CLUSTER_ID);
                         fpVibrationSensor.inClusters.push_back(DOOR_LOCK_CLUSTER_ID);
                     }
                 }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1249,7 +1249,8 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
     if (node->nodeDescriptor().manufacturerCode() == VENDOR_KEEN_HOME || // Keen Home Vent
         node->nodeDescriptor().manufacturerCode() == VENDOR_JENNIC || // Xiaomi lumi.ctrl_neutral1, lumi.ctrl_neutral2
         node->nodeDescriptor().manufacturerCode() == VENDOR_EMBER || // atsmart Z6-03 switch
-        node->nodeDescriptor().manufacturerCode() == VENDOR_NONE) // Climax Siren
+        node->nodeDescriptor().manufacturerCode() == VENDOR_NONE || // Climax Siren
+        node->nodeDescriptor().manufacturerCode() == VENDOR_1233) // Third Reality smart light switch
     {
         // whitelist
     }

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -262,7 +262,6 @@
 #define VENDOR_LUTRON       0x1144
 #define VENDOR_KEEN_HOME    0x115B
 #define VENDOR_115F         0x115F // Used by Xiaomi Aqara
-#define VENDOR_1234         0x1234 // Used by Xiaomi Mi
 #define VENDOR_INNR         0x1166
 #define VENDOR_INNR2        0x1168
 #define VENDOR_INSTA        0x117A
@@ -274,6 +273,8 @@
 #define VENDOR_MUELLER      0x121B // Used by Mueller Licht
 #define VENDOR_1224         0x1224 // Used by iCasa keypads
 #define VENDOR_XAL          0x122A
+#define VENDOR_1233         0x1233 // Used by Third Reality
+#define VENDOR_1234         0x1234 // Used by Xiaomi Mi
 #define VENDOR_SAMJIN       0x1241
 #define VENDOR_OSRAM_STACK  0xBBAA
 


### PR DESCRIPTION
Don't create ZHASwitch for lumi.vibration when creating ZHAVibration, to prevent two sensor resources with the same `uniqueid`.  See #748.

Fix scaling of `state.consumption` and `state.power` for Climax power switch, see #1409.

Whitelist Third Reality smart light switch, see #1413.