### PR TITLE
Send ZclDefaultResponse when requested in ConfigureReportingResponse

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -443,6 +443,12 @@ void DeRestPluginPrivate::handleZclConfigureReportingResponseIndication(const de
         allNodes.push_back(&l);
     }
 
+    // send DefaultResponse if not disabled
+    if (!(zclFrame.frameControl() & deCONZ::ZclFCDisableDefaultResponse))
+    {
+        sendZclDefaultResponse(ind, zclFrame, deCONZ::ZclSuccessStatus);
+    }
+
     for (RestNodeBase * restNode : allNodes)
     {
         if (restNode->address().ext() != ind.srcAddress().ext())


### PR DESCRIPTION
Fix a bug: ZCL specification requires to send a ZclDefaultResponse when this is requested by setting bit DisableDefaultResponse to False.

Part of issue #1261 