### PR TITLE
ORVIBO SF21 Smoke Sensor support

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1752,7 +1752,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId() == QLatin1String("RICI01") ||
         // ORVIBO
         sensor->modelId().startsWith(QLatin1String("SN10ZW")) ||
-        sensor->modelId().startsWith(QLatin1String("SF20")))
+        sensor->modelId().startsWith(QLatin1String("SF2")))
     {
         deviceSupported = true;
         if (!sensor->node()->nodeDescriptor().receiverOnWhenIdle() ||

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -213,7 +213,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_EMBER, "3AFE130104020015", konkeMacPrefix }, // Konke Kit Pro-Door Entry Sensor
     { VENDOR_NONE, "RICI01", tiMacPrefix}, // LifeControl smart plug
     { VENDOR_JENNIC, "SN10ZW", jennicMacPrefix }, // ORVIBO motion sensor
-    { VENDOR_OSRAM_STACK, "SF20", heimanMacPrefix }, // ORVIBO (Heiman) smoke sensor
+    { VENDOR_OSRAM_STACK, "SF2", heimanMacPrefix }, // ORVIBO (Heiman) smoke sensor
     { 0, nullptr, 0 }
 };
 
@@ -3626,6 +3626,10 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                                 {
                                     modelId = QLatin1String("SF20 smoke sensor");
                                 }
+                                else if (modelId == QLatin1String("98293058552c49f38ad0748541ee96ba"))
+                                {
+                                    modelId = QLatin1String("SF21 smoke sensor");
+                                }
                             }
                         }
                     }
@@ -3755,7 +3759,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                              modelId.startsWith(QLatin1String("Smoke")) ||            // Heiman fire sensor (newer model)
                              modelId.startsWith(QLatin1String("902010/24")) ||        // Bitron smoke detector
                              modelId.startsWith(QLatin1String("SMSZB-120")) ||        // Develco smoke detector
-                             modelId.startsWith(QLatin1String("SF20")) ||             // ORVIBO (Heiman) smoke sensor
+                             modelId.startsWith(QLatin1String("SF2")) ||              // ORVIBO (Heiman) smoke sensor
                              modelId.startsWith(QLatin1String("lumi.sensor_smoke")))  // Xiaomi Mi smoke sensor
                     {
                         // Gas sensor detects combustable gas, so fire is more appropriate than CO.
@@ -6188,6 +6192,17 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                             else
                                             {
                                                 str = QLatin1String("SF20 smoke sensor");
+                                            }
+                                        }
+                                        else if (str == QLatin1String("98293058552c49f38ad0748541ee96ba"))
+                                        {
+                                            if (i->modelId().startsWith(QLatin1String("SF21")))
+                                            {
+                                                continue; // skip if already replaced
+                                            }
+                                            else
+                                            {
+                                                str = QLatin1String("SF21 smoke sensor");
                                             }
                                         }
                                         i->setModelId(str);


### PR DESCRIPTION
Adds support for the ORVIBO SF21 smoke sensor. Closes #1875.