### PR TITLE
Add support for LEGRAND wireless shutter switch (synced with master)

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1869,6 +1869,8 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId() == QLatin1String("Cable outlet") ||
         //Legrand wireless switch
         sensor->modelId() == QLatin1String("Remote switch") ||
+        //Legrand wireless shutter switch
+        sensor->modelId() == QLatin1String("Shutters central remote switch") ||
         // ORVIBO
         sensor->modelId().startsWith(QLatin1String("SN10ZW")) ||
         sensor->modelId().startsWith(QLatin1String("SF2")) ||
@@ -1984,7 +1986,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
             {
                 continue; // process only once
             }
-            if (sensor->modelId() == QLatin1String("Remote switch") )
+            if (sensor->modelId() == QLatin1String("Remote switch") || sensor->modelId() == QLatin1String("Shutters central remote switch") )
             {
                 //This device don't support report attribute
                 continue;
@@ -2001,6 +2003,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
                      sensor->modelId() == QLatin1String("FLSZB-110") ||
                      sensor->modelId() == QLatin1String("Zen-01") ||
                      sensor->modelId() == QLatin1String("Remote switch") ||
+                     sensor->modelId() == QLatin1String("Shutters central remote switch") ||
                      sensor->modelId().startsWith(QLatin1String("ZHMS101")) ||
                      sensor->modelId().contains(QLatin1String("86opcn01"))) // Aqara Opple
             {
@@ -2327,6 +2330,12 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
         clusters.push_back(LEVEL_CLUSTER_ID);
         srcEndpoints.push_back(sensor->fingerPrint().endpoint);
     }
+    // LEGRAND Remote shutter switch
+    else if (sensor->modelId() == QLatin1String("Shutters central remote switch"))
+    {
+        clusters.push_back(WINDOW_COVERING_CLUSTER_ID);
+        srcEndpoints.push_back(sensor->fingerPrint().endpoint);
+    }
     else if (sensor->modelId().startsWith(QLatin1String("RC 110")))
     {
         clusters.push_back(ONOFF_CLUSTER_ID);
@@ -2522,7 +2531,8 @@ void DeRestPluginPrivate::checkSensorGroup(Sensor *sensor)
     {
 
     }
-    else if (sensor->modelId() == QLatin1String("Remote switch"))
+    else if (sensor->modelId() == QLatin1String("Remote switch") ||
+	     sensor->modelId() == QLatin1String("Shutters central remote switch"))
     {
         //Make group but without uniqueid
     }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -252,6 +252,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_LEGRAND, "Shutter switch with neutral", legrandMacPrefix }, // Legrand Shutter switch
     { VENDOR_LEGRAND, "Cable outlet", legrandMacPrefix }, // Legrand Cable outlet
     { VENDOR_LEGRAND, "Remote switch", legrandMacPrefix }, // Legrand wireless switch
+    { VENDOR_LEGRAND, "Shutters central remote switch", legrandMacPrefix }, // Legrand wireless shutter switch (battery)
     { VENDOR_NETVOX, "Z809AE3R", netvoxMacPrefix }, // Netvox smartplug
     { VENDOR_LDS, "ZB-ONOFFPlug-D0005", silabs2MacPrefix }, // Samsung SmartPlug 2019 (7A-PL-Z-J3)
     { VENDOR_PHYSICAL, "outletv4", stMacPrefix }, // Samsung SmartThings plug (IM6001-OTP)
@@ -3182,6 +3183,11 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
         checkReporting = true;
         checkClientCluster = true;
     }
