### PR TITLE
Enhancements and addition of various devices

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2020,7 +2020,9 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         // Sengled
         sensor->modelId().startsWith(QLatin1String("E13-")) ||
         // Immax
-        sensor->modelId() == QLatin1String("Plug-230V-ZB3.0"))
+        sensor->modelId() == QLatin1String("Plug-230V-ZB3.0") ||
+        // Sercomm
+        sensor->modelId().startsWith(QLatin1String("SZ-")))
     {
         deviceSupported = true;
         if (!sensor->node()->nodeDescriptor().receiverOnWhenIdle() ||

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1989,7 +1989,8 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         // Stelpro
         sensor->modelId().contains(QLatin1String("ST218")) ||
         // Tuya
-        sensor->modelId().contains(QLatin1String("TS0201")) ||
+        sensor->modelId().startsWith(QLatin1String("TS01")) ||
+        sensor->modelId().startsWith(QLatin1String("TS02")) ||
         // Tuyatec
         sensor->modelId().startsWith(QLatin1String("RH3040")) ||
         sensor->modelId().startsWith(QLatin1String("RH3001")) ||

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1925,6 +1925,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId().startsWith(QLatin1String("Door")) ||
         sensor->modelId().startsWith(QLatin1String("WarningDevice")) ||
         sensor->modelId().startsWith(QLatin1String("SKHMP30")) || // GS smart plug
+        sensor->modelId().startsWith(QLatin1String("RC_V14")) ||
         // Konke
         sensor->modelId() == QLatin1String("3AFE140103020000") ||
         sensor->modelId() == QLatin1String("3AFE130104020015") ||

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1906,6 +1906,8 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId().startsWith(QLatin1String("S2")) ||
         // IKEA
         sensor->modelId().startsWith(QLatin1String("TRADFRI")) ||
+        sensor->modelId().startsWith(QLatin1String("FYRTUR")) ||
+        sensor->modelId().startsWith(QLatin1String("KADRILJ")) ||
         sensor->modelId().startsWith(QLatin1String("SYMFONISK")) ||
         // Keen Home
         sensor->modelId().startsWith(QLatin1String("SV01-")) ||

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1668,7 +1668,7 @@ void DeRestPluginPrivate::checkLightBindingsForAttributeReporting(LightNode *lig
         else if (lightNode->manufacturerCode() == VENDOR_SINOPE)
         {
         }
-        else if (lightNode->modelId() == QLatin1String("SP 120"))
+        else if (lightNode->modelId().startsWith(QLatin1String("SP ")))
         {
         }
         else if (lightNode->manufacturer().startsWith(QLatin1String("Climax")))
@@ -1904,7 +1904,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         // iCasa
         sensor->modelId().startsWith(QLatin1String("ICZB-RM")) ||
         // innr
-        sensor->modelId() == QLatin1String("SP 120") ||
+        sensor->modelId().startsWith(QLatin1String("SP ")) ||
         sensor->modelId().startsWith(QLatin1String("RC 110")) ||
         // Eurotronic
         sensor->modelId() == QLatin1String("SPZB0001") ||

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1915,6 +1915,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId().startsWith(QLatin1String("PIR_")) ||
         sensor->modelId().startsWith(QLatin1String("GAS")) ||
         sensor->modelId().startsWith(QLatin1String("TH-")) ||
+        sensor->modelId().startsWith(QLatin1String("HT-")) ||
         sensor->modelId().startsWith(QLatin1String("SMOK_")) ||
         sensor->modelId().startsWith(QLatin1String("WATER_")) ||
         sensor->modelId().startsWith(QLatin1String("Smoke")) ||

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1240,8 +1240,9 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq.attributeId = 0x0000; // Curent Summation Delivered
         rq.minInterval = 1;
         rq.maxInterval = 300;
-        if (sensor && (sensor->modelId() == QLatin1String("SmartPlug") || // Heiman
-                       sensor->modelId() == QLatin1String("SKHMP30-I1"))) // GS smart plug
+        if (sensor && (sensor->modelId() == QLatin1String("SmartPlug") ||      // Heiman
+                       sensor->modelId() == QLatin1String("SKHMP30-I1") ||     // GS smart plug
+                       sensor->modelId().startsWith(QLatin1String("E13-"))))   // Sengled PAR38 Bulbs
         {
             rq.reportableChange48bit = 10; // 0.001 kWh (1 Wh)
         }
@@ -1999,7 +2000,9 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId().startsWith(QLatin1String("1116-S")) ||
         sensor->modelId().startsWith(QLatin1String("1117-S")) ||
         // Hive
-        sensor->modelId() == QLatin1String("MOT003"))
+        sensor->modelId() == QLatin1String("MOT003") ||
+        // Sengled
+        sensor->modelId().startsWith(QLatin1String("E13-")))
     {
         deviceSupported = true;
         if (!sensor->node()->nodeDescriptor().receiverOnWhenIdle() ||

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2004,7 +2004,9 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         // Hive
         sensor->modelId() == QLatin1String("MOT003") ||
         // Sengled
-        sensor->modelId().startsWith(QLatin1String("E13-")))
+        sensor->modelId().startsWith(QLatin1String("E13-")) ||
+        // Immax
+        sensor->modelId() == QLatin1String("Plug-230V-ZB3.0"))
     {
         deviceSupported = true;
         if (!sensor->node()->nodeDescriptor().receiverOnWhenIdle() ||

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1701,6 +1701,18 @@ void DeRestPluginPrivate::checkLightBindingsForAttributeReporting(LightNode *lig
         else if (lightNode->manufacturerCode() == VENDOR_NETVOX) // Netvox smart plug
         {
         }
+        else if (lightNode->manufacturer() == QLatin1String("Immax"))
+        {
+        }
+        else if (lightNode->manufacturer() == QLatin1String("sengled"))
+        {
+        }
+        else if (lightNode->manufacturer() == QLatin1String("LDS"))
+        {
+        }
+        else if (lightNode->manufacturer() == QLatin1String("Sercomm Corp."))
+        {
+        }
         else
         {
             return;

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2022,7 +2022,9 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         // Immax
         sensor->modelId() == QLatin1String("Plug-230V-ZB3.0") ||
         // Sercomm
-        sensor->modelId().startsWith(QLatin1String("SZ-")))
+        sensor->modelId().startsWith(QLatin1String("SZ-")) ||
+        // WAXMAN
+        sensor->modelId() == QLatin1String("leakSMART Water Sensor V2"))
     {
         deviceSupported = true;
         if (!sensor->node()->nodeDescriptor().receiverOnWhenIdle() ||

--- a/database.cpp
+++ b/database.cpp
@@ -3185,7 +3185,8 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     return 0;
                     // hasVoltage = false;
                 }
-                else if (sensor.modelId() == QLatin1String("ZB-ONOFFPlug-D0005"))
+                else if (sensor.modelId() == QLatin1String("ZB-ONOFFPlug-D0005") || 
+                         sensor.modelId() == QLatin1String("Plug-230V-ZB3.0"))
                 {
                     hasVoltage = false;
                 }

--- a/database.cpp
+++ b/database.cpp
@@ -3160,7 +3160,9 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             {
                 clusterId = clusterId ? clusterId : METERING_CLUSTER_ID;
                 if ((sensor.modelId() != QLatin1String("SP 120")) &&
-                    (sensor.modelId() != QLatin1String("ZB-ONOFFPlug-D0005")))
+                    (sensor.modelId() != QLatin1String("ZB-ONOFFPlug-D0005")) &&
+                    (sensor.modelId() != QLatin1String("TS0121")) &&
+                    (sensor.modelId() != QLatin1String("Plug-230V-ZB3.0")))
                 {
                     item = sensor.addItem(DataTypeInt16, RStatePower);
                     item->setValue(0);

--- a/database.cpp
+++ b/database.cpp
@@ -3193,7 +3193,10 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             else if (sensor.fingerPrint().hasInCluster(ANALOG_INPUT_CLUSTER_ID))
             {
                 clusterId = clusterId ? clusterId : ANALOG_INPUT_CLUSTER_ID;
-                hasVoltage = false;
+                if (!sensor.modelId().startsWith(QLatin1String("lumi.plug.mm"))) // Only available for new ZB3.0 Mi smart plugs?
+                {
+                    hasVoltage = false;
+                }
             }
             item = sensor.addItem(DataTypeInt16, RStatePower);
             item->setValue(0);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -286,6 +286,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_JENNIC, "113D", jennicMacPrefix }, // iHorn (Huawei) temperature and humidity sensor
     { VENDOR_SERCOMM, "SZ-ESW01", emberMacPrefix }, // Sercomm / Telstra smart plug
     { VENDOR_SERCOMM, "SZ-SRN12N", emberMacPrefix }, // Sercomm siren
+    { VENDOR_SERCOMM, "SZ-SRN12N", energyMiMacPrefix }, // Sercomm siren
     { VENDOR_ALERTME, "MOT003", tiMacPrefix }, // Hive Motion Sensor
     { VENDOR_SUNRICHER, "4512703", silabs2MacPrefix }, // Namron 4-ch remote controller
     { VENDOR_SENGLED_OPTOELEC, "E13-", zhejiangMacPrefix }, // Sengled PAR38 Bulbs
@@ -5359,6 +5360,10 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
     else if (sensorNode.manufacturer().startsWith(QLatin1String("TUYATEC")))
     {
         sensorNode.setManufacturer("Tuyatec");
+    }
+    else if (node->nodeDescriptor().manufacturerCode() == VENDOR_SERCOMM)
+    {
+        sensorNode.setManufacturer("Sercomm Corp.");
     }
 
     if (sensorNode.manufacturer().isEmpty() && !manufacturer.isEmpty())

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -210,6 +210,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_HEIMAN, "Smoke", emberMacPrefix }, // Heiman fire sensor - newer model
     { VENDOR_HEIMAN, "COSensor", emberMacPrefix }, // Heiman CO sensor - newer model
     { VENDOR_HEIMAN, "TH-", emberMacPrefix }, // Heiman temperature/humidity sensor - newer model
+    { VENDOR_HEIMAN, "HT-", emberMacPrefix }, // Heiman temperature/humidity sensor - newer model
     { VENDOR_HEIMAN, "Water", emberMacPrefix }, // Heiman water sensor - newer model
     { VENDOR_HEIMAN, "Door", emberMacPrefix }, // Heiman door/window sensor - newer model
     { VENDOR_HEIMAN, "WarningDevice", emberMacPrefix }, // Heiman siren
@@ -2675,7 +2676,7 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
 
                     if (ia->id() == 0x0004) // Manufacturer name
                     {
-                        QString str = ia->toString();
+                        QString str = ia->toString().trimmed();
                         if (!str.isEmpty() && str != lightNode->manufacturer())
                         {
                             if (str == QString("欧瑞博"))

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -285,6 +285,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_HANGZHOU_IMAGIC, "1117-S", energyMiMacPrefix }, // iris motion sensor v3
     { VENDOR_JENNIC, "113D", jennicMacPrefix }, // iHorn (Huawei) temperature and humidity sensor
     { VENDOR_SERCOMM, "SZ-ESW01", emberMacPrefix }, // Sercomm / Telstra smart plug
+    { VENDOR_SERCOMM, "SZ-SRN12N", emberMacPrefix }, // Sercomm siren
     { VENDOR_ALERTME, "MOT003", tiMacPrefix }, // Hive Motion Sensor
     { VENDOR_SUNRICHER, "4512703", silabs2MacPrefix }, // Namron 4-ch remote controller
     { VENDOR_SENGLED_OPTOELEC, "E13-", zhejiangMacPrefix }, // Sengled PAR38 Bulbs
@@ -4028,7 +4029,8 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     {
                         fpWaterSensor.inClusters.push_back(ci->id());
                     }
-                    else if (modelId == QLatin1String("WarningDevice"))               // Heiman siren
+                    else if (modelId == QLatin1String("WarningDevice") ||               // Heiman siren
+                             modelId == QLatin1String("SZ-SRN12N"))                     // Sercomm siren
                     {
                         fpAlarmSensor.inClusters.push_back(ci->id());
                     }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -14053,7 +14053,7 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
                 }
             }
 
-            if (sd.deviceId() == DEV_ID_IAS_ZONE && iasZoneType == 0)
+            if ((sd.deviceId() == DEV_ID_IAS_ZONE || sd.deviceId() == DEV_ID_IAS_WARNING_DEVICE) && iasZoneType == 0)
             {
                 deCONZ::ApsDataRequest apsReq;
 

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -287,6 +287,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_ALERTME, "MOT003", tiMacPrefix }, // Hive Motion Sensor
     { VENDOR_SUNRICHER, "4512703", silabs2MacPrefix }, // Namron 4-ch remote controller
     { VENDOR_SENGLED_OPTOELEC, "E13-", zhejiangMacPrefix }, // Sengled PAR38 Bulbs
+    { VENDOR_JENNIC, "Plug-230V-ZB3.0", silabs2MacPrefix }, // Immax NEO ZB3.0 smart plug
     { 0, nullptr, 0 }
 };
 
@@ -5020,6 +5021,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             item = sensorNode.addItem(DataTypeInt16, RStatePower);
             if ( (!modelId.startsWith(QLatin1String("Plug"))) &&
                  (!modelId.startsWith(QLatin1String("ZB-ONOFFPlug-D0005"))) &&
+                 (modelId != QLatin1String("Plug-230V-ZB3.0")) &&
                  (node->nodeDescriptor().manufacturerCode() != VENDOR_LEGRAND) ) // OSRAM and Legrand plug don't have theses options
             {
                 item = sensorNode.addItem(DataTypeUInt16, RStateVoltage);
@@ -7111,10 +7113,12 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 if (i->modelId() == QLatin1String("SmartPlug") ||       // Heiman
                                     i->modelId().startsWith(QLatin1String("PSMP5_")) || // Climax
                                     i->modelId().startsWith(QLatin1String("SKHMP30")))  // GS smart plug
+																						// Sengled PAR38 Bulbs
                                 {
                                     consumption += 5; consumption /= 10; // 0.1 Wh -> Wh
                                 }
-                                else if (i->modelId() == QLatin1String("SP 120")) // innr
+                                else if (i->modelId() == QLatin1String("SP 120") ||            // innr
+                                         i->modelId() == QLatin1String("Plug-230V-ZB3.0"))     // Immax
                                 {
                                     consumption *= 10; // 0.01 kWh = 10 Wh -> Wh
                                 }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -237,7 +237,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_SINOPE, "WL4200S", sinopeMacPrefix}, // Sinope water sensor
     { VENDOR_SINOPE, "TH1300ZB", sinopeMacPrefix }, // Sinope Thermostat
     { VENDOR_ZEN, "Zen-01", zenMacPrefix }, // Zen Thermostat
-    { VENDOR_C2DF, "3157100-E", emberMacPrefix }, // Centralite Thermostat
+    { VENDOR_C2DF, "3157100", emberMacPrefix }, // Centralite Thermostat
     { VENDOR_EMBER, "Super TR", emberMacPrefix }, // Elko Thermostat
     { VENDOR_ATMEL, "Thermostat", ecozyMacPrefix }, // eCozy Thermostat
     { VENDOR_STELPRO, "ST218", xalMacPrefix }, // Stelpro Thermostat

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -150,6 +150,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_IKEA, "TRADFRI open/close remote", ikeaMacPrefix },
     { VENDOR_IKEA, "FYRTUR", ikeaMacPrefix }, // smart blind
     { VENDOR_IKEA, "KADRILJ", ikeaMacPrefix }, // smart blind
