### PR TITLE
Fix GLEDOPTO lights not reporting the correct value for Enhanced Color Mode

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2147,6 +2147,11 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
                             //DBG_Printf(DBG_INFO, "Ignore color mode (0x0008) in favor for enhanced color mode (0x4001) for Ikea light 0x%016llx\n", lightNode->address().ext());
                             continue;
                         }
+                        if (ia->id() == 0x4001 && lightNode->manufacturer() == QLatin1String("GLEDOPTO"))
+                        {
+                            //DBG_Printf(DBG_INFO, "Ignore enhanced color mode (0x4001) in favor for color mode (0x0008) for GLEDOPTO light 0x%016llx\n", lightNode->address().ext());
+                            continue;
+                        }
 
                         uint8_t cm = ia->numericValue().u8;
                         {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4419,7 +4419,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             sensorNode.setManufacturer("OSRAM");
         }
     }
-    else if ((node->nodeDescriptor().manufacturerCode() == VENDOR_119C)) 
+    else if ((node->nodeDescriptor().manufacturerCode() == VENDOR_119C))
     {
         sensorNode.setManufacturer("Sinope");
     }
@@ -7567,16 +7567,16 @@ bool DeRestPluginPrivate::processZclAttributes(Sensor *sensorNode)
         }
     }
 
-    if (sensorNode->mustRead(READ_BATTERY) && tNow > sensorNode->nextReadTime(READ_BATTERY))
-    {
-        std::vector<uint16_t> attributes;
-        attributes.push_back(0x0021); // battery percentage remaining
-        if (readAttributes(sensorNode, sensorNode->fingerPrint().endpoint, POWER_CONFIGURATION_CLUSTER_ID, attributes))
-        {
-            sensorNode->clearRead(READ_BATTERY);
-            processed++;
-        }
-    }
+    // if (sensorNode->mustRead(READ_BATTERY) && tNow > sensorNode->nextReadTime(READ_BATTERY))
+    // {
+    //     std::vector<uint16_t> attributes;
+    //     attributes.push_back(0x0021); // battery percentage remaining
+    //     if (readAttributes(sensorNode, sensorNode->fingerPrint().endpoint, POWER_CONFIGURATION_CLUSTER_ID, attributes))
+    //     {
+    //         sensorNode->clearRead(READ_BATTERY);
+    //         processed++;
+    //     }
+    // }
 
     return (processed > 0);
 }
@@ -14097,21 +14097,21 @@ void DeRestPlugin::idleTimerFired()
                             }
                         }
 
-                        if (*ci == POWER_CONFIGURATION_CLUSTER_ID)
-                        {
-                            if (sensorNode->modelId().startsWith(QLatin1String("ICZB-KPD1"))) // iCasa Pulse keypads
-                            {
-                                val = sensorNode->getZclValue(*ci, 0x0021); // battery percentage remaining
-                                if (!val.timestamp.isValid() || val.timestamp.secsTo(now) > 1800)
-                                {
-                                    sensorNode->enableRead(READ_BATTERY);
-                                    sensorNode->setLastRead(READ_BATTERY, d->idleTotalCounter);
-                                    sensorNode->setNextReadTime(READ_BATTERY, d->queryTime);
-                                    d->queryTime = d->queryTime.addSecs(tSpacing);
-                                    processSensors = true;
-                                }
-                            }
-                        }
+                        // if (*ci == POWER_CONFIGURATION_CLUSTER_ID)
+                        // {
+                        //     if (sensorNode->modelId().startsWith(QLatin1String("ICZB-KPD1"))) // iCasa Pulse keypads
+                        //     {
+                        //         val = sensorNode->getZclValue(*ci, 0x0021); // battery percentage remaining
+                        //         if (!val.timestamp.isValid() || val.timestamp.secsTo(now) > 1800)
+                        //         {
+                        //             sensorNode->enableRead(READ_BATTERY);
+                        //             sensorNode->setLastRead(READ_BATTERY, d->idleTotalCounter);
+                        //             sensorNode->setNextReadTime(READ_BATTERY, d->queryTime);
+                        //             d->queryTime = d->queryTime.addSecs(tSpacing);
+                        //             processSensors = true;
+                        //         }
+                        //     }
+                        // }
                     }
 
                     DBG_Printf(DBG_INFO_L2, "Force read attributes for SensorNode %s\n", qPrintable(sensorNode->name()));

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -232,7 +232,7 @@
 #define READ_OCCUPANCY_CONFIG  (1 << 10)
 #define READ_GROUP_IDENTIFIERS (1 << 12)
 #define READ_THERMOSTAT_STATE  (1 << 17)
-#define READ_BATTERY           (1 << 18)
+// #define READ_BATTERY           (1 << 18)
 
 #define READ_MODEL_ID_INTERVAL   (60 * 60) // s
 #define READ_SWBUILD_ID_INTERVAL (60 * 60) // s


### PR DESCRIPTION
Fix GLEDOPTO lights not reporting the correct value for _Enhanced Color Mode_, see #1526.

I no longer have the old RGB+CCT model, so I cannot test whether it actually has the same issue, but I don't think the change will do any harm (as long as _Color Mode_ is supported). They use manufacturer code 0x0000, so I whitelist the manufacturer name instead.