### PR TITLE
Extend and refactor Scene class

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -96,6 +96,10 @@ void DeRestPluginPrivate::checkDbUserVersion()
     }
     else if (userVersion == 6)
     {
+        updated = upgradeDbToUserVersion7();
+    }
+    else if (userVersion == 7)
+    {
         // latest version
     }
     else
@@ -425,6 +429,45 @@ bool DeRestPluginPrivate::upgradeDbToUserVersion6()
     }
 
     return setDbUserVersion(6);
+}
+
+/*! Upgrades database to user_version 7. */
+bool DeRestPluginPrivate::upgradeDbToUserVersion7()
+{
+    int rc;
+    char *errmsg;
+
+    DBG_Printf(DBG_INFO, "DB upgrade to user_version 7\n");
+
+    // create tables
+    const char *sql[] = {
+        "ALTER TABLE scenes ADD COLUMN owner TEXT",
+        "ALTER TABLE scenes ADD COLUMN recycle BOOLEAN",
+        "ALTER TABLE scenes ADD COLUMN locked BOOLEAN",
+        "ALTER TABLE scenes ADD COLUMN appdata TEXT",
+        "ALTER TABLE scenes ADD COLUMN picture TEXT",
+        "ALTER TABLE scenes ADD COLUMN lastupdated TEXT",
+        "ALTER TABLE scenes ADD COLUMN version INT",
+        nullptr
+    };
+
+    for (int i = 0; sql[i] != nullptr; i++)
+    {
+        errmsg = nullptr;
+        rc = sqlite3_exec(db, sql[i], nullptr, nullptr, &errmsg);
+
+        if (rc != SQLITE_OK)
+        {
+            if (errmsg)
+            {
+                DBG_Printf(DBG_ERROR_L2, "SQL exec failed: %s, error: %s (%d)\n", sql[i], errmsg, rc);
+                sqlite3_free(errmsg);
+            }
+            return false;
+        }
+    }
+
+    return setDbUserVersion(7);
 }
 
 /*! Puts a new top level device entry in the db (mac address) or refreshes nwk address.
@@ -1825,8 +1868,19 @@ static int sqliteLoadAllScenesCallback(void *user, int ncols, char **colval , ch
     bool ok;
     bool ok1;
     bool ok2;
-    Scene scene;
-    DeRestPluginPrivate *d = static_cast<DeRestPluginPrivate*>(user);
+    QString id;
+    uint16_t gid = 0;
+    uint8_t sid = 0;
+    QString name;
+    uint16_t transitiontime = 4;
+    QString lights;
+    QString owner;
+    bool recycle = false;
+    bool locked = false;
+    QVariantMap appdata;
+    QString picture;
+    QDateTime lastupdated;
+    uint16_t version = 2;
 
     for (int i = 0; i < ncols; i++)
     {
@@ -1836,41 +1890,95 @@ static int sqliteLoadAllScenesCallback(void *user, int ncols, char **colval , ch
 
             DBG_Printf(DBG_INFO_L2, "Sqlite scene: %s = %s\n", colname[i], qPrintable(val));
 
-            if (strcmp(colname[i], "gid") == 0)
+            if (strcmp(colname[i], "gsid") == 0)
             {
-                scene.groupAddress = val.toUInt(&ok1, 16);
+                id = val;
+            }
+            else if (strcmp(colname[i], "gid") == 0)
+            {
+                gid = val.toUInt(&ok1);
             }
             else if (strcmp(colname[i], "sid") == 0)
             {
-                scene.id = val.toUInt(&ok2, 16);
+                sid = val.toUInt(&ok2);
             }
             else if (strcmp(colname[i], "name") == 0)
             {
-                scene.name = val;
+                name = val;
             }
             else if (strcmp(colname[i], "transitiontime") == 0)
             {
-                scene.setTransitiontime(val.toUInt(&ok));
+                transitiontime = val.toUInt(&ok);
             }
             else if (strcmp(colname[i], "lights") == 0)
             {
-                scene.setLights(Scene::jsonToLights(val));
+                lights = val;
+            }
+            else if (strcmp(colname[i], "owner") == 0)
+            {
+                owner = val;
+            }
+            else if (strcmp(colname[i], "recycle") == 0)
+            {
+                recycle = (val.toUInt(&ok) != 0);
+            }
+            else if (strcmp(colname[i], "locked") == 0)
+            {
+                locked = (val.toUInt(&ok) != 0);
+            }
+            else if (strcmp(colname[i], "appdata") == 0)
+            {
+                QVariant var = Json::parse(val, ok);
+                appdata = var.toMap();
+            }
+            else if (strcmp(colname[i], "picture") == 0)
+            {
+                picture = val;
+            }
+            else if (strcmp(colname[i], "lastupdated") == 0)
+            {
+                lastupdated = QDateTime::fromString(val, "yyyy-MM-ddTHH:mm:ss"); // ISO 8601
+            }
+            else if (strcmp(colname[i], "version") == 0)
+            {
+                version = val.toUInt(&ok);
             }
         }
     }
 
     if (ok1 && ok2)
     {
-        DBG_Printf(DBG_INFO_L2, "DB found scene sid: 0x%02X, gid: 0x%04X\n", scene.id, scene.groupAddress);
+        DBG_Printf(DBG_INFO_L2, "DB found scene id: %s, sid: 0x%02X, gid: 0x%04X\n", qPrintable(id), sid, gid);
 
-        Group *g = d->getGroupForId(scene.groupAddress);
+        DeRestPluginPrivate *d = static_cast<DeRestPluginPrivate*>(user);
+        Group *g = d->getGroupForId(gid);
         if (g)
         {
             // append scene to group if not already known
-            Scene *s = d->getSceneForId(scene.groupAddress,scene.id);
+            Scene *s = d->getSceneForId(gid, sid);
             if (!s)
             {
                 // append scene to group if not already known
+                Scene scene(gid, sid, gid == d->gwGroup0 ? Scene::LightScene : Scene::GroupScene);
+                scene.init(id, owner, lastupdated, version);
+                scene.name(name);
+                scene.transitiontime(transitiontime);
+
+                QVariantList ls = Json::parse(lights).toList();
+                for (QVariant l : ls)
+                {
+                    LightState state;
+                    QVariantMap l_map = l.toMap();
+                    QString lid = l_map[QLatin1String("lid")].toString();
+                    state.setLightId(lid);
+                    state.map(l_map);
+                    scene.addLight(state);
+                }
+
+                scene.recycle(recycle);
+                scene.locked(locked);
+                scene.appdata(appdata);
+                scene.picture(picture);
                 d->updateEtag(g->etag);
                 g->scenes.push_back(scene);
             }
@@ -2556,23 +2664,109 @@ static int sqliteLoadSceneCallback(void *user, int ncols, char **colval , char *
 
     Scene *scene = static_cast<Scene*>(user);
 
-    for (int i = 0; i < ncols; i++) {
+    bool ok;
+    bool ok1;
+    bool ok2;
+    QString id;
+    uint16_t gid = scene->gid();
+    uint8_t sid = scene->sid();
+    QString name;
+    uint16_t transitiontime = 4;
+    QString lights;
+    QString owner;
+    bool recycle = false;
+    bool locked = false;
+    QVariantMap appdata;
+    QString picture;
+    QDateTime lastupdated;
+    uint16_t version = 2;
+
+    for (int i = 0; i < ncols; i++)
+    {
         if (colval[i] && (colval[i][0] != '\0'))
         {
-            if (strcmp(colname[i], "name") == 0)
+            QString val = QString::fromUtf8(colval[i]);
+
+            DBG_Printf(DBG_INFO_L2, "Sqlite scene: %s = %s\n", colname[i], qPrintable(val));
+
+            if (strcmp(colname[i], "gsid") == 0)
             {
-                scene->name = QString::fromUtf8(colval[i]);
+                id = val;
             }
-            if (strcmp(colname[i], "transitiontime") == 0)
+            else if (strcmp(colname[i], "gid") == 0)
             {
-                QString tt = QString::fromUtf8(colval[i]);
-                scene->setTransitiontime(tt.toUInt());
+                gid = val.toUInt(&ok1);
             }
-            if (strcmp(colname[i], "lights") == 0)
+            else if (strcmp(colname[i], "sid") == 0)
             {
-                scene->setLights(Scene::jsonToLights(colval[i]));
+                sid = val.toUInt(&ok2);
+            }
+            else if (strcmp(colname[i], "name") == 0)
+            {
+                name = val;
+            }
+            else if (strcmp(colname[i], "transitiontime") == 0)
+            {
+                transitiontime = val.toUInt(&ok);
+            }
+            else if (strcmp(colname[i], "lights") == 0)
+            {
+                lights = val;
+            }
+            else if (strcmp(colname[i], "owner") == 0)
+            {
+                owner = val;
+            }
+            else if (strcmp(colname[i], "recycle") == 0)
+            {
+                recycle = (val.toUInt(&ok) != 0);
+            }
+            else if (strcmp(colname[i], "locked") == 0)
+            {
+                locked = (val.toUInt(&ok) != 0);
+            }
+            else if (strcmp(colname[i], "appdata") == 0)
+            {
+                QVariant var = Json::parse(val, ok);
+                appdata = var.toMap();
+            }
+            else if (strcmp(colname[i], "picture") == 0)
+            {
+                picture = val;
+            }
+            else if (strcmp(colname[i], "lastupdated") == 0)
+            {
+                lastupdated = QDateTime::fromString(val, "yyyy-MM-ddTHH:mm:ss"); // ISO 8601
+            }
+            else if (strcmp(colname[i], "version") == 0)
+            {
+                version = val.toUInt(&ok);
             }
         }
+    }
+
+    if (ok1 && ok2 && gid == scene->gid() && sid == scene->sid())
+    {
+        DBG_Printf(DBG_INFO_L2, "DB found scene id: %s, sid: 0x%02X, gid: 0x%04X\n", id, sid, gid);
+        scene->init(id, owner, lastupdated, version);
+        scene->name(name);
+        scene->transitiontime(transitiontime);
+
+        QVariantList ls = Json::parse(lights).toList();
+        for (QVariant l : ls)
+        {
+            LightState state;
+            QVariantMap l_map = l.toMap();
+            QString lid = l_map[QLatin1String("lid")].toString();
+            state.setLightId(lid);
+            state.map(l_map);
+            scene->addLight(state);
+        }
+
+        scene->recycle(recycle);
+        scene->locked(locked);
+        scene->appdata(appdata);
+        scene->picture(picture);
     }
 
     return 0;
@@ -2593,10 +2787,7 @@ void DeRestPluginPrivate::loadSceneFromDb(Scene *scene)
         return;
     }
 
-    QString gsid; // unique key
-    gsid = QString::asprintf("0x%04X%02X", scene->groupAddress, scene->id);
-
-    QString sql = QString("SELECT * FROM scenes WHERE gsid='%1'").arg(gsid);
+    QString sql = QString("SELECT * FROM scenes WHERE gid='%1' AND sid='%2'").arg(scene->gid()).arg(scene->sid());
 
     DBG_Printf(DBG_INFO_L2, "sql exec %s\n", qPrintable(sql));
     rc = sqlite3_exec(db, qPrintable(sql), sqliteLoadSceneCallback, scene, &errmsg);
@@ -4472,29 +4663,38 @@ void DeRestPluginPrivate::saveDb()
 
                 for (; si != send; ++si)
                 {
-                    QString gsid; // unique key
-                    gsid = QString::asprintf("0x%04X%02X", i->address(), si->id);
-
-                    QString sid;
-                    sid = QString::asprintf("0x%02X", si->id);
-
-                    QString lights = Scene::lightsToString(si->lights());
                     QString sql;
 
-                    if (si->state == Scene::StateDeleted)
+                    if (si->state() == Scene::StateDeleted)
                     {
                         // delete scene from db (if exist)
-                        sql = QString(QLatin1String("DELETE FROM scenes WHERE gsid='%1'")).arg(gsid);
+                        sql = QString(QLatin1String("DELETE FROM scenes WHERE gid='%1' AND sid='%2'")).arg(si->gid()).arg(si->sid());
                     }
                     else
                     {
-                        sql = QString(QLatin1String("REPLACE INTO scenes (gsid, gid, sid, name, transitiontime, lights) VALUES ('%1', '%2', '%3', '%4', '%5', '%6')"))
-                            .arg(gsid)
-                            .arg(gid)
-                            .arg(sid)
-                            .arg(si->name)
+                        QVariantList ls;
+                        for (const LightState& l : si->lights())
+                        {
+                            ls.append(l.map());
+                        }
+                        QString lights = Json::serialize(ls);
+                        QString appdata = Json::serialize(si->appdata());
+                        QString lastupdated = si->lastupdated().toString("yyyy-MM-ddTHH:mm:ss");
+
+                        sql = QString(QLatin1String("REPLACE INTO scenes (gsid, gid, sid, name, transitiontime, lights, owner, recycle, locked, appdata, picture, lastupdated, version) VALUES ('%1', '%2', '%3', '%4', '%5', '%6', '%7', '%8', '%9', '%10', '%11', '%12', '%13')"))
+                            .arg(si->id())
+                            .arg(si->gid())
+                            .arg(si->sid())
+                            .arg(si->name())
                             .arg(si->transitiontime())
-                            .arg(lights);
+                            .arg(lights)
+                            .arg(si->owner())
+                            .arg(si->recycle())
+                            .arg(si->locked())
+                            .arg(appdata)
+                            .arg(si->picture())
+                            .arg(lastupdated)
+                            .arg(si->version());
                     }
                     DBG_Printf(DBG_INFO_L2, "DB sql exec %s\n", qPrintable(sql));
                     errmsg = NULL;

--- a/database.cpp
+++ b/database.cpp
@@ -1972,7 +1972,7 @@ static int sqliteLoadAllScenesCallback(void *user, int ncols, char **colval , ch
                     QString lid = l_map[QLatin1String("lid")].toString();
                     state.setLightId(lid);
                     state.map(l_map);
-                    scene.addLight(state);
+                    scene.addLightState(state);
                 }
 
                 scene.recycle(recycle);
@@ -2760,7 +2760,7 @@ static int sqliteLoadSceneCallback(void *user, int ncols, char **colval , char *
             QString lid = l_map[QLatin1String("lid")].toString();
             state.setLightId(lid);
             state.map(l_map);
-            scene->addLight(state);
+            scene->addLightState(state);
         }
 
         scene->recycle(recycle);
@@ -4673,7 +4673,7 @@ void DeRestPluginPrivate::saveDb()
                     else
                     {
                         QVariantList ls;
-                        for (const LightState& l : si->lights())
+                        for (const LightState& l : si->lightStates())
                         {
                             ls.append(l.map());
                         }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -8755,7 +8755,7 @@ void DeRestPluginPrivate::deleteLightFromScenes(QString lightId, uint16_t groupI
 
         for (; i != end; ++i)
         {
-            i->removeLight(lightId);
+            i->removeLightState(lightId);
 
             // send remove scene request to lightNode
             if (isLightNodeInGroup(lightNode, group->address()))
@@ -9128,7 +9128,7 @@ bool DeRestPluginPrivate::removeScene(Group *group, Scene *scene)
     updateEtag(group->etag);
     updateEtag(gwConfigEtag);
 
-    for (const LightState& state : scene->lights())
+    for (const LightState& state : scene->lightStates())
     {
         LightNode* l = getLightNodeForId(state.lid());
         if (l)
@@ -10938,9 +10938,9 @@ void DeRestPluginPrivate::processGroupTasks()
 
                 if (scene)
                 {
-                    //const std::vector<LightState> &lights() const;
-                    std::vector<LightState>::const_iterator ls = scene->lights().begin();
-                    std::vector<LightState>::const_iterator lsend = scene->lights().end();
+                    //const std::vector<LightState> &lightStates() const;
+                    std::vector<LightState>::const_iterator ls = scene->lightStates().begin();
+                    std::vector<LightState>::const_iterator lsend = scene->lightStates().end();
 
                     for (; ls != lsend; ++ls)
                     {
@@ -11245,8 +11245,8 @@ void DeRestPluginPrivate::handleSceneClusterIndication(TaskItem &task, const deC
                         continue; // exists
                     }
 
-                    std::vector<LightState>::const_iterator st = i->lights().begin();
-                    std::vector<LightState>::const_iterator stend = i->lights().end();
+                    std::vector<LightState>::const_iterator st = i->lightStates().begin();
+                    std::vector<LightState>::const_iterator stend = i->lightStates().end();
 
                     for (; st != stend; ++st)
                     {
@@ -11318,7 +11318,7 @@ void DeRestPluginPrivate::handleSceneClusterIndication(TaskItem &task, const deC
                         {
                             bool foundLightstate = false;
 
-                            LightState* li = scene->getLight(lightNode->id());
+                            LightState* li = scene->getLightState(lightNode->id());
                             if (li)
                             {
                                 ResourceItem *item = lightNode->item(RStateOn);
@@ -11428,7 +11428,7 @@ void DeRestPluginPrivate::handleSceneClusterIndication(TaskItem &task, const deC
                                     state.setColorloopActive(lightNode->isColorLoopActive());
                                     state.setColorloopTime(lightNode->colorLoopSpeed());
                                 }
-                                scene->addLight(state);
+                                scene->addLightState(state);
 
                                 // only change capacity and count when creating a new scene
                                 uint8_t sceneCapacity = lightNode->sceneCapacity();
@@ -11496,13 +11496,13 @@ void DeRestPluginPrivate::handleSceneClusterIndication(TaskItem &task, const deC
 
                         if (scene)
                         {
-                            std::vector<LightState>::const_iterator li = scene->lights().begin();
-                            std::vector<LightState>::const_iterator lend = scene->lights().end();
+                            std::vector<LightState>::const_iterator li = scene->lightStates().begin();
+                            std::vector<LightState>::const_iterator lend = scene->lightStates().end();
                             for (; li != lend; ++li)
                             {
                                 if (li->lid() == lightNode->id())
                                 {
-                                    scene->removeLight(lightNode->id());
+                                    scene->removeLightState(lightNode->id());
                                     break;
                                 }
                             }
@@ -11700,7 +11700,7 @@ void DeRestPluginPrivate::handleSceneClusterIndication(TaskItem &task, const deC
 
             if (scene)
             {
-                LightState *lightState = scene->getLight(lightNode->id());
+                LightState *lightState = scene->getLightState(lightNode->id());
 
                 if (scene->state() == Scene::StateDeleted)
                 {
@@ -11809,7 +11809,7 @@ void DeRestPluginPrivate::handleSceneClusterIndication(TaskItem &task, const deC
                         newLightState.setEnhancedHue(ehue);
                         newLightState.setSaturation(sat);
                     }
-                    scene->addLight(newLightState);
+                    scene->addLightState(newLightState);
                     queSaveDb(DB_SCENES, DB_LONG_SAVE_DELAY);
                 }
             }
@@ -11872,8 +11872,8 @@ void DeRestPluginPrivate::handleSceneClusterIndication(TaskItem &task, const deC
 
         if (group && (group->state() == Group::StateNormal) && scene)
         {
-            std::vector<LightState>::const_iterator ls = scene->lights().begin();
-            std::vector<LightState>::const_iterator lsend = scene->lights().end();
+            std::vector<LightState>::const_iterator ls = scene->lightStates().begin();
+            std::vector<LightState>::const_iterator lsend = scene->lightStates().end();
 
             pollManager->delay(1500);
             for (; ls != lsend; ++ls)

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1240,7 +1240,7 @@ public:
     void setSceneName(Group *group, uint8_t sceneId, const QString &name);
     bool storeScene(Group *group, uint8_t sceneId);
     bool modifyScene(Group *group, uint8_t sceneId);
-    bool removeScene(Group *group, Scene* sceneId);
+    bool removeScene(Group *group, Scene* scene);
     bool callScene(Group *group, uint8_t sceneId);
     bool removeAllScenes(Group *group);
     void storeRecoverOnOffBri(LightNode *lightNode);

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1240,7 +1240,7 @@ public:
     void setSceneName(Group *group, uint8_t sceneId, const QString &name);
     bool storeScene(Group *group, uint8_t sceneId);
     bool modifyScene(Group *group, uint8_t sceneId);
-    bool removeScene(Group *group, uint8_t sceneId);
+    bool removeScene(Group *group, Scene* sceneId);
     bool callScene(Group *group, uint8_t sceneId);
     bool removeAllScenes(Group *group);
     void storeRecoverOnOffBri(LightNode *lightNode);
@@ -1339,6 +1339,7 @@ public:
     bool upgradeDbToUserVersion1();
     bool upgradeDbToUserVersion2();
     bool upgradeDbToUserVersion6();
+    bool upgradeDbToUserVersion7();
     void refreshDeviceDb(const deCONZ::Address &addr);
     void pushZdpDescriptorDb(quint64 extAddress, quint8 endpoint, quint16 type, const QByteArray &data);
     void pushZclValueDb(quint64 extAddress, quint8 endpoint, quint16 clusterId, quint16 attributeId, qint64 data);

--- a/group.cpp
+++ b/group.cpp
@@ -233,7 +233,7 @@ Scene *Group::getScene(quint8 sceneId)
     std::vector<Scene>::iterator end = scenes.end();
     for (; i != end; ++i)
     {
-        if (i->id == sceneId && i->state == Scene::StateNormal)
+        if (i->sid() == sceneId && i->state() == Scene::StateNormal)
         {
             return &*i;
         }

--- a/rest_capabilities.cpp
+++ b/rest_capabilities.cpp
@@ -76,7 +76,7 @@ int DeRestPluginPrivate::getCapabilities(const ApiRequest &req, ApiResponse &rsp
             std::vector<Scene>::const_iterator s_end = g->scenes.end();
             for (; s != s_end; ++s)
             {
-                lightstates_size += s->lights().size();
+                lightstates_size += s->lightStates().size();
             }
         }
     }

--- a/rest_groups.cpp
+++ b/rest_groups.cpp
@@ -1931,7 +1931,7 @@ bool DeRestPluginPrivate::groupToMap(const ApiRequest &req, const Group *group, 
             scene["id"] = sid;
             scene["name"] = si->name();
             scene["transitiontime"] = si->transitiontime();
-            scene["lightcount"] = (double)si->lights().size();
+            scene["lightcount"] = (double)si->lightStates().size();
 
             scenes.append(scene);
         }
@@ -2173,7 +2173,7 @@ int DeRestPluginPrivate::createScene(const ApiRequest &req, ApiResponse &rsp)
                 state.setColorMode(QLatin1String("none"));
             }
 
-            scene.addLight(state);
+            scene.addLightState(state);
             queSaveDb(DB_SCENES, DB_LONG_SAVE_DELAY);
         }
     }
@@ -2226,8 +2226,8 @@ int DeRestPluginPrivate::getAllScenes(const ApiRequest &req, ApiResponse &rsp)
             scene["name"] = i->name();
 
             QVariantList lights;
-            std::vector<LightState>::const_iterator l = i->lights().begin();
-            std::vector<LightState>::const_iterator lend = i->lights().end();
+            std::vector<LightState>::const_iterator l = i->lightStates().begin();
+            std::vector<LightState>::const_iterator lend = i->lightStates().end();
             for (; l != lend; ++l)
             {
                 lights.append(l->lid());
@@ -2278,8 +2278,8 @@ int DeRestPluginPrivate::getSceneAttributes(const ApiRequest &req, ApiResponse &
             if ((i->sid() == sceneId) && (i->state() == Scene::StateNormal))
             {
                 QVariantList lights;
-                std::vector<LightState>::const_iterator l = i->lights().begin();
-                std::vector<LightState>::const_iterator lend = i->lights().end();
+                std::vector<LightState>::const_iterator l = i->lightStates().begin();
+                std::vector<LightState>::const_iterator lend = i->lightStates().end();
                 for (; l != lend; ++l)
                 {
                     QVariantMap lstate;
@@ -2522,7 +2522,7 @@ int DeRestPluginPrivate::storeScene(const ApiRequest &req, ApiResponse &rsp)
         }
 
         bool needModify = false;
-        LightState *ls = scene->getLight(lightNode->id());
+        LightState *ls = scene->getLightState(lightNode->id());
 
         if (!ls)
         {
@@ -2534,8 +2534,8 @@ int DeRestPluginPrivate::storeScene(const ApiRequest &req, ApiResponse &rsp)
                 rsp.list.append(errorToMap(ERR_DEVICE_SCENES_TABLE_FULL, QString("/groups/%1/scenes/lights/%2").arg(gid).arg(lightNode->id()), QString("Could not set scene for %1. Scene capacity of the device is reached.").arg(qPrintable(lightNode->name()))));
             }*/
 
