### PR TITLE
Add support for serveral thermostats.

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -212,6 +212,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_119C, "WL4200S", sinopeMacPrefix}, // Sinope water sensor
     { VENDOR_119C, "TH1300ZB", sinopeMacPrefix }, // Sinope Thermostat
     { VENDOR_ZEN, "Zen-01", zenMacPrefix }, // Zen Thermostat
+    { VENDOR_C2DF, "3157100-E", emberMacPrefix }, // Centralite Thermostat
     { VENDOR_DEVELCO, "SMSZB-120", develcoMacPrefix }, // Develco smoke sensor
     { VENDOR_DEVELCO, "SPLZB-131", develcoMacPrefix }, // Develco smart plug
     { VENDOR_DEVELCO, "WISZB-120", develcoMacPrefix }, // Develco window sensor

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -213,6 +213,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_119C, "TH1300ZB", sinopeMacPrefix }, // Sinope Thermostat
     { VENDOR_ZEN, "Zen-01", zenMacPrefix }, // Zen Thermostat
     { VENDOR_C2DF, "3157100-E", emberMacPrefix }, // Centralite Thermostat
+    { VENDOR_EMBER, "Super TR", emberMacPrefix }, // Elko Thermostat
     { VENDOR_DEVELCO, "SMSZB-120", develcoMacPrefix }, // Develco smoke sensor
     { VENDOR_DEVELCO, "SPLZB-131", develcoMacPrefix }, // Develco smart plug
     { VENDOR_DEVELCO, "WISZB-120", develcoMacPrefix }, // Develco window sensor

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -209,6 +209,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_JENNIC, "SPZB0001", jennicMacPrefix }, // Eurotronic thermostat
     { VENDOR_NONE, "RES001", tiMacPrefix }, // Hubitat environment sensor, see #1308
     { VENDOR_119C, "WL4200S", sinopeMacPrefix}, // Sinope water sensor
+    { VENDOR_119C, "TH1300ZB", sinopeMacPrefix }, // Sinope Thermostat
     { VENDOR_DEVELCO, "SMSZB-120", develcoMacPrefix }, // Develco smoke sensor
     { VENDOR_DEVELCO, "SPLZB-131", develcoMacPrefix }, // Develco smart plug
     { VENDOR_DEVELCO, "WISZB-120", develcoMacPrefix }, // Develco window sensor

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -78,6 +78,7 @@ const quint64 philipsMacPrefix    = 0x0017880000000000ULL;
 const quint64 ubisysMacPrefix     = 0x001fee0000000000ULL;
 const quint64 deMacPrefix         = 0x00212e0000000000ULL;
 const quint64 keenhomeMacPrefix   = 0x0022a30000000000ULL;
+const quint64 zenMacPrefix        = 0x0024460000000000ULL;
 const quint64 heimanMacPrefix     = 0x0050430000000000ULL;
 const quint64 konkeMacPrefix      = 0x086bd70000000000ULL;
 const quint64 ikea2MacPrefix      = 0x14b4570000000000ULL;
@@ -210,6 +211,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_NONE, "RES001", tiMacPrefix }, // Hubitat environment sensor, see #1308
     { VENDOR_119C, "WL4200S", sinopeMacPrefix}, // Sinope water sensor
     { VENDOR_119C, "TH1300ZB", sinopeMacPrefix }, // Sinope Thermostat
+    { VENDOR_ZEN, "Zen-01", zenMacPrefix }, // Zen Thermostat
     { VENDOR_DEVELCO, "SMSZB-120", develcoMacPrefix }, // Develco smoke sensor
     { VENDOR_DEVELCO, "SPLZB-131", develcoMacPrefix }, // Develco smart plug
     { VENDOR_DEVELCO, "WISZB-120", develcoMacPrefix }, // Develco window sensor

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -286,6 +286,7 @@
 #define VENDOR_SAMJIN       0x1241
 #define VENDOR_OSRAM_STACK  0xBBAA
 #define VENDOR_LEGRAND      0x1021
+#define VENDOR_C2DF         0xC2DF
 
 #define ANNOUNCE_INTERVAL 10 // minutes default announce interval
 

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -266,6 +266,7 @@
 #define VENDOR_BOSCH        0x1133
 #define VENDOR_DDEL         0x1135
 #define VENDOR_LUTRON       0x1144
+#define VENDOR_ZEN          0x1158
 #define VENDOR_KEEN_HOME    0x115B
 #define VENDOR_115F         0x115F // Used by Xiaomi Aqara
 #define VENDOR_INNR         0x1166


### PR DESCRIPTION
Add the following thermostats to supported devices list.

- Centralite Thermostat, issue #1601 .
- Zen thermostat, issue #1702 .
- Sinope thermostat TH1300ZB, issue #1289 .

In order to also add Elko thermostat, the node info is required, i.e. mac prefix and manufacturer code, issue #1291 .