### PR TITLE
Further enhancements and device integration

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1215,7 +1215,8 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq.attributeId = 0x0000; // Curent Summation Delivered
         rq.minInterval = 1;
         rq.maxInterval = 300;
-        if (sensor && sensor->modelId() == QLatin1String("SmartPlug")) // Heiman
+        if (sensor && (sensor->modelId() == QLatin1String("SmartPlug") || // Heiman
+                       sensor->modelId() == QLatin1String("SKHMP30-I1"))) // GS smart plug
         {
             rq.reportableChange48bit = 10; // 0.001 kWh (1 Wh)
         }
@@ -1230,7 +1231,8 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq2.minInterval = 1;
         rq2.maxInterval = 300;
         if (sensor && (sensor->modelId() == QLatin1String("SmartPlug") || // Heiman
-                       sensor->modelId() == QLatin1String("902010/25"))) // Bitron
+                       sensor->modelId() == QLatin1String("902010/25") || // Bitron
+                       sensor->modelId() == QLatin1String("SKHMP30-I1"))) // GS smart plug
         {
             rq2.reportableChange24bit = 10; // 1 W
         }
@@ -1249,7 +1251,8 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq.attributeId = 0x050B; // Active power
         rq.minInterval = 1;
         rq.maxInterval = 300;
-        if (sensor && sensor->modelId() == QLatin1String("SmartPlug")) // Heiman
+        if (sensor && (sensor->modelId() == QLatin1String("SmartPlug") || // Heiman
+                       sensor->modelId() == QLatin1String("SKHMP30-I1"))) // GS smart plug
         {
             rq.reportableChange16bit = 10; // 1 W
         }
@@ -1263,7 +1266,8 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq2.attributeId = 0x0505; // RMS Voltage
         rq2.minInterval = 1;
         rq2.maxInterval = 300;
-        if (sensor && sensor->modelId() == QLatin1String("SmartPlug")) // Heiman
+        if (sensor && (sensor->modelId() == QLatin1String("SmartPlug") || // Heiman
+                       sensor->modelId() == QLatin1String("SKHMP30-I1"))) // GS smart plug
         {
             rq2.reportableChange16bit = 100; // 1 V
         }
@@ -1287,7 +1291,8 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq3.reportableChange16bit = 100; // 0.1 A
         }
         else if (sensor && (sensor->modelId() == QLatin1String("SmartPlug") ||  // Heiman
-                            sensor->modelId() == QLatin1String("EMIZB-132")))   // Develco
+                            sensor->modelId() == QLatin1String("EMIZB-132") ||  // Develco
+                            sensor->modelId() == QLatin1String("SKHMP30-I1")))  // GS smart plug
         {
             rq3.reportableChange16bit = 10; // 0.1 A
         }

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1267,6 +1267,10 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         {
             rq2.reportableChange16bit = 100; // 1 V
         }
