### PR TITLE
Add generic support for Device ID 0x0203 "Window Covering Controller" (e.g. Sunricher SR-ZG9080A)

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -91,6 +91,7 @@ const quint64 silabsMacPrefix     = 0x90fd9f0000000000ULL;
 const quint64 silabs2MacPrefix    = 0xcccccc0000000000ULL;
 const quint64 energyMiMacPrefix   = 0xd0cf5e0000000000ULL;
 const quint64 bjeMacPrefix        = 0xd85def0000000000ULL;
+const quint64 sunricherMacPrefix  = 0xec1bbd0000000000ULL;
 const quint64 xalMacPrefix        = 0xf8f0050000000000ULL;
 const quint64 lutronMacPrefix     = 0xffff000000000000ULL;
 const quint64 legrandMacPrefix    = 0x0004740000000000ULL;
@@ -218,6 +219,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_SUNRICHER, "ICZB-RM", silabs2MacPrefix }, // iCasa remote
     { VENDOR_SUNRICHER, "ZGRC-KEY", emberMacPrefix }, // Sunricher wireless CCT remote
     { VENDOR_SUNRICHER, "ZG2833K", emberMacPrefix }, // Sunricher remote controller
+    { VENDOR_SUNRICHER, "Motor Controller", sunricherMacPrefix }, // Sunricher window covering controller
     { VENDOR_JENNIC, "SPZB0001", jennicMacPrefix }, // Eurotronic thermostat
     { VENDOR_NONE, "RES001", tiMacPrefix }, // Hubitat environment sensor, see #1308
     { VENDOR_119C, "WL4200S", sinopeMacPrefix}, // Sinope water sensor
@@ -1628,6 +1630,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
                 case DEV_ID_Z30_EXTENDED_COLOR_LIGHT:
                 case DEV_ID_Z30_COLOR_TEMPERATURE_LIGHT:
                 case DEV_ID_HA_WINDOW_COVERING_DEVICE:
+                case DEV_ID_HA_WINDOW_COVERING_CONTROLLER:
                 case DEV_ID_FAN:
                 {
                     if (hasServerOnOff)
@@ -2232,6 +2235,7 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
             case DEV_ID_ZLL_ONOFF_PLUGIN_UNIT:
             case DEV_ID_Z30_ONOFF_PLUGIN_UNIT:
             case DEV_ID_HA_WINDOW_COVERING_DEVICE:
+            case DEV_ID_HA_WINDOW_COVERING_CONTROLLER:
             case DEV_ID_ZLL_ONOFF_SENSOR:
             case DEV_ID_XIAOMI_SMART_PLUG:
             case DEV_ID_IAS_ZONE:
@@ -7757,6 +7761,7 @@ bool DeRestPluginPrivate::processZclAttributes(LightNode *lightNode)
         case DEV_ID_Z30_ONOFF_PLUGIN_UNIT:
         case DEV_ID_ZLL_ONOFF_SENSOR:
         case DEV_ID_HA_WINDOW_COVERING_DEVICE:
+        case DEV_ID_HA_WINDOW_COVERING_CONTROLLER:
         case DEV_ID_FAN:
             break;
 

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -91,7 +91,6 @@ const quint64 silabsMacPrefix     = 0x90fd9f0000000000ULL;
 const quint64 silabs2MacPrefix    = 0xcccccc0000000000ULL;
 const quint64 energyMiMacPrefix   = 0xd0cf5e0000000000ULL;
 const quint64 bjeMacPrefix        = 0xd85def0000000000ULL;
-const quint64 sunricherMacPrefix  = 0xec1bbd0000000000ULL;
 const quint64 xalMacPrefix        = 0xf8f0050000000000ULL;
 const quint64 lutronMacPrefix     = 0xffff000000000000ULL;
 const quint64 legrandMacPrefix    = 0x0004740000000000ULL;
@@ -219,7 +218,6 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_SUNRICHER, "ICZB-RM", silabs2MacPrefix }, // iCasa remote
     { VENDOR_SUNRICHER, "ZGRC-KEY", emberMacPrefix }, // Sunricher wireless CCT remote
     { VENDOR_SUNRICHER, "ZG2833K", emberMacPrefix }, // Sunricher remote controller
