### PR TITLE
Add siren support to smoke sensors

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -72,6 +72,7 @@ const quint64 tiMacPrefix         = 0x00124b0000000000ULL;
 const quint64 netvoxMacPrefix     = 0x00137a0000000000ULL;
 const quint64 boschMacPrefix      = 0x00155f0000000000ULL;
 const quint64 jennicMacPrefix     = 0x00158d0000000000ULL;
+const quint64 develcoMacPrefix    = 0x0015bc0000000000ULL;
 const quint64 philipsMacPrefix    = 0x0017880000000000ULL;
 const quint64 ubisysMacPrefix     = 0x001fee0000000000ULL;
 const quint64 deMacPrefix         = 0x00212e0000000000ULL;
@@ -195,6 +196,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_JENNIC, "SPZB0001", jennicMacPrefix }, // Eurotronic thermostat
     { VENDOR_NONE, "RES001", tiMacPrefix }, // Hubitat environment sensor, see #1308
     { VENDOR_119C, "WL4200S", sinopeMacPrefix}, // Sinope water sensor
+    { VENDOR_DEVELCO, "SMSZB-120", develcoMacPrefix }, // Develco smoke sensor
     { 0, nullptr, 0 }
 };
 

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1377,6 +1377,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
         node->nodeDescriptor().manufacturerCode() == VENDOR_JENNIC || // Xiaomi lumi.ctrl_neutral1, lumi.ctrl_neutral2
         node->nodeDescriptor().manufacturerCode() == VENDOR_EMBER || // atsmart Z6-03 switch
         node->nodeDescriptor().manufacturerCode() == VENDOR_NONE || // Climax Siren
+        node->nodeDescriptor().manufacturerCode() == VENDOR_DEVELCO || // Develco Smoke sensor with siren
         node->nodeDescriptor().manufacturerCode() == VENDOR_1233) // Third Reality smart light switch
     {
         // whitelist

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1392,6 +1392,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
         bool hasServerOnOff = false;
         bool hasServerLevel = false;
         bool hasServerColor = false;
+        bool hasIASWDCluster = false;
 
         for (int c = 0; c < i->inClusters().size(); c++)
         {
@@ -1399,6 +1400,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
             else if (i->inClusters()[c].id() == LEVEL_CLUSTER_ID) { hasServerLevel = true; }
             else if (i->inClusters()[c].id() == COLOR_CLUSTER_ID) { hasServerColor = true; }
             else if (i->inClusters()[c].id() == WINDOW_COVERING_CLUSTER_ID) { hasServerOnOff = true; }
+            else if (i->inClusters()[c].id() == IAS_WD_CLUSTER_ID) { hasIASWDCluster = true; }
         }
 
         // check if node already exist
@@ -1583,6 +1585,15 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
                         {
                             // Xiaomi wall switch lumi.ctrl_neutral1, lumi.ctrl_neutral2
                             // TODO exclude endpoint 0x03 for lumi.ctrl_neutral1
+                            lightNode.setHaEndpoint(*i);
+                        }
+                    }
+                    break;
+
+                case DEV_ID_IAS_ZONE:
+                    {
+                        if (hasIASWDCluster)
+                        {
                             lightNode.setHaEndpoint(*i);
                         }
                     }
@@ -2080,6 +2091,7 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
             case DEV_ID_HA_WINDOW_COVERING_DEVICE:
             case DEV_ID_ZLL_ONOFF_SENSOR:
             case DEV_ID_XIAOMI_SMART_PLUG:
+            case DEV_ID_IAS_ZONE:
             case DEV_ID_IAS_WARNING_DEVICE:
             case DEV_ID_FAN:
                 break;

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -251,6 +251,7 @@
 #define VENDOR_PHILIPS      0x100B // Also used by iCasa routers
 #define VENDOR_VISONIC      0x1011
 #define VENDOR_ATMEL        0x1014
+#define VENDOR_DEVELCO      0x1015
 #define VENDOR_LGE          0x102E
 #define VENDOR_JENNIC       0x1037 // Used by Xiaomi, Trust, Eurotronic
 #define VENDOR_CENTRALITE   0x104E

--- a/light_node.cpp
+++ b/light_node.cpp
@@ -476,6 +476,11 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
                 else if (i->id() == FAN_CONTROL_CLUSTER_ID) {
                     addItem(DataTypeUInt8, RStateSpeed);
                 }
