### PR TITLE
Improve pairing for Legrand

### DIFF
--- a/basic.cpp
+++ b/basic.cpp
@@ -1,7 +1,7 @@
 /*
  * basic.cpp
  *
- * Full implementation of Basic cluster server.
+ * Implementation of Basic cluster server.
  * Send ZCL attribute response to read request on Basic Cluster attributes.
  *
  * 0x0000 ZCL Version    / Just to test
@@ -21,7 +21,7 @@ void DeRestPluginPrivate::handleBasicClusterIndication(const deCONZ::ApsDataIndi
 {
     if (zclFrame.isProfileWideCommand() && zclFrame.commandId() == deCONZ::ZclReadAttributesId)
     {
-    	sendBasicClusterResponse(ind, zclFrame);
+        sendBasicClusterResponse(ind, zclFrame);
     }
 }
 
@@ -47,12 +47,13 @@ void DeRestPluginPrivate::sendBasicClusterResponse(const deCONZ::ApsDataIndicati
     outZclFrame.setFrameControl(deCONZ::ZclFCProfileCommand |
                                 deCONZ::ZclFCDirectionServerToClient |
                                 deCONZ::ZclFCDisableDefaultResponse);
-                                
-    //Sensor *sensor = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), 0x01);                          
-    if (true)
+
+    //is there manufacture field in the request, if yes add it.
+    if (zclFrame.frameControl() & deCONZ::ZclFCManufacturerSpecific) 
     {
+        quint16 manucode = zclFrame.manufacturerCode();
         outZclFrame.setFrameControl(outZclFrame.frameControl() | deCONZ::ZclFCManufacturerSpecific);
-        outZclFrame.setManufacturerCode(0x1021);
+        outZclFrame.setManufacturerCode(manucode);
     }
 
     { // payload
@@ -66,31 +67,31 @@ void DeRestPluginPrivate::sendBasicClusterResponse(const deCONZ::ApsDataIndicati
 
         while (!instream.atEnd())
         {
-        	instream >> attr;
-        	stream << attr;
+            instream >> attr;
+            stream << attr;
 
-        	switch(attr)
-        	{
-        	case 0x0000:
-        	    //ZCL version
-        		stream << code;
-        		stream << (quint8) deCONZ::Zcl8BitUint;
-        		stream << 0x02;
-        		break;
+            switch(attr)
+            {
+            case 0x0000:
+                //ZCL version
+                stream << code;
+                stream << (quint8) deCONZ::Zcl8BitUint;
+                stream << 0x02;
+                break;
 
-        	case 0xF000:
-        	    //Legrand attribute used for pairing
-        		stream << code;
-        		stream << (quint8) deCONZ::Zcl32BitUint;
-        		stream << 0x000000d5;
-        		break;
+            case 0xF000:
+                //Legrand attribute used for pairing
+                stream << code;
+                stream << (quint8) deCONZ::Zcl32BitUint;
+                stream << 0x000000d5;
+                break;
 
-        	default:
-        	{
-        		stream << (quint8) 0x86;  // unsupported_attribute
-        	}
-        	break;
-        	}
+            default:
+            {
+                stream << (quint8) 0x86;  // unsupported_attribute
+            }
+            break;
+            }
         }
     }
 

--- a/basic.cpp
+++ b/basic.cpp
@@ -1,0 +1,108 @@
+/*
+ * basic.cpp
+ *
+ * Full implementation of Basic cluster server.
+ * Send ZCL attribute response to read request on Basic Cluster attributes.
+ *
+ * 0x0000 ZCL Version    / Just to test
+ * 0xF000 Running time   / Used for Legrand device
+ *
+ */
+
+#include "de_web_plugin.h"
+#include "de_web_plugin_private.h"
+
+
+/*! Handle packets related to the ZCL Basic cluster.
+    \param ind the APS level data indication containing the ZCL packet
+    \param zclFrame the actual ZCL frame which holds the read attribute request
+ */
+void DeRestPluginPrivate::handleBasicClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame)
+{
+    if (zclFrame.isProfileWideCommand() && zclFrame.commandId() == deCONZ::ZclReadAttributesId)
+    {
+    	sendBasicClusterResponse(ind, zclFrame);
+    }
+}
+
+/*! Sends read attributes response to Basic client.
+    \param ind the APS level data indication containing the ZCL packet
+    \param zclFrame the actual ZCL frame which holds the read attributes request
+ */
+void DeRestPluginPrivate::sendBasicClusterResponse(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame)
+{
+    deCONZ::ApsDataRequest req;
+    deCONZ::ZclFrame outZclFrame;
+
+    req.setProfileId(ind.profileId());
+    req.setClusterId(ind.clusterId());
+    req.setDstAddressMode(ind.srcAddressMode());
+    req.dstAddress() = ind.srcAddress();
+    req.setDstEndpoint(ind.srcEndpoint());
+    req.setSrcEndpoint(endpoint());
+
+    outZclFrame.setSequenceNumber(zclFrame.sequenceNumber());
+    outZclFrame.setCommandId(deCONZ::ZclReadAttributesResponseId);
+
+    outZclFrame.setFrameControl(deCONZ::ZclFCProfileCommand |
+                                deCONZ::ZclFCDirectionServerToClient |
+                                deCONZ::ZclFCDisableDefaultResponse);
+                                
+    //Sensor *sensor = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), 0x01);                          
+    if (true)
+    {
+        outZclFrame.setFrameControl(outZclFrame.frameControl() | deCONZ::ZclFCManufacturerSpecific);
+        outZclFrame.setManufacturerCode(0x1021);
+    }
+
+    { // payload
+        QDataStream stream(&outZclFrame.payload(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+
+        QDataStream instream(zclFrame.payload());
+        instream.setByteOrder(QDataStream::LittleEndian);
+        quint8 code = 0x00; // success
+        quint16 attr;
+
+        while (!instream.atEnd())
+        {
+        	instream >> attr;
+        	stream << attr;
+
+        	switch(attr)
+        	{
+        	case 0x0000:
+        	    //ZCL version
+        		stream << code;
+        		stream << (quint8) deCONZ::Zcl8BitUint;
+        		stream << 0x02;
+        		break;
+
+        	case 0xF000:
+        	    //Legrand attribute used for pairing
+        		stream << code;
+        		stream << (quint8) deCONZ::Zcl32BitUint;
+        		stream << 0x000000d5;
+        		break;
+
+        	default:
+        	{
+        		stream << (quint8) 0x86;  // unsupported_attribute
+        	}
+        	break;
+        	}
+        }
+    }
+
+    { // ZCL frame
+        QDataStream stream(&req.asdu(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+        outZclFrame.writeToStream(stream);
+    }
+
+    if (apsCtrl && apsCtrl->apsdeDataRequest(req) != deCONZ::Success)
+    {
+        DBG_Printf(DBG_INFO, "Basic failed to send reponse\n");
+    }
+
+}

--- a/de_web.pro
+++ b/de_web.pro
@@ -164,6 +164,7 @@ SOURCES  = authorisation.cpp \
            sensor.cpp \
            thermostat.cpp \
            time.cpp \
+           basic.cpp \
            reset_device.cpp \
            rest_userparameter.cpp \
            zcl_tasks.cpp \

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -622,6 +622,10 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
         case THERMOSTAT_CLUSTER_ID:
             handleThermostatClusterIndication(ind, zclFrame);
             break;
+            
+        case BASIC_CLUSTER_ID:
+            handleBasicClusterIndication(ind, zclFrame);
+            break;
 
         default:
         {

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1308,6 +1308,8 @@ public:
     void handleThermostatClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleTimeClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void sendTimeClusterResponse(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
+    void handleBasicClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
+    void sendBasicClusterResponse(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleZclAttributeReportIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleZclConfigureReportingResponseIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void sendZclDefaultResponse(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame, quint8 status);

--- a/poll_manager.cpp
+++ b/poll_manager.cpp
@@ -402,10 +402,20 @@ void PollManager::pollTimerFired()
     }
     else if (suffix == RStatePower)
     {
+        bool NotOnlyPower = true;
         clusterId = ELECTRICAL_MEASUREMENT_CLUSTER_ID;
         attributes.push_back(0x050b); // Active Power
         item = r->item(RAttrModelId);
-        if (! item->toString().startsWith(QLatin1String("Plug"))) // OSRAM plug
+        if (!item->toString().startsWith(QLatin1String("Plug"))) //Osram plug
+        {
+            NotOnlyPower = false;
+        }
+        item = r->item(RAttrManufacturerName);
+        if (!item->toString().startsWith(QLatin1String("Legrand")))  // All legrand Devices
+        {
+            NotOnlyPower = false;
+        }
+        if (NotOnlyPower)
         {
             attributes.push_back(0x0505); // RMS Voltage
             attributes.push_back(0x0508); // RMS Current


### PR DESCRIPTION
Long story here https://github.com/dresden-elektronik/deconz-rest-plugin/issues/2369

- Solve some issue with missing feature on devices.
- Improve pairing.

I know lines 52/54 in basic.cpp aren't fantastic, but I haven't found a way to make this part manufacture specific (the device is not in the database so I can't use it for test, and I don't see a way to use zclFrame).
I haven't find declaration for deCONZ::ApsDataIndication, perhaps this class have something to retreive the manufacture code (the read attribute request have it)

I can remove the 0x0000 attribute, it is here just for tests (or future use).