-            scene->addLight(lsnew);
-            ls = scene->getLight(lightNode->id());
+            scene->addLightState(lsnew);
+            ls = scene->getLightState(lightNode->id());
             needModify = true;
         }
 
@@ -2765,8 +2765,8 @@ int DeRestPluginPrivate::recallScene(const ApiRequest &req, ApiResponse &rsp)
     }
 
     bool groupOn = false;
-    std::vector<LightState>::const_iterator ls = scene->lights().begin();
-    std::vector<LightState>::const_iterator lsend = scene->lights().end();
+    std::vector<LightState>::const_iterator ls = scene->lightStates().begin();
+    std::vector<LightState>::const_iterator lsend = scene->lightStates().end();
 
     for (; ls != lsend; ++ls)
     {
@@ -2827,8 +2827,8 @@ int DeRestPluginPrivate::recallScene(const ApiRequest &req, ApiResponse &rsp)
     bool groupColorModeChanged = false;
 
     //turn on colorloop if scene was saved with colorloop (FLS don't save colorloop at device)
-    ls = scene->lights().begin();
-    lsend = scene->lights().end();
+    ls = scene->lightStates().begin();
+    lsend = scene->lightStates().end();
 
     for (; ls != lsend; ++ls)
     {
@@ -3129,7 +3129,7 @@ int DeRestPluginPrivate::modifyScene(const ApiRequest &req, ApiResponse &rsp)
         if (QString::number(i->sid()) == sid && i->state() != Scene::StateDeleted)
         {
             foundScene = true;
-            LightState* l = i->getLight(lid);
+            LightState* l = i->getLightState(lid);
             if (l)
             {
                     if (hasOn)

--- a/scene.cpp
+++ b/scene.cpp
@@ -111,31 +111,31 @@ void Scene::name(const QString& name)
 
 /*! Returns the lightstates of the scene.
  */
-const std::vector<LightState> &Scene::lights() const
+const std::vector<LightState> &Scene::lightStates() const
 {
-    return m_lights;
+    return m_lightstates;
 }
 
 /*! Adds a light to the lightstates of the scene.
     \param light the light that should be added
  */
-void Scene::addLight(const LightState& light)
+void Scene::addLightState(const LightState& state)
 {
-    m_lights.push_back(light);
+    m_lightstates.push_back(state);
 }
 
 /*! Removes a light from the lightstates of the scene if present.
     \param lid the light id that should be removed
     \return true if light was found and removed
  */
-bool Scene::removeLight(const QString& lid)
+bool Scene::removeLightState(const QString& lid)
 {
     int position = 0;
-    for (LightState& l : m_lights)
+    for (LightState& l : m_lightstates)
     {
         if (l.lid() == lid)
         {
-            m_lights.erase(m_lights.begin() + position);
+            m_lightstates.erase(m_lightstates.begin() + position);
             return true;
         }
         position++;
@@ -147,9 +147,9 @@ bool Scene::removeLight(const QString& lid)
     \param lid the light id
     \return the light state or 0 if not found
  */
-LightState* Scene::getLight(const QString& lid)
+LightState* Scene::getLightState(const QString& lid)
 {
-    for (LightState& l : m_lights)
+    for (LightState& l : m_lightstates)
     {
         if (l.lid() == lid)
         {
@@ -282,8 +282,8 @@ QVariantMap Scene::map() const
     }
 
     QVariantList lights;
-    std::vector<LightState>::const_iterator i = m_lights.begin();
-    std::vector<LightState>::const_iterator i_end = m_lights.end();
+    std::vector<LightState>::const_iterator i = m_lightstates.begin();
+    std::vector<LightState>::const_iterator i_end = m_lightstates.end();
     for (; i != i_end; ++i)
     {
         lights.append(i->lid());

--- a/scene.cpp
+++ b/scene.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2016-2019 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -10,81 +10,132 @@
 #include <QStringBuilder>
 #include "scene.h"
 
+
 /*! Constructor.
  */
-Scene::Scene() :
-    state(StateNormal),
-    externalMaster(false),
-    groupAddress(0),
-    id(0),
-    m_transitiontime(0)
+Scene::Scene(const uint16_t gid, const uint8_t sid, const Type type) :
+    m_state(StateNormal),
+    m_type(type),
+    m_externalMaster(false),
+    m_gid(gid),
+    m_sid(sid),
+    m_transitiontime(0),
+    m_owner(QLatin1String("")),
+    m_recycle(false),
+    m_locked(false),
+    m_appdata(QVariantMap()),
+    m_picture(QLatin1String("")),
+    m_version(2)
 {
+    m_id.sprintf("0x%04X%02X", gid, sid);
+    m_name = "Scene " + m_id;
 }
 
-/*! Returns the transitiontime of the scene.
+/*! Initializer.
  */
-const uint16_t &Scene::transitiontime() const
+void Scene::init(const QString& id, const QString& owner, const QDateTime& lastupdated, const uint16_t version)
 {
-    return m_transitiontime;
+    m_id = id;
+    m_owner = owner;
+    m_lastupdated = lastupdated;
+    m_version = version;
+    m_name = "Scene " + m_id;
 }
 
-/*! Sets the transitiontime of the scene.
-    \param transitiontime the transitiontime of the scene
+/*! Returns the state of the scene.
  */
-void Scene::setTransitiontime(const uint16_t &transitiontime)
+const Scene::State& Scene::state() const
 {
-    m_transitiontime = transitiontime;
+    return m_state;
 }
 
-/*! Returns the lights of the scene.
+/*! Sets the state of the scene.
+    \param state the state of the scene
  */
-std::vector<LightState> &Scene::lights()
+void Scene::state(const State& state)
 {
-    return m_lights;
+    m_state = state;
 }
 
-/*! Returns the lights of the scene.
+
+/*! Returns the external master state of the scene.
+ */
+bool Scene::externalMaster() const
+{
+    return m_externalMaster;
+}
+
+/*! Sets the external master state of the scene.
+    \param bool the external master state of the scene
+ */
+void Scene::externalMaster(const bool externalMaster)
+{
+    m_externalMaster = externalMaster;
+}
+
+/*! Returns the id of the scene.
+ */
+const QString& Scene::id() const
+{
+    return m_id;
+}
+
+/*! Returns the group id of the scene.
+ */
+uint16_t Scene::gid() const
+{
+    return m_gid;
+}
+
+/*! Returns the scene id of the scene.
+ */
+uint8_t Scene::sid() const
+{
+    return m_sid;
+}
+
+/*! Returns the name of the scene.
+ */
+const QString& Scene::name() const
+{
+    return m_name;
+}
+
+/*! Sets the name of the scene.
+    \param name the name of the scene
+ */
+void Scene::name(const QString& name)
+{
+    m_name = name;
+}
+
+/*! Returns the lightstates of the scene.
  */
 const std::vector<LightState> &Scene::lights() const
 {
     return m_lights;
 }
 
-/*! Sets the lights of the scene.
-    \param lights the lights of the scene
- */
-void Scene::setLights(const std::vector<LightState> &lights)
-{
-    m_lights = lights;
-}
-
-/*! Adds a light to the lights of the scene.
+/*! Adds a light to the lightstates of the scene.
     \param light the light that should be added
  */
-void Scene::addLightState(const LightState &light)
+void Scene::addLight(const LightState& light)
 {
     m_lights.push_back(light);
 }
 
-/*! removes a light from the lights of the scene if present.
-    \param lid the lightId that should be removed
+/*! Removes a light from the lightstates of the scene if present.
+    \param lid the light id that should be removed
     \return true if light was found and removed
  */
-bool Scene::deleteLight(const QString &lid)
+bool Scene::removeLight(const QString& lid)
 {
-    std::vector<LightState>::const_iterator l = m_lights.begin();
-    std::vector<LightState>::const_iterator lend = m_lights.end();
     int position = 0;
-    for (; l != lend; ++l)
+    for (LightState& l : m_lights)
     {
-        if (l->lid() == lid)
+        if (l.lid() == lid)
         {
             m_lights.erase(m_lights.begin() + position);
-            // delete scene if it contains no lights
-            if (m_lights.size() == 0)
-            {
-                state = Scene::StateDeleted;
-            }
             return true;
         }
         position++;
@@ -92,144 +143,161 @@ bool Scene::deleteLight(const QString &lid)
     return false;
 }
 
-/*! Returns light satte for given light id of the scene if present.
-    \param lid the lightId
+/*! Get the light for the given light id of the scene if present.
+    \param lid the light id
     \return the light state or 0 if not found
  */
-LightState *Scene::getLightState(const QString &lid)
+LightState* Scene::getLight(const QString& lid)
 {
-    std::vector<LightState>::iterator i = m_lights.begin();
-    std::vector<LightState>::iterator end = m_lights.end();
-
-    for (; i != end; ++i)
+    for (LightState& l : m_lights)
     {
-        if (i->lid() == lid)
+        if (l.lid() == lid)
         {
-           return &*i;
+            return &l;
         }
     }
     return 0;
 }
 
-/*! Transfers lights of the scene into JSONString.
-    \param lights vector<LightState>
+/*! Returns the transitiontime of the scene.
  */
-QString Scene::lightsToString(const std::vector<LightState> &lights)
+uint16_t Scene::transitiontime() const
 {
-    std::vector<LightState>::const_iterator i = lights.begin();
-    std::vector<LightState>::const_iterator i_end = lights.end();
-    QVariantList ls;
-
-    for (; i != i_end; ++i)
-    {
-        QVariantMap map;
-        map[QLatin1String("lid")] = i->lid();
-        map[QLatin1String("on")] = i->on();
-        map[QLatin1String("bri")] = (double)i->bri();
-        map[QLatin1String("tt")] = (double)i->transitionTime();
-        map[QLatin1String("cm")] = i->colorMode();
-
-        if (i->colorMode() != QLatin1String("none"))
-        {
-            map[QLatin1String("x")] = (double)i->x();
-            map[QLatin1String("y")] = (double)i->y();
-
-            if (i->colorMode() == QLatin1String("hs"))
-            {
-                map[QLatin1String("ehue")] = (double)i->enhancedHue();
-                map[QLatin1String("sat")] = (double)i->saturation();
-            }
-            else if (i->colorMode() == QLatin1String("ct"))
-            {
-                map[QLatin1String("ct")] = (double)i->colorTemperature();
-            }
-
-            map[QLatin1String("cl")] = i->colorloopActive();
-            map[QLatin1String("clTime")] = (double)i->colorloopTime();
-        }
-
-        ls.append(map);
-    }
-
-    return Json::serialize(ls);
+    return m_transitiontime;
 }
 
-std::vector<LightState> Scene::jsonToLights(const QString &json)
+/*! Sets the transitiontime of the scene.
+    \param transitiontime the transitiontime of the scene
+ */
+void Scene::transitiontime(const uint16_t transitiontime)
 {
-    bool ok;
-    QVariantList var = Json::parse(json, ok).toList();
-    QVariantMap map;
-    std::vector<LightState> lights;
+    m_transitiontime = transitiontime;
+}
 
-    QVariantList::const_iterator i = var.begin();
-    QVariantList::const_iterator i_end = var.end();
+/*! Returns the owner id of the scene.
+ */
+const QString& Scene::owner() const
+{
+    return m_owner;
+}
 
-    if (!ok)
+/*! Returns the recycle state of the scene.
+ */
+bool Scene::recycle() const
+{
+    return m_recycle;
+}
+
+/*! Sets the recycle state of the scene.
+    \param bool the recycle state of the scene
+ */
+void Scene::recycle(const bool recycle)
+{
+    m_recycle = recycle;
+}
+
+/*! Returns the locked state of the scene.
+ */
+bool Scene::locked() const
+{
+    return m_locked;
+}
+
+/*! Sets the locked state of the scene.
+    \param bool the locked state of the scene
+ */
+void Scene::locked(const bool locked)
+{
+    m_locked = locked;
+}
+
+/*! Returns the appdata of the scene.
+ */
+const QVariantMap& Scene::appdata() const
+{
+    return m_appdata;
+}
+
+/*! Sets the appdata of the scene.
+    \param appdata the appdata of the scene
+ */
+void Scene::appdata(const QVariantMap& appdata)
+{
+    m_appdata = appdata;
+}
+
+/*! Returns the picture id of the scene.
+ */
+const QString& Scene::picture() const
+{
+    return m_picture;
+}
+
+/*! Sets the picture id of the scene.
+    \param picture the picture id of the scene
+ */
+void Scene::picture(const QString& picture)
+{
+    m_picture = picture;
+}
+
+/*! Returns the lastupdated date of the scene.
+ */
+const QDateTime& Scene::lastupdated() const
+{
+    return m_lastupdated;
+}
+
+/*! Update the lastupdated state.
+ */
+void Scene::lastupdated(const bool lastupdated)
+{
+    if (lastupdated)
     {
-        return lights;
+        m_lastupdated = QDateTime::currentDateTimeUtc();
+    }
+}
+
+/*! Returns the version of the scene.
+ */
+uint16_t Scene::version() const
+{
+    return m_version;
+}
+
+/*! Put all parameters in a map for later json serialization.
+    \return map
+ */
+QVariantMap Scene::map() const
+{
+    QVariantMap map;
+
+    map[QLatin1String("name")] = m_name;
+    if (m_type == LightScene) {
+        map[QLatin1String("type")] = QLatin1String("LightScene");
+    }
+    else {
+        map[QLatin1String("type")] = QLatin1String("GroupScene");
+        map[QLatin1String("group")] = QString::number(m_gid);
     }
 
+    QVariantList lights;
+    std::vector<LightState>::const_iterator i = m_lights.begin();
+    std::vector<LightState>::const_iterator i_end = m_lights.end();
     for (; i != i_end; ++i)
     {
-        LightState state;
-        map = i->toMap();
-        state.setLightId(map[QLatin1String("lid")].toString());
-        state.setOn(map[QLatin1String("on")].toBool());
-        state.setBri(map[QLatin1String("bri")].toUInt());
-        state.setTransitionTime(map[QLatin1String("tt")].toUInt());
-
-        if (map.contains(QLatin1String("x")) && map.contains(QLatin1String("y")))
-        {
-            state.setX(map[QLatin1String("x")].toUInt());
-            state.setY(map[QLatin1String("y")].toUInt());
-
-            if (!map.contains(QLatin1String("cm")))
-            {
-                state.setColorMode(QLatin1String("xy")); // backward compatibility
-            }
-        }
-
-        if (map.contains(QLatin1String("cl")) && map.contains(QLatin1String("clTime")))
-        {
-            state.setColorloopActive(map[QLatin1String("cl")].toBool());
-            state.setColorloopTime(map[QLatin1String("clTime")].toUInt());
-        }
-
-        if (map.contains(QLatin1String("cm")))
-        {
-            QString colorMode = map[QLatin1String("cm")].toString();
-            if (!colorMode.isEmpty())
-            {
-                state.setColorMode(colorMode);
-            }
-        }
-
-        if (state.colorMode() == QLatin1String("ct") && map.contains(QLatin1String("ct")))
-        {
-            quint16 ct = map[QLatin1String("ct")].toUInt(&ok);
-            if (ok)
-            {
-                state.setColorTemperature(ct);
-            }
-        }
-        else if (state.colorMode() == QLatin1String("hs") && map.contains(QLatin1String("ehue")) && map.contains(QLatin1String("sat")))
-        {
-            quint16 ehue = map[QLatin1String("ehue")].toUInt(&ok);
-            if (ok)
-            {
-                quint16 sat = map[QLatin1String("sat")].toUInt(&ok);
-                if (ok)
-                {
-                    state.setEnhancedHue(ehue);
-                    state.setSaturation(sat);
-                }
-            }
-        }
-
-        lights.push_back(state);
+        lights.append(i->lid());
     }
+    map[QLatin1String("lights")] = lights;
 
-    return lights;
+    map[QLatin1String("appdata")] = m_appdata;
+    map[QLatin1String("picture")] = m_picture;
+    map[QLatin1String("owner")] = m_owner;
+    map[QLatin1String("locked")] = m_locked;
+    map[QLatin1String("recycle")] = m_recycle;
+    map[QLatin1String("lastupdated")] = m_lastupdated.toString(QLatin1String("yyyy-MM-ddTHH:mm:ss"));
+    map[QLatin1String("version")] = m_version;
+    return map;
 }
 
 
@@ -458,4 +526,104 @@ void LightState::setTransitionTime(uint16_t transitiontime)
 void LightState::setNeedRead(bool needRead)
 {
     m_needRead = needRead;
+}
+
+/*! Put all parameters in a map for later json serialization.
+    \return map
+ */
+QVariantMap LightState::map() const
+{
+    QVariantMap map;
+    map[QLatin1String("lid")] = lid(); // deCONZ
+    map[QLatin1String("on")] = on();
+    map[QLatin1String("bri")] = bri();
+    map[QLatin1String("cm")] = colorMode(); // deCONZ
+    if (colorMode() != QLatin1String("none"))
+    {
+        if (colorMode() == QLatin1String("hs"))
+        {
+            map[QLatin1String("hue")] = enhancedHue(); // Hue
+            map[QLatin1String("ehue")] = enhancedHue(); // deCONZ
+            map[QLatin1String("sat")] = saturation();
+        }
+        QVariantList xy;
+        double dx = x() / 65535.0;
+        double dy = y() / 65535.0;
+        if      (dx < 0) { dx = 0; }
+        else if (dx > 1) { dx = 1; }
+        if      (dy < 0) { dy = 0; }
+        else if (dy > 1) { dy = 1; }
+        xy.append(dx);
+        xy.append(dy);
+        map[QLatin1String("xy")] = xy; // Hue
+        map[QLatin1String("x")] = x(); // deCONZ
+        map[QLatin1String("y")] = y(); // deCONZ
+        map[QLatin1String("ct")] = colorTemperature();
+        map[QLatin1String("effect")] = colorloopActive() ? "colorloop" : "none"; // Hue
+        map[QLatin1String("cl")] = colorloopActive(); // deCONZ
+        map[QLatin1String("clTime")] = colorloopTime(); // deCONZ
+    }
+    map[QLatin1String("transitiontime")] = transitionTime();
+
+    return map;
+}
+
+/*! Sets the transitiontime of the scene.
+    \param transitiontime the transitiontime of the scene
+ */
+void LightState::map(QVariantMap& map)
+{
+    setLightId(map[QLatin1String("lid")].toString());
+    setOn(map[QLatin1String("on")].toBool());
+    setBri(map[QLatin1String("bri")].toUInt());
+    setTransitionTime(map[QLatin1String("tt")].toUInt());
+
+    if (map.contains(QLatin1String("x")) && map.contains(QLatin1String("y")))
+    {
+        setX(map[QLatin1String("x")].toUInt());
+        setY(map[QLatin1String("y")].toUInt());
+
+        if (!map.contains(QLatin1String("cm")))
+        {
+            setColorMode(QLatin1String("xy")); // backward compatibility
+        }
+    }
+
+    if (map.contains(QLatin1String("cl")) && map.contains(QLatin1String("clTime")))
+    {
+        setColorloopActive(map[QLatin1String("cl")].toBool());
+        setColorloopTime(map[QLatin1String("clTime")].toUInt());
+    }
+
+    if (map.contains(QLatin1String("cm")))
+    {
+        QString colorMode = map[QLatin1String("cm")].toString();
+        if (!colorMode.isEmpty())
+        {
+            setColorMode(colorMode);
+        }
+    }
+
+    bool ok;
+    if (colorMode() == QLatin1String("ct") && map.contains(QLatin1String("ct")))
+    {
+        quint16 ct = map[QLatin1String("ct")].toUInt(&ok);
+        if (ok)
+        {
+            setColorTemperature(ct);
+        }
+    }
+    else if (colorMode() == QLatin1String("hs") && map.contains(QLatin1String("ehue")) && map.contains(QLatin1String("sat")))
+    {
+        quint16 ehue = map[QLatin1String("ehue")].toUInt(&ok);
+        if (ok)
+        {
+            quint16 sat = map[QLatin1String("sat")].toUInt(&ok);
+            if (ok)
+            {
+                setEnhancedHue(ehue);
+                setSaturation(sat);
+            }
+        }
+    }
 }

--- a/scene.h
+++ b/scene.h
@@ -53,10 +53,10 @@ public:
     const QString& name() const;
     void name(const QString& name);
 
-    const std::vector<LightState>& lights() const;
-    void addLight(const LightState& light);
-    bool removeLight(const QString& lid);
-    LightState* getLight(const QString& lid);
+    const std::vector<LightState>& lightStates() const;
+    void addLightState(const LightState& state);
+    bool removeLightState(const QString& lid);
+    LightState* getLightState(const QString& lid);
 
     // deCONZ only
     uint16_t transitiontime() const;
@@ -87,7 +87,7 @@ private:
     uint16_t m_gid;
     uint8_t m_sid;
     QString m_name;
-    std::vector<LightState> m_lights;
+    std::vector<LightState> m_lightstates;
 
     uint16_t m_transitiontime;
 

--- a/scene.h
+++ b/scene.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2016-2019 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -15,6 +15,7 @@
 #include <QString>
 #include <vector>
 #include <QElapsedTimer>
+#include <QDateTime>
 #include "json.h"
 
 class LightState;
@@ -32,30 +33,71 @@ public:
         StateNormal,
         StateDeleted
     };
+    enum Type
+    {
+        LightScene,
+        GroupScene
+    };
 
-    Scene();
-    State state;
-    bool externalMaster;
-    uint16_t groupAddress;
-    uint8_t id;
-    QString name;
+    Scene(const uint16_t gid, const uint8_t sid, const Type type);
+    void init(const QString& id, const QString& owner, const QDateTime& lastupdated, const uint16_t version);
 
-    const uint16_t &transitiontime() const;
-    void setTransitiontime(const uint16_t &transitiontime);
+    const State& state() const;
+    void state(const State& state);
+    bool externalMaster() const;
+    void externalMaster(const bool externalMaster);
 
-    std::vector<LightState> &lights();
-    const std::vector<LightState> &lights() const;
-    void setLights(const std::vector<LightState> &lights);
-    void addLightState(const LightState &light);
-    bool deleteLight(const QString &lid);
-    LightState *getLightState(const QString &lid);
+    const QString& id() const;
+    uint16_t gid() const;
+    uint8_t sid() const;
+    const QString& name() const;
+    void name(const QString& name);
 
-    static QString lightsToString(const std::vector<LightState> &lights);
-    static std::vector<LightState> jsonToLights(const QString &json);
+    const std::vector<LightState>& lights() const;
+    void addLight(const LightState& light);
+    bool removeLight(const QString& lid);
+    LightState* getLight(const QString& lid);
+
+    // deCONZ only
+    uint16_t transitiontime() const;
+    void transitiontime(const uint16_t transitiontime);
+
+    // Hue only
+    const QString& owner() const;
+    bool recycle() const;
+    void recycle(const bool recycle);
+    bool locked() const;
+    void locked(const bool locked);
+    const QVariantMap& appdata() const;
+    void appdata(const QVariantMap& appdata);
+    const QString& picture() const;
+    void picture(const QString& picture);
+    const QDateTime& lastupdated() const;
+    void lastupdated(const bool lastupdated);
+    uint16_t version() const;
+
+    QVariantMap map() const;
 
 private:
-    uint16_t m_transitiontime;
+    State m_state;
+    Type m_type;
+    bool m_externalMaster;
+
+    QString m_id;
+    uint16_t m_gid;
+    uint8_t m_sid;
+    QString m_name;
     std::vector<LightState> m_lights;
+
+    uint16_t m_transitiontime;
+
+    QString m_owner;
+    bool m_recycle;
+    bool m_locked;
+    QVariantMap m_appdata;
+    QString m_picture;
+    QDateTime m_lastupdated;
+    uint16_t m_version;
 };
 
 
@@ -99,6 +141,9 @@ public:
     void setNeedRead(bool needRead);
 
     QElapsedTimer tVerified;
+
+    QVariantMap map() const;
+    void map(QVariantMap& map);
 
 private:
     QString m_lid;

--- a/zcl_tasks.cpp
+++ b/zcl_tasks.cpp
@@ -1212,7 +1212,7 @@ bool DeRestPluginPrivate::addTaskAddScene(TaskItem &task, uint16_t groupId, uint
     {
         if (i->sid() == sceneId && i->state() != Scene::StateDeleted)
         {
-            LightState* l = i->getLight(lightId);
+            LightState* l = i->getLightState(lightId);
             if (l)
             {
                 task.taskType = TaskAddScene;

--- a/zcl_tasks.cpp
+++ b/zcl_tasks.cpp
@@ -1210,18 +1210,11 @@ bool DeRestPluginPrivate::addTaskAddScene(TaskItem &task, uint16_t groupId, uint
 
     for ( ;i != end; ++i)
     {
-        if (i->id == sceneId && i->state != Scene::StateDeleted)
+        if (i->sid() == sceneId && i->state() != Scene::StateDeleted)
         {
-            std::vector<LightState>::iterator l = i->lights().begin();
-            std::vector<LightState>::iterator lend = i->lights().end();
-
-            for ( ;l != lend; ++l)
+            LightState* l = i->getLight(lightId);
+            if (l)
             {
-                if (l->lid() != lightId)
-                {
-                    continue;
-                }
-
                 task.taskType = TaskAddScene;
 
                 task.req.setClusterId(SCENE_CLUSTER_ID);


### PR DESCRIPTION
This is mostly the second commit from #1471 so it can be reviewed and merged in stages, cherry-picked onto the current master. This:
- extends the scene class with all fields additionally available with the Hue api and adds those to the database, and
- refactors the scene class.
This PR should not result in any functional changes to the deCONZ api or behaviour. The only change visible on the api side is that the additional fields are returned when retrieving lightstates for a scene. All previous fields should also still be included.