+    { VENDOR_IKEA, "KADRILJ", silabs4MacPrefix }, // smart blind
     { VENDOR_IKEA, "SYMFONISK", ikea2MacPrefix }, // sound controller
     { VENDOR_INSTA, "Remote", instaMacPrefix },
     { VENDOR_INSTA, "HS_4f_GJ_1", instaMacPrefix },

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5026,6 +5026,11 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
         {
             clusterId = ANALOG_INPUT_CLUSTER_ID;
             item = sensorNode.addItem(DataTypeInt16, RStatePower);
+            if (modelId.startsWith(QLatin1String("lumi.plug.mm"))) // Only available for new ZB3.0 Mi smart plugs?
+            {
+                item = sensorNode.addItem(DataTypeUInt16, RStateVoltage);
+                item = sensorNode.addItem(DataTypeUInt16, RStateCurrent);
+            }
         }
     }
     else if (sensorNode.type().endsWith(QLatin1String("Thermostat")))

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -274,6 +274,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_NONE, "RH3052", emberMacPrefix }, // Tuyatec temperature sensor
     { VENDOR_EMBER, "TS0201", silabs3MacPrefix }, // Tuya/Blitzwolf temperature and humidity sensor
     { VENDOR_NONE, "TS0204", silabs3MacPrefix }, // Tuya gas sensor
