### PR TITLE
Hue dimmer, Hue smart button, Lutron Aurora, innr RC 110, icasa Remote, Xiaomi B1 curtain motor

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2337,11 +2337,16 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
     std::vector<quint16> clusters;
 
     if (sensor->modelId().startsWith(QLatin1String("RWL02")) || // Hue dimmer switch
-        sensor->modelId().startsWith(QLatin1String("ROM00")) || // Hue smart button
-        sensor->modelId().startsWith(QLatin1String("Z3-1BRL"))) // Lutron Aurora FoH dimmer switch
+        sensor->modelId().startsWith(QLatin1String("ROM00"))) // Hue smart button
+
     {
         srcEndpoints.push_back(0x01);
         clusters.push_back(ONOFF_CLUSTER_ID);
+        clusters.push_back(LEVEL_CLUSTER_ID);
+    }
+    else if (sensor->modelId().startsWith(QLatin1String("Z3-1BRL"))) // Lutron Aurora FoH dimmer switch
+    {
+        srcEndpoints.push_back(0x01);
         clusters.push_back(LEVEL_CLUSTER_ID);
     }
     // Busch-Jaeger

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1112,14 +1112,19 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq.maxInterval = 7200;       // value used by Hue bridge
             rq.reportableChange8bit = 0; // value used by Hue bridge
         }
-        else if (sensor && (sensor->modelId().startsWith(QLatin1String("RWL02")) || // Hue dimmer switch
-                            sensor->modelId().startsWith(QLatin1String("ROM00")))) // Hue smart button
+        else if (sensor && sensor->modelId().startsWith(QLatin1String("RWL02"))) // Hue dimmer switch
         {
             rq.minInterval = 300;        // value used by Hue bridge
             rq.maxInterval = 300;        // value used by Hue bridge
             rq.reportableChange8bit = 0; // value used by Hue bridge
         }
-        else if (sensor->modelId().startsWith(QLatin1String("Z3-1BRL"))) // Lutron Aurora Friends-of-Hue dimmer switch
+        else if (sensor && sensor->modelId().startsWith(QLatin1String("ROM00"))) // Hue smart button
+        {
+            rq.minInterval = 900;        // value used by Hue bridge
+            rq.maxInterval = 900;        // value used by Hue bridge
+            rq.reportableChange8bit = 2; // value used by Hue bridge
+        }
+        else if (sensor && sensor->modelId().startsWith(QLatin1String("Z3-1BRL"))) // Lutron Aurora Friends-of-Hue dimmer switch
         {
             rq.minInterval = 900;        // value used by Hue bridge
             rq.maxInterval = 900;        // value used by Hue bridge

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2337,7 +2337,8 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
     std::vector<quint16> clusters;
 
     if (sensor->modelId().startsWith(QLatin1String("RWL02")) || // Hue dimmer switch
-        sensor->modelId().startsWith(QLatin1String("ROM00"))) // Hue smart button
+        sensor->modelId().startsWith(QLatin1String("ROM00")) || // Hue smart button
+        sensor->modelId().startsWith(QLatin1String("Z3-1BRL"))) // Lutron Aurora FoH dimmer switch
     {
         srcEndpoints.push_back(0x01);
         clusters.push_back(ONOFF_CLUSTER_ID);
@@ -2613,22 +2614,16 @@ void DeRestPluginPrivate::checkSensorGroup(Sensor *sensor)
     }
 
     if (sensor->modelId().startsWith(QLatin1String("RWL02")) || // Hue dimmer switch
-        sensor->modelId().startsWith(QLatin1String("ROM00"))) // Hue smart button
-    {
-        if (!group)
-        {
-            getGroupIdentifiers(sensor, 0x01, 0x00);
-            return;
-        }
-    }
-    else if (sensor->modelId().startsWith(QLatin1String("TRADFRI on/off switch")) ||
-             sensor->modelId().startsWith(QLatin1String("TRADFRI open/close remote")) ||
-             sensor->modelId().startsWith(QLatin1String("TRADFRI motion sensor")) ||
-             sensor->modelId().startsWith(QLatin1String("TRADFRI remote control")) ||
-             sensor->modelId().startsWith(QLatin1String("TRADFRI wireless dimmer")) ||
-             sensor->modelId().startsWith(QLatin1String("SYMFONISK")) ||
-             sensor->modelId().startsWith(QLatin1String("902010/23")) || // bitron remote
-             sensor->modelId().startsWith(QLatin1String("RC 110"))) // innr remote
+        sensor->modelId().startsWith(QLatin1String("ROM00")) || // Hue smart button
+        sensor->modelId().startsWith(QLatin1String("Z3-1BRL")) || // Lutron Aurora FoH smart dimmer
+        sensor->modelId().startsWith(QLatin1String("TRADFRI on/off switch")) ||
+        sensor->modelId().startsWith(QLatin1String("TRADFRI open/close remote")) ||
+        sensor->modelId().startsWith(QLatin1String("TRADFRI motion sensor")) ||
+        sensor->modelId().startsWith(QLatin1String("TRADFRI remote control")) ||
+        sensor->modelId().startsWith(QLatin1String("TRADFRI wireless dimmer")) ||
+        sensor->modelId().startsWith(QLatin1String("SYMFONISK")) ||
+        sensor->modelId().startsWith(QLatin1String("902010/23")) || // bitron remote
+        sensor->modelId().startsWith(QLatin1String("RC 110"))) // innr remote
     {
 
     }

