### PR TITLE
Periodic report, set presence sensor state to false.

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -9348,6 +9348,16 @@ void DeRestPluginPrivate::handleZclAttributeReportIndicationXiaomiSpecial(const 
                 // don't update Mija devices
                 // e.g. lumi.sensor_motion always reports 1
             }
+            else if (sensor.modelId().startsWith(QLatin1String("lumi.sensor_motion")))
+            {
+                // don't update Motion sensor state.
+                // Imcompatibility with delay feature, and not really usefull
+               sensor.updateStateTimestamp();
+               enqueueEvent(Event(RSensors, RStateLastUpdated, sensor.id()));
+               updated = true;
+            }
+            else if (sensor.modelId().startsWith(QLatin1String("lumi.sensor_wleak")))
+            {
             else if (sensor.modelId().startsWith(QLatin1String("lumi.sensor_wleak")))
             {
                // only update state timestamp assuming last known value is valid

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -9358,8 +9358,6 @@ void DeRestPluginPrivate::handleZclAttributeReportIndicationXiaomiSpecial(const 
             }
             else if (sensor.modelId().startsWith(QLatin1String("lumi.sensor_wleak")))
             {
-            else if (sensor.modelId().startsWith(QLatin1String("lumi.sensor_wleak")))
-            {
                // only update state timestamp assuming last known value is valid
                 sensor.updateStateTimestamp();
                 enqueueEvent(Event(RSensors, RStateLastUpdated, sensor.id()));


### PR DESCRIPTION
All informations here https://github.com/dresden-elektronik/deconz-rest-plugin/issues/1551

I m agree, this patch is a little "hacky", it will be better using for exemple something like 
`if (sensor->durationDue.isValid())`
To check if there is an active timer, but I don't see an utility to do that yet. The Vibration sensor for exemple don't need it in reality.