### PR TITLE
Set tiltangle to 0 by defaut.

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6138,6 +6138,13 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     const quint16 value = ia->numericValue().u16;
                                     DBG_Printf(DBG_INFO, "0x%016llX: 0x0101/0x0055: event: %d\n", event.node()->address().ext(), value);
 
+                                    //Set tiltangle to 0 by defaut, but without queueEvent
+                                    ResourceItem *item = i->item(RStateTiltAngle);
+                                    if (item)
+                                    {
+                                        item->setValue(0);
+                                    }
+
                                     if (value == 0x0001) // vibration
                                     {
                                         ResourceItem *item = i->item(RStateVibration);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6128,6 +6128,15 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
 
                             if (i->modelId().startsWith(QLatin1String("lumi.vibration")) && i->type() == QLatin1String("ZHAVibration"))
                             {
+
+                                //Set tiltangle to 0 by defaut, but without queueEvent
+                                ResourceItem *item = i->item(RStateTiltAngle);
+                                if (item)
+                                {
+                                    item->setValue(0);
+                                    enqueueEvent(Event(RSensors, RStateTiltAngle, i->id(), item));
+                                }
+                                
                                 if (ia->id() == 0x0055) // u16: event type
                                 {
                                     if (updateType != NodeValue::UpdateInvalid)
@@ -6137,13 +6146,6 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     }
                                     const quint16 value = ia->numericValue().u16;
                                     DBG_Printf(DBG_INFO, "0x%016llX: 0x0101/0x0055: event: %d\n", event.node()->address().ext(), value);
-
-                                    //Set tiltangle to 0 by defaut, but without queueEvent
-                                    ResourceItem *item = i->item(RStateTiltAngle);
-                                    if (item)
-                                    {
-                                        item->setValue(0);
-                                    }
 
                                     if (value == 0x0001) // vibration
                                     {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6134,7 +6134,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 if (item)
                                 {
                                     item->setValue(0);
-                                    enqueueEvent(Event(RSensors, RStateTiltAngle, i->id(), item));
+                                    //enqueueEvent(Event(RSensors, RStateTiltAngle, i->id(), item));
                                 }
                                 
                                 if (ia->id() == 0x0055) // u16: event type

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -2510,13 +2510,23 @@ void DeRestPluginPrivate::checkSensorStateTimerFired()
                 }
                 else if (!item && sensor->modelId() == QLatin1String("lumi.vibration.aq1") && sensor->type() == QLatin1String("ZHAVibration"))
                 {
+                    //Set tiltangle to 0 by defaut but without QueueEvent
+                    item = sensor->item(RStateTiltAngle);
+                    if (item && item->toNumber() != 0)
+                    {
+                        DBG_Printf(DBG_INFO, "sensor %s (%s): reset tiltangle\n", qPrintable(sensor->id()), qPrintable(sensor->modelId()));
+                        item->setValue(0);
+                        //enqueueEvent(Event(RSensors, RStateTiltAngle, sensor->id(), item));
+                        //enqueueEvent(Event(RSensors, RStateLastUpdated, sensor->id()));
+                    }
+                    
                     item = sensor->item(RStateVibration);
                     if (item && item->toBool())
                     {
                         DBG_Printf(DBG_INFO, "sensor %s (%s): disable vibration\n", qPrintable(sensor->id()), qPrintable(sensor->modelId()));
                         item->setValue(false);
                         sensor->updateStateTimestamp();
-                        enqueueEvent(Event(RSensors, RStatePresence, sensor->id(), item));
+                        enqueueEvent(Event(RSensors, RStateVibration, sensor->id(), item));
                         enqueueEvent(Event(RSensors, RStateLastUpdated, sensor->id()));
                     }
                 }


### PR DESCRIPTION
With this modification you will have a value in "tiltangle" field ONLY if there is a mouvement.
For exemple, if you make vibration without mouvements, this value will be 0.
There is only one modification, you will have 2 notifications (like before) : 1 with "tiltangle" with the value, and a second one with "orientation" but now with a 0 value in "tiltangle".