--- a/database.cpp
+++ b/database.cpp
@@ -2931,8 +2931,8 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 sensor.addItem(DataTypeInt32, RStateGesture);
             }
             else if (sensor.modelId().startsWith(QLatin1String("RWL02")) ||
-                  // sensor.modelId().startsWith(QLatin1String("Z3-1BRL")) ||
-                     sensor.modelId().startsWith(QLatin1String("ROM00")))
+                     sensor.modelId().startsWith(QLatin1String("ROM00")) ||
+                     sensor.modelId().startsWith(QLatin1String("Z3-1BRL")))
             {
                 sensor.addItem(DataTypeUInt16, RStateEventDuration);
             }
@@ -3274,7 +3274,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             sensor.addItem(DataTypeTime, RStateLocaltime);
         }
 
-        if (sensor.modelId().startsWith(QLatin1String("RWL02"))) // Hue dimmer switch
+        if (sensor.modelId().startsWith(QLatin1String("Z32"))) // Hue dimmer switch
         {
             clusterId = VENDOR_CLUSTER_ID;
             endpoint = 2;

--- a/database.cpp
+++ b/database.cpp
@@ -3274,7 +3274,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             sensor.addItem(DataTypeTime, RStateLocaltime);
         }
 
-        if (sensor.modelId().startsWith(QLatin1String("Z32"))) // Hue dimmer switch
+        if (sensor.modelId().startsWith(QLatin1String("RWL02"))) // Hue dimmer switch
         {
             clusterId = VENDOR_CLUSTER_ID;
             endpoint = 2;

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -217,6 +217,12 @@
 #define SCENE_COMMAND_IKEA_STEP_CT 0x07
 #define SCENE_COMMAND_IKEA_MOVE_CT 0x08
 #define SCENE_COMMAND_IKEA_STOP_CT 0x09
+#define WINDOW_COVERING_COMMAND_OPEN          0x00
+#define WINDOW_COVERING_COMMAND_CLOSE         0x01
+#define WINDOW_COVERING_COMMAND_STOP          0x02
+#define WINDOW_COVERING_COMMAND_GOTO_LIFT_PCT 0x05
+#define WINDOW_COVERING_COMMAND_GOTO_TILT_PCT 0x08
+
 
 // IAS Zone Types
 #define IAS_ZONE_TYPE_STANDARD_CIE            0x0000
@@ -922,6 +928,8 @@ public:
     int getLightData(const ApiRequest &req, ApiResponse &rsp);
     int getLightState(const ApiRequest &req, ApiResponse &rsp);
     int setLightState(const ApiRequest &req, ApiResponse &rsp);
+    int setWindowCoveringState(const ApiRequest &req, ApiResponse &rsp, TaskItem &taskRef, QVariantMap &map);
+    int setWarningDeviceState(const ApiRequest &req, ApiResponse &rsp, TaskItem &taskRef, QVariantMap &map);
     int setLightAttributes(const ApiRequest &req, ApiResponse &rsp);
     int deleteLight(const ApiRequest &req, ApiResponse &rsp);
     int removeAllScenes(const ApiRequest &req, ApiResponse &rsp);

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -2056,34 +2056,48 @@ void DeRestPluginPrivate::handleSensorEvent(const Event &e)
             return;
         }
 
-        Group *group = getGroupForId(item->toString());
+        QStringList gids = item->toString().split(',', QString::SkipEmptyParts);
 
