### PR TITLE
Refactor logic for setting light state.

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -920,16 +920,28 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         {
             bt.restNode->setZclValue(NodeValue::UpdateInvalid, bt.binding.srcEndpoint, bt.binding.clusterId, IAS_ZONE_CLUSTER_ATTR_ZONE_STATUS_ID, dummy);
         }
-        rq.minInterval = 1;
-        rq.maxInterval = 300;
 
         const Sensor *sensor = dynamic_cast<Sensor *>(bt.restNode);
-        const ResourceItem *item = sensor ? sensor->item(RConfigDuration) : nullptr;
 
-        if (item && item->toNumber() > 15 && item->toNumber() <= UINT16_MAX)
+        if (sensor->type() == QLatin1String("ZHAVibration") && sensor->modelId() == QLatin1String("multi")) // FIXME: check if this also applies to other Samjin sensors
+        // if (bt.restNode->node()->nodeDescriptor().manufacturerCode() == VENDOR_SAMJIN)
         {
-            rq.maxInterval = static_cast<quint16>(item->toNumber());
-            rq.maxInterval -= 5; // report before going presence: false
+            // Only configure periodic reports, as events are already sent though zone status change notification commands
+            rq.minInterval = 300;
+            rq.maxInterval = 300;
+        }
+        else
+        {
+            rq.minInterval = 1;
+            rq.maxInterval = 300;
+
+            const ResourceItem *item = sensor ? sensor->item(RConfigDuration) : nullptr;
+
+            if (item && item->toNumber() > 15 && item->toNumber() <= UINT16_MAX)
+            {
+                rq.maxInterval = static_cast<quint16>(item->toNumber());
+                rq.maxInterval -= 5; // report before going presence: false
+            }
         }
 
         rq.dataType = deCONZ::Zcl16BitBitMap;
@@ -1431,7 +1443,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq.dataType = deCONZ::Zcl16BitInt;
             rq.attributeId = 0x0012; // acceleration x
             rq.minInterval = 1;
-            rq.maxInterval = 3600;
+            rq.maxInterval = 300;
             rq.reportableChange16bit = 1;
             rq.manufacturerCode = VENDOR_SAMJIN;
 
@@ -1439,7 +1451,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq2.dataType = deCONZ::Zcl16BitInt;
             rq2.attributeId = 0x0013; // acceleration y
             rq2.minInterval = 1;
-            rq2.maxInterval = 3600;
+            rq2.maxInterval = 300;
             rq2.reportableChange16bit = 1;
             rq2.manufacturerCode = VENDOR_SAMJIN;
 
@@ -1447,7 +1459,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq3.dataType = deCONZ::Zcl16BitInt;
             rq3.attributeId = 0x0014; // acceleration z
             rq3.minInterval = 1;
-            rq3.maxInterval = 3600;
+            rq3.maxInterval = 300;
             rq3.reportableChange16bit = 1;
             rq3.manufacturerCode = VENDOR_SAMJIN;
 

--- a/database.cpp
+++ b/database.cpp
@@ -3141,6 +3141,8 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 item = sensor.addItem(DataTypeInt16, RStateOrientationX);
                 item = sensor.addItem(DataTypeInt16, RStateOrientationY);
                 item = sensor.addItem(DataTypeInt16, RStateOrientationZ);
+                item = sensor.addItem(DataTypeUInt16, RConfigDuration);
+                item->setValue(0);
             }
         }
         else if (sensor.type().endsWith(QLatin1String("Water")))

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -3486,11 +3486,10 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                     ok = true;
                 }
             }
-            else if (ind.clusterId() == IAS_ZONE_CLUSTER_ID)
+            else if (ind.clusterId() == SCENE_CLUSTER_ID && zclFrame.commandId() == 0x04) // store scene
             {
-                ok = false;
-                // following works for Samjin button
-                if (zclFrame.payload().size() == 6 && buttonMap->zclParam0 == zclFrame.payload().at(0))
+                ok = false; // payload: groupId, sceneId
+                if (zclFrame.payload().size() >= 3 && buttonMap->zclParam0 == zclFrame.payload().at(2))
                 {
                     ok = true;
                 }
@@ -3583,6 +3582,15 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                         sensor->previousDirection = 0xFF;
                         ok = true;
                     }
