### PR TITLE
Various updates

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -593,9 +593,11 @@ bool DeRestPluginPrivate::sendBindRequest(BindingTask &bt)
 
         if (!s.node() || s.node()->nodeDescriptor().isNull())
         {
-            //whitelist sensors which don't seem to have a valid node descriptor
-            //This is a workaround currently only required for Develco smoke sensor
-            if (s.modelId().startsWith(QLatin1String("SMSZB-120")))
+            // Whitelist sensors which don't seem to have a valid node descriptor.
+            // This is a workaround currently only required for Develco smoke sensor
+            // and potentially Bosch motion sensor
+            if (s.modelId().startsWith(QLatin1String("SMSZB-120")) ||    // Develco smoke sensor
+                s.modelId().startsWith(QLatin1String("ISW-ZPR1-WP13")))  // Bosch motion sensor
             {
             }
             else
@@ -1724,9 +1726,11 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
 
     if (sensor->node()->nodeDescriptor().isNull())
     {
-        //whitelist sensors which don't seem to have a valid node descriptor
-        //This is a workaround currently only required for Develco smoke sensor
-        if (sensor->modelId().startsWith(QLatin1String("SMSZB-120")))
+        // Whitelist sensors which don't seem to have a valid node descriptor.
+        // This is a workaround currently only required for Develco smoke sensor
+        // and potentially Bosch motion sensor
+        if (sensor->modelId().startsWith(QLatin1String("SMSZB-120")) ||   // Develco smoke sensor
+            sensor->modelId().startsWith(QLatin1String("ISW-ZPR1-WP13"))) // Bosch motion sensor
         {
         }
         else
@@ -1840,6 +1844,8 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId().startsWith(QLatin1String("ZB-ONOFFPlug-D0005")))
         // Aurora
         sensor->modelId().startsWith(QLatin1String("DoubleSocket50AU")))
+        // Bosch
+        sensor->modelId().startsWith(QLatin1String("ISW-ZPR1-WP13")))
     {
         deviceSupported = true;
         if (!sensor->node()->nodeDescriptor().receiverOnWhenIdle() ||

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1814,7 +1814,9 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId().startsWith(QLatin1String("SN10ZW")) ||
         sensor->modelId().startsWith(QLatin1String("SF2")) ||
         // Netvox
-        sensor->modelId().startsWith(QLatin1String("Z809A")))
+        sensor->modelId().startsWith(QLatin1String("Z809A")) ||
+        // Samsung SmartPlug 2019
+        sensor->modelId().startsWith(QLatin1String("ZB-ONOFFPlug-D0005")))
     {
         deviceSupported = true;
         if (!sensor->node()->nodeDescriptor().receiverOnWhenIdle() ||

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1841,9 +1841,9 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         // Netvox
         sensor->modelId().startsWith(QLatin1String("Z809A")) ||
         // Samsung SmartPlug 2019
-        sensor->modelId().startsWith(QLatin1String("ZB-ONOFFPlug-D0005")))
+        sensor->modelId().startsWith(QLatin1String("ZB-ONOFFPlug-D0005")) ||
         // Aurora
-        sensor->modelId().startsWith(QLatin1String("DoubleSocket50AU")))
+        sensor->modelId().startsWith(QLatin1String("DoubleSocket50AU")) ||
         // Bosch
         sensor->modelId().startsWith(QLatin1String("ISW-ZPR1-WP13")))
     {

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1246,7 +1246,8 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq3.attributeId = 0x0508; // RMS Current
         rq3.minInterval = 1;
         rq3.maxInterval = 300;
-        if (sensor && sensor->modelId() == QLatin1String("SP 120")) // innr
+        if (sensor && (sensor->modelId() == QLatin1String("SP 120") ||           // innr
+                       sensor->modelId() == QLatin1String("DoubleSocket50AU")))  // Aurora
         {
             rq3.reportableChange16bit = 100; // 0.1 A
         }
@@ -1835,6 +1836,8 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId().startsWith(QLatin1String("Z809A")) ||
         // Samsung SmartPlug 2019
         sensor->modelId().startsWith(QLatin1String("ZB-ONOFFPlug-D0005")))