+    { VENDOR_NONE, "TS0121", silabs3MacPrefix }, // Tuya/Blitzwolf smart plug
     { VENDOR_AURORA, "DoubleSocket50AU", jennicMacPrefix }, // Aurora AOne Double Socket UK
     { VENDOR_COMPUTIME, "SP600", computimeMacPrefix }, // Salus smart plug
     { VENDOR_HANGZHOU_IMAGIC, "1116-S", energyMiMacPrefix }, // iris contact sensor v3
@@ -7268,7 +7269,8 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                         i->modelId().startsWith(QLatin1String("outlet")) ||   // Samsung SmartThings IM6001-OTP/IM6001-OTP01
                                         i->modelId() == QLatin1String("DoubleSocket50AU") ||  // Aurora
                                         i->modelId() == QLatin1String("RICI01") ||            // LifeControl Smart Plug
-                                        i->modelId().startsWith(QLatin1String("SZ-ESW01")))   // Sercomm / Telstra smart plug
+                                        i->modelId().startsWith(QLatin1String("SZ-ESW01")) || // Sercomm / Telstra smart plug
+                                        i->modelId() == QLatin1String("TS0121"))              // Tuya smart plug
                                     {
                                         // already in mA
                                     }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -90,6 +90,7 @@ const quint64 sinopeMacPrefix     = 0x500b910000000000ULL;
 const quint64 ecozyMacPrefix      = 0x70b3d50000000000ULL;
 const quint64 osramMacPrefix      = 0x8418260000000000ULL;
 const quint64 silabsMacPrefix     = 0x90fd9f0000000000ULL;
+const quint64 zhejiangMacPrefix   = 0xb0ce180000000000ULL;
 const quint64 silabs2MacPrefix    = 0xcccccc0000000000ULL;
 const quint64 silabs3MacPrefix    = 0xec1bbd0000000000ULL;
 const quint64 energyMiMacPrefix   = 0xd0cf5e0000000000ULL;
@@ -281,6 +282,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_SERCOMM, "SZ-ESW01", emberMacPrefix }, // Sercomm / Telstra smart plug
     { VENDOR_ALERTME, "MOT003", tiMacPrefix }, // Hive Motion Sensor
     { VENDOR_SUNRICHER, "4512703", silabs2MacPrefix }, // Namron 4-ch remote controller
+    { VENDOR_SENGLED_OPTOELEC, "E13-", zhejiangMacPrefix }, // Sengled PAR38 Bulbs
     { 0, nullptr, 0 }
 };
 
@@ -7108,6 +7110,10 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 else if (i->modelId().startsWith(QLatin1String("SZ-ESW01"))) // Sercomm / Telstra smart plug
                                 {
                                     consumption /= 1000;
+                                }
+                                else if (i->modelId().startsWith(QLatin1String("E13-"))) // Sengled PAR38 Bulbs
+                                {
+                                    consumption /= 10000;
                                 }
 
                                 if (item)

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -191,6 +191,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_XIAOMI, "lumi.remote.b486opcn01", xiaomiMacPrefix }, // Xiaomi Aqara Opple WXCJKG12LM
     { VENDOR_XIAOMI, "lumi.remote.b686opcn01", xiaomiMacPrefix }, // Xiaomi Aqara Opple WXCJKG13LM
     { VENDOR_XIAOMI, "lumi.sen_ill.mgl01", xiaomiMacPrefix }, // Xiaomi ZB3.0 light sensor
