### PR TITLE
Workaround to make GLEDOPTO led driver turning lights on/off as expected.

### DIFF
--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -622,12 +622,14 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
                 // map.contains("transitiontime") || // FIXME: use bri if transitionTime is given
                 addTaskSetOnOff(task, isOn ? ONOFF_COMMAND_ON : ONOFF_COMMAND_OFF, 0)) // onOff task only if no bri or transitionTime is given
             {
-                // GLEDOPTO "W" (1 channel) version 1.0.3 does not honor "with on/off" in
-                // a "Move to level (with on/off)" command.
+                // GLEDOPTO "W" (1 channel) "GL-C-009" version 1.0.3
+                // GLEDOPTO "RGB/WW/CW" (5 channel) "GL-C-008" version 1.0.3
+                // do not honor "with on/off" in a "Move to level (with on/off)" command.
                 // Workaround by sending ONOFF_COMMAND and a LEVEL_COMMAND:
                 if (task.lightNode
-                        && task.lightNode->modelId() == QLatin1String("GL-C-009")
-                        && task.lightNode->swBuildId().startsWith(QLatin1String("1.0")))
+                    && (task.lightNode->modelId() == QLatin1String("GL-C-008") ||
+                        task.lightNode->modelId() == QLatin1String("GL-C-009"))
+                    && task.lightNode->swBuildId().startsWith(QLatin1String("1.0")))
                 {
                     if (hasBri ||
                         // map.contains("transitiontime") || // FIXME: use bri if transitionTime is given


### PR DESCRIPTION
Some GLEDOPTO devices do not turn on/off in some cases. Namely if a "Move to Level (with on/off)" command is sent to them. They do not honor the "with on/off".
The provided fix sends an extra "On/Off" command to make these devices work as expected.