-        if (group && group->state() != Group::StateNormal)
-        {
-            group->setState(Group::StateNormal);
-            group->setName(sensor->modelId() + QLatin1String(" ") + sensor->id());
-            updateGroupEtag(group);
-            queSaveDb(DB_GROUPS, DB_SHORT_SAVE_DELAY);
-            DBG_Printf(DBG_INFO, "reanimate group %s\n", qPrintable(group->name()));
-        }
+        for (int j = 0; j < gids.size(); j++) {
+            const QString gid = gids[j];
+            Group *group = getGroupForId(gid);
 
-        if (group && group->addDeviceMembership(sensor->id()))
-        {
-            DBG_Printf(DBG_INFO, "Attached sensor %s to group %s\n", qPrintable(sensor->id()), qPrintable(group->name()));
-            queSaveDb(DB_GROUPS, DB_LONG_SAVE_DELAY);
-            updateGroupEtag(group);
-        }
+            if (group && group->state() != Group::StateNormal)
+            {
+                DBG_Printf(DBG_INFO, "reanimate group %s for sensor %s\n", qPrintable(gid), qPrintable(sensor->id()));
+                group->setState(Group::StateNormal);
+                group->setName(sensor->modelId() + QLatin1String(" ") + sensor->id());
+                updateGroupEtag(group);
+                queSaveDb(DB_GROUPS, DB_SHORT_SAVE_DELAY);
+            }
 
-        if (!group) // create
-        {
-            Group g;
-            g.setAddress(item->toString().toUInt());
-            g.setName(sensor->modelId() + QLatin1String(" ") + sensor->id());
-            g.addDeviceMembership(sensor->id());
-            groups.push_back(g);
-            updateGroupEtag(&groups.back());
-            queSaveDb(DB_GROUPS, DB_SHORT_SAVE_DELAY);
-            checkSensorBindingsForClientClusters(sensor);
+            if (group && group->addDeviceMembership(sensor->id()))
+            {
+                DBG_Printf(DBG_INFO, "attach group %s to sensor %s\n", qPrintable(gid), qPrintable(sensor->id()));
+                queSaveDb(DB_GROUPS, DB_LONG_SAVE_DELAY);
+                updateGroupEtag(group);
+            }
+
+            if (!group) // create
+            {
+                DBG_Printf(DBG_INFO, "create group %s for sensor %s\n", qPrintable(gid), qPrintable(sensor->id()));
+                Group g;
+                g.setAddress(gid.toUInt());
+                g.setName(sensor->modelId() + QLatin1String(" ") + sensor->id());
+                g.addDeviceMembership(sensor->id());
+                ResourceItem *item2 = g.addItem(DataTypeString, RAttrUniqueId);
+                DBG_Assert(item2);
+                if (item2)
+                {
+                    // FIXME: use the endpoint from which the group command was sent.
+                    const QString uid = generateUniqueId(sensor->address().ext(), 0, 0);
+                    item2->setValue(uid);
+                }
+                groups.push_back(g);
+                updateGroupEtag(&groups.back());
+                queSaveDb(DB_GROUPS, DB_SHORT_SAVE_DELAY);
+                checkSensorBindingsForClientClusters(sensor);
+            }
         }
     }
 }

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -383,6 +383,7 @@ static const Sensor::ButtonMap lutronLZL4BWHLSwitchMap[] = {
 };
 
 static const Sensor::ButtonMap lutronAuroraMap[] = {
+    // Use buttonMap until we can figure out how to activate the 0xFC00 cluster.
 //    mode                          ep    cluster cmd   param button                                       name
     // Special encoding of param handled in code.
     { Sensor::ModeScenes,           0x01, 0x0008, 0x04, 0x00,  S_BUTTON_1 + S_BUTTON_ACTION_SHORT_RELEASED, "Toggle" },


### PR DESCRIPTION
Improve handling of:
- Hue dimmer switch,
- Hue smart button (#2077),
- Lutron Aurora FoH dimmer switch (#2305),
- innr RC 110 (#635),
- icasa Remote (#1978),
- Xiaomi B1 curtain motor (#1654).

Details:
- Changed configuration of attribute reporting for the battery to match the Hue bridge.
- No longer get the group identifiers from the _ZLL Commissioning_ cluster.  Bluntly creating a group and binding the client clusters to it (as for ZigBee 3.0 devices) seems to work just fine for the Hue dimmer switch and the Hue button.  The Aurora doesn't support the _get group identifiers_ command.
- Expose innr RC 110 and icasa Remote as single ZHASwitch `/sensors` resource, with multiple (7 and 4) group IDs in `config.group`, see #2541.
- Added the switch endpoint to the `uniqueid` of the associated `/groups` resource (for RC 110 and icasa remote).
- Handle `config.group` containing list of group IDs.
- Refactored setting the `state` attributes of _Window covering_ "lights" and of _Warning device_ "lights", also in preparation of #2475.
- Removed dead code.

Tested the pairing of the switches extensively, both on RaspBee and on ConBee II.

Tested the setting of "light" `state` for lights, Heiman siren, and old model Xiaomi curtain controller (using _Window Covering_ cluster as well as _Analog Output_ cluster).  I don't have any other _Window covering_ devices to test, nor any other _Warning device_ devices (notably fire/smoke sensors that expose _IAS WD_ cluster).

Open issues:
- We still need to figure out how to activate the 0xFC00 cluster on the Aurora.
- The Aurora seems to be fixed on the group it picked on reset (0xF105 (61701) in my case), and doesn't change this when binding the client clusters.
- There's still some code in `database.cpp` that might not be needed, but I left it in as a safety net:
https://github.com/dresden-elektronik/deconz-rest-plugin/blob/15ff6d3582ee65fef2bd57d6ab594b6488ca69da/database.cpp#L3277-L3310
- There's still some code in `DeRestPluginPrivate::checkSensorsGroup()` in `bindings.cpp` that doesn't handle multiple group IDs in `config.group`.  I don't know how to fix that; I'm simply not calling this method for the innr nor the icasa.
- `taskToLocalData()` only handles light tasks.
- Still no support for groups containing _Window covering_ or _Warning device_ "lights".