### PR TITLE
Update for Legrand device

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1791,6 +1791,8 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId() == QLatin1String("Dimmer switch w/o neutral") ||
         //Legrand Cable outlet
         sensor->modelId() == QLatin1String("Cable outlet") ||
+        //Legrand wireless switch
+        sensor->modelId() == QLatin1String("Remote switch") ||
         // ORVIBO
         sensor->modelId().startsWith(QLatin1String("SN10ZW")) ||
         sensor->modelId().startsWith(QLatin1String("SF2")) ||
@@ -1888,7 +1890,11 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
             {
                 continue; // process only once
             }
-
+            if (sensor->modelId() == QLatin1String("Remote switch") )
+            {
+                //This device don't support report attribute
+                continue;
+            }
             if (sensor->manufacturer().startsWith(QLatin1String("Climax")))
             {
                 val = sensor->getZclValue(*i, 0x0035); // battery alarm mask
@@ -1899,6 +1905,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
                      sensor->modelId() == QLatin1String("WISZB-120") ||
                      sensor->modelId() == QLatin1String("MOSZB-130") ||
                      sensor->modelId() == QLatin1String("FLSZB-110") ||
+		             sensor->modelId() == QLatin1String("Remote switch") ||
                      sensor->modelId().startsWith(QLatin1String("ZHMS101")))
             {
                 val = sensor->getZclValue(*i, 0x0020); // battery voltage
@@ -2216,6 +2223,13 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
         clusters.push_back(LEVEL_CLUSTER_ID);
         srcEndpoints.push_back(sensor->fingerPrint().endpoint);
     }
+    // LEGRAND Remote switch
+    else if (sensor->modelId() == QLatin1String("Remote switch"))
+    {
+        clusters.push_back(ONOFF_CLUSTER_ID);
+        clusters.push_back(LEVEL_CLUSTER_ID);
+        srcEndpoints.push_back(sensor->fingerPrint().endpoint);
+    }
     else if (sensor->modelId().startsWith(QLatin1String("RC 110")))
     {
         clusters.push_back(ONOFF_CLUSTER_ID);
@@ -2402,6 +2416,10 @@ void DeRestPluginPrivate::checkSensorGroup(Sensor *sensor)
              sensor->modelId().startsWith(QLatin1String("RC 110"))) // innr remote
     {
 
+    }
+    else if (sensor->modelId() == QLatin1String("Remote switch"))
+    {
+        //Make group but without uniqueid
     }
     else if (sensor->modelId() == QLatin1String("RB01") ||
              sensor->modelId() == QLatin1String("RM01"))

--- a/database.cpp
+++ b/database.cpp
@@ -3210,26 +3210,26 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             }
             else
             {
-				item = sensor.addItem(DataTypeInt16, RStateTemperature);
-				item->setValue(0);
-				item = sensor.addItem(DataTypeInt16, RConfigOffset);
-				item->setValue(0);
-				sensor.addItem(DataTypeInt16, RConfigHeatSetpoint);    // Heating set point
-				sensor.addItem(DataTypeBool, RStateOn);           // Heating on/off
-				if (sensor.modelId().startsWith(QLatin1String("SPZB"))) // Eurotronic Spirit
-				{
-					sensor.addItem(DataTypeUInt8, RStateValve);
-					sensor.addItem(DataTypeUInt32, RConfigHostFlags); // hidden
-					sensor.addItem(DataTypeBool, RConfigDisplayFlipped);
-					sensor.addItem(DataTypeBool, RConfigLocked);
-					sensor.addItem(DataTypeString, RConfigMode);
-				}
-				else
-				{
-					sensor.addItem(DataTypeBool, RConfigSchedulerOn); // Scheduler state on/off
-					sensor.addItem(DataTypeString, RConfigScheduler); // Scheduler setting
-				}
-		    }
+                item = sensor.addItem(DataTypeInt16, RStateTemperature);
+                item->setValue(0);
+                item = sensor.addItem(DataTypeInt16, RConfigOffset);
+                item->setValue(0);
+                sensor.addItem(DataTypeInt16, RConfigHeatSetpoint);    // Heating set point
+                sensor.addItem(DataTypeBool, RStateOn);           // Heating on/off
+                if (sensor.modelId().startsWith(QLatin1String("SPZB"))) // Eurotronic Spirit
+                {
+                    sensor.addItem(DataTypeUInt8, RStateValve);
+                    sensor.addItem(DataTypeUInt32, RConfigHostFlags); // hidden
+                    sensor.addItem(DataTypeBool, RConfigDisplayFlipped);
+                    sensor.addItem(DataTypeBool, RConfigLocked);
+                    sensor.addItem(DataTypeString, RConfigMode);
+                }
+                else
+                {
+                    sensor.addItem(DataTypeBool, RConfigSchedulerOn); // Scheduler state on/off
+                    sensor.addItem(DataTypeString, RConfigScheduler); // Scheduler setting
+                }
+            }
         }
         else if (sensor.type().endsWith(QLatin1String("Battery")))
         {
@@ -3415,18 +3415,18 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             ResourceItem *itemWindowCovering = 0;
             if (isWindowCovering)
             {
-            	itemWindowCovering = sensor.addItem(DataTypeUInt8, RConfigWindowCoveringType);
+                itemWindowCovering = sensor.addItem(DataTypeUInt8, RConfigWindowCoveringType);
             }
 
             if (configCol >= 0)
             {
-            	sensor.jsonToConfig(QLatin1String(colval[configCol])); // needed again otherwise item isEmpty
+                sensor.jsonToConfig(QLatin1String(colval[configCol])); // needed again otherwise item isEmpty
             }
 
             if (isWindowCovering)
             {
-            	int val = itemWindowCovering->toNumber(); // prevent null value
-            	itemWindowCovering->setValue(val);
+                int val = itemWindowCovering->toNumber(); // prevent null value
+                itemWindowCovering->setValue(val);
             }
 
             if (item->toString().isEmpty() || !supportedModes.contains(item->toString()))

--- a/database.cpp
+++ b/database.cpp
@@ -3203,7 +3203,8 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             }
             
             //only for legrand cluster. Add only mode field.