+        else if (sensor && sensor->modelId() == QLatin1String("SZ-ESW01-AU")) // Sercomm / Telstra smart plug
+        {
+            rq2.reportableChange16bit = 125; // 1 V
+        }
         else
         {
             rq2.reportableChange16bit = 1; // 1 V

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1220,6 +1220,10 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         {
             rq.reportableChange48bit = 10; // 0.001 kWh (1 Wh)
         }
+        else if (sensor && (sensor->modelId() == QLatin1String("SZ-ESW01-AU"))) // Sercomm / Telstra smart plug
+        {
+            rq.reportableChange48bit = 1000; // 0.001 kWh (1 Wh)
+        }
         else
         {
             rq.reportableChange48bit = 1; // 0.001 kWh (1 Wh)
@@ -1236,6 +1240,10 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         {
             rq2.reportableChange24bit = 10; // 1 W
         }
+        else if (sensor && (sensor->modelId() == QLatin1String("SZ-ESW01-AU"))) // Sercomm / Telstra smart plug
+        {
+            rq2.reportableChange24bit = 1000; // 1 W
+        }
         else
         {
             rq2.reportableChange24bit = 1; // 1 W
@@ -1251,8 +1259,9 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq.attributeId = 0x050B; // Active power
         rq.minInterval = 1;
         rq.maxInterval = 300;
-        if (sensor && (sensor->modelId() == QLatin1String("SmartPlug") || // Heiman
-                       sensor->modelId() == QLatin1String("SKHMP30-I1"))) // GS smart plug
+        if (sensor && (sensor->modelId() == QLatin1String("SmartPlug") ||   // Heiman
+                       sensor->modelId() == QLatin1String("SKHMP30-I1") ||  // GS smart plug
+                       sensor->modelId() == QLatin1String("SZ-ESW01-AU")))  // Sercomm / Telstra smart plug
         {
             rq.reportableChange16bit = 10; // 1 W
         }
@@ -1286,7 +1295,8 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq3.minInterval = 1;
         rq3.maxInterval = 300;
         if (sensor && (sensor->modelId() == QLatin1String("SP 120") ||           // innr
-                       sensor->modelId() == QLatin1String("DoubleSocket50AU")))  // Aurora
+                       sensor->modelId() == QLatin1String("DoubleSocket50AU") || // Aurora
+                       sensor->modelId() == QLatin1String("SZ-ESW01-AU")))       // Sercomm / Telstra smart plug
         {
             rq3.reportableChange16bit = 100; // 0.1 A
         }

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1823,6 +1823,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         // CentraLite
         sensor->modelId().startsWith(QLatin1String("Motion Sensor-A")) ||
         sensor->modelId().startsWith(QLatin1String("332")) ||
+        sensor->modelId().startsWith(QLatin1String("3200-S")) ||
         // dresden elektronik
         (sensor->manufacturer() == QLatin1String("dresden elektronik") && sensor->modelId() == QLatin1String("de_spect")) ||
         // GE

--- a/database.cpp
+++ b/database.cpp
@@ -3325,7 +3325,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
         else if (sensor.modelId().startsWith(QLatin1String("lumi.")))
         {
             if (!sensor.modelId().startsWith(QLatin1String("lumi.ctrl_")) &&
-                sensor.modelId() != QLatin1String("lumi.plug") &&
+                !sensor.modelId().startsWith(QLatin1String("lumi.plug")) &&
                 sensor.modelId() != QLatin1String("lumi.curtain") &&
                 !sensor.type().endsWith(QLatin1String("Battery")))
             {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -112,6 +112,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_CENTRALITE, "Motion Sensor-A", emberMacPrefix },
     { VENDOR_CENTRALITE, "3321-S", emberMacPrefix }, // Centralite multipurpose sensor
     { VENDOR_CENTRALITE, "3325-S", emberMacPrefix }, // Centralite motion sensor
+    { VENDOR_CLS, "3200-S", emberMacPrefix }, // Centralite smart plug / Samsung smart outlet
 //    { VENDOR_CENTRALITE, "3326-L", emberMacPrefix }, // Iris motion sensor
     { VENDOR_CENTRALITE, "3328-G", emberMacPrefix }, // Centralite micro motion sensor
     { VENDOR_DDEL, "de_spect", silabs3MacPrefix }, // dresden elektronic spectral sensor
@@ -7159,7 +7160,8 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     }
                                     else if (i->modelId() == QLatin1String("SmartPlug") ||      // Heiman
                                              i->modelId() == QLatin1String("EMIZB-132") ||      // Develco EMI Norwegian HAN
-                                             i->modelId().startsWith(QLatin1String("SKHMP30"))) // GS smart plug
+                                             i->modelId().startsWith(QLatin1String("SKHMP30")) || // GS smart plug
+                                             i->modelId().startsWith(QLatin1String("3200-S"))   // Samsung smart outlet
                                     {
                                         current *= 10; // 0.01A -> mA
                                     }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -7130,8 +7130,9 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     {
                                         voltage += 50; voltage /= 100; // 0.01V -> V
                                     }
-                                    else if (i->modelId() == QLatin1String("RICI01") || // LifeControl Smart Plug
-                                            i->modelId() == QLatin1String("outletv4"))  // Samsung SmartThings IM6001-OTP
+                                    else if (i->modelId() == QLatin1String("RICI01") ||    // LifeControl Smart Plug
+                                             i->modelId() == QLatin1String("outletv4") ||  // Samsung SmartThings IM6001-OTP
+                                             i->modelId() == QLatin1String("EMIZB-13"))    // Develco EMI
                                     {
                                         voltage /= 10; // 0.1V -> V
                                     }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -7022,6 +7022,10 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 {
                                     consumption *= 10; // 0.01 kWh = 10 Wh -> Wh
                                 }
+                                else if (i->modelId().startsWith(QLatin1String("SZ-ESW01"))) // Sercomm / Telstra smart plug
+                                {
+                                    consumption /= 1000;
+                                }
 
                                 if (item)
                                 {
@@ -7047,6 +7051,10 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     i->modelId().startsWith(QLatin1String("SKHMP30")))  // GS smart plug
                                 {
                                     power += 5; power /= 10; // 0.1 W -> W
+                                }
+                                else if (i->modelId().startsWith(QLatin1String("SZ-ESW01"))) // Sercomm / Telstra smart plug
+                                {
+                                    power /= 1000;
                                 }
 
                                 if (item)
@@ -7104,6 +7112,10 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                              i->modelId().startsWith(QLatin1String("3200-S"))) // Samsung/Centralite smart outlet
                                     {
                                         power /= 10; // 0.1W -> W
+                                    }
+                                    else if (i->modelId().startsWith(QLatin1String("SZ-ESW01"))) // Sercomm / Telstra smart plug
+                                    {
+                                        power *= 128; power /= 1000;
                                     }
                                     item->setValue(power); // in W
                                     enqueueEvent(Event(RSensors, RStatePower, i->id(), item));

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -269,6 +269,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_COMPUTIME, "SP600", computimeMacPrefix }, // Salus smart plug
     { VENDOR_HANGZHOU_IMAGIC, "1117-S", energyMiMacPrefix }, // iris motion sensor v3
     { VENDOR_JENNIC, "113D", jennicMacPrefix }, // iHorn (Huawei) temperature and humidity sensor