+        // Aurora
+        sensor->modelId().startsWith(QLatin1String("DoubleSocket50AU")))
     {
         deviceSupported = true;
         if (!sensor->node()->nodeDescriptor().receiverOnWhenIdle() ||

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -952,11 +952,29 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
     }
     else if (bt.binding.clusterId == TEMPERATURE_MEASUREMENT_CLUSTER_ID)
     {
+        Sensor *sensor = dynamic_cast<Sensor *>(bt.restNode);
+		
         rq.dataType = deCONZ::Zcl16BitInt;
         rq.attributeId = 0x0000;       // measured value
-        rq.minInterval = 10;           // value used by Hue bridge
-        rq.maxInterval = 300;          // value used by Hue bridge
-        rq.reportableChange16bit = 20; // value used by Hue bridge
+
+        if (sensor && (sensor->modelId().startsWith(QLatin1String("SMSZB-120")) ||   // Develco smoke sensor
+                        sensor->modelId().startsWith(QLatin1String("HESZB-120")) ||  // Develco heat sensor
+                        sensor->modelId().startsWith(QLatin1String("MOSZB-130")) ||  // Develco motion sensor
+                        sensor->modelId().startsWith(QLatin1String("WISZB-120")) ||  // Develco window sensor
+                        sensor->modelId().startsWith(QLatin1String("FLSZB-110")) ||  // Develco water leak sensor
+                        sensor->modelId().startsWith(QLatin1String("ZHMS101"))))     // Wattle (Develco) magnetic sensor
+        {
+            rq.minInterval = 60;           // according to technical manual
+            rq.maxInterval = 600;          // according to technical manual
+            rq.reportableChange16bit = 10; // according to technical manual
+        }
+        else
+        {
+            rq.minInterval = 10;           // value used by Hue bridge
+            rq.maxInterval = 300;          // value used by Hue bridge
+            rq.reportableChange16bit = 20; // value used by Hue bridge
+        }	
+
         return sendConfigureReportingRequest(bt, {rq});
     }
     else if (bt.binding.clusterId == THERMOSTAT_CLUSTER_ID)
@@ -1089,7 +1107,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq.reportableChange8bit = 0;
         }
         else if (sensor && (sensor->modelId().startsWith(QLatin1String("SMSZB-120")) || // Develco smoke sensor
-                           sensor->modelId().startsWith(QLatin1String("HESZB-120")) || // Develco heat sensor
+                           sensor->modelId().startsWith(QLatin1String("HESZB-120")) ||  // Develco heat sensor
                            sensor->modelId().startsWith(QLatin1String("MOSZB-130")) ||  // Develco motion sensor
                            sensor->modelId().startsWith(QLatin1String("WISZB-120")) ||  // Develco window sensor
                            sensor->modelId().startsWith(QLatin1String("FLSZB-110")) ||  // Develco water leak sensor

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1092,7 +1092,9 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq.maxInterval = 1800;
             rq.reportableChange8bit = 0xFF;
         }
-        else if (sensor && sensor->modelId() == QLatin1String("Motion Sensor-A"))
+        else if (sensor && (sensor->modelId() == QLatin1String("Motion Sensor-A") ||
+                            sensor->modelId() == QLatin1String("tagv4") ||
+                            sensor->modelId() == QLatin1String("RFDL-ZB-MS")))
         {
             rq.attributeId = 0x0020;   // battery voltage
             rq.minInterval = 3600;

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1466,6 +1466,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
         node->nodeDescriptor().manufacturerCode() == VENDOR_EMBER || // atsmart Z6-03 switch
         node->nodeDescriptor().manufacturerCode() == VENDOR_NONE || // Climax Siren
         node->nodeDescriptor().manufacturerCode() == VENDOR_DEVELCO || // Develco Smoke sensor with siren
+        node->nodeDescriptor().manufacturerCode() == VENDOR_LDS || // Samsung SmartPlug 2019
         node->nodeDescriptor().manufacturerCode() == VENDOR_IKEA || // IKEA FYRTUR and KADRILJ smart binds
         node->nodeDescriptor().manufacturerCode() == VENDOR_1233) // Third Reality smart light switch
     {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -106,6 +106,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_BUSCH_JAEGER, "RM01", bjeMacPrefix },
     { VENDOR_BOSCH, "ISW-ZDL1-WP11G", boschMacPrefix },
     { VENDOR_BOSCH, "ISW-ZPR1-WP13", boschMacPrefix },
+    { VENDOR_BOSCH, "RFDL-ZB-MS", emberMacPrefix }, // Bosch motion sensor
     { VENDOR_CENTRALITE, "Motion Sensor-A", emberMacPrefix },
     { VENDOR_CENTRALITE, "3321-S", emberMacPrefix }, // Centralite multipurpose sensor
     { VENDOR_CENTRALITE, "3325-S", emberMacPrefix }, // Centralite motion sensor

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -93,6 +93,7 @@ const quint64 bjeMacPrefix        = 0xd85def0000000000ULL;
 const quint64 xalMacPrefix        = 0xf8f0050000000000ULL;
 const quint64 lutronMacPrefix     = 0xffff000000000000ULL;
 const quint64 legrandMacPrefix    = 0x0004740000000000ULL;
+const quint64 xiaomiMacPrefix     = 0x04cf8c0000000000ULL;
 
 struct SupportedDevice {
     quint16 vendorId;
@@ -171,6 +172,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_JENNIC, "lumi.relay.c", jennicMacPrefix }, // Xiaomi Aqara LLKZMK11LM
     { VENDOR_115F, "lumi.plug", jennicMacPrefix }, // Xiaomi smart plug (router)
     { VENDOR_115F, "lumi.ctrl_ln", jennicMacPrefix}, // Xiaomi Wall Switch (router)
+    { VENDOR_115F, "lumi.plug.maeu01", xiaomiMacPrefix}, // Xiaomi Aqara outlet
     // { VENDOR_115F, "lumi.curtain", jennicMacPrefix}, // Xiaomi curtain controller (router) - exposed only as light
     { VENDOR_UBISYS, "C4", ubisysMacPrefix },
     { VENDOR_UBISYS, "D1", ubisysMacPrefix },

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -129,6 +129,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_DDEL, "FLS-NB2", deMacPrefix },
     { VENDOR_IKEA, "TRADFRI remote control", ikeaMacPrefix },
     { VENDOR_IKEA, "TRADFRI remote control", silabsMacPrefix },