+    { VENDOR_XIAOMI, "lumi.plug", xiaomiMacPrefix }, // Xiaomi Xiaomi smart plugs (router)
     // { VENDOR_XIAOMI, "lumi.curtain", jennicMacPrefix}, // Xiaomi curtain controller (router) - exposed only as light
     { VENDOR_UBISYS, "C4", ubisysMacPrefix },
     { VENDOR_UBISYS, "D1", ubisysMacPrefix },

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -64,6 +64,7 @@ static uint MaxGroupTasks = 4;
 
 const quint64 macPrefixMask       = 0xffffff0000000000ULL;
 
+// New mac prefixes can be checked here: https://wintelguy.com/index.pl 
 const quint64 legrandMacPrefix    = 0x0004740000000000ULL;
 const quint64 ikeaMacPrefix       = 0x000b570000000000ULL;
 const quint64 emberMacPrefix      = 0x000d6f0000000000ULL;
@@ -87,6 +88,7 @@ const quint64 ikea2MacPrefix      = 0x14b4570000000000ULL;
 const quint64 stMacPrefix         = 0x24fd5b0000000000ULL;
 const quint64 samjinMacPrefix     = 0x286d970000000000ULL;
 const quint64 sinopeMacPrefix     = 0x500b910000000000ULL;
+const quint64 silabs4MacPrefix    = 0x680ae20000000000ULL;
 const quint64 ecozyMacPrefix      = 0x70b3d50000000000ULL;
 const quint64 osramMacPrefix      = 0x8418260000000000ULL;
 const quint64 silabsMacPrefix     = 0x90fd9f0000000000ULL;

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -7110,10 +7110,10 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 quint64 consumption = ia->numericValue().u64;
                                 ResourceItem *item = i->item(RStateConsumption);
 
-                                if (i->modelId() == QLatin1String("SmartPlug") ||       // Heiman
-                                    i->modelId().startsWith(QLatin1String("PSMP5_")) || // Climax
-                                    i->modelId().startsWith(QLatin1String("SKHMP30")))  // GS smart plug
-																						// Sengled PAR38 Bulbs
+                                if (i->modelId() == QLatin1String("SmartPlug") ||        // Heiman
+                                    i->modelId().startsWith(QLatin1String("PSMP5_")) ||  // Climax
+                                    i->modelId().startsWith(QLatin1String("SKHMP30")) || // GS smart plug
+									i->modelId().startsWith(QLatin1String("E13-")))      // Sengled PAR38 Bulbs
                                 {
                                     consumption += 5; consumption /= 10; // 0.1 Wh -> Wh
                                 }
@@ -7125,10 +7125,6 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 else if (i->modelId().startsWith(QLatin1String("SZ-ESW01"))) // Sercomm / Telstra smart plug
                                 {
                                     consumption /= 1000;
-                                }
-                                else if (i->modelId().startsWith(QLatin1String("E13-"))) // Sengled PAR38 Bulbs
-                                {
-                                    consumption /= 10000;
                                 }
 
                                 if (item)

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5002,7 +5002,10 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
         {
             clusterId = METERING_CLUSTER_ID;
             item = sensorNode.addItem(DataTypeUInt64, RStateConsumption);
-            if ((modelId != QLatin1String("SP 120")) && (modelId != QLatin1String("ZB-ONOFFPlug-D0005")))
+            if ((modelId != QLatin1String("SP 120")) &&
+                (modelId != QLatin1String("ZB-ONOFFPlug-D0005")) &&
+                (modelId != QLatin1String("TS0121")) &&
+                (modelId != QLatin1String("Plug-230V-ZB3.0")))
             {
                 item = sensorNode.addItem(DataTypeInt16, RStatePower);
             }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -206,6 +206,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_OSRAM_STACK, "TH-", heimanMacPrefix }, // Heiman temperature/humidity sensor
     { VENDOR_OSRAM_STACK, "SMOK_", heimanMacPrefix }, // Heiman fire sensor - older model
     { VENDOR_OSRAM_STACK, "WATER_", heimanMacPrefix }, // Heiman water sensor
+    { VENDOR_OSRAM_STACK, "RC_V14", heimanMacPrefix }, // Heiman HS1RC-M remote control
     { VENDOR_LGE, "LG IP65 HMS", emberMacPrefix },
     { VENDOR_EMBER, "SmartPlug", emberMacPrefix }, // Heiman smart plug
     { VENDOR_HEIMAN, "SmartPlug", emberMacPrefix }, // Heiman smart plug
@@ -5957,7 +5958,8 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                         i->modelId().startsWith(QLatin1String("ZGRC-KEY")) || //  Sunricher wireless CCT remote
                                         i->modelId().startsWith(QLatin1String("ZG2833K")) || // Sunricher remote controller
                                         i->modelId().startsWith(QLatin1String("SV01-")) || // Keen Home vent
-                                        i->modelId().startsWith(QLatin1String("4512703"))) // Namron 4-ch remote controller
+                                        i->modelId().startsWith(QLatin1String("4512703")) || // Namron 4-ch remote controller
+                                        i->modelId().startsWith(QLatin1String("RC_V14"))) // Heiman remote controller
                                     {
                                         bat = ia->numericValue().u8;
                                     }
@@ -5992,7 +5994,8 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                         i->modelId().startsWith(QLatin1String("ZGRC-KEY")) || // Sunricher wireless CCT remote
                                         i->modelId().startsWith(QLatin1String("ZG2833K")) || // Sunricher remote controller
                                         i->modelId().startsWith(QLatin1String("SV01-")) || // Keen Home vent
-                                        i->modelId().startsWith(QLatin1String("4512703"))) // Namron 4-ch remote controller
+                                        i->modelId().startsWith(QLatin1String("4512703")) || // Namron 4-ch remote controller
+                                        i->modelId().startsWith(QLatin1String("RC_V14"))) // Heiman remote controller
                                     {
                                         bat = ia->numericValue().u8;
                                     }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -290,6 +290,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_SUNRICHER, "4512703", silabs2MacPrefix }, // Namron 4-ch remote controller
     { VENDOR_SENGLED_OPTOELEC, "E13-", zhejiangMacPrefix }, // Sengled PAR38 Bulbs
     { VENDOR_JENNIC, "Plug-230V-ZB3.0", silabs2MacPrefix }, // Immax NEO ZB3.0 smart plug