+    { VENDOR_SERCOMM, "SZ-ESW01", emberMacPrefix }, // Sercomm / Telstra smart plug
     { 0, nullptr, 0 }
 };
 
@@ -7133,6 +7134,10 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     {
                                         voltage /= 10; // 0.1V -> V
                                     }
+                                    else if (i->modelId().startsWith(QLatin1String("SZ-ESW01"))) // Sercomm / Telstra smart plug
+                                    {
+                                        voltage /= 125; // -> V
+                                    }
                                     item->setValue(voltage); // in V
                                     enqueueEvent(Event(RSensors, RStateVoltage, i->id(), item));
                                     updated = true;
@@ -7154,14 +7159,15 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     if (i->modelId() == QLatin1String("SP 120") ||            // innr
                                         i->modelId() == QLatin1String("outletv4") ||          // Samsung SmartThings IM6001-OTP
                                         i->modelId() == QLatin1String("DoubleSocket50AU") ||  // Aurora
-                                        i->modelId() == QLatin1String("RICI01"))              // LifeControl Smart Plug
+                                        i->modelId() == QLatin1String("RICI01") ||            // LifeControl Smart Plug
+                                        i->modelId().startsWith(QLatin1String("SZ-ESW01")))   // Sercomm / Telstra smart plug
                                     {
                                         // already in mA
                                     }
                                     else if (i->modelId() == QLatin1String("SmartPlug") ||      // Heiman
                                              i->modelId() == QLatin1String("EMIZB-132") ||      // Develco EMI Norwegian HAN
                                              i->modelId().startsWith(QLatin1String("SKHMP30")) || // GS smart plug
-                                             i->modelId().startsWith(QLatin1String("3200-S"))   // Samsung smart outlet
+                                             i->modelId().startsWith(QLatin1String("3200-S")))   // Samsung smart outlet
                                     {
                                         current *= 10; // 0.01A -> mA
                                     }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5171,7 +5171,8 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
         sensorNode.setManufacturer("LUMI");
         if (!sensorNode.modelId().startsWith(QLatin1String("lumi.ctrl_")) &&
             !sensorNode.modelId().startsWith(QLatin1String("lumi.plug")) &&
-            sensorNode.modelId() != QLatin1String("lumi.curtain"))
+            sensorNode.modelId() != QLatin1String("lumi.curtain") &&
+            !sensor.type().endsWith(QLatin1String("Battery")))
         {
             sensorNode.addItem(DataTypeUInt8, RConfigBattery);
         }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -7099,8 +7099,9 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     {
                                         power = power == 28000 ? 0 : power / 10;
                                     }
-                                    else if (i->modelId() == QLatin1String("RICI01") || // LifeControl Smart Plug
-                                            i->modelId() == QLatin1String("outletv4"))  // Samsung SmartThings IM6001-OTP
+                                    else if (i->modelId() == QLatin1String("RICI01") ||   // LifeControl Smart Plug
+                                             i->modelId() == QLatin1String("outletv4") || // Samsung SmartThings IM6001-OTP
+                                             i->modelId().startsWith(QLatin1String("3200-S"))) // Samsung/Centralite smart outlet
                                     {
                                         power /= 10; // 0.1W -> W
                                     }

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -282,6 +282,7 @@
 #define VENDOR_OSRAM        0x110C
 #define VENDOR_JASCO        0x1124 // Used by GE
 #define VENDOR_BUSCH_JAEGER 0x112E
+#define VENDOR_SERCOMM      0x1131
 #define VENDOR_BOSCH        0x1133
 #define VENDOR_DDEL         0x1135
 #define VENDOR_LUTRON       0x1144

--- a/poll_manager.cpp
+++ b/poll_manager.cpp
@@ -397,8 +397,14 @@ void PollManager::pollTimerFired()
     else if (suffix == RStateConsumption)
     {
         clusterId = METERING_CLUSTER_ID;
-        attributes.push_back(0x0000); // Curent Summation Delivered
-        attributes.push_back(0x0400); // Instantaneous Demand
+        attributes.push_back(0x0000); // Current Summation Delivered
+        item = r->item(RAttrModelId);
+        if (!item->toString().startsWith(QLatin1String("SP 120")) &&  // Attribute is not available
+            !item->toString().startsWith(QLatin1String("lumi.plug.ma")) &&
+            !item->toString().startsWith(QLatin1String("ZB-ONOFFPlug-D0005")))
+        {
+            attributes.push_back(0x0400); // Instantaneous Demand
+        }
     }
     else if (suffix == RStatePower)
     {


### PR DESCRIPTION
- Removed config item "battery" for Xiaomi smart plugs
- Optimize consumption polling for smart plugs 
- Added support for Samsung/Centralite smart outlet (#819)
- Added initial support for Sercomm / Telstra SZ-ESW01-AU smart plug (#2496)
- Amended report configuration for GS SKHMP30-I1 smart plug
- Corrected power value for Samsung/Centralite smart outlet
- Updated measurement units for Sercomm / Telstra SZ-ESW01-AU smart plug
- Added reporting values for for Sercomm / Telstra SZ-ESW01-AU smart plug