+    { VENDOR_IKEA, "TRADFRI remote control", silabs2MacPrefix },
     { VENDOR_IKEA, "TRADFRI motion sensor", ikeaMacPrefix },
     { VENDOR_IKEA, "TRADFRI wireless dimmer", ikeaMacPrefix },
     { VENDOR_IKEA, "TRADFRI on/off switch", ikeaMacPrefix },
@@ -237,7 +238,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_LEGRAND, "Remote switch", legrandMacPrefix }, // Legrand wireless switch
     { VENDOR_NETVOX, "Z809AE3R", netvoxMacPrefix }, // Netvox smartplug
     { VENDOR_LDS, "ZB-ONOFFPlug-D0005", silabs2MacPrefix }, // Samsung SmartPlug 2019 (7A-PL-Z-J3)
-	{ VENDOR_PHYSICAL, "outletv4", stMacPrefix }, // Samsung SmartThings plug (IM6001-OTP)
+    { VENDOR_PHYSICAL, "outletv4", stMacPrefix }, // Samsung SmartThings plug (IM6001-OTP)
     { 0, nullptr, 0 }
 };
 

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -242,6 +242,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_LDS, "ZB-ONOFFPlug-D0005", silabs2MacPrefix }, // Samsung SmartPlug 2019 (7A-PL-Z-J3)
     { VENDOR_PHYSICAL, "outletv4", stMacPrefix }, // Samsung SmartThings plug (IM6001-OTP)
     { VENDOR_NONE, "RH3052", emberMacPrefix }, // Lupus small zigbee temperature sensor
+    { VENDOR_AURORA, "DoubleSocket50AU", jennicMacPrefix }, // Aurora AOne Double Socket UK
     { 0, nullptr, 0 }
 };
 
