### PR TITLE
Update json.loads line for python 3.5

### DIFF
--- a/ikea-ota-download.py
+++ b/ikea-ota-download.py
@@ -16,7 +16,7 @@ except ImportError:
 f = urlopen("http://fw.ota.homesmart.ikea.net/feed/version_info.json")
 data = f.read()
 
-arr = json.loads(data)
+arr = json.loads(data.decode('utf-8'))
 
 otapath = '%s/otau' % os.path.expanduser('~')
 


### PR DESCRIPTION
Running the script inside a docker container with python 3.5 throws an "TypeError: the JSON object must be str, not 'bytes'".

Fixed it by decoding downloaded json to utf-8