### PR TITLE
Vendor codes

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1475,6 +1475,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
     }
     if (node->nodeDescriptor().manufacturerCode() == VENDOR_KEEN_HOME || // Keen Home Vent
         node->nodeDescriptor().manufacturerCode() == VENDOR_JENNIC || // Xiaomi lumi.ctrl_neutral1, lumi.ctrl_neutral2
+        node->nodeDescriptor().manufacturerCode() == VENDOR_115F || // Xiaomi lumi.curtain.hagl04
         node->nodeDescriptor().manufacturerCode() == VENDOR_EMBER || // atsmart Z6-03 switch
         node->nodeDescriptor().manufacturerCode() == VENDOR_NONE || // Climax Siren
         node->nodeDescriptor().manufacturerCode() == VENDOR_DEVELCO || // Develco Smoke sensor with siren
@@ -3436,7 +3437,7 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                 }
             }
             else if (ind.clusterId() == COLOR_CLUSTER_ID &&
-                     (zclFrame.commandId() == 0x4b && zclFrame.payload().size() >= 7) && // move color temperature 
+                     (zclFrame.commandId() == 0x4b && zclFrame.payload().size() >= 7) && // move color temperature
                      !sensor->modelId().contains(QLatin1String("86opcn01")))  // do not use this for Aqara Opple switches, they are missing the additional payload
             {
                 ok = false;
@@ -5017,7 +5018,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
         sensorNode.setManufacturer("LUMI");
         if (!sensorNode.modelId().startsWith(QLatin1String("lumi.ctrl_")) &&
             sensorNode.modelId() != QLatin1String("lumi.plug") &&
-            !sensorNode.modelId().startsWith(QLatin1String("lumi.curtain")))
+            sensorNode.modelId() != QLatin1String("lumi.curtain"))
         {
             sensorNode.addItem(DataTypeUInt8, RConfigBattery);
         }