@@ -6935,8 +6936,9 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
 
                                 if (item && current != 65535)
                                 {
-                                    if (i->modelId() == QLatin1String("SP 120") || // innr
-                                        i->modelId() == QLatin1String("outletv4"))  // Samsung SmartThings IM6001-OTP
+                                    if (i->modelId() == QLatin1String("SP 120") ||          // innr
+                                        i->modelId() == QLatin1String("outletv4") ||        // Samsung SmartThings IM6001-OTP
+                                        i->modelId() == QLatin1String("DoubleSocket50AU"))  // Aurora
                                     {
                                         // already in mA
                                     }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -237,6 +237,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_LEGRAND, "Remote switch", legrandMacPrefix }, // Legrand wireless switch
     { VENDOR_NETVOX, "Z809AE3R", netvoxMacPrefix }, // Netvox smartplug
     { VENDOR_LDS, "ZB-ONOFFPlug-D0005", silabs2MacPrefix }, // Samsung SmartPlug 2019 (7A-PL-Z-J3)
+	{ VENDOR_PHYSICAL, "outletv4", stMacPrefix }, // Samsung SmartThings plug (IM6001-OTP)
     { 0, nullptr, 0 }
 };
 
@@ -6879,7 +6880,8 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     {
                                         power = power == 28000 ? 0 : power / 10;
                                     }
-                                    else if (i->modelId() == QLatin1String("RICI01")) //LifeControl Smart Plug
+                                    else if (i->modelId() == QLatin1String("RICI01") || // LifeControl Smart Plug
+                                            i->modelId() == QLatin1String("outletv4"))  // Samsung SmartThings IM6001-OTP
                                     {
                                         power /= 10; // 0.1W -> W
                                     }
@@ -6906,7 +6908,8 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     {
                                         voltage += 50; voltage /= 100; // 0.01V -> V
                                     }
-                                    else if (i->modelId() == QLatin1String("RICI01")) //LifeControl Smart Plug
+                                    else if (i->modelId() == QLatin1String("RICI01") || // LifeControl Smart Plug
+                                            i->modelId() == QLatin1String("outletv4"))  // Samsung SmartThings IM6001-OTP
                                     {
                                         voltage /= 10; // 0.1V -> V
                                     }
@@ -6928,7 +6931,8 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
 
                                 if (item && current != 65535)
                                 {
-                                    if (i->modelId() == QLatin1String("SP 120")) // innr
+                                    if (i->modelId() == QLatin1String("SP 120") || // innr
+                                        i->modelId() == QLatin1String("outletv4"))  // Samsung SmartThings IM6001-OTP
                                     {
                                         // already in mA
                                     }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -236,6 +236,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_LEGRAND, "Cable outlet", legrandMacPrefix }, // Legrand Cable outlet
     { VENDOR_LEGRAND, "Remote switch", legrandMacPrefix }, // Legrand wireless switch
     { VENDOR_NETVOX, "Z809AE3R", netvoxMacPrefix }, // Netvox smartplug
+    { VENDOR_LDS, "ZB-ONOFFPlug-D0005", silabs2MacPrefix }, // Samsung SmartPlug 2019 (7A-PL-Z-J3)
     { 0, nullptr, 0 }
 };
 

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -241,6 +241,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_NETVOX, "Z809AE3R", netvoxMacPrefix }, // Netvox smartplug
     { VENDOR_LDS, "ZB-ONOFFPlug-D0005", silabs2MacPrefix }, // Samsung SmartPlug 2019 (7A-PL-Z-J3)
     { VENDOR_PHYSICAL, "outletv4", stMacPrefix }, // Samsung SmartThings plug (IM6001-OTP)
+    { VENDOR_NONE, "RH3052", emberMacPrefix }, // Lupus small zigbee temperature sensor
     { 0, nullptr, 0 }
 };
 

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -417,7 +417,8 @@ inline bool checkMacVendor(quint64 addr, quint16 vendor)
         case VENDOR_BITRON:
             return prefix == tiMacPrefix;
         case VENDOR_BOSCH:
-            return prefix == boschMacPrefix;
+            return prefix == boschMacPrefix ||
+            return prefix == emberMacPrefix;
         case VENDOR_BUSCH_JAEGER:
             return prefix == bjeMacPrefix;
         case VENDOR_CENTRALITE:

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -273,7 +273,7 @@
 #define VENDOR_KEEN_HOME    0x115B
 #define VENDOR_115F         0x115F // Used by Xiaomi Aqara
 #define VENDOR_INNR         0x1166
-#define VENDOR_INNR2        0x1168
+#define VENDOR_LDS          0x1168 // Used by Samsung SmartPlug 2019
 #define VENDOR_INSTA        0x117A
 #define VENDOR_IKEA         0x117C
 #define VENDOR_BUSCH_JAEGER 0x112E