+                }
+            }
+            else if (ind.clusterId() == IAS_ZONE_CLUSTER_ID)
+            {
+                ok = false;
+                // following works for Samjin button
+                if (zclFrame.payload().size() == 6 && buttonMap->zclParam0 == zclFrame.payload().at(0))
+                {
+                    ok = true;
                 }
             }
             else if (ind.clusterId() == COLOR_CLUSTER_ID &&

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1002,6 +1002,8 @@ void DeRestPluginPrivate::gpProcessButtonEvent(const deCONZ::GpDataIndication &i
     {
         return;
     }
+    sensor->rx();
+
     quint32 btn = ind.gpdCommandId();
     if (sensor->modelId() == QLatin1String("FOHSWITCH"))
     {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -10633,7 +10633,8 @@ bool DeRestPluginPrivate::addTask(const TaskItem &task)
     std::list<TaskItem>::iterator i = tasks.begin();
     std::list<TaskItem>::iterator end = tasks.end();
 
-    if ((task.taskType != TaskGetSceneMembership) &&
+    if ((task.taskType != TaskSetLevel) &&
+        (task.taskType != TaskGetSceneMembership) &&
         (task.taskType != TaskGetGroupMembership) &&
         (task.taskType != TaskGetGroupIdentifiers) &&
         (task.taskType != TaskStoreScene) &&
@@ -10657,7 +10658,7 @@ bool DeRestPluginPrivate::addTask(const TaskItem &task)
                     (i->req.asdu().size() ==  task.req.asdu().size()))
 
                 {
-                    DBG_Printf(DBG_INFO, "Replace task %d type %d in queue cluster 0x%04X with newer task of same type. %u runnig tasks\n", task.taskId, task.taskType, task.req.clusterId(), runningTasks.size());
+                    DBG_Printf(DBG_INFO, "Replace task %d type %d in queue cluster 0x%04X with newer task %d of same type. %u runnig tasks\n", i->taskId, task.taskType, task.req.clusterId(), task.taskId, runningTasks.size());
                     *i = task;
                     return true;
                 }

--- a/general.xml
+++ b/general.xml
@@ -1076,7 +1076,9 @@ that measures a physical quantity that can take on one of a number of discrete s
 					<value name="Count down" value="4"></value>
 					<value name="Wait for more" value="5"></value>
 				</attribute>
-								<attribute id="0x0009" name="Min block request delay" type="u16" default="0" access="r" required="m"></attribute>
+				<attribute id="0x0007" name="Manufacturer ID" type="u16" access="r" required="o" showas="hex"></attribute>
+				<attribute id="0x0008" name="Image Type ID" type="u16" access="r" required="o" showas="hex"></attribute>
+				<attribute id="0x0009" name="Min block request delay" type="u16" default="0" access="r" required="m"></attribute>
 				<command id="0x01" dir="send" name="Query next image" required="m">
 					<description></description>
 					<payload>
@@ -2619,19 +2621,19 @@ devices can operate on either battery or mains power, and can have a wide variet
 				<attribute id="0x0000" type="u8" name="On" required="m" access="rw" default="0">
 					<description>Enable Sensor </description>
 				</attribute>
-				
+
 				<attribute id="0x0001" name="X-Value" type="u16" default="0x0000" access="r" required="m" showas="dec">
 					<description>X-Value</description>
 				</attribute>
-				
+
 				<attribute id="0x0002" name="Y-Value" type="u16" default="0x0000" access="r" required="m" showas="dec">
 					<description>Y-Value</description>
 				</attribute>
-				
+
 				<attribute id="0x0003" name="Z-Value" type="u16" default="0x0000" access="r" required="m" showas="dec">
 					<description>Z-Value</description>
 				</attribute>
-				
+
 			</server>
 			<client>
 			</client>

--- a/resource.cpp
+++ b/resource.cpp
@@ -32,6 +32,8 @@ const char *RAttrType = "attr/type";
 const char *RAttrClass = "attr/class";
 const char *RAttrUniqueId = "attr/uniqueid";
 const char *RAttrSwVersion = "attr/swversion";
+const char *RAttrLastAnnounce = "attr/lastannounced";
+const char *RAttrLastSeen = "attr/lastseen";
 
 const char *RActionScene = "action/scene";
 
@@ -164,6 +166,8 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RAttrClass));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RAttrUniqueId));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RAttrSwVersion));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeTime, RAttrLastAnnounce));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeTime, RAttrLastSeen));
 
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, RStateAlarm));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RStateAlert));
@@ -373,7 +377,7 @@ const QString &ResourceItem::toString() const
                 QDateTime dt;
                 dt.setOffsetFromUtc(0);
                 dt.setMSecsSinceEpoch(m_num);
