### PR TITLE
fix: rename IAS Zone Carbon Monoxide (CO) sensor to Gas sensor

### DIFF
--- a/general.xml
+++ b/general.xml
@@ -2170,7 +2170,7 @@ controller device, that supports a keypad and LCD screen.</description>
 						<value name="Contact switch" value="0x0015"></value>
 						<value name="Fire sensor" value="0x0028"></value>
 						<value name="Water sensor" value="0x002a"></value>
-						<value name="Carbon Monoxide (CO) sensor" value="0x002b"></value>
+						<value name="Gas sensor" value="0x002b"></value>
 						<value name="Personal emergency device" value="0x002c"></value>
 						<value name="Vibration / Movement sensor" value="0x002d"></value>
 						<value name="Remote Control" value="0x010f"></value>


### PR DESCRIPTION
The value 0x002B (IAS_ZONE_TYPE_GAS_SENSOR) _can_ by a CO sensor, but also, e.g., a combustible gas sensor, too. Therefore the label in the GUI is ~wrong~ confusing.

See, e.g., http://dev.ti.com/tirex/content/simplelink_cc13x2_26x2_sdk_3_40_00_02/docs/zigbee/doxygen/zigbee/html/group___t_y_p_e___s_s___i_a_s___z_o_n_e.html#ga3ba58ff7204f89aad419a95bdeee533a

Ref #2633 (but does not close)