@@ -397,6 +397,7 @@ extern const quint64 ubisysMacPrefix;
 extern const quint64 xalMacPrefix;
 extern const quint64 develcoMacPrefix;
 extern const quint64 legrandMacPrefix;
+extern const quint64 silabs2MacPrefix;
 
 inline bool checkMacVendor(quint64 addr, quint16 vendor)
 {
@@ -428,8 +429,9 @@ inline bool checkMacVendor(quint64 addr, quint16 vendor)
                    prefix == energyMiMacPrefix ||
                    prefix == emberMacPrefix;
         case VENDOR_INNR:
-        case VENDOR_INNR2:
-            return prefix == jennicMacPrefix;
+        case VENDOR_LDS:
+            return prefix == jennicMacPrefix ||
+                   prefix == silabs2MacPrefix;
         case VENDOR_INSTA:
             return prefix == instaMacPrefix;
         case VENDOR_JENNIC:

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -282,6 +282,7 @@
 #define VENDOR_PAULMANN     0x119D
 #define VENDOR_120B         0x120B // Used by Heiman
 #define VENDOR_MUELLER      0x121B // Used by Mueller Licht
+#define VENDOR_AURORA       0x121C // Used by Aurora Aone
 #define VENDOR_SUNRICHER    0x1224 // Used by iCasa keypads
 #define VENDOR_XAL          0x122A
 #define VENDOR_1233         0x1233 // Used by Third Reality
@@ -473,6 +474,8 @@ inline bool checkMacVendor(quint64 addr, quint16 vendor)
             return prefix == legrandMacPrefix;
         case VENDOR_NETVOX:
             return prefix == netvoxMacPrefix;
+        case VENDOR_AURORA:
+            return prefix == jennicMacPrefix;
         default:
             return false;
     }

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -418,7 +418,7 @@ inline bool checkMacVendor(quint64 addr, quint16 vendor)
             return prefix == tiMacPrefix;
         case VENDOR_BOSCH:
             return prefix == boschMacPrefix ||
-            return prefix == emberMacPrefix;
+                   prefix == emberMacPrefix;
         case VENDOR_BUSCH_JAEGER:
             return prefix == bjeMacPrefix;
         case VENDOR_CENTRALITE:

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -398,13 +398,15 @@ extern const quint64 xalMacPrefix;
 extern const quint64 develcoMacPrefix;
 extern const quint64 legrandMacPrefix;
 extern const quint64 silabs2MacPrefix;