-            if (sensor.fingerPrint().hasInCluster(LEGRAND_CONTROL_CLUSTER_ID))
+            if ( (sensor.fingerPrint().hasInCluster(LEGRAND_CONTROL_CLUSTER_ID)) &&
+                 (sensorNode.modelId() == QLatin1String("Cable outlet") ) )
             {
                 clusterId = LEGRAND_CONTROL_CLUSTER_ID;
                 sensor.addItem(DataTypeString, RConfigMode);

--- a/database.cpp
+++ b/database.cpp
@@ -3201,25 +3201,35 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             {
                 clusterId = THERMOSTAT_CLUSTER_ID;
             }
-            item = sensor.addItem(DataTypeInt16, RStateTemperature);
-            item->setValue(0);
-            item = sensor.addItem(DataTypeInt16, RConfigOffset);
-            item->setValue(0);
-            sensor.addItem(DataTypeInt16, RConfigHeatSetpoint);    // Heating set point
-            sensor.addItem(DataTypeBool, RStateOn);           // Heating on/off
-            if (sensor.modelId().startsWith(QLatin1String("SPZB"))) // Eurotronic Spirit
+            
+            //only for legrand cluster. Add only mode field.
+            if (sensor.fingerPrint().hasInCluster(LEGRAND_CONTROL_CLUSTER_ID))
             {
-                sensor.addItem(DataTypeUInt8, RStateValve);
-                sensor.addItem(DataTypeUInt32, RConfigHostFlags); // hidden
-                sensor.addItem(DataTypeBool, RConfigDisplayFlipped);
-                sensor.addItem(DataTypeBool, RConfigLocked);
+                clusterId = LEGRAND_CONTROL_CLUSTER_ID;
                 sensor.addItem(DataTypeString, RConfigMode);
             }
             else
             {
-                sensor.addItem(DataTypeBool, RConfigSchedulerOn); // Scheduler state on/off
-                sensor.addItem(DataTypeString, RConfigScheduler); // Scheduler setting
-            }
+				item = sensor.addItem(DataTypeInt16, RStateTemperature);
+				item->setValue(0);
+				item = sensor.addItem(DataTypeInt16, RConfigOffset);
+				item->setValue(0);
+				sensor.addItem(DataTypeInt16, RConfigHeatSetpoint);    // Heating set point
+				sensor.addItem(DataTypeBool, RStateOn);           // Heating on/off
+				if (sensor.modelId().startsWith(QLatin1String("SPZB"))) // Eurotronic Spirit
+				{
+					sensor.addItem(DataTypeUInt8, RStateValve);
+					sensor.addItem(DataTypeUInt32, RConfigHostFlags); // hidden
+					sensor.addItem(DataTypeBool, RConfigDisplayFlipped);
+					sensor.addItem(DataTypeBool, RConfigLocked);
+					sensor.addItem(DataTypeString, RConfigMode);
+				}
+				else
+				{
+					sensor.addItem(DataTypeBool, RConfigSchedulerOn); // Scheduler state on/off
+					sensor.addItem(DataTypeString, RConfigScheduler); // Scheduler setting
+				}
+		    }
         }
         else if (sensor.type().endsWith(QLatin1String("Battery")))
         {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4044,7 +4044,10 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
 
                 case LEGRAND_CONTROL_CLUSTER_ID:
                 {
-                    fpThermostatSensor.inClusters.push_back(LEGRAND_CONTROL_CLUSTER_ID);
+                    if (sensorNode.modelId() == QLatin1String("Cable outlet"))
+                    {
+                        fpThermostatSensor.inClusters.push_back(LEGRAND_CONTROL_CLUSTER_ID);
+                    }
                 }
                     break;
 
@@ -4455,7 +4458,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
 
         // ZHAThermostat
         if (fpThermostatSensor.hasInCluster(THERMOSTAT_CLUSTER_ID) ||
-        fpThermostatSensor.hasInCluster(LEGRAND_CONTROL_CLUSTER_ID))
+        ( fpThermostatSensor.hasInCluster(LEGRAND_CONTROL_CLUSTER_ID) && (sensorNode.modelId() == QLatin1String("Cable outlet")) ) )
         {
             fpThermostatSensor.endpoint = i->endpoint();
             fpThermostatSensor.deviceId = i->deviceId();
@@ -4785,7 +4788,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             clusterId = THERMOSTAT_CLUSTER_ID;
         }
         //Only for legrand cluster, add only mode field.
