### PR TITLE
Support state.ontime in combination with state.alert

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -627,7 +627,7 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
         case THERMOSTAT_CLUSTER_ID:
             handleThermostatClusterIndication(ind, zclFrame);
             break;
-            
+
         case BASIC_CLUSTER_ID:
             handleBasicClusterIndication(ind, zclFrame);
             break;
@@ -2702,7 +2702,7 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
                 {
                     if (ia->id() == 0x0055) // Present Value
                     {
-                        uint8_t level = 255 * (100 - ia->numericValue().real) / 100;
+                        uint8_t level = 254 * (100 - ia->numericValue().real) / 100;
                         ResourceItem *item = lightNode->item(RStateBri);
                         if (item && item->toNumber() != level)
                         {
@@ -5788,7 +5788,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 if (i->modelId().startsWith(QLatin1String("tagv4")) || // SmartThings Arrival sensor
                                     i->modelId() == QLatin1String("Remote switch") || //Legrand switch
                                     i->modelId() == QLatin1String("Zen-01") || // Zen thermostat
-                                    i->modelId() == QLatin1String("Motion Sensor-A") || 
+                                    i->modelId() == QLatin1String("Motion Sensor-A") ||
                                     i->modelId().contains(QLatin1String("86opcn01"))) //Aqara Opple
                                 {  }
                                 else
@@ -9853,7 +9853,7 @@ void DeRestPluginPrivate::handleZclAttributeReportIndicationXiaomiSpecial(const 
             item = lightNode.item(RStateBri);
             if (item)
             {
-                const uint bri = currentPositionLift * 255 / 100;
+                const uint bri = currentPositionLift * 254 / 100;
                 item->setValue(bri);
                 enqueueEvent(Event(RLights, item->descriptor().suffix, lightNode.id(), item));
                 value = bri != 0;

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1350,16 +1350,12 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         }
         else if (alert == "select")
         {
-            if (isWarningDevice && isSmokeDetector)
+            if (isWarningDevice)
             {
                 task.taskType = TaskWarning;
-                task.options = 0x12; // Warning mode 2 (fire), strobe
-                task.duration = 1;
-            }
-            else if (isWarningDevice)
-            {
-                task.taskType = TaskWarning;
-                task.options = 0x14; // Warning mode 1 (burglar), Strobe
+                task.options = isSmokeDetector
+                  ? 0x12  // Warning mode 2 (fire), Strobe
+                  : 0x14; // Warning mode 1 (burglar), Strobe
                 task.duration = 1;
             }
             else
@@ -1370,22 +1366,18 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         }
         else if (alert == "lselect")
         {
-            if (isWarningDevice && isSmokeDetector)
+            if (isWarningDevice)
             {
                 task.taskType = TaskWarning;
-                task.options = 0x12; // Warning mode 2 (fire), strobe
-                task.duration = 300;
-            }
-            else if (isWarningDevice)
-            {
-                task.taskType = TaskWarning;
-                task.options = 0x14; // Warning mode 1 (burglar), Strobe
-                task.duration = 300;
+                task.options = isSmokeDetector
+                  ? 0x12  // Warning mode 2 (fire), Strobe
+                  : 0x14; // Warning mode 1 (burglar), Strobe
+                task.duration = taskRef.onTime > 0 ? taskRef.onTime : 300;
             }
             else
             {
                 task.taskType = TaskIdentify;
-                task.identifyTime = 15;   // Default for Philips Hue bridge
+                task.identifyTime = taskRef.onTime > 0 ? taskRef.onTime : 15; // Default for Philips Hue bridge
             }
         }
         else if (alert == "blink")
@@ -1394,7 +1386,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
             {
                 task.taskType = TaskWarning;
                 task.options = 0x04; // Warning mode 0 (no warning), Strobe
-                task.duration = 300;
+                task.duration = taskRef.onTime > 0 ? taskRef.onTime : 300;
             }
             else
             {


### PR DESCRIPTION
Support `state.ontime` in combination with setting `state.alert` to `lselect` or (for Warning Devices) to `blink`.  The default duration of the warning (300s) or identification (15s) can be overwritten using `state.ontime` (in seconds).
See https://github.com/ebaauw/homebridge-hue/issues/614.