-    { VENDOR_SUNRICHER, "Motor Controller", sunricherMacPrefix }, // Sunricher window covering controller
     { VENDOR_JENNIC, "SPZB0001", jennicMacPrefix }, // Eurotronic thermostat
     { VENDOR_NONE, "RES001", tiMacPrefix }, // Hubitat environment sensor, see #1308
     { VENDOR_119C, "WL4200S", sinopeMacPrefix}, // Sinope water sensor

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -415,7 +415,6 @@ extern const quint64 silabs2MacPrefix;
 extern const quint64 xiaomiMacPrefix;
 extern const quint64 computimeMacPrefix;
 extern const quint64 konkeMacPrefix;
-extern const quint64 sunricherMacPrefix;
 
 inline bool checkMacVendor(quint64 addr, quint16 vendor)
 {
@@ -430,8 +429,7 @@ inline bool checkMacVendor(quint64 addr, quint16 vendor)
             return prefix == emberMacPrefix ||
                    prefix == jennicMacPrefix;
         case VENDOR_SUNRICHER:
-            return prefix == emberMacPrefix ||
-                   prefix == sunricherMacPrefix;
+            return prefix == emberMacPrefix;
         case VENDOR_BITRON:
             return prefix == tiMacPrefix;
         case VENDOR_BOSCH:

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -115,6 +115,7 @@
 
 // Other HA devices
 #define DEV_ID_HA_WINDOW_COVERING_DEVICE    0x0202 // Window Covering Device
+#define DEV_ID_HA_WINDOW_COVERING_CONTROLLER 0x0203 // Window Covering Controller
 //
 #define DEV_ID_IAS_ZONE                     0x0402 // IAS Zone
 #define DEV_ID_IAS_WARNING_DEVICE           0x0403 // IAS Warning Device
@@ -414,6 +415,7 @@ extern const quint64 silabs2MacPrefix;
 extern const quint64 xiaomiMacPrefix;
 extern const quint64 computimeMacPrefix;
 extern const quint64 konkeMacPrefix;
+extern const quint64 sunricherMacPrefix;
 
 inline bool checkMacVendor(quint64 addr, quint16 vendor)
 {
@@ -428,7 +430,8 @@ inline bool checkMacVendor(quint64 addr, quint16 vendor)
             return prefix == emberMacPrefix ||
                    prefix == jennicMacPrefix;
         case VENDOR_SUNRICHER:
-            return prefix == emberMacPrefix;
+            return prefix == emberMacPrefix ||
+                   prefix == sunricherMacPrefix;
         case VENDOR_BITRON:
             return prefix == tiMacPrefix;
         case VENDOR_BOSCH:

--- a/light_node.cpp
+++ b/light_node.cpp
@@ -538,6 +538,7 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
             case DEV_ID_IAS_WARNING_DEVICE:          removeItem(RStateOn);
                                                      ltype = QLatin1String("Warning device"); break;
             case DEV_ID_HA_WINDOW_COVERING_DEVICE:   ltype = QLatin1String("Window covering device"); break;
+            case DEV_ID_HA_WINDOW_COVERING_CONTROLLER: ltype = QLatin1String("Window covering controller"); break;
             case DEV_ID_FAN:                         ltype = QLatin1String("Fan"); break;
             default:
                 break;


### PR DESCRIPTION
This adds support for Sunricher window covering controller SR-ZG9080A cf.

https://sunricher.en.alibaba.com/product/62134471426-811954196/Zigbee_3_0_Zigbee_Curtain_Motor_Controller_Zigbee_Curtain_Controller_Smarthome.html
https://en.robbshop.nl/rollershutter-control-400w-zigbee-robb-smart?sqr=rollershutter%20controller&

![Unbenannt2c](https://user-images.githubusercontent.com/2014249/74058487-7441da80-49e6-11ea-8603-717820ebf41b.png)

![Unbenannt2a](https://user-images.githubusercontent.com/2014249/74058489-74da7100-49e6-11ea-8c82-209a6774046a.png)

![Unbenannt2b](https://user-images.githubusercontent.com/2014249/74058490-74da7100-49e6-11ea-864c-2c60a4a1766a.png)