+                else if (i->id() == IAS_WD_CLUSTER_ID)
+                {
+                    removeItem(RStateOn);
+                    ltype = QLatin1String("Warning device");
+                }
             }
         }
 

--- a/light_node.cpp
+++ b/light_node.cpp
@@ -478,8 +478,12 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
                 }
                 else if (i->id() == IAS_WD_CLUSTER_ID)
                 {
-                    removeItem(RStateOn);
-                    ltype = QLatin1String("Warning device");
+                    if (    modelId() == QLatin1String("902010/24") ||   // Bitron Smoke Detector with siren
+                            modelId() == QLatin1String("SMSZB-120"))     // Develco Smoke Alarm with siren
+                    {
+                        removeItem(RStateOn);
+                        ltype = QLatin1String("Warning device");
+                    }
                 }
             }
         }

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1295,7 +1295,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
 
         bool isSmokeDetector = false;
         if (taskRef.lightNode->modelId() == QLatin1String("902010/24")  // Bitron Smoke Detector with siren
-                )
+                || taskRef.lightNode->modelId() == QLatin1String("SMSZB-120"))  // Develco smoke sensor
         {
             isSmokeDetector = true;
             taskRef.lightNode->rx();  // otherwise device is marked as zombie and task is dropped

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1293,6 +1293,14 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         QString alert = map["alert"].toString();
         bool isWarningDevice = taskRef.lightNode->type() == QLatin1String("Warning device");
 
+        bool isSmokeDetector = false;
+        if (taskRef.lightNode->modelId() == QLatin1String("902010/24")  // Bitron Smoke Detector with siren
+                )
+        {
+            isSmokeDetector = true;
+            taskRef.lightNode->rx();  // otherwise device is marked as zombie and task is dropped
+        }
+
         if (alert == "none")
         {
             if (isWarningDevice)
@@ -1309,7 +1317,13 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         }
         else if (alert == "select")
         {
-            if (isWarningDevice)
+            if (isWarningDevice && isSmokeDetector)
+            {
+                task.taskType = TaskWarning;
+                task.options = 0x12; // Warning mode 2 (fire), strobe
+                task.duration = 1;
+            }
+            else if (isWarningDevice)
             {
                 task.taskType = TaskWarning;
                 task.options = 0x14; // Warning mode 1 (burglar), Strobe
@@ -1323,7 +1337,13 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         }
         else if (alert == "lselect")
         {
-            if (isWarningDevice)
+            if (isWarningDevice && isSmokeDetector)
+            {
+                task.taskType = TaskWarning;
+                task.options = 0x12; // Warning mode 2 (fire), strobe
+                task.duration = 300;
+            }
+            else if (isWarningDevice)
             {
                 task.taskType = TaskWarning;
                 task.options = 0x14; // Warning mode 1 (burglar), Strobe


### PR DESCRIPTION
Add siren support to Bitron Smoke Detector with siren.

Add Develco smoke sensor to supported devices list, issue #1534.

Add siren support to Develco smoke detector.

A smoke detector has device id 0x0402 `WD Zone`. Therefore, the smoke detector was not added to type `Warning device` (device id 0x0403). But the smoke detector does have the clusters `IAS Zone (0x0500)` and `IAS WD (0x0502)`. This PR adds device type `Warning device` whenever a `IAD WD` cluster is found. 

The following REST API calls are now supported on Bitron smoke sensors and on (untested) Develco smoke sensors in order to start or stop the siren.
```
/api/<apikey>/lights/<id>/state -X PUT -d '{ "alert": "select" }'
```
```
/api/<apikey>/lights/<id>/state -X PUT -d '{ "alert": "lselect" }'
```
```
/api/<apikey>/lights/<id>/state -X PUT -d '{ "alert": "none" }'
```

```
{
    "etag": "8dc0ac55f158350cf99ed489e23fb2c1",
    "hascolor": false,
    "manufacturername": "Bitron Home",
    "modelid": "902010/24",
    "name": "Light 32",
    "state": {
        "alert": "none",
        "reachable": true
    },
    "swversion": "20150615",
    "type": "Warning device",
    "uniqueid": "00:12:4b:00:07:7f:13:44-01"
}
```
Note: The smoke detector is a battery powered end device. Before sending a command to the smoke detector, a lightNode->rx() is necessary otherwise deCONZ did mark the device as zombie and dropped the sending command.