-                *m_str = dt.toString("yyyy-MM-ddTHH:mm:ss");
+                *m_str = dt.toString(m_rid.suffix == RStateLastUpdated ? "yyyy-MM-ddTHH:mm:ss.zzz" : "yyyy-MM-ddTHH:mm:ss");
             }
             else
             {

--- a/resource.h
+++ b/resource.h
@@ -47,6 +47,8 @@ extern const char *RAttrType;
 extern const char *RAttrClass;
 extern const char *RAttrUniqueId;
 extern const char *RAttrSwVersion;
+extern const char *RAttrLastAnnounce;
+extern const char *RAttrLastSeen;
 
 extern const char *RActionScene;
 

--- a/rest_groups.cpp
+++ b/rest_groups.cpp
@@ -3025,11 +3025,13 @@ int DeRestPluginPrivate::modifyScene(const ApiRequest &req, ApiResponse &rsp)
     uint tt = 0;
     uint16_t xy_x;
     uint16_t xy_y;
+    uint16_t ct = 0;
 
     bool hasOn = false;
     bool hasBri = false;
     bool hasTt = false;
     bool hasXy = false;
+    bool hasCt = false;
 
     // on
     if (map.contains("on"))
@@ -3079,6 +3081,23 @@ int DeRestPluginPrivate::modifyScene(const ApiRequest &req, ApiResponse &rsp)
         else
         {
             rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/groups/%1/scenes/%2/lights/%3/state/bri").arg(gid).arg(sid).arg(lid), QString("invalid value, %1, for parameter bri").arg(tt)));
+            rsp.httpStatus = HttpStatusBadRequest;
+            return REQ_READY_SEND;
+        }
+    }
+
+    if (map.contains("ct"))
+    {
+        bool ok;
+        ct = map["ct"].toUInt(&ok);
+
+        if (ok && map["ct"].type() == QVariant::Double && (ct < 1000))
+        {
+            hasCt = true;
+        }
+        else
+        {
+            rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/groups/%1/scenes/%2/lights/%3/state/ct").arg(gid).arg(sid).arg(lid), QString("invalid value, %1, for parameter ct").arg(ct)));
             rsp.httpStatus = HttpStatusBadRequest;
             return REQ_READY_SEND;
         }
@@ -3157,8 +3176,14 @@ int DeRestPluginPrivate::modifyScene(const ApiRequest &req, ApiResponse &rsp)
                     }
                     if (hasXy)
                     {
+                        l->setColorMode(QLatin1String("xy"));
                         l->setX(xy_x);
                         l->setY(xy_y);
+                    }
+                    else if (hasCt)
+                    {
+                        l->setColorMode(QLatin1String("ct"));
+                        l->setColorTemperature(ct);
                     }
 
                     if (!modifyScene(group, i->id))

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1243,16 +1243,17 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
     {
         if (taskRef.lightNode->isColorLoopActive())
         {
-            taskRef.lightNode->setColorLoopSpeed(15);
-            taskRef.lightNode->setColorLoopActive(false);
+            TaskItem task;
+            copyTaskReq(taskRef, task);
+            addTaskSetColorLoop(task, false, colorloopSpeed);
         }
-
-        // send Off_with_effect(0, 0)
 
         TaskItem task;
         copyTaskReq(taskRef, task);
-
-        if (addTaskSetOnOff(task, ONOFF_COMMAND_OFF, 0, 0))
+        const quint8 cmd = taskRef.lightNode->manufacturerCode() == VENDOR_PHILIPS // FIXME: use light capabilities
+            ? ONOFF_COMMAND_OFF_WITH_EFFECT
+            : ONOFF_COMMAND_OFF;
+        if (addTaskSetOnOff(task, cmd, 0, 0))
         {
             QVariantMap rspItem;
             QVariantMap rspItemState;

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -838,7 +838,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         TaskItem task;
         copyTaskReq(taskRef, task);
 
-        if (!isOn && targetBri != 0xFF)
+        if (!isOn && hasBri)
         {
             TaskItem task;
             copyTaskReq(taskRef, task);
@@ -1562,7 +1562,7 @@ int DeRestPluginPrivate::setWarningDeviceState(const ApiRequest &req, ApiRespons
     bool ok;
     QString id = req.path[3];
 
-    bool requestOk = false;
+    bool requestOk = true;
     bool hasCmd = false;
     QString alert;
     quint16 onTime = 0;

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -961,6 +961,10 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         {
             rsp.list.append(errorToMap(ERR_DEVICE_OFF, QString("/lights/%1/state").arg(id), QString("parameter, xy, is not modifiable. Device is set to off.")));
         }
+        else if (taskRef.lightNode->isColorLoopActive())
+        {
+            rsp.list.append(errorToMap(ERR_PARAMETER_NOT_MODIFIEABLE, QString("/lights/%1/state").arg(id), QString("parameter, xy, is not modifiable. Colorloop is active.")));
+        }
         else if (addTaskSetXyColor(task, targetX, targetY))
         {
             QVariantMap rspItem;
@@ -984,6 +988,10 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         {
             rsp.list.append(errorToMap(ERR_DEVICE_OFF, QString("/lights/%1/state").arg(id), QString("parameter, ct, is not modifiable. Device is set to off.")));
         }
+        else if (taskRef.lightNode->isColorLoopActive())
+        {
+            rsp.list.append(errorToMap(ERR_PARAMETER_NOT_MODIFIEABLE, QString("/lights/%1/state").arg(id), QString("parameter, ct, is not modifiable. Colorloop is active.")));
+        }
         else if (addTaskSetColorTemperature(task, targetCt))
         {
             QVariantMap rspItem;
@@ -1006,6 +1014,10 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         if (!isOn)
         {
             rsp.list.append(errorToMap(ERR_DEVICE_OFF, QString("/lights/%1/state").arg(id), QString("parameter, ct_inc, is not modifiable. Device is set to off.")));
+        }
+        else if (taskRef.lightNode->isColorLoopActive())
+        {
+            rsp.list.append(errorToMap(ERR_PARAMETER_NOT_MODIFIEABLE, QString("/lights/%1/state").arg(id), QString("parameter, ct_inc, is not modifiable. Colorloop is active.")));
         }
         else if (addTaskIncColorTemperature(task, targetCtInc))
         {
@@ -1037,6 +1049,18 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
                 rsp.list.append(errorToMap(ERR_DEVICE_OFF, QString("/lights/%1/state").arg(id), QString("parameter, sat, is not modifiable. Device is set to off.")));
             }
         }
+        else if (taskRef.lightNode->isColorLoopActive())
+        {
+            if (hasHue)
+            {
+                rsp.list.append(errorToMap(ERR_PARAMETER_NOT_MODIFIEABLE, QString("/lights/%1/state").arg(id), QString("parameter, hue, is not modifiable. Colorloop is active.")));
+            }
+            if (hasSat)
+            {
+                rsp.list.append(errorToMap(ERR_PARAMETER_NOT_MODIFIEABLE, QString("/lights/%1/state").arg(id), QString("parameter, sat, is not modifiable. Colorloop is active.")));
+            }
+        }
+
         else if (!hasSat) // only state.hue
         {
             ok = addTaskSetEnhancedHue(task, targetHue);

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -732,6 +732,12 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
                 colorloopSpeed = speed;
             }
         }
+        else if (param == "colormode" && taskRef.lightNode->item(RStateColorMode)) {
+            paramOk = true;
+            valueOk = true;
+            rsp.list.append(errorToMap(ERR_PARAMETER_NOT_MODIFIEABLE, QString("/lights/%1/state").arg(id), QString("parameter, %1, is not modifiable.").arg(param)));
+            requestOk = false;
+        }
         else if (param == "alert" && taskRef.lightNode->item(RStateAlert))
         {
             paramOk = true;

--- a/rest_node_base.cpp
+++ b/rest_node_base.cpp
@@ -288,7 +288,7 @@ void RestNodeBase::setZclValue(NodeValue::UpdateType updateType, quint8 endpoint
 
             if (DBG_IsEnabled(DBG_INFO_L2))
             {
-                DBG_Printf(DBG_INFO_L2, "update ZCL value 0x%04X/0x%04X for ep: 0x%02X 0x%016llX after %lld s\n", endpoint, clusterId, attributeId, address().ext(), i->timestamp.secsTo(now));
+                DBG_Printf(DBG_INFO_L2, "0x%016llX: update ZCL value 0x%02X/0x%04X/0x%04X after %lld s\n", address().ext(), endpoint, clusterId, attributeId, i->timestamp.secsTo(now));
             }
             return;
         }
@@ -306,7 +306,7 @@ void RestNodeBase::setZclValue(NodeValue::UpdateType updateType, quint8 endpoint
     val.updateType = updateType;
     val.value = value;
 
-    DBG_Printf(DBG_INFO_L2, "added ZCL value 0x%04X/0x%04X for ep: 0x%02X 0x%016llX\n", clusterId, attributeId, endpoint, address().ext());
+    DBG_Printf(DBG_INFO_L2, "0x%016llX: added ZCL value 0x%02/0x%04X/0x%04X\n", address().ext(), endpoint, clusterId, attributeId);
 
     m_values.push_back(val);
 }

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1708,12 +1708,18 @@ bool DeRestPluginPrivate::sensorToMap(const Sensor *sensor, QVariantMap &map, co
         {
             const char *key = item->descriptor().suffix + 6;
 
-            if (rid.suffix == RStateLastUpdated && (!item->lastSet().isValid() || (item->lastSet().date().year() < 2000)))
+            if (rid.suffix == RStateLastUpdated)
             {
-                state[key] = QLatin1String("none");
-                continue;
+                if (!item->lastSet().isValid() || item->lastSet().date().year() < 2000)
+                {
+                    state[key] = QLatin1String("none");
+                }
+                else
+                {
+                    state[key] = item->toVariant().toDateTime().toString("yyyy-MM-ddTHH:mm:ss.zzz");
+                }
             }
-            if (rid.suffix == RStateOrientationX)
+            else if (rid.suffix == RStateOrientationX)
             {
                 ix = item;
             }
@@ -1742,6 +1748,10 @@ bool DeRestPluginPrivate::sensorToMap(const Sensor *sensor, QVariantMap &map, co
     //sensor
     map["name"] = sensor->name();
     map["type"] = sensor->type();
+    if (sensor->type().startsWith(QLatin1String("Z"))) // ZigBee sensor
+    {
+        map["lastseen"] = sensor->lastRx().toUTC().toString("yyyy-MM-ddTHH:mm:ss.zzz");
+    }
 
     if (req.path.size() > 2 && req.path[2] == QLatin1String("devices"))
     {
@@ -1981,6 +1991,26 @@ void DeRestPluginPrivate::handleSensorEvent(const Event &e)
             }
         }
     }
+    else if (strncmp(e.what(), "attr/", 5) == 0)
+    {
+        ResourceItem *item = sensor->item(e.what());
+        if (item)
+        {
+            QVariantMap map;
+            map["t"] = QLatin1String("event");
+            map["e"] = QLatin1String("changed");
+            map["r"] = QLatin1String("sensors");
+            map["id"] = e.id();
+            map["uniqueid"] = sensor->uniqueId();
+            QVariantMap config;
+
+            // For now, don't collect top-level attributes into a single event.
+            const char *key = item->descriptor().suffix + 5;
+            map[key] = item->toVariant();
+
+            webSocketServer->broadcastTextMessage(Json::serialize(map));
+        }
+    }
     else if (e.what() == REventAdded)
     {
         checkSensorGroup(sensor);
@@ -2028,21 +2058,6 @@ void DeRestPluginPrivate::handleSensorEvent(const Event &e)
         smap["id"] = e.id();
         map["sensor"] = smap;
 
-        webSocketServer->broadcastTextMessage(Json::serialize(map));
-    }
-    else if (e.what() == RAttrName)
-    {
-        QVariantMap map;
-        map["t"] = QLatin1String("event");
-        map["e"] = QLatin1String("changed");
-        map["r"] = QLatin1String("sensors");
-        map["id"] = e.id();
-        map["uniqueid"] = sensor->uniqueId();
-
-        if (e.what() == RAttrName) // new attributes might be added in future
-        {
-            map["name"] = sensor->name();
-        }
         webSocketServer->broadcastTextMessage(Json::serialize(map));
     }
     else if (e.what() == REventValidGroup)

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -986,7 +986,6 @@ int Sensor::rxCounter() const
     return m_rxCounter;
 }
 
-
 /*! Returns the sensor manufacturer.
  */
 const QString &Sensor::manufacturer() const

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -480,11 +480,17 @@ static const Sensor::ButtonMap icasaKeypadMap[] = {
     { Sensor::ModeScenes,           0x01, 0x0008, 0x07, 0,    S_BUTTON_2 + S_BUTTON_ACTION_LONG_RELEASED, "Stop_ (with on/off)" },
     // Scene buttons
     { Sensor::ModeScenes,           0x01, 0x0005, 0x05, 1,    S_BUTTON_3 + S_BUTTON_ACTION_SHORT_RELEASED, "Recall scene 1" },
+    { Sensor::ModeScenes,           0x01, 0x0005, 0x04, 1,    S_BUTTON_3 + S_BUTTON_ACTION_LONG_RELEASED, "Store scene 1" },
     { Sensor::ModeScenes,           0x01, 0x0005, 0x05, 2,    S_BUTTON_4 + S_BUTTON_ACTION_SHORT_RELEASED, "Recall scene 2" },
+    { Sensor::ModeScenes,           0x01, 0x0005, 0x04, 2,    S_BUTTON_4 + S_BUTTON_ACTION_LONG_RELEASED, "Store scene 2" },
     { Sensor::ModeScenes,           0x01, 0x0005, 0x05, 3,    S_BUTTON_5 + S_BUTTON_ACTION_SHORT_RELEASED, "Recall scene 3" },
+    { Sensor::ModeScenes,           0x01, 0x0005, 0x04, 3,    S_BUTTON_5 + S_BUTTON_ACTION_LONG_RELEASED, "Store scene 3" },
     { Sensor::ModeScenes,           0x01, 0x0005, 0x05, 4,    S_BUTTON_6 + S_BUTTON_ACTION_SHORT_RELEASED, "Recall scene 4" },
+    { Sensor::ModeScenes,           0x01, 0x0005, 0x04, 4,    S_BUTTON_6 + S_BUTTON_ACTION_LONG_RELEASED, "Store scene 4" },
     { Sensor::ModeScenes,           0x01, 0x0005, 0x05, 5,    S_BUTTON_7 + S_BUTTON_ACTION_SHORT_RELEASED, "Recall scene 5" },
+    { Sensor::ModeScenes,           0x01, 0x0005, 0x04, 5,    S_BUTTON_7 + S_BUTTON_ACTION_LONG_RELEASED, "Store scene 5" },
     { Sensor::ModeScenes,           0x01, 0x0005, 0x05, 6,    S_BUTTON_8 + S_BUTTON_ACTION_SHORT_RELEASED, "Recall scene 6" },
+    { Sensor::ModeScenes,           0x01, 0x0005, 0x04, 6,    S_BUTTON_8 + S_BUTTON_ACTION_LONG_RELEASED, "Store scene 6" },
     // end
     { Sensor::ModeNone,             0x00, 0x0000, 0x00, 0,    0,                                           nullptr }
 };

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -1076,7 +1076,9 @@ void Sensor::jsonToState(const QString &json)
     QDateTime dt = QDateTime::currentDateTime().addSecs(-120);
     if (map.contains("lastupdated"))
     {
-        QDateTime lu = QDateTime::fromString(map["lastupdated"].toString(), QLatin1String("yyyy-MM-ddTHH:mm:ss"));
+        QString lastupdated = map["lastupdated"].toString();
+        QString format = lastupdated.length() == 19 ? QLatin1String("yyyy-MM-ddTHH:mm:ss") : QLatin1String("yyyy-MM-ddTHH:mm:ss.zzz");
+        QDateTime lu = QDateTime::fromString(lastupdated, format);
         if (lu < dt)
         {
             dt = lu;

--- a/zcl_tasks.cpp
+++ b/zcl_tasks.cpp
@@ -797,13 +797,18 @@ bool DeRestPluginPrivate::addTaskSetColorLoop(TaskItem &task, bool colorLoopActi
     task.colorLoop = colorLoopActive;
     task.taskType = TaskSetColorLoop;
 
-    if (task.lightNode && colorLoopActive)
+    if (task.lightNode)
     {
-        if (task.lightNode->colorMode() != QLatin1String("hs"))
+        task.lightNode->setColorLoopActive(colorLoopActive);
+        task.lightNode->setColorLoopSpeed(speed);
+        if (colorLoopActive)
         {
-            task.lightNode->setColorMode(QLatin1String("hs"));
-            Event e(RLights, RStateColorMode, task.lightNode->id());
-            enqueueEvent(e);
+            if (task.lightNode->colorMode() != QLatin1String("xy"))
+            {
+                task.lightNode->setColorMode(QLatin1String("xy"));
+                Event e(RLights, RStateColorMode, task.lightNode->id());
+                enqueueEvent(e);
+            }
         }
     }
 

--- a/zcl_tasks.cpp
+++ b/zcl_tasks.cpp
@@ -96,8 +96,8 @@ bool DeRestPluginPrivate::addTaskMoveLevel(TaskItem &task, bool withOnOff, bool 
  */
 bool DeRestPluginPrivate::addTaskSetOnOff(TaskItem &task, quint8 cmd, quint16 ontime, quint8 flags)
 {
-    DBG_Assert(cmd == ONOFF_COMMAND_ON || cmd == ONOFF_COMMAND_OFF || cmd == ONOFF_COMMAND_TOGGLE || cmd == ONOFF_COMMAND_ON_WITH_TIMED_OFF);
-    if (!(cmd == ONOFF_COMMAND_ON || cmd == ONOFF_COMMAND_OFF || cmd == ONOFF_COMMAND_TOGGLE || cmd == ONOFF_COMMAND_ON_WITH_TIMED_OFF))
+    DBG_Assert(cmd == ONOFF_COMMAND_ON || cmd == ONOFF_COMMAND_OFF || cmd == ONOFF_COMMAND_TOGGLE || cmd == ONOFF_COMMAND_OFF_WITH_EFFECT || cmd == ONOFF_COMMAND_ON_WITH_TIMED_OFF);
+    if (!(cmd == ONOFF_COMMAND_ON || cmd == ONOFF_COMMAND_OFF || cmd == ONOFF_COMMAND_TOGGLE || cmd == ONOFF_COMMAND_OFF_WITH_EFFECT || cmd == ONOFF_COMMAND_ON_WITH_TIMED_OFF))
     {
         return false;
     }
@@ -114,7 +114,16 @@ bool DeRestPluginPrivate::addTaskSetOnOff(TaskItem &task, quint8 cmd, quint16 on
                              deCONZ::ZclFCDirectionClientToServer |
                              deCONZ::ZclFCDisableDefaultResponse);
 
-    if (cmd == ONOFF_COMMAND_ON_WITH_TIMED_OFF)
+    if (cmd == ONOFF_COMMAND_OFF_WITH_EFFECT)
+    {
+        const quint8 effect = 0;
+        const quint8 variant = 0;
+        QDataStream stream(&task.zclFrame.payload(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+        stream << effect;
+        stream << variant;
+    }
+    else if (cmd == ONOFF_COMMAND_ON_WITH_TIMED_OFF)
     {
         const quint16 offWaitTime = 0;
         QDataStream stream(&task.zclFrame.payload(), QIODevice::WriteOnly);

--- a/zcl_tasks.cpp
+++ b/zcl_tasks.cpp
@@ -1285,32 +1285,10 @@ bool DeRestPluginPrivate::addTaskAddScene(TaskItem &task, uint16_t groupId, uint
                     {
                         stream << (uint16_t)0x0300; // color cluster
                         stream << (uint8_t)11; // size
-                        if (l->colorMode() == QLatin1String("xy"))
-                        {
-                            stream << l->x();
-                            stream << l->y();
-                            stream << l->enhancedHue();
-                            stream << l->saturation();
-#if 0
-                            stream << l->x();
-                            stream << l->y();
-
-                            if (task.lightNode->manufacturerCode() == VENDOR_OSRAM ||
-                                    task.lightNode->manufacturerCode() == VENDOR_OSRAM_STACK)
-                            {
-                                stream << l->enhancedHue();
-                                stream << l->saturation();
-                            }
-                            else
-                            {
-                                stream << (quint16)0; //enhanced hue
-                                stream << (quint8)0; // saturation
-                            }
-#endif
-                        }
-                        else if (l->colorMode() == QLatin1String("ct"))
+                        if (l->colorMode() == QLatin1String("ct"))
                         {
                             quint16 x,y;
+                            quint16 enhancedHue = 0;
                             ResourceItem *ctMin = task.lightNode->item(RConfigCtMin);
                             ResourceItem *ctMax = task.lightNode->item(RConfigCtMax);
 
@@ -1330,6 +1308,13 @@ bool DeRestPluginPrivate::addTaskAddScene(TaskItem &task, uint16_t groupId, uint
                             {
                                 // quirks mode Ribag Air O stores color temperature in x
                                 x = l->colorTemperature();
+                                y = 0;
+                            }
+                            else if (task.lightNode->modelId().startsWith(QLatin1String("ICZB-F")))
+                            {
+                                // quirks mode icasa filament lights store color temperature in hue
+                                enhancedHue = l->colorTemperature();
+                                x = 0;
                                 y = 0;
                             }
                             else
@@ -1358,10 +1343,10 @@ bool DeRestPluginPrivate::addTaskAddScene(TaskItem &task, uint16_t groupId, uint
 
                             stream << x;
                             stream << y;
-                            stream << (quint16)0; //enhanced hue
+                            stream << enhancedHue;
                             stream << (quint8)0; // saturation
                         }
-                        else if (l->colorMode() == QLatin1String("hs"))
+                        else
                         {
                             stream << l->x();
                             stream << l->y();

--- a/zcl_tasks.cpp
+++ b/zcl_tasks.cpp
@@ -803,9 +803,9 @@ bool DeRestPluginPrivate::addTaskSetColorLoop(TaskItem &task, bool colorLoopActi
         task.lightNode->setColorLoopSpeed(speed);
         if (colorLoopActive)
         {
-            if (task.lightNode->colorMode() != QLatin1String("xy"))
+            if (task.lightNode->colorMode() != QLatin1String("hs"))
             {
-                task.lightNode->setColorMode(QLatin1String("xy"));
+                task.lightNode->setColorMode(QLatin1String("hs"));
                 Event e(RLights, RStateColorMode, task.lightNode->id());
                 enqueueEvent(e);
             }


### PR DESCRIPTION
See #2475.
- Implement `state.on` / `state.bri` logic more like the Hue bridge, see https://github.com/dresden-elektronik/deconz-rest-plugin/issues/1111#issuecomment-456464872.  Try setting something fun, like `{"on": true, "ontime": 100, "bri": 254, "transitiontime": 100}`;
- Implement parameter validation (both keys and values, as well as combinations) for body.  All parameters are checked before any action is taken, and validation continues after one error;
- Also adds support for setting `state.speed` for _Fan_ devices, like the Hampton Bay (see #932).

I've tested this on a Hue bulb and on a GLEDOPTO controller.  The latter doesn't turn on on _Move to Level (with On/Off)_, but it does set the level (even while the light is off).  The subsequent _On_ then turns the light on at level 2, causing almost the same behaviour as Hue lights.  I would appreciate people testing this on other lights, notably IKEA.

For discussion on the functionality, please see #2475.