+    { VENDOR_WAXMAN, "leakSMART Water Sensor V2", celMacPrefix }, // WAXMAN LeakSMART v2
     { 0, nullptr, 0 }
 };
 

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -414,6 +414,7 @@ extern const quint64 ikea2MacPrefix;
 extern const quint64 silabsMacPrefix;
 extern const quint64 silabs2MacPrefix;
 extern const quint64 silabs3MacPrefix;
+extern const quint64 silabs4MacPrefix;
 extern const quint64 instaMacPrefix;
 extern const quint64 boschMacPrefix;
 extern const quint64 jennicMacPrefix;
@@ -478,6 +479,8 @@ inline bool checkMacVendor(quint64 addr, quint16 vendor)
         case VENDOR_JASCO:
             return prefix == celMacPrefix;
         case VENDOR_INNR:
+            return prefix == jennicMacPrefix ||
+                   prefix == silabs4MacPrefix;
         case VENDOR_LDS:
             return prefix == jennicMacPrefix ||
                    prefix == silabs2MacPrefix;

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -475,6 +475,7 @@ inline bool checkMacVendor(quint64 addr, quint16 vendor)
             return prefix == ikeaMacPrefix ||
                    prefix == silabsMacPrefix ||
                    prefix == silabs2MacPrefix ||
+                   prefix == silabs4MacPrefix ||
                    prefix == energyMiMacPrefix ||
                    prefix == emberMacPrefix;
         case VENDOR_JASCO:

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -293,6 +293,7 @@
 #define VENDOR_SERCOMM      0x1131
 #define VENDOR_BOSCH        0x1133
 #define VENDOR_DDEL         0x1135
+#define VENDOR_WAXMAN       0x113B
 #define VENDOR_LUTRON       0x1144
 #define VENDOR_ZEN          0x1158
 #define VENDOR_KEEN_HOME    0x115B

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -487,7 +487,8 @@ inline bool checkMacVendor(quint64 addr, quint16 vendor)
         case VENDOR_INSTA:
             return prefix == instaMacPrefix;
         case VENDOR_JENNIC:
-            return prefix == jennicMacPrefix;
+            return prefix == jennicMacPrefix ||
+                   prefix == silabs2MacPrefix;
         case VENDOR_KEEN_HOME:
             return prefix == keenhomeMacPrefix;
         case VENDOR_LGE:

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -297,6 +297,7 @@
 #define VENDOR_ZEN          0x1158
 #define VENDOR_KEEN_HOME    0x115B
 #define VENDOR_XIAOMI       0x115F
+#define VENDOR_SENGLED_OPTOELEC 0x1160
 #define VENDOR_INNR         0x1166
 #define VENDOR_LDS          0x1168 // Used by Samsung SmartPlug 2019
 #define VENDOR_INSTA        0x117A
@@ -433,6 +434,7 @@ extern const quint64 xiaomiMacPrefix;
 extern const quint64 computimeMacPrefix;
 extern const quint64 konkeMacPrefix;
 extern const quint64 ecozyMacPrefix;
