### PR TITLE
Various bug fixes

### DIFF
--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -706,7 +706,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         		TaskItem task;
         		copyTaskReq(taskRef, task);
         		uint8_t moveToPct = 0x00;
-        		moveToPct = bri * 100 / 255;  // Percent 0 - 100 (0x00 - 0x64)
+        		moveToPct = bri * 100 / 254;  // Percent 0 - 100 (0x00 - 0x64)
                 if (taskRef.lightNode->modelId().startsWith(QLatin1String("lumi.curtain")) )
                 {
                     moveToPct = 100 - moveToPct;
@@ -957,7 +957,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         		TaskItem task;
         		copyTaskReq(taskRef, task);
         		uint8_t moveToPct = 0x00;
-        		moveToPct = sat2 * 100 / 255;  // Percent 0 - 100 (0x00 - 0x64)
+        		moveToPct = sat2 * 100 / 254;  // Percent 0 - 100 (0x00 - 0x64)
         		if (addTaskWindowCovering(task, 0x08 /*move to Tilt Percent*/, 0, moveToPct))
         		{
         			QVariantMap rspItem;

--- a/rest_rules.cpp
+++ b/rest_rules.cpp
@@ -1372,7 +1372,8 @@ bool DeRestPluginPrivate::evaluateRule(Rule &rule, const Event &e, Resource *eRe
             }
 
             QDateTime dt = item->lastChanged().addSecs(c->seconds());
-            if (now.secsTo(dt) != 0)
+            qint64 delta = now.msecsTo(dt);
+            if (delta < -500 || delta >= 500)
             {
                 return false;
             }
@@ -1820,6 +1821,10 @@ void DeRestPluginPrivate::handleRuleEvent(const Event &e)
     if (!e.id().isEmpty())
     {
         DBG_Printf(DBG_INFO, "rule event: %s/%s %s num (%d -> %d)\n", e.resource(), qPrintable(e.id()), e.what(), e.numPrevious(), e.num());
+    }
+    else
+    {
+        DBG_Printf(DBG_INFO_L2, "rule event: %s %s\n", e.resource(), e.what());
     }
 
     QElapsedTimer t;

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -157,7 +157,7 @@ static const Sensor::ButtonMap ikeaRemoteMap[] = {
 //    mode                          ep    cluster cmd   param button                                       name
     // big button
     { Sensor::ModeColorTemperature, 0x01, 0x0006, 0x02, 0,    S_BUTTON_1 + S_BUTTON_ACTION_SHORT_RELEASED, "Toggle" },
-    { Sensor::ModeColorTemperature, 0x01, 0x0005, 0x07, 2,    S_BUTTON_1 + S_BUTTON_ACTION_HOLD,           "Setup 10s" },
+    // { Sensor::ModeColorTemperature, 0x01, 0x0005, 0x07, 2,    S_BUTTON_1 + S_BUTTON_ACTION_HOLD,           "Setup 10s" },
     // top button
     { Sensor::ModeColorTemperature, 0x01, 0x0008, 0x06, 0,    S_BUTTON_2 + S_BUTTON_ACTION_SHORT_RELEASED, "Step up (with on/off)" },
     { Sensor::ModeColorTemperature, 0x01, 0x0008, 0x05, 0,    S_BUTTON_2 + S_BUTTON_ACTION_HOLD,           "Move up (with on/off)" },

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -157,7 +157,7 @@ static const Sensor::ButtonMap ikeaRemoteMap[] = {
 //    mode                          ep    cluster cmd   param button                                       name
     // big button
     { Sensor::ModeColorTemperature, 0x01, 0x0006, 0x02, 0,    S_BUTTON_1 + S_BUTTON_ACTION_SHORT_RELEASED, "Toggle" },
-    // { Sensor::ModeColorTemperature, 0x01, 0x0005, 0x07, 2,    S_BUTTON_1 + S_BUTTON_ACTION_HOLD,           "Setup 10s" },
+    { Sensor::ModeColorTemperature, 0x01, 0x0005, 0x07, 2,    S_BUTTON_1 + S_BUTTON_ACTION_HOLD,           "Setup 10s" },
     // top button
     { Sensor::ModeColorTemperature, 0x01, 0x0008, 0x06, 0,    S_BUTTON_2 + S_BUTTON_ACTION_SHORT_RELEASED, "Step up (with on/off)" },
     { Sensor::ModeColorTemperature, 0x01, 0x0008, 0x05, 0,    S_BUTTON_2 + S_BUTTON_ACTION_HOLD,           "Move up (with on/off)" },

--- a/window_covering.cpp
+++ b/window_covering.cpp
@@ -152,12 +152,12 @@ void DeRestPluginPrivate::handleWindowCoveringClusterIndication(const deCONZ::Ap
 
     		if (attrid == 0x0008) // current CurrentPositionLiftPercentage 0-100
     		{
-			//Reverse it for Xiaomi curtain and Legrand switch
+			    //Reverse it for Xiaomi curtain and Legrand switch
     			if (lightNode->modelId().startsWith(QLatin1String("lumi.curtain")) || (lightNode->modelId() == QLatin1String("Shutter switch with neutral")))
     			{
     				attrValue = 100 - attrValue;
     			}
-    			uint8_t level = attrValue * 255 / 100;
+    			uint8_t level = attrValue * 254 / 100;
     			numericValue.u8 = level;
     			ResourceItem *item = lightNode->item(RStateBri);
     			if (item && item->toNumber() != level)
@@ -171,7 +171,7 @@ void DeRestPluginPrivate::handleWindowCoveringClusterIndication(const deCONZ::Ap
 
     				// also change on-state if bri changes to/from 0
     				bool on = (attrValue > 0 ? true : false) ;
-    				
+
     				ResourceItem *itemOn = lightNode->item(RStateOn);
     				if (itemOn && itemOn->toBool() != on)
     				{
@@ -186,7 +186,7 @@ void DeRestPluginPrivate::handleWindowCoveringClusterIndication(const deCONZ::Ap
     		}
     		else if (attrid == 0x0009) // current CurrentPositionTiltPercentage 0-100
     		{
-    			uint8_t sat = attrValue * 255 / 100;
+    			uint8_t sat = attrValue * 254 / 100;
     			numericValue.u8 = sat;
     			ResourceItem *item = lightNode->item(RStateSat);
     			if (item && item->toNumber() != sat)


### PR DESCRIPTION
Various bug fixes:
- Trådfri remote: don't issue 1001 button events without corresponding 1003s.  See #2201.  I'm not sure every-one would agree to this change; please see the discussion in the issue;
- Sometimes `ddx` rules are triggered twice, see #2148;
- Illegal `state.bri` and `state.sat` value of 255 for window covering devices, see #2257.