### PR TITLE
Add Ikea OTA download with curl and jq

### DIFF
--- a/linux/deCONZ/usr/bin/deCONZ-ikea-ota-download.sh
+++ b/linux/deCONZ/usr/bin/deCONZ-ikea-ota-download.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+curl 'http://fw.ota.homesmart.ikea.net/feed/version_info.json' | jq -r '[.[] | .fw_binary_url] | .[]'  > $HOME/files.txt
+
+cd $HOME/otau && xargs -n 1 curl -O < $HOME/files.txt
+
+rm $HOME/files.txt


### PR DESCRIPTION
Ikea OTA download script with curl and jq. No Python needed.

Script is also tested in the [Deconz Docker image](https://hub.docker.com/r/marthoc/deconz/)

See [1606](https://github.com/dresden-elektronik/deconz-rest-plugin/issues/1606)