### PR TITLE
Several small api fixes

### DIFF
--- a/rest_resourcelinks.cpp
+++ b/rest_resourcelinks.cpp
@@ -162,6 +162,7 @@ int DeRestPluginPrivate::createResourcelinks(const ApiRequest &req, ApiResponse 
         QVariantMap available;
         available["name"] = static_cast<uint>(QVariant::String);
         available["description"] = static_cast<uint>(QVariant::String);
+        available["type"] = static_cast<uint>(QVariant::String);
         available["classid"] = static_cast<uint>(QVariant::Double);
         available["links"] = static_cast<uint>(QVariant::List);
         available["recycle"] = static_cast<uint>(QVariant::Bool);

--- a/rest_rules.cpp
+++ b/rest_rules.cpp
@@ -843,7 +843,7 @@ bool DeRestPluginPrivate::checkActions(QVariantList actionsList, ApiResponse &rs
         }
 
         //no dublicate addresses allowed
-        const char *resources[] = { "groups", "lights", "schedules", "sensors", "rules", nullptr };
+        const char *resources[] = { "groups", "lights", "schedules", "scenes", "sensors", "rules", nullptr };
 
         for (int i = 0; ; i++)
         {
@@ -1564,6 +1564,22 @@ void DeRestPluginPrivate::triggerRule(Rule &rule)
         else if (path[2] == QLatin1String("lights"))
         {
             if (handleLightsApi(req, rsp) == REQ_NOT_HANDLED)
+            {
+                return;
+            }
+            triggered = true;
+        }
+        else if (path[2] == QLatin1String("schedules"))
+        {
+            if (handleSchedulesApi(req, rsp) == REQ_NOT_HANDLED)
+            {
+                return;
+            }
+            triggered = true;
+        }
+        else if (path[2] == QLatin1String("scenes"))
+        {
+            if (handleScenesApi(req, rsp) == REQ_NOT_HANDLED)
             {
                 return;
             }

--- a/rest_schedules.cpp
+++ b/rest_schedules.cpp
@@ -713,7 +713,7 @@ bool DeRestPluginPrivate::jsonToSchedule(const QString &jsonString, Schedule &sc
     }
 
     // check required parameters
-    if (!(map.contains("command") && map.contains("time")))
+    if (!(map.contains("command") && (map.contains("time") || map.contains("localtime"))))
     {
         if (rsp)
         {

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -300,7 +300,7 @@ int DeRestPluginPrivate::createSensor(const ApiRequest &req, ApiResponse &rsp)
 
     for (; pi != pend; ++pi)
     {
-        if(!((pi.key() == "name") || (pi.key() == "modelid") || (pi.key() == "swversion") || (pi.key() == "type")  || (pi.key() == "uniqueid")  || (pi.key() == "manufacturername")  || (pi.key() == "state")  || (pi.key() == "config")))
+        if(!((pi.key() == "name") || (pi.key() == "modelid") || (pi.key() == "swversion") || (pi.key() == "type")  || (pi.key() == "uniqueid")  || (pi.key() == "manufacturername")  || (pi.key() == "state")  || (pi.key() == "config")  || (pi.key() == "recycle")))
         {
             rsp.list.append(errorToMap(ERR_PARAMETER_NOT_AVAILABLE, QString("/sensors/%2").arg(pi.key()), QString("parameter, %1, not available").arg(pi.key())));
             rsp.httpStatus = HttpStatusBadRequest;
@@ -892,11 +892,6 @@ int DeRestPluginPrivate::updateSensor(const ApiRequest &req, ApiResponse &rsp)
         error = true;
         rsp.list.append(errorToMap(ERR_PARAMETER_NOT_AVAILABLE, QString("/sensors/state"), QString("parameter, state, not modifiable")));
     }
-    if (map.contains("config"))
-    {
-        error = true;
-        rsp.list.append(errorToMap(ERR_PARAMETER_NOT_AVAILABLE, QString("/sensors/config"), QString("parameter, config, not modifiable")));
-    }
 
     if (error)
     {
@@ -961,6 +956,15 @@ int DeRestPluginPrivate::updateSensor(const ApiRequest &req, ApiResponse &rsp)
             rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/sensors/%1/mode").arg(id), QString("invalid value, %1, for parameter, /sensors/%2/mode").arg((int)mode).arg(id)));
             rsp.httpStatus = HttpStatusBadRequest;
         }
+    }
+
+    if (map.contains("config")) // optional
+    {
+        QStringList path = req.path;
+        path.append(QLatin1String("config"));
+        QString content = Json::serialize(map[QLatin1String("config")].toMap());
+        ApiRequest req2(req.hdr, path, NULL, content);
+        return changeSensorConfig(req2, rsp);
     }
 
     return REQ_READY_SEND;


### PR DESCRIPTION
- allow "type" as a resourcelink attribute on creation (even though there is only one option)
- allow schedules and scenes actions in rules
- a schedule is also valid if providing localtime instead of time as a required attribute
- also allow a sensor config as a json dictionary

Together this enables me to set up a Hue dimmer switch and a Hue motion sensor from the Hue app.