### PR TITLE
disable state.bri for innr zigbee 3.0 devices

### DIFF
--- a/light_node.cpp
+++ b/light_node.cpp
@@ -361,6 +361,7 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
                 {
                     if ((manufacturerCode() == VENDOR_IKEA && endpoint.deviceId() == DEV_ID_Z30_ONOFF_PLUGIN_UNIT) || // IKEA Tradfri control outlet
                         (manufacturerCode() == VENDOR_INNR && endpoint.deviceId() == DEV_ID_ZLL_ONOFF_PLUGIN_UNIT) || // innr SP120 smart plug
+                        (manufacturerCode() == VENDOR_INNR && endpoint.deviceId() == DEV_ID_Z30_ONOFF_PLUGIN_UNIT) || // innr ZigBee 3.0 smart plugs (SP2xx)
                         (manufacturerCode() == VENDOR_PHILIPS && endpoint.deviceId() == DEV_ID_HA_ONOFF_LIGHT && endpoint.profileId() == HA_PROFILE_ID)) // iCasa in-wall switch
                     { } // skip state.bri not supported
                     else


### PR DESCRIPTION
disables state.bri for innr 2xx series plug devices, originally fixed for the sp 120 in #1444 commit 364ce0d0d86cbb5a34ffe15d277eed8502af383f