### PR TITLE
Update rest_sensors.cpp

### DIFF
--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1033,7 +1033,6 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                 }
                 else if (rid.suffix == RConfigHeatSetpoint)
                 {
-                    bool ok;
                     int16_t heatsetpoint = map[pi.key()].toUInt(&ok);
                     uint16_t mfrCode = 0;
                     uint16_t attrId = 0x0012;
@@ -1043,9 +1042,8 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                         mfrCode = VENDOR_JENNIC;
                         attrId = 0x4003;
 
-                        // Setting the heat setpoint disables off/boost modes,
-			// but this is not reported back by the thermostat.
-			// Hence, the off/boost flags will be removed here to reflect the actual operating state.
+                        // Setting the heat setpoint disables off/boost modes, but this is not reported back by the thermostat.
+			                  // Hence, the off/boost flags will be removed here to reflect the actual operating state.
                         if (hostFlags == 0)
                         {
                             ResourceItem *item = sensor->item(RConfigHostFlags);
@@ -1056,7 +1054,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                         hostFlags |=  0x10; // set `disable off` flag
                     }
 
-                    if (ok && addTaskThermostatReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, mfrCode, attrId, deCONZ::Zcl16BitInt, heatsetpoint))
+                    if (addTaskThermostatReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, mfrCode, attrId, deCONZ::Zcl16BitInt, heatsetpoint))
                     {
                         updated = true;
                     }


### PR DESCRIPTION
Bug fix: sometimes updated `config.heatsetpoint` isn't sent to Eurotronic Spirit.  See #1098.