### PR TITLE
Add support for newer Heiman HS1DS-E door/window sensor

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -179,7 +179,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_NONE, "Z716A", netvoxMacPrefix },
     // { VENDOR_OSRAM_STACK, "Plug", osramMacPrefix }, // OSRAM plug - exposed only as light
     { VENDOR_OSRAM_STACK, "CO_", heimanMacPrefix }, // Heiman CO sensor
-    { VENDOR_OSRAM_STACK, "DOOR_", heimanMacPrefix }, // Heiman door/window sensor
+    { VENDOR_OSRAM_STACK, "DOOR_", heimanMacPrefix }, // Heiman door/window sensor - older model
     { VENDOR_OSRAM_STACK, "PIR_", heimanMacPrefix }, // Heiman motion sensor
     { VENDOR_OSRAM_STACK, "GAS_", heimanMacPrefix }, // Heiman gas sensor - older model
     { VENDOR_OSRAM_STACK, "TH-", heimanMacPrefix }, // Heiman temperature/humidity sensor
@@ -193,6 +193,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_120B, "COSensor", emberMacPrefix }, // Heiman CO sensor - newer model
     { VENDOR_120B, "TH-", emberMacPrefix }, // Heiman temperature/humidity sensor - newer model
     { VENDOR_120B, "Water", emberMacPrefix }, // Heiman water sensor - newer model
+    { VENDOR_120B, "Door", emberMacPrefix }, // Heiman door/window sensor - newer model
     { VENDOR_120B, "WarningDevice", emberMacPrefix }, // Heiman siren
     { VENDOR_LUTRON, "LZL4BWHL01", lutronMacPrefix }, // Lutron LZL-4B-WH-L01 Connected Bulb Remote
     { VENDOR_KEEN_HOME , "SV01-", keenhomeMacPrefix}, // Keen Home Vent
@@ -3811,6 +3812,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                         fpCarbonMonoxideSensor.inClusters.push_back(ci->id());
                     }
                     else if (modelId.startsWith(QLatin1String("DOOR_")) ||            // Heiman door/window sensor
+                             modelId.startsWith(QLatin1String("Door")) ||             // Heiman door/window sensor (newer model)
                              modelId == QLatin1String("3AFE130104020015") ||          // Konke door/window sensor
                              modelId.startsWith(QLatin1String("902010/21")) ||        // Bitron door/window sensor
                              modelId.startsWith(QLatin1String("WISZB-120")) ||        // Develco door/window sensor


### PR DESCRIPTION
I’ve bought a new Heiman HS1DS-E door/window sensor. They use a new model ID: `DoorSensor-EM` (I haven’t compiled nor tested this change).

Cluster Info screenshot:
![2019-12-31_17-29](https://user-images.githubusercontent.com/9890538/71643006-8d4ec180-2cab-11ea-9b58-462a348293e0.png)

Node Info screenshot:
![2019-12-31_17-31](https://user-images.githubusercontent.com/9890538/71643015-a35c8200-2cab-11ea-96a3-603bb09bb1af.png)

Thanks for your work!