+extern const quint64 zhejiangMacPrefix;
 
 inline bool checkMacVendor(quint64 addr, quint16 vendor)
 {
@@ -499,6 +501,8 @@ inline bool checkMacVendor(quint64 addr, quint16 vendor)
             return prefix == philipsMacPrefix;
         case VENDOR_PHYSICAL:
             return prefix == stMacPrefix;
+        case VENDOR_SENGLED_OPTOELEC:
+            return prefix == zhejiangMacPrefix;
         case VENDOR_SI_LABS:
             return prefix == silabsMacPrefix ||
                    prefix == energyMiMacPrefix ||

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -508,6 +508,9 @@ inline bool checkMacVendor(quint64 addr, quint16 vendor)
             return prefix == stMacPrefix;
         case VENDOR_SENGLED_OPTOELEC:
             return prefix == zhejiangMacPrefix;
+        case VENDOR_SERCOMM:
+            return prefix == emberMacPrefix ||
+                   prefix == energyMiMacPrefix;
         case VENDOR_SI_LABS:
             return prefix == silabsMacPrefix ||
                    prefix == energyMiMacPrefix ||

--- a/general.xml
+++ b/general.xml
@@ -2802,7 +2802,7 @@ Fil pilote > Off=0001 - On=0002</description>
 				<attribute id="0x0100" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
 				<attribute id="0x0200" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
 				<attribute id="0x0201" name="Restore Power on Outage" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
-				<attribute id="0x0202" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
+				<attribute id="0x0202" name="Auto-off after 20m below 2W" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
 				<attribute id="0x0203" name="Device LED off" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
 				<attribute id="0x0204" name="Unknown" type="float" mfcode="0x115f" access="rw" required="m"> </attribute>
 				<attribute id="0x0205" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>

--- a/general.xml
+++ b/general.xml
@@ -2815,6 +2815,23 @@ Fil pilote > Off=0001 - On=0002</description>
 			<client>
 			</client>
 		</cluster>
+		
+		<!-- INNR -->
+		<cluster id="0xfc82" name="innr" mfcode="0x1166">
+			<description>innr specific attributes.</description>
+			<server>
+				<attribute id="0x0006" name="Unknown" type="cstring" mfcode="0x1166" access="rw" required="m"> </attribute>
+				<attribute id="0x0010" name="Unknown" type="u32" mfcode="0x1166" access="r" required="m"> </attribute>
+				<attribute id="0x0011" name="Unknown" type="u32" mfcode="0x1166" access="r" required="m"> </attribute>
+				<attribute id="0x0012" name="Unknown" type="u32" mfcode="0x1166" access="r" required="m"> </attribute>
+				<attribute id="0x0013" name="Unknown" type="u32" mfcode="0x1166" access="rw" required="m"> </attribute>
+				<attribute id="0x0014" name="Unknown" type="u32" mfcode="0x1166" access="rw" required="m"> </attribute>
+				<attribute id="0x0015" name="Unknown" type="u32" mfcode="0x1166" access="rw" required="m"> </attribute>
+				<attribute id="0xfffd" name="Unknown" type="u16" mfcode="0x1166" access="r" required="m"> </attribute>
+			</server>
+			<client>
+			</client>
+		</cluster>
 
 	</domain>
 

--- a/general.xml
+++ b/general.xml
@@ -193,6 +193,14 @@
 			<attribute id="0x0032" name="Usertest" type="bool" default="0" access="rw" required="o" mfcode="0x100b"></attribute>
 			<attribute id="0x0033" name="LED Indication" type="bool" default="0" access="rw" required="o" mfcode="0x100b"></attribute>
 		</attribute-set>
+		<attribute-set id="0x4000" description="Manufacturer specific" mfcode="0x1037">
+			<attribute id="0x4001" name="128-Bit security key" type="seckey" access="r" required="m" mfcode="0x1037"></attribute>
+			<attribute id="0x4002" name="IEEE address" type="uid" access="rw" required="m" mfcode="0x1037"></attribute>
+		</attribute-set>
+		<attribute-set id="0x4000" description="Manufacturer specific" mfcode="0x1166">
+			<attribute id="0x4001" name="128-Bit security key" type="seckey" access="r" required="m" mfcode="0x1166"></attribute>
+			<attribute id="0x4002" name="IEEE address" type="uid" access="rw" required="m" mfcode="0x1166"></attribute>
+		</attribute-set>
 		<attribute-set id="0x8000" description="Develco Specific" mfcode="0x1015">
 			<attribute id="0x8000" name="Primary SW Version" type="ostring" access="r" required="m" mfcode="0x1015"></attribute>
 			<attribute id="0x8010" name="Primary Bootloader SW Version" type="ostring" access="r" required="m" mfcode="0x1015"></attribute>
@@ -2576,6 +2584,7 @@ devices can operate on either battery or mains power, and can have a wide variet
 			<attribute-set id="00" description="Reading Information Set">
 				<attribute id="0000" name="Current Summation Delivered" type="u48" access="r" required="m"></attribute>
 				<attribute id="0001" name="Current Summation Received" type="u48" access="r" required="o"></attribute>
+				<attribute id="041b" name="Unknown" type="u64" access="rw" required="o" mfcode="0x1037"></attribute>
 				<!-- TODO -->
 			</attribute-set>
 			<attribute-set id="01" description="TOU Information Set">
@@ -3050,6 +3059,20 @@ Fil pilote > Off=0001 - On=0002</description>
 				<attribute id="0x0014" name="Unknown" type="u32" mfcode="0x1166" access="rw" required="m"> </attribute>
 				<attribute id="0x0015" name="Unknown" type="u32" mfcode="0x1166" access="rw" required="m"> </attribute>
 				<attribute id="0xfffd" name="Unknown" type="u16" mfcode="0x1166" access="r" required="m"> </attribute>
+			</server>
+			<client>
+			</client>
+		</cluster>
+
+		<!-- IMMAX -->
+		<cluster id="0xfc82" name="Immax" mfcode="0x1037">
+			<description>Immax specific attributes.</description>
+			<server>
+				<attribute id="0x0010" name="Turned on since" type="u32" mfcode="0x1037" access="r" required="m"> </attribute>
+				<attribute id="0x0011" name="Turned on (total)" type="u32" mfcode="0x1037" access="r" required="m"> </attribute>
+				<attribute id="0x0012" name="Consumption since turned on" type="u32" mfcode="0x1037" access="r" required="m"> </attribute>
+				<attribute id="0x0013" name="Unknown" type="u32" mfcode="0x1037" access="rw" required="m"> </attribute>
+				<attribute id="0xfffd" name="Unknown" type="u16" mfcode="0x1037" access="r" required="m"> </attribute>
 			</server>
 			<client>
 			</client>

--- a/general.xml
+++ b/general.xml
@@ -3038,7 +3038,7 @@ Fil pilote > Off=0001 - On=0002</description>
 				<attribute id="0x0204" name="Unknown" type="float" mfcode="0x115f" access="rw" required="m"> </attribute>
 				<attribute id="0x0205" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
 				<attribute id="0x0206" name="Unknown" type="float" mfcode="0x115f" access="rw" required="m"> </attribute>
-				<attribute id="0x0207" name="Unknown" type="bool" mfcode="0x115f" access="r" required="m"> </attribute>
+				<attribute id="0x0207" name="Consumer connected" type="bool" mfcode="0x115f" access="r" required="m"> </attribute>
 				<attribute id="0x020b" name="Max. Load exceeded at (in W)???" type="float" mfcode="0x115f" access="rw" required="m"> </attribute>
 				<attribute id="0xf000" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
 				<attribute id="0xfffd" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>

--- a/general.xml
+++ b/general.xml
@@ -2263,6 +2263,228 @@ controller device, that supports a keypad and LCD screen.</description>
 			<client>
 			</client>
 		</cluster>
+		
+		<cluster id="0x0501" name="IAS ACE">
+			<description>The IAS ACE cluster defines an interface to the functionality of any Ancillary Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE device can access a IAS CIE device and manipulate the IAS system, on behalf of a level-2 user.</description>
+			<server>
+				<attribute></attribute>
+				<command id="0x00" dir="recv" name="Arm" required="m">
+					<payload>
+						<attribute id="0x00" type="enum8" name="Arm Mode" required="m">
+							<value name="Disarm" value="0x00"></value>
+							<value name="Arm Day/Home Zones Only" value="0x01"></value>
+							<value name="Arm Night/Sleep Zones Only" value="0x02"></value>
+							<value name="Arm All Zones" value="0x03"></value>
+						</attribute>
+						<attribute id="0x01" type="cstring" name="Arm/Disarm Code" required="m"></attribute>
+						<attribute id="0x02" type="u8" name="Zone ID" required="m"></attribute>
+					</payload>
+				</command>
+				<command id="0x01" dir="recv" name="Bypass" required="m">
+					<payload>
+						<attribute id="0x00" type="u8" name="Number of Zones" required="m"></attribute>
+						<attribute id="0x01" type="u8" name="Zone ID" required="m"></attribute>
+						<attribute id="0x02" type="cstring" name="Arm/Disarm Code" required="m"></attribute>
+					</payload>
+				</command>
+				<command id="0x02" dir="recv" name="Emergency" required="m">
+				</command>
+				<command id="0x03" dir="recv" name="Fire" required="m">
+				</command>
+				<command id="0x04" dir="recv" name="Panic" required="m">
+				</command>
+				<command id="0x05" dir="recv" name="Get Zone ID Map" required="m">
+				</command>
+				<command id="0x06" dir="recv" name="Get Zone Information" required="m">
+					<payload>
+						<attribute id="0x00" type="u8" name="Zone ID" required="m"></attribute>
+					</payload>
+				</command>
+				<command id="0x07" dir="recv" name="Get Panel Status" required="m">
+				</command>
+				<command id="0x08" dir="recv" name="Get Bypassed Zone List" required="m">
+				</command>
+				<command id="0x09" dir="recv" name="Get Zone Status" required="m">
+					<payload>
+						<attribute id="0x00" type="u8" name="Starting Zone ID" required="m"></attribute>
+						<attribute id="0x01" type="u8" name="Max Number of Zone IDs" required="m"></attribute>
+						<attribute id="0x02" type="bool" name="Zone Status Mask Flag" required="m"></attribute>
+						<attribute id="0x03" type="bmp16" name="Zone Status Mask" required="m"></attribute>
+						<!--More to do here!!!-->
+					</payload>
+				</command>
+			</server>
+			<client>
+				<command id="0x00" dir="recv" name="Arm Response" required="m">
+					<payload>
+						<attribute id="0x00" type="enum8" name="Arm Notification" required="m">
+							<value name="All Zones Disarmed" value="0x00"></value>
+							<value name="Only Day/Home Zones Armed" value="0x01"></value>
+							<value name="Only Night/Sleep Zones Armed" value="0x02"></value>
+							<value name="All Zones Armed" value="0x03"></value>
+							<value name="Invalid Arm/Disarm Code" value="0x04"></value>
+							<value name="Not ready to arm" value="0x05"></value>
+							<value name="Already disarmed" value="0x06"></value>
+						</attribute>
+						<attribute id="0x01" type="cstring" name="Arm/Disarm Code" required="m"></attribute>
+						<attribute id="0x02" type="u8" name="Zone ID" required="m"></attribute>
+					</payload>
+				</command>
+				<command id="0x01" dir="recv" name="Get Zone ID Map Response" required="m">
+					<payload>
+						<attribute id="0x00" type="bmp16" name="Zone ID Map section 0" required="m"></attribute>
+						<!--More to do here!!!-->
+					</payload>
+				</command>
+				<command id="0x02" dir="recv" name="Get Zone Information Response" required="m">
+					<payload>
+						<attribute id="0x00" type="u8" name="Zone ID" required="m"></attribute>
+						<attribute id="0x01" type="enum16" name="Zone Type" required="m">
+							<value name="All Zones Disarmed" value="0x00"></value>
+							<value name="Only Day/Home Zones Armed" value="0x01"></value>
+							<value name="Only Night/Sleep Zones Armed" value="0x02"></value>
+							<value name="All Zones Armed" value="0x03"></value>
+							<value name="Invalid Arm/Disarm Code" value="0x04"></value>
+							<value name="Not ready to arm" value="0x05"></value>
+							<value name="Already disarmed" value="0x06"></value>
+						</attribute>
+						<attribute id="0x02" type="uid" name="IEEE address" required="m"></attribute>
+						<attribute id="0x03" type="cstring" name="Zone Label" required="m"></attribute>
+					</payload>
+				</command>
+				<command id="0x03" dir="recv" name="Zone Status Changed" required="m">
+					<payload>
+						<attribute id="0x00" type="u8" name="Zone ID" required="m"></attribute>
+						<attribute id="0x01" type="enum16" name="Zone Status" required="m">
+							<!--More to do here!!!-->
+							<value name="All Zones Disarmed" value="0x00"></value>
+							<value name="Only Day/Home Zones Armed" value="0x01"></value>
+							<value name="Only Night/Sleep Zones Armed" value="0x02"></value>
+							<value name="All Zones Armed" value="0x03"></value>
+							<value name="Invalid Arm/Disarm Code" value="0x04"></value>
+							<value name="Not ready to arm" value="0x05"></value>
+							<value name="Already disarmed" value="0x06"></value>
+						</attribute>
+						<attribute id="0x02" type="enum8" name="Audible Notification" default="0x01" required="m">
+							<value name="Mute" value="0x00"></value>
+							<value name="Default sound" value="0x01"></value>
+						</attribute>
+						<attribute id="0x03" type="cstring" name="Zone Label" required="m"></attribute>
+					</payload>
+				</command>
+				<command id="0x04" dir="recv" name="Panel Status Changed" required="m">
+					<payload>
+						<attribute id="0x00" type="enum8" name="Panel Status" required="m">
+							<value name="Panel disarmed (all zones disarmed) and ready to arm" value="0x00"></value>
+							<value name="Armed stay" value="0x01"></value>
+							<value name="Armed night" value="0x02"></value>
+							<value name="Armed away" value="0x03"></value>
+							<value name="Exit delay" value="0x04"></value>
+							<value name="Entry delay" value="0x05"></value>
+							<value name="Not ready to arm" value="0x06"></value>
+							<value name="In alarm" value="0x07"></value>
+							<value name="Arming stay" value="0x08"></value>
+							<value name="Arming night" value="0x09"></value>
+							<value name="Arming away" value="0x0a"></value>
+						</attribute>
+						<attribute id="0x01" type="u8" name="Seconds Remaining" default="0x00" required="m"></attribute>
+						<attribute id="0x02" type="enum8" name="Audible Notification" default="0x01" required="m">
+							<value name="Mute" value="0x00"></value>
+							<value name="Default sound" value="0x01"></value>
+						</attribute>
+						<attribute id="0x03" type="enum8" name="Alarm Status" default="0x00" required="m">
+							<value name="No alarm" value="0x00"></value>
+							<value name="Burglar" value="0x01"></value>
+							<value name="Fire" value="0x02"></value>
+							<value name="Emergency" value="0x03"></value>
+							<value name="Police Panic" value="0x04"></value>
+							<value name="Fire Panic" value="0x05"></value>
+							<value name="Emergency Panic (i.e., medical issue)" value="0x06"></value>
+						</attribute>
+						<attribute id="0x04" type="cstring" name="Zone Label" required="m"></attribute>
+					</payload>
+				</command>
+				<command id="0x05" dir="recv" name="Get Panel Status Response" required="m">
+					<payload>
+						<attribute id="0x00" type="enum8" name="Panel Status" required="m">
+							<value name="Panel disarmed (all zones disarmed) and ready to arm" value="0x00"></value>
+							<value name="Armed stay" value="0x01"></value>
+							<value name="Armed night" value="0x02"></value>
+							<value name="Armed away" value="0x03"></value>
+							<value name="Exit delay" value="0x04"></value>
+							<value name="Entry delay" value="0x05"></value>
+							<value name="Not ready to arm" value="0x06"></value>
+							<value name="In alarm" value="0x07"></value>
+							<value name="Arming stay" value="0x08"></value>
+							<value name="Arming night" value="0x09"></value>
+							<value name="Arming away" value="0x0a"></value>
+						</attribute>
+						<attribute id="0x01" type="u8" name="Seconds Remaining" default="0x00" required="m"></attribute>
+						<attribute id="0x02" type="enum8" name="Audible Notification" default="0x01" required="m">
+							<value name="Mute" value="0x00"></value>
+							<value name="Default sound" value="0x01"></value>
+						</attribute>
+						<attribute id="0x03" type="enum8" name="Alarm Status" default="0x00" required="m">
+							<value name="No alarm" value="0x00"></value>
+							<value name="Burglar" value="0x01"></value>
+							<value name="Fire" value="0x02"></value>
+							<value name="Emergency" value="0x03"></value>
+							<value name="Police Panic" value="0x04"></value>
+							<value name="Fire Panic" value="0x05"></value>
+							<value name="Emergency Panic (i.e., medical issue)" value="0x06"></value>
+						</attribute>
+						<attribute id="0x04" type="cstring" name="Zone Label" required="m"></attribute>
+					</payload>
+				</command>
+				<command id="0x06" dir="recv" name="Set Bypassed Zone List" required="m">
+					<payload>
+						<attribute id="0x00" type="u8" name="Number of Zones" required="m"></attribute>
+						<attribute id="0x01" type="u8" name="Zone ID 1" required="m"></attribute>
+						<attribute id="0x02" type="u8" name="Zone ID 2" required="m"></attribute>
+						<attribute id="0x03" type="u8" name="Zone ID 3" required="m"></attribute>
+						<attribute id="0x04" type="u8" name="Zone ID 4" required="m"></attribute>
+						<attribute id="0x05" type="u8" name="Zone ID 5" required="m"></attribute>
+						<attribute id="0x06" type="u8" name="Zone ID 6" required="m"></attribute>
+						<attribute id="0x07" type="u8" name="Zone ID 7" required="m"></attribute>
+						<attribute id="0x08" type="u8" name="Zone ID 8" required="m"></attribute>
+					</payload>
+				</command>
+				<command id="0x07" dir="recv" name="Bypass Response" required="m">
+					<payload>
+						<attribute id="0x00" type="u8" name="Number of Zones" required="m"></attribute>
+						<attribute id="0x01" type="u8" name="Bypass Result for Zone ID 1" required="m"></attribute>
+						<attribute id="0x02" type="u8" name="Bypass Result for Zone ID 2" required="m"></attribute>
+						<attribute id="0x03" type="u8" name="Bypass Result for Zone ID 3" required="m"></attribute>
+						<attribute id="0x04" type="u8" name="Bypass Result for Zone ID 4" required="m"></attribute>
+						<attribute id="0x05" type="u8" name="Bypass Result for Zone ID 5" required="m"></attribute>
+						<attribute id="0x06" type="u8" name="Bypass Result for Zone ID 6" required="m"></attribute>
+						<attribute id="0x07" type="u8" name="Bypass Result for Zone ID 7" required="m"></attribute>
+						<attribute id="0x08" type="u8" name="Bypass Result for Zone ID 8" required="m"></attribute>
+							<!--<value name="Zone bypassed" value="0x00"></value>
+							<value name="Zone not bypassed" value="0x01"></value>
+							<value name="Not allowed" value="0x02"></value>
+							<value name="Invalid Zone ID" value="0x03"></value>
+							<value name="Unknown Zone ID" value="0x04"></value>
+							<value name="Invalid Arm/Disarm Code" value="0x05"></value>-->
+					</payload>
+				</command>
+				<command id="0x08" dir="recv" name="Get Zone Status Response" required="m">
+					<payload>
+						<attribute id="0x00" type="bool" name="Zone Status Complete" required="m"></attribute>
+						<attribute id="0x01" type="u8" name="Number of Zones" required="m"></attribute>
+						<attribute id="0x02" type="u8" name="Zone ID 1" required="m"></attribute>
+						<attribute id="0x03" type="bmp16" name="Zone ID 1 Zone Status" required="m"></attribute>
+						<attribute id="0x04" type="u8" name="Zone ID 2" required="m"></attribute>
+						<attribute id="0x05" type="bmp16" name="Zone ID 2 Zone Status" required="m"></attribute>
+						<attribute id="0x06" type="u8" name="Zone ID 3" required="m"></attribute>
+						<attribute id="0x07" type="bmp16" name="Zone ID 3 Zone Status" required="m"></attribute>
+						<attribute id="0x08" type="u8" name="Zone ID 4" required="m"></attribute>
+						<attribute id="0x09" type="bmp16" name="Zone ID 4 Zone Status" required="m"></attribute>
+					</payload>
+				</command>
+			</client>
+		</cluster>
+		
 		<cluster id="0x0502" name="IAS WD">
 			<description>The IAS WD cluster provides an interface to the functionality of any Warning Device equipment of the IAS system. Using this cluster, a ZigBee enabled CIE device can access a ZigBee enabled IAS WD device and issue alarm warning indications (siren, strobe lighting, etc.) when a system alarm condition is detected.</description>
 			<server>

--- a/poll_manager.cpp
+++ b/poll_manager.cpp
@@ -402,7 +402,8 @@ void PollManager::pollTimerFired()
         if (!item->toString().startsWith(QLatin1String("SP 120")) &&  // Attribute is not available
             !item->toString().startsWith(QLatin1String("lumi.plug.ma")) &&
             !item->toString().startsWith(QLatin1String("ZB-ONOFFPlug-D0005")) &&
-            !item->toString().startsWith(QLatin1String("TS0121")))
+            !item->toString().startsWith(QLatin1String("TS0121")) &&
+            item->toString() != QLatin1String("Plug-230V-ZB3.0"))
         {
             attributes.push_back(0x0400); // Instantaneous Demand
         }

