### PR TITLE
Implement "group 0" as a regular zigbee group

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -1040,6 +1040,18 @@ static int sqliteLoadConfigCallback(void *user, int ncols, char **colval , char 
             }
         }
     }
+    else if (strcmp(colval[0], "group0") == 0)
+    {
+        if (!val.isEmpty())
+        {
+            uint group0 = val.toUInt(&ok);
+            if (ok && (group0 <= 65535))
+            {
+                d->gwGroup0 = group0;
+                d->gwConfig["group0"] = (uint16_t)group0;
+            }
+        }
+    }
     else if (strcmp(colval[0], "updatechannel") == 0)
     {
         if ((val == "stable") || (val == "alpha") || (val == "beta"))
@@ -3976,6 +3988,7 @@ void DeRestPluginPrivate::saveDb()
         gwConfig["announceurl"] = gwAnnounceUrl;
         gwConfig["groupdelay"] = gwGroupSendDelay;
         gwConfig["zigbeechannel"] = gwZigbeeChannel;
+        gwConfig["group0"] = gwGroup0;
         gwConfig["gwusername"] = gwAdminUserName;
         gwConfig["gwpassword"] = gwAdminPasswordHash;
         gwConfig["homebridge"] = gwHomebridge;

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1418,6 +1418,7 @@ public:
     QString gwUpdateChannel;
     int gwGroupSendDelay;
     uint gwZigbeeChannel;
+    uint16_t gwGroup0;
     QVariantMap gwConfig;
     QString gwSensorsEtag;
     QString gwLightsEtag;

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -79,6 +79,7 @@ void DeRestPluginPrivate::initConfig()
     gwRgbwDisplay = "1";
     gwTimeFormat = "12h";
     gwZigbeeChannel = 0;
+    gwGroup0 = 0;
     gwName = GW_DEFAULT_NAME;
     gwUpdateVersion = GW_SW_VERSION; // will be replaced by discovery handler
     {

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -1136,7 +1136,7 @@ int DeRestPluginPrivate::getFullState(const ApiRequest &req, ApiResponse &rsp)
                 continue;
             }
 
-            if (i->id() != "0")
+            if (i->address() != gwGroup0) // don't return special group 0
             {
                 QVariantMap map;
                 if (groupToMap(req, &(*i), map))

--- a/rest_groups.cpp
+++ b/rest_groups.cpp
@@ -137,7 +137,7 @@ int DeRestPluginPrivate::getAllGroups(const ApiRequest &req, ApiResponse &rsp)
             continue;
         }
 
-        if (i->address() != 0) // don't return special group 0
+        if (i->address() != gwGroup0) // don't return special group 0
         {
             QVariantMap mnode;
             groupToMap(req, &(*i), mnode);
@@ -750,18 +750,8 @@ int DeRestPluginPrivate::setGroupState(const ApiRequest &req, ApiResponse &rsp)
     rsp.httpStatus = HttpStatusOk;
 
     // set destination parameters
-    if (id == "0")
-    {
-        // use a broadcast
-        taskRef.req.dstAddress().setNwk(deCONZ::BroadcastRouters);
-        taskRef.req.dstAddress().setGroup(0); // taskToLocal() needs this
-        taskRef.req.setDstAddressMode(deCONZ::ApsNwkAddress);
-    }
-    else
-    {
-        taskRef.req.dstAddress().setGroup(group->address());
-        taskRef.req.setDstAddressMode(deCONZ::ApsGroupAddress);
-    }
+    taskRef.req.dstAddress().setGroup(group->address());
+    taskRef.req.setDstAddressMode(deCONZ::ApsGroupAddress);
     taskRef.req.setDstEndpoint(0xFF); // broadcast endpoint
     taskRef.req.setSrcEndpoint(getSrcEndpoint(0, taskRef.req));
 
@@ -1729,7 +1719,7 @@ int DeRestPluginPrivate::deleteGroup(const ApiRequest &req, ApiResponse &rsp)
 
     userActivity();
 
-    if (!group || (group->state() == Group::StateDeleted))
+    if (!group || (group->state() == Group::StateDeleted) || (group->address() == gwGroup0))
     {
         rsp.httpStatus = HttpStatusNotFound;
         rsp.list.append(errorToMap(ERR_RESOURCE_NOT_AVAILABLE, QString("/groups/%1").arg(id), QString("resource, /groups/%1, not available").arg(id)));


### PR DESCRIPTION
This is mostly the first commit from #1471 so it can be reviewed and merged in stages. This:

- creates a (regular Zigbee) group with all the lights in it and translates api "group 0" to this Zigbee group
-- just using Zigbee group id 0 did not work for all lights nor 65535, so it finds a free group from 65520 going downwards
-- removes all "group0" special cases

This should cause not change in behavior. On the Zigbee side each light will now have an extra group, and turning off or on all lights via group 0 on the api side is now achieved on the Zigbee side with a groupcast to this zigbee group instead of a broadcast.