@@ -5772,7 +5773,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                             {
                                 if (i->modelId().startsWith(QLatin1String("tagv4")) || // SmartThings Arrival sensor
                                     i->modelId() == QLatin1String("Remote switch") || //Legrand switch
-                                    i->modelId() == QLatin1String("Motion Sensor-A") || 
+                                    i->modelId() == QLatin1String("Motion Sensor-A") ||
                                     i->modelId().contains(QLatin1String("86opcn01"))) //Aqara Opple
                                 {  }
                                 else

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -983,7 +983,7 @@ public:
     int updateRule(const ApiRequest &req, ApiResponse &rsp);
     int deleteRule(const ApiRequest &req, ApiResponse &rsp);
     void queueCheckRuleBindings(const Rule &rule);
-    bool evaluateRule(Rule &rule, const Event &e, Resource *eResource, ResourceItem *eItem);
+    bool evaluateRule(Rule &rule, const Event &e, Resource *eResource, ResourceItem *eItem, QDateTime now);
     void indexRuleTriggers(Rule &rule);
     void triggerRule(Rule &rule);
     bool ruleToMap(const Rule *rule, QVariantMap &map);

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -292,7 +292,7 @@
 #define VENDOR_120B         0x120B // Used by Heiman
 #define VENDOR_MUELLER      0x121B // Used by Mueller Licht
 #define VENDOR_AURORA       0x121C // Used by Aurora Aone
-#define VENDOR_SHENZHEN     0x2224 // Used by iCasa keypads
+#define VENDOR_SHENZHEN     0x1224 // Used by iCasa keypads
 #define VENDOR_SUNRICHER    0x1224 // wrong name?
 #define VENDOR_XAL          0x122A
 #define VENDOR_THIRD_REALITY 0x1233

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -248,50 +248,62 @@
 #define WRITE_USERTEST          (1 << 16)
 
 // manufacturer codes
-// http://cgit.osmocom.org/wireshark/plain/epan/dissectors/packet-zbee.h
+// https://github.com/wireshark/wireshark/blob/master/epan/dissectors/packet-zbee.h
 #define VENDOR_NONE         0x0000
 #define VENDOR_EMBER        0x1002
 #define VENDOR_PHILIPS      0x100B // Also used by iCasa routers
-#define VENDOR_VISONIC      0x1011
+#define VENDOR_VISIONIC     0x1011
+#define VENDOR_VISONIC      0x1011 // spelling error?
 #define VENDOR_ATMEL        0x1014
 #define VENDOR_DEVELCO      0x1015
+#define VENDOR_VANTAGE      0x1021
+#define VENDOR_LEGRAND      0x1021 // wrong name?
 #define VENDOR_LGE          0x102E
 #define VENDOR_JENNIC       0x1037 // Used by Xiaomi, Trust, Eurotronic
-#define VENDOR_CENTRALITE   0x104E
+#define VENDOR_CLS          0x104E
+#define VENDOR_CENTRALITE   0x104E // wrong name?
 #define VENDOR_SI_LABS      0x1049
-#define VENDOR_BITRON       0x1071
+#define VENDOR_4_NOKS       0x1071
+#define VENDOR_BITRON       0x1071 // wrong name?
 #define VENDOR_NETVOX       0x109F
 #define VENDOR_NYCE         0x10B9
 #define VENDOR_UBISYS       0x10F2
 #define VENDOR_BEGA         0x1105
 #define VENDOR_PHYSICAL     0x110A // Used by SmartThings
 #define VENDOR_OSRAM        0x110C
+#define VENDOR_BUSCH_JAEGER 0x112E
 #define VENDOR_BOSCH        0x1133
 #define VENDOR_DDEL         0x1135
 #define VENDOR_LUTRON       0x1144
 #define VENDOR_ZEN          0x1158
 #define VENDOR_KEEN_HOME    0x115B
+#define VENDOR_LUMI         0x115F
 #define VENDOR_115F         0x115F // Used by Xiaomi Aqara
 #define VENDOR_INNR         0x1166
 #define VENDOR_LDS          0x1168 // Used by Samsung SmartPlug 2019
 #define VENDOR_INSTA        0x117A
 #define VENDOR_IKEA         0x117C
-#define VENDOR_BUSCH_JAEGER 0x112E
 #define VENDOR_LEDVANCE     0x1189
+#define VENDOR_SINOPE       0x119C
 #define VENDOR_119C         0x119C // Used by Sinope
-#define VENDOR_PAULMANN     0x119D
+#define VENDOR_JIUZHOU      0x119D
+#define VENDOR_PAULMANN     0x119D // wrong name?
+#define VENDOR_HEIMAN       0x120B
 #define VENDOR_120B         0x120B // Used by Heiman
 #define VENDOR_MUELLER      0x121B // Used by Mueller Licht
 #define VENDOR_AURORA       0x121C // Used by Aurora Aone
-#define VENDOR_SUNRICHER    0x1224 // Used by iCasa keypads
+#define VENDOR_SHENZHEN     0x2224 // Used by iCasa keypads
+#define VENDOR_SUNRICHER    0x1224 // wrong name?
 #define VENDOR_XAL          0x122A
+#define VENDOR_THIRD_REALITY 0x1233
 #define VENDOR_1233         0x1233 // Used by Third Reality
+#define VENDOR_DSR          0x1234
 #define VENDOR_1234         0x1234 // Used by Xiaomi Mi
 #define VENDOR_SAMJIN       0x1241
 #define VENDOR_KONKE        0x1268
-#define VENDOR_OSRAM_STACK  0xBBAA
-#define VENDOR_LEGRAND      0x1021
+
 #define VENDOR_C2DF         0xC2DF
+#define VENDOR_OSRAM_STACK  0xBBAA
 
 #define ANNOUNCE_INTERVAL 10 // minutes default announce interval
 


### PR DESCRIPTION
I found a [new source](https://github.com/wireshark/wireshark/blob/master/epan/dissectors/packet-zbee.h) for ZigBee manufacturer codes, which contains the missing codes that we couldn't find earlier.  There are some mismatches between this list from WireShark and our current list, which I've highlighted in this PR.  I haven't marked any literal differences, like names with or without "Technology" in them, or "DDEL" vs "Dresden".  I think the mismatches I marked are mostly OEM vs commercial names, like "Shenzhen" vs "Sunricher", or "Jiuzhou" vs "Paulman".

I also sorted the list, once again, on manufacturer code.

Main reason I've created this PR is to start/continue the discussion how we want to deal with these definitions.  Should we continue to maintain them ourselves, or should we include/re-use the WireShark list?  Should we continue to use our own names, or do we want to use exactly the same names as the WireShark list?  Of course, I have no idea what the official status of the WireShark list is.

Pending this discussion, I haven't yet (?) removed any of the numeric or (possibly) wrong names, and I haven't yet (?) updated the rest of the code to use the new names.