--- a/poll_manager.cpp
+++ b/poll_manager.cpp
@@ -401,7 +401,8 @@ void PollManager::pollTimerFired()
         item = r->item(RAttrModelId);
         if (!item->toString().startsWith(QLatin1String("SP 120")) &&  // Attribute is not available
             !item->toString().startsWith(QLatin1String("lumi.plug.ma")) &&
-            !item->toString().startsWith(QLatin1String("ZB-ONOFFPlug-D0005")))
+            !item->toString().startsWith(QLatin1String("ZB-ONOFFPlug-D0005")) &&
+            !item->toString().startsWith(QLatin1String("TS0121")))
         {
             attributes.push_back(0x0400); // Instantaneous Demand
         }


### PR DESCRIPTION
- Added support for Klik Aan Klik Uit ZTHS-100 (#2657)
- Added initial support for Sengled PAR38 bulbs (#2667, #2155)
- Updated Centralite thermostat model ID (#2630). Some versions do not contain the previously set "-E" at the end of the model ID
- Identified purpose of further Xiaomi specific attributes
- Expose voltage and current for Xiaomi smart plug lumi.plug.mmeu01 (#2583)
- Added initial support for Tuya smart plug (TS0121) (#2677)
- Added support for innr SP 220 smart plug (#2678)
- Added IAS ACE cluster to general.xml
- Added initial support for Heiman remote control HS1RC-M (#2697)
- Added support for Immax NEO ZB3.0 smart plug 07048L (#2688)
- Enable light bindings for additional manufacturers 
- Whitelist Xiaomi smart plugs with Xiaomi MAC address (#2583)
- Enable IAS warning devices to automatically enroll
- Added support for Sercom siren SZ-SRN12N (#2051, #2629)
- Added initial support for WAXMAN LeakSMART v2 (#2701)