### PR TITLE
disable state.bri for 3A zigbee 3.0 devices

### DIFF
--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -292,6 +292,7 @@
 #define VENDOR_LDS          0x1168 // Used by Samsung SmartPlug 2019
 #define VENDOR_INSTA        0x117A
 #define VENDOR_IKEA         0x117C
+#define VENDOR_3A_SMART_HOME  0x117E
 #define VENDOR_STELPRO      0x1185
 #define VENDOR_LEDVANCE     0x1189
 #define VENDOR_SINOPE       0x119C

--- a/light_node.cpp
+++ b/light_node.cpp
@@ -364,6 +364,7 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
                     if ((manufacturerCode() == VENDOR_IKEA && endpoint.deviceId() == DEV_ID_Z30_ONOFF_PLUGIN_UNIT) || // IKEA Tradfri control outlet
                         (manufacturerCode() == VENDOR_INNR && endpoint.deviceId() == DEV_ID_ZLL_ONOFF_PLUGIN_UNIT) || // innr SP120 smart plug
                         (manufacturerCode() == VENDOR_INNR && endpoint.deviceId() == DEV_ID_Z30_ONOFF_PLUGIN_UNIT) || // innr ZigBee 3.0 smart plugs (SP2xx)
+                        (manufacturerCode() == VENDOR_3A_SMART_HOME && endpoint.deviceId() == DEV_ID_ZLL_ONOFF_LIGHT) || // 3A in-wall switch
                         (manufacturerCode() == VENDOR_PHILIPS && endpoint.deviceId() == DEV_ID_HA_ONOFF_LIGHT && endpoint.profileId() == HA_PROFILE_ID)) // iCasa in-wall switch
                     { } // skip state.bri not supported
                     else


### PR DESCRIPTION
Don't expose state.bri for 3A Smart Home