+extern const quint64 xiaomiMacPrefix;
 
 inline bool checkMacVendor(quint64 addr, quint16 vendor)
 {
     const quint64 prefix = addr & macPrefixMask;
     switch (vendor) {
         case VENDOR_115F:
-            return prefix == jennicMacPrefix;
+            return prefix == jennicMacPrefix ||
+                   prefix == xiaomiMacPrefix;
         case VENDOR_119C:
             return prefix == sinopeMacPrefix;
         case VENDOR_120B:

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -426,6 +426,7 @@ inline bool checkMacVendor(quint64 addr, quint16 vendor)
         case VENDOR_IKEA:
             return prefix == ikeaMacPrefix ||
                    prefix == silabsMacPrefix ||
+                   prefix == silabs2MacPrefix ||
                    prefix == energyMiMacPrefix ||
                    prefix == emberMacPrefix;
         case VENDOR_INNR:

--- a/general.xml
+++ b/general.xml
@@ -2076,7 +2076,7 @@ Note: It does not clear or delete previous weekly schedule programming configura
 				<attribute id="0x0905" name="RMS Voltage" type="u16" access="r" required="o" default="0xFFFF"></attribute>
 				<attribute id="0x0908" name="RMS Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
 			</attribute-set>
-			<attribute-set id="0x09" description="AC (Phase C) Measurements">
+			<attribute-set id="0x0a" description="AC (Phase C) Measurements">
 				<attribute id="0x0a05" name="RMS Voltage" type="u16" access="r" required="o" default="0xFFFF"></attribute>
 				<attribute id="0x0a08" name="RMS Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
 			</attribute-set>

--- a/general.xml
+++ b/general.xml
@@ -253,7 +253,23 @@
 	</cluster>
 	<cluster id="0002" name="Device Temperature Configuration">
 		<description>Attributes for determining information about a device’s internal temperature, and for configuring under/over temperature alarms.</description>
-		<!-- TODO -->
+		<server>
+			<attribute-set id="0x000" description="Device Temperature Information">
+				<attribute id="0000" name="Current Temperature" type="s16" access="r" range="-200,200" required="m"></attribute>
+				<attribute id="0001" name="Min Temp Experienced" type="s16" access="r" range="-200,200" required="o"></attribute>
+				<attribute id="0002" name="Max Temp Experienced" type="s16" access="r" range="-200,200" required="o"></attribute>
+				<attribute id="0003" name="Over Temp Total Dwell" type="u16" access="r" range="0x0000,0xffff" default="0" required="o"></attribute>
+			</attribute-set>
+			<attribute-set id="0x001" description="Device Temperature Settings">
+				<attribute id="0010" name="Device Temp Alarm Mask" type="bmp8" access="rw" range="00000000,00000011" default="00000000" required="o"></attribute>
+				<attribute id="0011" name="Low Temp Threshold" type="s16" access="rw" range="-200,200" required="o"></attribute>
+				<attribute id="0012" name="High Temp Threshold" type="s16" access="rw" range="-200,200" required="o"></attribute>
+				<attribute id="0013" name="Low Temp Dwell Trip Point" type="u24" access="rw" range="0x000000,0xffffff" required="o"></attribute>
+				<attribute id="0014" name="High Temp Dwell Trip Point" type="u24" access="rw" range="0x000000,0xffffff" required="o"></attribute>
+			</attribute-set>
+		</server>
+		<client>
+		</client>
 	</cluster>
 	<cluster id="0003" name="Identify">
 		<description>Attributes and commands for putting a device into Identification mode (e.g. flashing a light)</description>

--- a/light_node.cpp
+++ b/light_node.cpp
@@ -90,7 +90,7 @@ void LightNode::setManufacturerCode(uint16_t code)
         case VENDOR_BEGA:    name = QLatin1String("BEGA"); break;
         case VENDOR_IKEA:    name = QLatin1String("IKEA of Sweden"); break;
         case VENDOR_INNR:    name = QLatin1String("innr"); break;
-        case VENDOR_INNR2:   name = QLatin1String("innr"); break;
+        case VENDOR_LDS:     name = QLatin1String("LDS"); break;
         case VENDOR_INSTA:   name = QLatin1String("Insta"); break;
         case VENDOR_PHILIPS: name = QLatin1String("Philips"); break;
         case VENDOR_LEDVANCE: name = QLatin1String("LEDVANCE"); break;

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -2340,7 +2340,13 @@ void DeRestPluginPrivate::handleIndicationSearchSensors(const deCONZ::ApsDataInd
         }
         else if (macCapabilities & deCONZ::MacDeviceIsFFD)
         {
-            return;
+            if (checkMacVendor(ext, VENDOR_LDS))
+            { //  Fix to allow Samsung SmartThings plug sensors to be created (7A-PL-Z-J3, modelId ZB-ONOFFPlug-D0005)
+            }
+            else
+            {
+                return;
+            }
         }
         else if (macCapabilities == 0)
         {


### PR DESCRIPTION
- Add support for Samsung SmartThings plug (IM6001-OTP, modelId "outletv4")
- Add support for Samsung SmartThings plug (7A-PL-Z-J3, modelId "ZB-ONOFFPlug-D0005", #2121)
- Update for TRADFRI remote with different Silabs MAC than before (#2243)
- Added cluster "Device Temperature Configuration"
- Amended Develco temperature reporting interval
- Initial support for Xiaomi smart plug (lumi.plug.maeu01, untested #2267)
- Attribute Set Identifier correction in electrical measurement cluster
- Added support for Lupus small zigbee temperature sensor (untested #2281, #1961)
- Added support for Aurora AOne Double Socket UK (untested, #2292)
- Added support for Bosch RFDL-ZB-MS (untested, #2289)
- Fix to allow Samsung SmartThings plug sensors to be created (7A-PL-Z-J3, modelId ZB-ONOFFPlug-D0005, #2121 )
- Potential fix for Bosch ISW-ZPR1-WP13 temperature reporting (#1619, #669)