+    else if (sensor->modelId() == QLatin1String("Shutters central remote switch")) // legrand shutter switch
+    {
+        checkReporting = true;
+        checkClientCluster = true;
+    }
     else if (sensor->modelId().startsWith(QLatin1String("RWL02")) || // Hue dimmer switch
              sensor->modelId().startsWith(QLatin1String("Z3-1BRL"))) // Lutron Aurora Friends-of-Hue dimmer switch
     {
@@ -4651,6 +4657,11 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
         {
             clusterId = ONOFF_CLUSTER_ID;
         }
+        else if (sensorNode.fingerPrint().hasInCluster(WINDOW_COVERING_CLUSTER_ID) ||
+                 sensorNode.fingerPrint().hasOutCluster(WINDOW_COVERING_CLUSTER_ID))
+        {
+            clusterId = WINDOW_COVERING_CLUSTER_ID;
+        }
         else if (sensorNode.fingerPrint().hasInCluster(ANALOG_INPUT_CLUSTER_ID))
         {
             clusterId = ANALOG_INPUT_CLUSTER_ID;
@@ -5257,7 +5268,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             else if (*ci == POWER_CONFIGURATION_CLUSTER_ID)
             {
                 //This device make a Rejoin every time, you trigger it, it's the only moment where you can read attribute.
-                if (sensorNode.modelId() == QLatin1String("Remote switch") )
+                if (sensorNode.modelId() == QLatin1String("Remote switch") || sensorNode.modelId() == QLatin1String("Shutters central remote switch") )
                 {
                     //Ask for battery but only every day max
                     //int diff = idleTotalCounter - sensorNode.lastRead(READ_BATTERY);
@@ -5818,6 +5829,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 if (i->modelId().startsWith(QLatin1String("tagv4")) ||   // SmartThings Arrival sensor
                                     i->modelId().startsWith(QLatin1String("motionv4")) ||// SmartThings motion sensor
                                     i->modelId() == QLatin1String("Remote switch") ||    // Legrand switch
+                                    i->modelId() == QLatin1String("Shutters central remote switch") || //Legrand shutter switch
                                     i->modelId() == QLatin1String("Zen-01") ||           // Zen thermostat
                                     i->modelId() == QLatin1String("Thermostat") ||       // eCozy thermostat
                                     i->modelId() == QLatin1String("Motion Sensor-A") ||  // Osram motion sensor
@@ -14111,6 +14123,11 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
             checkSensorBindingsForClientClusters(sensor);
         }
         else if (sensor->modelId().contains(QLatin1String("86opcn01"))) // Aqara Opple
+        {
+            checkSensorGroup(sensor);
+            checkSensorBindingsForClientClusters(sensor);
+        }
+        else if (sensor->modelId() == QLatin1String("Shutters central remote switch"))// Legrand switch
         {
             checkSensorGroup(sensor);
             checkSensorBindingsForClientClusters(sensor);

--- a/general.xml
+++ b/general.xml
@@ -1131,6 +1131,10 @@ out based on either the Check-inInterval, or the next Check-in value in the Fast
 by the Poll Control Cluster Client.</description>
 					<payload></payload>
 				</command>
+				<command id="0x01" dir="send" name="Stop" required="m">
+				    <description>send Fast Poll Stop</description>
+					<payload></payload>
+				</command>
 				<command id="0x02" dir="recv" name="Set Long Poll Interval" required="o">
 					<description>Sets the Read Only LongPollInterval attribute.</description>
 					<payload>

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -599,7 +599,7 @@ static const Sensor::ButtonMap sunricherMap[] = {
 };
 
 static const Sensor::ButtonMap legrandSwitchRemote[] = {
-    //    mode                          ep    cluster cmd   param button                                       name
+//    mode                          ep    cluster cmd   param button                                       name
     { Sensor::ModeScenes,           0x01, 0x0006, 0x01, 0,    S_BUTTON_1 + S_BUTTON_ACTION_SHORT_RELEASED, "On" },
     { Sensor::ModeScenes,           0x01, 0x0006, 0x00, 0,    S_BUTTON_2 + S_BUTTON_ACTION_SHORT_RELEASED, "Off" },
     { Sensor::ModeScenes,           0x01, 0x0008, 0x01, 0,    S_BUTTON_1 + S_BUTTON_ACTION_HOLD,           "Dimm up" },
@@ -670,6 +670,18 @@ static const Sensor::ButtonMap aqaraOpple6Map[] = {
     // end
     { Sensor::ModeNone,             0x00, 0x0000, 0x00, 0,    0,                                           nullptr }
 };
+
+static const Sensor::ButtonMap legrandShutterSwitchRemote[] = {
+//    mode                          ep    cluster cmd   param button                                       name
+    { Sensor::ModeScenes,           0x01, 0x0102, 0x00, 0,    S_BUTTON_1 + S_BUTTON_ACTION_SHORT_RELEASED, "Move up (with on/off)" },
+    { Sensor::ModeScenes,           0x01, 0x0102, 0x01, 0,    S_BUTTON_2 + S_BUTTON_ACTION_SHORT_RELEASED, "Move down (with on/off)" },
+    { Sensor::ModeScenes,           0x01, 0x0102, 0x02, 0,    S_BUTTON_3 + S_BUTTON_ACTION_SHORT_RELEASED, "Stop_ (with on/off)" }, // non detecte
+    { Sensor::ModeScenes,           0x01, 0x0102, 0x02, 1,    S_BUTTON_3 + S_BUTTON_ACTION_LONG_RELEASED,  "Stop_ (with on/off)" },
+    { Sensor::ModeScenes,           0x01, 0x0102, 0x02, 2,    S_BUTTON_3 + S_BUTTON_ACTION_SHORT_RELEASED, "Stop_ (with on/off)" },
+    // end
+    { Sensor::ModeNone,             0x00, 0x0000, 0x00, 0,    0,                                           nullptr }
+};
+
 
 /*! Returns a fingerprint as JSON string. */
 QString SensorFingerprint::toString() const
@@ -1232,6 +1244,7 @@ const Sensor::ButtonMap *Sensor::buttonMap()
         else if (manufacturer == QLatin1String("Legrand"))
         {
             if (modelid == QLatin1String("Remote switch")) { m_buttonMap = legrandSwitchRemote; }
+	    else if (modelid == QLatin1String("Shutters central remote switch")) { m_buttonMap = legrandShutterSwitchRemote; }
         }
         else if (manufacturer == QLatin1String("Sunricher"))
         {


### PR DESCRIPTION
New PR !
This code adds support LEGRAND wireless shutter switch / REF 067646

https://www.legrand.fr/pro/catalogue/42569-version-celiane-with-netatmo/commande-sans-fil-pour-interrupteur-filaire-de-volet-roulant-connecte-celiane-with-netatmo-blanc

![PR1](https://user-images.githubusercontent.com/58689380/74589086-8fbe6e00-5002-11ea-8029-e7f325a57d64.png)

![PR2](https://user-images.githubusercontent.com/58689380/74589088-9947d600-5002-11ea-9ef6-b4b264743fab.png)

![PR3](https://user-images.githubusercontent.com/58689380/74589091-9e0c8a00-5002-11ea-9110-883cbb929b62.png)