-        if (sensorNode.fingerPrint().hasInCluster(LEGRAND_CONTROL_CLUSTER_ID))
+        if ((sensorNode.fingerPrint().hasInCluster(LEGRAND_CONTROL_CLUSTER_ID)) && (sensorNode.modelId() == QLatin1String("Cable outlet") ) )
         {
             clusterId = LEGRAND_CONTROL_CLUSTER_ID;
             sensorNode.addItem(DataTypeString, RConfigMode);

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -185,6 +185,7 @@
 #define VENDOR_CLUSTER_ID                     0xFC00
 #define UBISYS_DEVICE_SETUP_CLUSTER_ID        0xFC00
 #define SAMJIN_CLUSTER_ID                     0xFC02
+#define LEGRAND_CONTROL_CLUSTER_ID            0xFC40
 #define XAL_CLUSTER_ID                        0xFCCE
 
 #define IAS_ZONE_CLUSTER_ATTR_ZONE_STATUS_ID  0x0002
@@ -232,8 +233,9 @@
 #define READ_BINDING_TABLE     (1 << 9)
 #define READ_OCCUPANCY_CONFIG  (1 << 10)
 #define READ_GROUP_IDENTIFIERS (1 << 12)
+#define READ_MODE_CONFIG       (1 << 13)
 #define READ_THERMOSTAT_STATE  (1 << 17)
-// #define READ_BATTERY           (1 << 18)
+#define READ_BATTERY           (1 << 18)
 
 #define READ_MODEL_ID_INTERVAL   (60 * 60) // s
 #define READ_SWBUILD_ID_INTERVAL (60 * 60) // s
@@ -1272,6 +1274,7 @@ public:
     bool addTaskThermostatCmd(TaskItem &task, uint8_t cmd, int8_t setpoint, const QString &schedule, uint8_t daysToReturn);
     bool addTaskThermostatSetAndGetSchedule(TaskItem &task, const QString &sched);
     bool addTaskThermostatReadWriteAttribute(TaskItem &task, uint8_t readOrWriteCmd, uint16_t mfrCode, uint16_t attrId, uint8_t attrType, uint32_t attrValue);
+    bool addTaskControlModeCmd(TaskItem &task, uint8_t cmdId, int8_t mode);
     void handleGroupClusterIndication(TaskItem &task, const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleSceneClusterIndication(TaskItem &task, const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleOnOffClusterIndication(TaskItem &task, const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);

--- a/general.xml
+++ b/general.xml
@@ -2538,18 +2538,58 @@ devices can operate on either battery or mains power, and can have a wide variet
 
 		<!-- Legrand -->
 		<cluster id="0xfc01" name="Legrand - Specific clusters" mfcode="1021">
-			<description>Legrand Specific clusters.</description>
+			<description>Legrand Classic Specific clusters, used by all devices. But take care they are device specific.
+			
+> Dimmer switch without neutral : Option 1 = Dimmer on/off.
+> Cable outlet : Option 1 = Fil pilote on/off.
+			</description>
 			<server>
-				<attribute id="0x0000" name="Dimmer" type="dat16" default="0x0101" access="rw" required="m" showas="hex">
-					<description>0100 = Dimmer Off, 0101 = Dimmer On</description>
+				<attribute id="0x0000" type="dat16" name="Option 1" default="0x0101" access="rw" required="m" showas="hex">
+					<description>Choose correctly according to your device Dimmer OR fil pilote.
+Dimmer > Off=0100 - On=0101
+Fil pilote > Off=0001 - On=0002</description>
 				</attribute>
-				<attribute id="0x0001" type="bool" name="LED" required="m" access="rw" default="0">
-					<description>Enable LED in dark</description>
+				<attribute id="0x0001" type="bool" name="Option 2" required="m" access="rw" default="0">
+					<description>Option 1</description>
+				</attribute>
+				<attribute id="0x0002" type="bool" name="Option 3" required="m" access="rw" default="0">
+					<description>Option 2</description>
 				</attribute>
 			</server>
 			<client>
 			</client>
 		</cluster>
+		<cluster id="0xfc40" name="Legrand - Specific clusters 2" mfcode="1021">
+			<description>Legrand Specific clusters, Used by cable outlet.</description>
+			<server>
+				
+			<command id="00" dir="recv" name="Unknow" required="m">
+				<description>Set fil pilote mode</description>
+				<payload>
+					<attribute id="0x0000" type="enum8" name="Mode" required="m" default="0x00">
+						<value name="Confort" value="0x00"></value>
+						<value name="Confort -1" value="0x01"></value>
+						<value name="Confort -2" value="0x02"></value>
+						<value name="Eco" value="0x03"></value>
+						<value name="Hors-Gel" value="0x04"></value>
+						<value name="Off" value="0x05"></value>
+					</attribute>
+				</payload>
+			</command>
+			
+			<attribute id="0x0000" type="enum8" name="Mode" default="0x00" access="r" required="m">
+				<description>Heating mode</description>
+					<value name="Confort" value="0x00"></value>
+					<value name="Confort -1" value="0x01"></value>
+					<value name="Confort -2" value="0x02"></value>
+					<value name="Eco" value="0x03"></value>
+					<value name="Hors-Gel" value="0x04"></value>
+					<value name="Off" value="0x05"></value>
+			</attribute>
+			</server>
+			<client>
+			</client>
+                </cluster>
 
 		<!-- ubisys -->
 		<cluster id="0xfc00" name="Device Setup" mfcode="0x10f2">

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -711,6 +711,18 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
                 {
                     moveToPct = 100 - moveToPct;
                 }
+                //Legrand invert bri and don't support other value than 0
+                if (taskRef.lightNode->modelId() == QLatin1String("Shutter switch with neutral"))
+                {
+					if (bri == 0)
+					{
+						moveToPct = 254;
+					}
+					else
+					{
+						moveToPct = 0;
+					}
+                }
         		if (addTaskWindowCovering(task, 0x05 /*move to Lift Percent*/, 0, moveToPct))
         		{
         			QVariantMap rspItem;

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -714,14 +714,14 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
                 //Legrand invert bri and don't support other value than 0
                 if (taskRef.lightNode->modelId() == QLatin1String("Shutter switch with neutral"))
                 {
-					if (bri == 0)
-					{
-						moveToPct = 254;
-					}
-					else
-					{
-						moveToPct = 0;
-					}
+                    if (bri == 0)
+                    {
+                        moveToPct = 254;
+                    }
+                    else
+                    {
+                        moveToPct = 0;
+                    }
                 }
         		if (addTaskWindowCovering(task, 0x05 /*move to Lift Percent*/, 0, moveToPct))
         		{

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -850,6 +850,31 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                     		}
                     		rspItem["success"] = rspItemState;
                     	}
+ 
+                        else if (sensor->modelId() == QLatin1String("Cable outlet"))
+                        {
+                            QString mode_set = map[pi.key()].toString();
+                            quint64 mode = 10;
+                            if (mode_set == "confort") { mode = 0x00; }
+                            else if (mode_set == "confort-1") { mode = 0x01; }
+                            else if (mode_set == "confort-2") { mode = 0x02; }
+                            else if (mode_set == "eco") { mode = 0x03; }
+                            else if (mode_set == "hors gel") { mode = 0x04; }
+                            else if (mode_set == "off") { mode = 0x05; }
+                            else
+                            {
+                                rspItemState[QString("error unknow mode for %1").arg(sensor->modelId())] = val;
+                            }
+                            
+                            if (mode < 10)
+                            {
+                                if (!addTaskControlModeCmd(task, 0x00, mode))
+                                {
+                                    rspItemState[QString("error sending command for %1").arg(sensor->modelId())] = val;
+                                }
+                            }
+                            rspItem["success"] = rspItemState;
+                        }
                     }
 
                     if (rid.suffix == RConfigWindowCoveringType)

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -626,6 +626,19 @@ static const Sensor::ButtonMap sunricherMap[] = {
     { Sensor::ModeNone,             0x00, 0x0000, 0x00, 0,    0,                                           nullptr }
 };
 
+static const Sensor::ButtonMap legrandSwitchRemote[] = {
+    //    mode                          ep    cluster cmd   param button                                       name
+    { Sensor::ModeScenes,           0x01, 0x0006, 0x01, 0,    S_BUTTON_1 + S_BUTTON_ACTION_SHORT_RELEASED, "On" },
+    { Sensor::ModeScenes,           0x01, 0x0006, 0x00, 0,    S_BUTTON_2 + S_BUTTON_ACTION_SHORT_RELEASED, "Off" },
+    { Sensor::ModeScenes,           0x01, 0x0008, 0x01, 0,    S_BUTTON_1 + S_BUTTON_ACTION_HOLD,           "Dimm up" },
+    { Sensor::ModeScenes,           0x01, 0x0008, 0x03, 0,    S_BUTTON_1 + S_BUTTON_ACTION_LONG_RELEASED,  "Dimm up stop" },
+    { Sensor::ModeScenes,           0x01, 0x0008, 0x01, 1,    S_BUTTON_2 + S_BUTTON_ACTION_HOLD,           "Dimm down" },
+    { Sensor::ModeScenes,           0x01, 0x0008, 0x03, 1,    S_BUTTON_2 + S_BUTTON_ACTION_LONG_RELEASED,  "Dimm down stop" },
+
+    // end
+    { Sensor::ModeNone,             0x00, 0x0000, 0x00, 0,    0,                                           nullptr }
+};
+
 /*! Returns a fingerprint as JSON string. */
 QString SensorFingerprint::toString() const
 {
@@ -1180,6 +1193,10 @@ const Sensor::ButtonMap *Sensor::buttonMap()
         else if (manufacturer == QLatin1String("Samjin"))
         {
             if (modelid == QLatin1String("button")) { m_buttonMap = samjinButtonMap; }
+        }
+        else if (manufacturer == QLatin1String("Legrand"))
+        {
+            if (modelid == QLatin1String("Remote switch")) { m_buttonMap = legrandSwitchRemote; }
         }
         else if (manufacturer == QLatin1String("Sunricher"))
         {


### PR DESCRIPTION
Long version here :
https://github.com/dresden-elektronik/deconz-rest-plugin/issues/883

Short version:
- Bug correction on window covering switch (not working if bri = 1)
- Adding basic support for cable outlet, working with 2 working mode, on/off and "fil pilote", for the second one, creation of a sensor with "mode" field, mode supported confort/confort-1/confort-2/eco/hors gel/off. This support is realy basic (no attributes reporting) but I think it's used only in France. And I have "vampirized" the  thermostat.cpp file, to add my function, but it's a kind of thermostat too.
- Adding support for wireless switch.

For the wireless switch, it create a group but with uniqueid, so I have some question about it > https://github.com/dresden-elektronik/deconz-rest-plugin/issues/2123

This device have a special working mode, when it is in sleeping mode, it really sleep. It can stay like this somes days without any reports. But every time you use it, it make a Rejoin (with a special command to make difference with Join) and it's the only moment where you can ask for attributes, like batterie.

BTW, I haven't see something in the API to make difference between a Join and a Rejoin ?
In both situation it's the fonction DeRestPluginPrivate::handleDeviceAnnceIndication(const deCONZ::ApsDataIndication &ind) that is triggered but only with seq/nwk/ext/macCapabilities.