### PR TITLE
Refactor IAS zone enrollment and further device integration

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2019,6 +2019,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId().startsWith(QLatin1String("RH3052")) ||
         // Xiaomi
         sensor->modelId().startsWith(QLatin1String("lumi.plug.maeu01")) ||
+        sensor->modelId().startsWith(QLatin1String("lumi.sen_ill.mgl01")) ||
         // iris
         sensor->modelId().startsWith(QLatin1String("1116-S")) ||
         sensor->modelId().startsWith(QLatin1String("1117-S")) ||

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -908,6 +908,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
     {
         // zone status reporting only supported by some devices
         if (bt.restNode->node()->nodeDescriptor().manufacturerCode() != VENDOR_CENTRALITE &&
+            bt.restNode->node()->nodeDescriptor().manufacturerCode() != VENDOR_C2DF &&
             bt.restNode->node()->nodeDescriptor().manufacturerCode() != VENDOR_SAMJIN)
         {
             return false;
@@ -1884,6 +1885,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId().startsWith(QLatin1String("3200-S")) ||
         sensor->modelId().startsWith(QLatin1String("3305-S")) ||
         sensor->modelId().startsWith(QLatin1String("3320-L")) ||
+        sensor->modelId().startsWith(QLatin1String("3323")) ||
         sensor->modelId().startsWith(QLatin1String("3326-L")) ||
         // dresden elektronik
         (sensor->manufacturer() == QLatin1String("dresden elektronik") && sensor->modelId() == QLatin1String("de_spect")) ||
@@ -2149,6 +2151,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
                      sensor->modelId().endsWith(QLatin1String("86opcn01")) || // Aqara Opple
                      sensor->modelId().startsWith(QLatin1String("1116-S")) ||
                      sensor->modelId().startsWith(QLatin1String("1117-S")) ||
+                     sensor->modelId().startsWith(QLatin1String("3323")) ||
                      sensor->modelId().startsWith(QLatin1String("3326-L")) ||
                      sensor->modelId().startsWith(QLatin1String("3305-S")) ||
                      sensor->modelId() == QLatin1String("113D"))

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2029,7 +2029,10 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         // Sercomm
         sensor->modelId().startsWith(QLatin1String("SZ-")) ||
         // WAXMAN
-        sensor->modelId() == QLatin1String("leakSMART Water Sensor V2"))
+        sensor->modelId() == QLatin1String("leakSMART Water Sensor V2") ||
+        // RGBgenie
+        sensor->modelId().startsWith(QLatin1String("RGBgenie ZB-5")) ||
+        sensor->modelId().startsWith(QLatin1String("ZGRC-KEY")))
     {
         deviceSupported = true;
         if (!sensor->node()->nodeDescriptor().receiverOnWhenIdle() ||
@@ -2569,6 +2572,22 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
         clusters.push_back(ONOFF_CLUSTER_ID);
         clusters.push_back(LEVEL_CLUSTER_ID);
         srcEndpoints.push_back(sensor->fingerPrint().endpoint);
+    }
+    // RGBgenie remote control
+    else if (sensor->modelId().startsWith(QLatin1String("RGBgenie ZB-5")))
+    {
+        clusters.push_back(ONOFF_CLUSTER_ID);
+        clusters.push_back(LEVEL_CLUSTER_ID);
+        clusters.push_back(SCENE_CLUSTER_ID);
+        srcEndpoints.push_back(sensor->fingerPrint().endpoint);
+    }
+    // RGBgenie remote control
+    else if (sensor->modelId().startsWith(QLatin1String("ZGRC-KEY")))
+    {
+        clusters.push_back(ONOFF_CLUSTER_ID);
+        clusters.push_back(LEVEL_CLUSTER_ID);
+        srcEndpoints.push_back(0x01);
+        srcEndpoints.push_back(0x02);
     }
     else
     {

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2561,14 +2561,6 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
         srcEndpoints.push_back(0x04);
         sensor->setMgmtBindSupported(true);
     }
-    // LifeControl Enviroment Sensor
-    else if (sensor->modelId().startsWith(QLatin1String("VOC_Sensor")))
-    {
-        clusters.push_back(TEMPERATURE_MEASUREMENT_CLUSTER_ID);
-        srcEndpoints.push_back(0x00);
-        srcEndpoints.push_back(0x01);
-        sensor->setMgmtBindSupported(true);
-    }
     // Bitron remote control
     else if (sensor->modelId().startsWith(QLatin1String("902010/23")))
     {

--- a/database.cpp
+++ b/database.cpp
@@ -3404,6 +3404,8 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 item->setValue(false);
                 item = sensor.addItem(DataTypeBool, RStateTampered);
                 item->setValue(false);
+                item = sensor.addItem(DataTypeUInt8, RConfigPending);
+                item->setValue(0);
             }
         }
 

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4327,7 +4327,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
 
                 case METERING_CLUSTER_ID:
                 {
-                    if(!modelId == QLatin1String("lumi.plug.mmeu01"))
+                    if(modelId != QLatin1String("lumi.plug.mmeu01"))
                     {
                         fpConsumptionSensor.inClusters.push_back(ci->id());
                     }
@@ -4336,7 +4336,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
 
                 case ELECTRICAL_MEASUREMENT_CLUSTER_ID:
                 {
-                    if(!modelId == QLatin1String("lumi.plug.mmeu01"))
+                    if(modelId != QLatin1String("lumi.plug.mmeu01"))
                     {
                         fpPowerSensor.inClusters.push_back(ci->id());
                     }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -292,6 +292,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_SERCOMM, "SZ-ESW01", emberMacPrefix }, // Sercomm / Telstra smart plug
     { VENDOR_SERCOMM, "SZ-SRN12N", emberMacPrefix }, // Sercomm siren
     { VENDOR_SERCOMM, "SZ-SRN12N", energyMiMacPrefix }, // Sercomm siren
+    { VENDOR_SERCOMM, "SZ-DWS04", emberMacPrefix }, // Sercomm open/close sensor
     { VENDOR_ALERTME, "MOT003", tiMacPrefix }, // Hive Motion Sensor
     { VENDOR_SUNRICHER, "4512703", silabs2MacPrefix }, // Namron 4-ch remote controller
     { VENDOR_SENGLED_OPTOELEC, "E13-", zhejiangMacPrefix }, // Sengled PAR38 Bulbs
@@ -6129,7 +6130,8 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     i->modelId().startsWith(QLatin1String("1117-S")) ||    // iris motion sensor v3
                                     i->modelId().startsWith(QLatin1String("3326-L")) ||    // iris motion sensor v2
                                     i->modelId().startsWith(QLatin1String("3320-L")) ||    // Centralite contact sensor
-                                    i->modelId().startsWith(QLatin1String("lumi.sen_ill")))// Xiaomi ZB3.0 light sensor
+                                    i->modelId().startsWith(QLatin1String("lumi.sen_ill")) || // Xiaomi ZB3.0 light sensor
+                                    i->modelId().startsWith(QLatin1String("SZ-DWS04")))    // Sercomm open/close sensor
                                 {  }
                                 else
                                 {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -3381,8 +3381,8 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
         checkReporting = true;
         checkClientCluster = true;
     }
-    else if (sensor->modelId().startsWith(QLatin1String("RGBGenie ZB-5"))  // RGBGenie remote control
-             sensor->modelId().startsWith(QLatin1String("ZGRC-KEY")))      // RGBGenie ZB-5001
+    else if (sensor->modelId().startsWith(QLatin1String("RGBGenie ZB-5")) || // RGBGenie remote control
+             sensor->modelId().startsWith(QLatin1String("ZGRC-KEY")))        // RGBGenie ZB-5001
     {
         checkReporting = true;
         checkClientCluster = true;
@@ -6100,7 +6100,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                         i->modelId().startsWith(QLatin1String("ZG2833K")) || // Sunricher remote controller
                                         i->modelId().startsWith(QLatin1String("SV01-")) || // Keen Home vent
                                         i->modelId().startsWith(QLatin1String("4512703")) || // Namron 4-ch remote controller
-                                        i->modelId().startsWith(QLatin1String("RC_V14")) // Heiman remote controller
+                                        i->modelId().startsWith(QLatin1String("RC_V14")) || // Heiman remote controller
                                         i->modelId().startsWith(QLatin1String("RGBgenie ZB-5"))) // RGBgenie remote control
                                     {
                                         bat = ia->numericValue().u8;

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4192,10 +4192,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
 
                 case TEMPERATURE_MEASUREMENT_CLUSTER_ID:
                 {
-                    if (modelId == QLatin1String("VOC_Sensor"))
-                    {
-                        fpHumiditySensor.inClusters.push_back(ci->id());
-                    }
                     fpTemperatureSensor.inClusters.push_back(ci->id());
                 }
                     break;

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4192,24 +4192,17 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
 
                 case TEMPERATURE_MEASUREMENT_CLUSTER_ID:
                 {
-                    if (modelId.startsWith(QLatin1String("VOC_Sensor")) && i->endpoint() == 0x01)
+                    if (modelId == QLatin1String("VOC_Sensor"))
                     {
                         fpHumiditySensor.inClusters.push_back(ci->id());
                     }
-                    else
-                    {
-                        fpTemperatureSensor.inClusters.push_back(ci->id());
-                    }
+                    fpTemperatureSensor.inClusters.push_back(ci->id());
                 }
                     break;
 
                 case RELATIVE_HUMIDITY_CLUSTER_ID:
                 {
-                    if (modelId.startsWith(QLatin1String("VOC_Sensor")))
-                    {
-                        // Ignore RELATIVE HUMIDITY CLUSTER
-                    }
-                    else
+                    if(modelId != QLatin1String("VOC_Sensor"))
                     {
                         fpHumiditySensor.inClusters.push_back(ci->id());
                     }
@@ -4345,11 +4338,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
 
                 case THERMOSTAT_CLUSTER_ID:
                 {
-                    if (modelId.startsWith(QLatin1String("VOC_Sensor")))
-                    {
-                        // Ignore THERMOSTAT CLUSTER
-                    }
-                    else
+                    if(modelId != QLatin1String("VOC_Sensor"))
                     {
                         fpThermostatSensor.inClusters.push_back(ci->id());
                     }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -122,6 +122,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_CENTRALITE, "3326-L", emberMacPrefix }, // Iris motion sensor v2
     { VENDOR_C2DF, "3326-L", emberMacPrefix }, // Iris motion sensor v2
     { VENDOR_CENTRALITE, "3328-G", emberMacPrefix }, // Centralite micro motion sensor
+    { VENDOR_CENTRALITE, "3323", emberMacPrefix }, // Centralite contact sensor
     { VENDOR_DDEL, "de_spect", silabs3MacPrefix }, // dresden elektronic spectral sensor
     { VENDOR_JASCO, "45856", celMacPrefix },
     { VENDOR_NONE, "LM_",  tiMacPrefix },
@@ -4182,7 +4183,8 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
 
                 case OCCUPANCY_SENSING_CLUSTER_ID:
                 {
-                    if (node->nodeDescriptor().manufacturerCode() == VENDOR_CENTRALITE)
+                    if (node->nodeDescriptor().manufacturerCode() == VENDOR_CENTRALITE ||
+                        node->nodeDescriptor().manufacturerCode() == VENDOR_C2DF)
                     {
                         // only use IAS Zone cluster on endpoint 0x01 for Centralite motion sensors
                     }
@@ -5432,7 +5434,8 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
     {
         sensorNode.setManufacturer("Visonic");
     }
-    else if (node->nodeDescriptor().manufacturerCode() == VENDOR_CENTRALITE)
+    else if (node->nodeDescriptor().manufacturerCode() == VENDOR_CENTRALITE ||
+             node->nodeDescriptor().manufacturerCode() == VENDOR_C2DF)
     {
         sensorNode.setManufacturer("CentraLite");
     }
@@ -6143,6 +6146,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     i->modelId().startsWith(QLatin1String("1117-S")) ||    // iris motion sensor v3
                                     i->modelId().startsWith(QLatin1String("3326-L")) ||    // iris motion sensor v2
                                     i->modelId().startsWith(QLatin1String("3320-L")) ||    // Centralite contact sensor
+                                    i->modelId().startsWith(QLatin1String("3323")) ||      // Centralite contact sensor
                                     i->modelId().startsWith(QLatin1String("lumi.sen_ill")) || // Xiaomi ZB3.0 light sensor
                                     i->modelId().startsWith(QLatin1String("SZ-DWS04")))    // Sercomm open/close sensor
                                 {  }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -238,6 +238,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_SUNRICHER, "ICZB-RM", silabs2MacPrefix }, // iCasa remote
     { VENDOR_SUNRICHER, "ZGRC-KEY", emberMacPrefix }, // Sunricher wireless CCT remote
     { VENDOR_SUNRICHER, "ZG2833K", emberMacPrefix }, // Sunricher remote controller
+    { VENDOR_SUNRICHER, "RGBgenie ZB-5", emberMacPrefix }, // RGBgenie remote control
     { VENDOR_JENNIC, "SPZB0001", jennicMacPrefix }, // Eurotronic thermostat
     { VENDOR_NONE, "RES001", tiMacPrefix }, // Hubitat environment sensor, see #1308
     { VENDOR_SINOPE, "WL4200S", sinopeMacPrefix}, // Sinope water sensor
@@ -3380,6 +3381,12 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
         checkReporting = true;
         checkClientCluster = true;
     }
+    else if (sensor->modelId().startsWith(QLatin1String("RGBGenie ZB-5"))  // RGBGenie remote control
+             sensor->modelId().startsWith(QLatin1String("ZGRC-KEY")))      // RGBGenie ZB-5001
+    {
+        checkReporting = true;
+        checkClientCluster = true;
+    }
     else if (sensor->modelId().startsWith(QLatin1String("RC 110"))) // innr remote
     {
         checkClientCluster = true;
@@ -6056,7 +6063,8 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                         i->modelId().startsWith(QLatin1String("ZG2833K")) || // Sunricher remote controller
                                         i->modelId().startsWith(QLatin1String("SV01-")) || // Keen Home vent
                                         i->modelId().startsWith(QLatin1String("4512703")) || // Namron 4-ch remote controller
-                                        i->modelId().startsWith(QLatin1String("RC_V14"))) // Heiman remote controller
+                                        i->modelId().startsWith(QLatin1String("RC_V14")) || // Heiman remote controller
+                                        i->modelId().startsWith(QLatin1String("RGBgenie ZB-5"))) // RGBgenie remote control
                                     {
                                         bat = ia->numericValue().u8;
                                     }
@@ -6092,7 +6100,8 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                         i->modelId().startsWith(QLatin1String("ZG2833K")) || // Sunricher remote controller
                                         i->modelId().startsWith(QLatin1String("SV01-")) || // Keen Home vent
                                         i->modelId().startsWith(QLatin1String("4512703")) || // Namron 4-ch remote controller
-                                        i->modelId().startsWith(QLatin1String("RC_V14"))) // Heiman remote controller
+                                        i->modelId().startsWith(QLatin1String("RC_V14")) // Heiman remote controller
+                                        i->modelId().startsWith(QLatin1String("RGBgenie ZB-5"))) // RGBgenie remote control
                                     {
                                         bat = ia->numericValue().u8;
                                     }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4327,13 +4327,19 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
 
                 case METERING_CLUSTER_ID:
                 {
-                    fpConsumptionSensor.inClusters.push_back(ci->id());
+                    if(!modelId == QLatin1String("lumi.plug.mmeu01"))
+                    {
+                        fpConsumptionSensor.inClusters.push_back(ci->id());
+                    }
                 }
                     break;
 
                 case ELECTRICAL_MEASUREMENT_CLUSTER_ID:
                 {
-                    fpPowerSensor.inClusters.push_back(ci->id());
+                    if(!modelId == QLatin1String("lumi.plug.mmeu01"))
+                    {
+                        fpPowerSensor.inClusters.push_back(ci->id());
+                    }
                 }
                     break;
 

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5476,6 +5476,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             item->setValue(false);
             item = sensorNode.addItem(DataTypeUInt8, RConfigPending);
             item->setValue(item->toNumber() | R_PENDING_WRITE_CIE_ADDRESS | R_PENDING_ENROLL_RESPONSE);
+            writeIasCieAddress(&sensorNode);
         }
     }
 

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4516,6 +4516,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
             else
             {
                 checkSensorNodeReachable(sensor);
+                checkIasEnrollmentStatus(sensor);
             }
         }
 
@@ -4535,6 +4536,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
             else
             {
                 checkSensorNodeReachable(sensor);
+                checkIasEnrollmentStatus(sensor);
             }
         }
 
@@ -4625,6 +4627,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
             else
             {
                 checkSensorNodeReachable(sensor);
+                checkIasEnrollmentStatus(sensor);
             }
         }
 
@@ -4643,6 +4646,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
             else
             {
                 checkSensorNodeReachable(sensor);
+                checkIasEnrollmentStatus(sensor);
             }
         }
 
@@ -4661,6 +4665,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
             else
             {
                 checkSensorNodeReachable(sensor);
+                checkIasEnrollmentStatus(sensor);
             }
         }
 
@@ -4681,6 +4686,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
             else
             {
                 checkSensorNodeReachable(sensor);
+                checkIasEnrollmentStatus(sensor);
             }
         }
 
@@ -4699,6 +4705,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
             else
             {
                 checkSensorNodeReachable(sensor);
+                checkIasEnrollmentStatus(sensor);
             }
         }
 
@@ -5467,6 +5474,8 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             item->setValue(false);
             item = sensorNode.addItem(DataTypeBool, RStateTampered);
             item->setValue(false);
+            item = sensorNode.addItem(DataTypeUInt8, RConfigPending);
+            item->setValue(item->toNumber() | R_PENDING_WRITE_CIE_ADDRESS | R_PENDING_ENROLL_RESPONSE);
         }
     }
 
@@ -5529,11 +5538,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                     sensorNode.enableRead(READ_VENDOR_NAME);
                     queryTime = queryTime.addSecs(1);
                 }
-            }
-            else if (*ci == IAS_ZONE_CLUSTER_ID)
-            {
-                item = sensorNode.addItem(DataTypeUInt8, RConfigPending);
-                item->setValue(item->toNumber() | R_PENDING_WRITE_CIE_ADDRESS | R_PENDING_ENROLL_RESPONSE);
             }
             else if (*ci == POWER_CONFIGURATION_CLUSTER_ID)
             {
@@ -5914,6 +5918,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
             case ELECTRICAL_MEASUREMENT_CLUSTER_ID:
             case DOOR_LOCK_CLUSTER_ID:
             case SAMJIN_CLUSTER_ID:
+            case IAS_ZONE_CLUSTER_ID:
                 break;
 
             case VENDOR_CLUSTER_ID:
@@ -7623,6 +7628,35 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                             i->setNeedSaveDatabase(true);
                             enqueueEvent(Event(RSensors, RStateLastUpdated, i->id()));
                             updateSensorEtag(&*i);
+                        }
+                    }
+                    else if (event.clusterId() == IAS_ZONE_CLUSTER_ID)
+                    {
+                        for (;ia != enda; ++ia)
+                        {
+                            if (ia->id() == 0x0000) // IAS zone status
+                            {
+                                if (updateType != NodeValue::UpdateInvalid)
+                                {
+                                    i->setZclValue(updateType, event.endpoint(), event.clusterId(), 0x0000, ia->numericValue());
+                                    pushZclValueDb(event.node()->address().ext(), event.endpoint(), event.clusterId(), ia->id(), ia->numericValue().u8);
+                                }
+                                
+                                ResourceItem *item = i->item(RConfigPending);
+                                if(ia->numericValue().u8 == 1)
+                                {
+                                    DBG_Printf(DBG_INFO_L2, "[IAS] Sensor already enrolled\n");
+                                    item->setValue(item->toNumber() & ~R_PENDING_WRITE_CIE_ADDRESS);
+                                    item->setValue(item->toNumber() & ~R_PENDING_ENROLL_RESPONSE);
+                                }
+                                else
+                                {
+                                    DBG_Printf(DBG_INFO_L2, "[IAS] Sensor NOT enrolled\n");
+                                    writeIasCieAddress(&*i);
+                                }
+
+                                updateSensorEtag(&*i);
+                            }
                         }
                     }
                 }
@@ -14173,7 +14207,6 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
         QString modelId;
         QString swBuildId;
         QString dateCode;
-        quint16 iasZoneType = 0;
         bool swBuildIdAvailable = false;
         bool dateCodeAvailable = false;
         quint8 thermostatClusterEndpoint = 0;
@@ -14234,66 +14267,11 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
                             unavailBasicAttr.push_back(attr.id());
                         }
                     }
-                    else if (cl.id() == IAS_ZONE_CLUSTER_ID)
-                    {
-                        if (attr.id() == 0x0001 && attr.numericValue().u64 != 0) // Zone type
-                        {
-                            DBG_Assert(attr.numericValue().u64 <= UINT16_MAX);
-                            iasZoneType = static_cast<quint16>(attr.numericValue().u64);
-                        }
-                    }
                     else if (cl.id() == THERMOSTAT_CLUSTER_ID)
                     {
                         thermostatClusterEndpoint = sd.endpoint();
                     }
                 }
-            }
-
-            if ((sd.deviceId() == DEV_ID_IAS_ZONE || sd.deviceId() == DEV_ID_IAS_WARNING_DEVICE) && iasZoneType == 0)
-            {
-                deCONZ::ApsDataRequest apsReq;
-
-                DBG_Printf(DBG_INFO, "[3.1] get IAS Zone type for 0x%016llx\n", sc->address.ext());
-
-                // ZDP Header
-                apsReq.dstAddress() = sc->address;
-                apsReq.setDstAddressMode(deCONZ::ApsNwkAddress);
-                apsReq.setDstEndpoint(sd.endpoint());
-                apsReq.setSrcEndpoint(endpoint());
-                apsReq.setProfileId(HA_PROFILE_ID);
-                apsReq.setRadius(0);
-                apsReq.setClusterId(IAS_ZONE_CLUSTER_ID);
-                apsReq.setTxOptions(deCONZ::ApsTxAcknowledgedTransmission);
-
-                deCONZ::ZclFrame zclFrame;
-                zclFrame.setSequenceNumber(zclSeq++);
-                zclFrame.setCommandId(deCONZ::ZclReadAttributesId);
-                zclFrame.setFrameControl(deCONZ::ZclFCProfileCommand |
-                                         deCONZ::ZclFCDirectionClientToServer |
-                                         deCONZ::ZclFCDisableDefaultResponse);
-
-                { // payload
-                    QDataStream stream(&zclFrame.payload(), QIODevice::WriteOnly);
-                    stream.setByteOrder(QDataStream::LittleEndian);
-
-                    stream << (quint16)0x0001; // IAS Zone type
-                }
-
-                { // ZCL frame
-                    QDataStream stream(&apsReq.asdu(), QIODevice::WriteOnly);
-                    stream.setByteOrder(QDataStream::LittleEndian);
-                    zclFrame.writeToStream(stream);
-                }
-
-                deCONZ::ApsController *apsCtrl = deCONZ::ApsController::instance();
-
-                if (apsCtrl && apsCtrl->apsdeDataRequest(apsReq) == deCONZ::Success)
-                {
-                    queryTime = queryTime.addSecs(1);
-                    sc->timeout.restart();
-                    sc->waitIndicationClusterId = apsReq.clusterId();
-                }
-                return;
             }
         }
 
@@ -14344,8 +14322,6 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
             bool skip = false;
 
             if (thermostatClusterEndpoint == 0) // e.g. Eurotronic SPZB0001 thermostat
-            {  }
-            else if (iasZoneType > 0) // Trust / and IAS motion and contact sensors
             {  }
             else if (modelId.startsWith(QLatin1String("lumi.")))
             {
@@ -14431,92 +14407,6 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
         if (!sensor || searchSensorsState != SearchSensorsActive)
         {
             // do nothing
-        }
-        else if (iasZoneType != 0)
-        {
-            ResourceItem *item = nullptr;
-            // the RConfigPending pending item might be in another sensor resource
-            for (auto &s: sensors)
-            {
-                if (fastProbeAddr.ext() != s.address().ext() || s.deletedState() != Sensor::StateNormal)
-                {
-                    continue;
-                }
-
-                if (s.fingerPrint().hasInCluster(IAS_ZONE_CLUSTER_ID))
-                {
-                    item = s.item(RConfigPending);
-                }
-
-                if (item)
-                {
-                    break;
-                }
-            }
-
-            if (item && (item->toNumber() & R_PENDING_WRITE_CIE_ADDRESS))
-            {
-                // write CIE address needed for some IAS Zone devices
-                const quint64 iasCieAddress = apsCtrl->getParameter(deCONZ::ParamMacAddress);
-                deCONZ::ZclAttribute attr(0x0010, deCONZ::ZclIeeeAddress, QLatin1String("CIE address"), deCONZ::ZclReadWrite, false);
-                attr.setValue(iasCieAddress);
-
-                DBG_Printf(DBG_INFO, "[5] write IAS CIE address for 0x%016llx\n", sc->address.ext());
-
-                if (writeAttribute(sensor, sensor->fingerPrint().endpoint, IAS_ZONE_CLUSTER_ID, attr, 0))
-                {
-                    // mark done
-                    item->setValue(item->toNumber() & ~R_PENDING_WRITE_CIE_ADDRESS);
-                    return;
-                }
-            }
-            else if (item && (item->toNumber() & R_PENDING_ENROLL_RESPONSE))
-            {
-                DBG_Printf(DBG_INFO, "[6] send IAS zone enroll response to 0x%016llx\n", sc->address.ext());
-
-                deCONZ::ApsDataRequest req;
-                deCONZ::ZclFrame zclFrame;
-
-                // ZDP Header
-                req.dstAddress() = sc->address;
-                req.setDstAddressMode(deCONZ::ApsNwkAddress);
-                req.setProfileId(sensor->fingerPrint().profileId);
-                req.setClusterId(IAS_ZONE_CLUSTER_ID);
-                req.setDstAddressMode(deCONZ::ApsExtAddress);
-                req.setSrcEndpoint(endpoint());
-                req.setTxOptions(deCONZ::ApsTxAcknowledgedTransmission);
-
-                zclFrame.setSequenceNumber(zclSeq++);
-                zclFrame.setCommandId(0x00); // enroll response
-
-                zclFrame.setFrameControl(deCONZ::ZclFCClusterCommand |
-                                            deCONZ::ZclFCDirectionClientToServer);
-
-                { // payload
-                    QDataStream stream(&zclFrame.payload(), QIODevice::WriteOnly);
-                    stream.setByteOrder(QDataStream::LittleEndian);
-
-                    quint8 code = 0x00; // success
-                    quint8 zoneId = 100;
-
-                    stream << code;
-                    stream << zoneId;
-                }
-
-                { // ZCL frame
-                    QDataStream stream(&req.asdu(), QIODevice::WriteOnly);
-                    stream.setByteOrder(QDataStream::LittleEndian);
-                    zclFrame.writeToStream(stream);
-                }
-
-                DBG_Printf(DBG_INFO, "IAS Zone send enroll reponse\n");
-                if (apsCtrl->apsdeDataRequest(req) == deCONZ::Success)
-                {
-                    // mark done
-                    item->setValue(item->toNumber() & ~R_PENDING_ENROLL_RESPONSE);
-                    return;
-                }
-            }
         }
         else if (sensor->modelId().startsWith(QLatin1String("RWL02")) || // Hue dimmer switch
                  sensor->modelId().startsWith(QLatin1String("ROM00")) || // Hue smart button

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1312,6 +1312,8 @@ public:
     bool flsNbMaintenance(LightNode *lightNode);
     bool pushState(QString json, QTcpSocket *sock);
     void patchNodeDescriptor(const deCONZ::ApsDataIndication &ind);
+    void writeIasCieAddress(Sensor*);
+    void checkIasEnrollmentStatus(Sensor*);
 
     void pushClientForClose(QTcpSocket *sock, int closeTimeout, const QHttpRequestHeader &hdr);
 

--- a/general.xml
+++ b/general.xml
@@ -824,112 +824,312 @@
 	<!-- TODO -->
 	</cluster>
 	<cluster id="0x000c" name="Analog Input (Basic)">
-		<description>An interface for reading the value of an analog measurement and accessing
-various characteristics of that measurement.</description>
+		<description>An interface for reading the value of an analog measurement and accessing various characteristics of that measurement.</description>
 		<server>
-			<attribute id="0x0051" type="bool" name="Out of service" required="m" access="rw" default="0"></attribute>
-			<attribute id="0x0055" type="float" name="Present value" required="m" access="rw" default="0"></attribute>
-			<attribute id="0x006f" type="bmp8" name="Status flags" required="m" access="r" default="0">
+            <attribute id="0x001c" name="Description" type="cstring" required="o" access="rw"></attribute>
+            <attribute id="0x0041" name="Max Present Value" type="float" required="o" access="rw"></attribute>
+            <attribute id="0x0045" name="Min Present Value" type="float" required="o" access="rw"></attribute>
+			<attribute id="0x0051" name="Out of service" type="bool" required="m" access="rw" default="0"></attribute>
+			<attribute id="0x0055" name="Present value" type="float" required="m" access="rw" default="0"></attribute>
+            <attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0"></attribute>
+                <value name="No fault detected" value="0"></value>
+                <value name="No sensor" value="1"></value>
+                <value name="Over range" value="2"></value>
+                <value name="Under range" value="3"></value>
+                <value name="Open loop" value="4"></value>
+                <value name="Shorted loop" value="5"></value>
+                <value name="No output" value="6"></value>
+                <value name="Unreliable other" value="7"></value>
+                <value name="Process error" value="8"></value>
+                <value name="Multi state fault" value="9"></value>
+                <value name="Configuration error" value="10"></value>
+            </attribute>
+            <attribute id="0x006a" name="Resolution" type="float" required="o" access="rw"></attribute>
+			<attribute id="0x006f" name="Status flags" type="bmp8" required="m" access="r" default="0">
 				<value name="In Alarm" value="0x01"></value>
 				<value name="Fault" value="0x02"></value>
 				<value name="Overidden" value="0x04"></value>
 				<value name="Out of Service" value="0x08"></value>
 			</attribute>
-			<attribute id="0xff05" type="u16" name="Unknown" required="o" access="r" default="0" showas="hex"></attribute>
+            <attribute id="0x0075" name="Engineering Units" type="enum16" required="o" access="rw"></attribute>
+            <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
+			<attribute id="0xff05" name="Unknown" type="u16" required="o" access="r" default="0" showas="hex"></attribute>
 		</server>
         <client>
         </client>
-	<!-- TODO -->
 	</cluster>
-  <cluster id="0x000d" name="Analog Output (Basic)">
-    <description>The Analog Output (Basic) cluster provides an interface for setting the value of an analog output (typically to the environment) and accessing various characteristics of that value.</description>
-    <server>
-      <attribute id="0x001c" type="cstring" name="Description" required="o" access="rw"></attribute>
-      <attribute id="0x0041" type="float" name="Max Present Value" required="o" access="rw"></attribute>
-      <attribute id="0x0045" type="float" name="Min Present Value" required="o" access="rw"></attribute>
-      <attribute id="0x0051" type="bool" name="Out of service" required="m" access="rw" default="0"></attribute>
-      <attribute id="0x0055" type="float" name="Present value" required="m" access="rw" default="0"></attribute>
-      <attribute id="0x006f" type="bmp8" name="Status flags" required="m" access="r" default="0">
-        <value name="In Alarm" value="0x01"></value>
-        <value name="Fault" value="0x02"></value>
-        <value name="Overidden" value="0x04"></value>
-        <value name="Out of Service" value="0x08"></value>
-      </attribute>
-      <attribute id="0xf000" type="u32" name="Xiaomi 0xf000" required="o" access="r"></attribute>
-     </server>
-     <client>
-     </client>
-   </cluster>
+    <cluster id="0x000d" name="Analog Output (Basic)">
+        <description>The Analog Output (Basic) cluster provides an interface for setting the value of an analog output (typically to the environment) and accessing various characteristics of that value.</description>
+        <server>
+            <attribute id="0x001c" name="Description" type="cstring" required="o" access="rw"></attribute>
+            <attribute id="0x0041" name="Max Present Value" type="float" required="o" access="rw"></attribute>
+            <attribute id="0x0045" name="Min Present Value" type="float" required="o" access="rw"></attribute>
+            <attribute id="0x0051" name="Out of service" type="bool" required="m" access="rw" default="0"></attribute>
+            <attribute id="0x0055" name="Present value" type="float" required="m" access="rw" default="0"></attribute>
+            <attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0"></attribute>
+                <value name="No fault detected" value="0"></value>
+                <value name="No sensor" value="1"></value>
+                <value name="Over range" value="2"></value>
+                <value name="Under range" value="3"></value>
+                <value name="Open loop" value="4"></value>
+                <value name="Shorted loop" value="5"></value>
+                <value name="No output" value="6"></value>
+                <value name="Unreliable other" value="7"></value>
+                <value name="Process error" value="8"></value>
+                <value name="Multi state fault" value="9"></value>
+                <value name="Configuration error" value="10"></value>
+            </attribute>
+            <attribute id="0x0068" name="Relinquish Default" type="float" required="o" access="rw"></attribute>
+            <attribute id="0x006a" name="Resolution" type="float" required="o" access="rw"></attribute>
+            <attribute id="0x006f" name="Status flags" type="bmp8" required="m" access="r" default="0">
+                <value name="In Alarm" value="0x01"></value>
+                <value name="Fault" value="0x02"></value>
+                <value name="Overidden" value="0x04"></value>
+                <value name="Out of Service" value="0x08"></value>
+            </attribute>
+            <attribute id="0x0075" name="Engineering Units" type="enum16" required="o" access="rw"></attribute>
+            <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
+            <attribute id="0xf000" name="Xiaomi 0xf000" type="u32" required="o" access="r"></attribute>
+        </server>
+        <client>
+        </client>
+    </cluster>
 	<cluster id="000e" name="Analog Value (Basic)">
 	<description>An interface for setting an analog value, typically used as a control system parameter, and accessing various characteristics of that value.</description>
-	<!-- TODO -->
+        <server>
+            <attribute id="0x001c" name="Description" type="cstring" required="o" access="rw"></attribute>
+            <attribute id="0x0051" name="Out of service" type="bool" required="m" access="rw" default="0"></attribute>
+            <attribute id="0x0055" name="Present value" type="float" required="m" access="rw" default="0"></attribute>
+            <attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0"></attribute>
+                <value name="No fault detected" value="0"></value>
+                <value name="No sensor" value="1"></value>
+                <value name="Over range" value="2"></value>
+                <value name="Under range" value="3"></value>
+                <value name="Open loop" value="4"></value>
+                <value name="Shorted loop" value="5"></value>
+                <value name="No output" value="6"></value>
+                <value name="Unreliable other" value="7"></value>
+                <value name="Process error" value="8"></value>
+                <value name="Multi state fault" value="9"></value>
+                <value name="Configuration error" value="10"></value>
+            </attribute>
+            <attribute id="0x0068" name="Relinquish Default" type="float" required="o" access="rw"></attribute>
+            <attribute id="0x006f" name="Status flags" type="bmp8" required="m" access="r" default="0">
+                <value name="In Alarm" value="0x01"></value>
+                <value name="Fault" value="0x02"></value>
+                <value name="Overidden" value="0x04"></value>
+                <value name="Out of Service" value="0x08"></value>
+            </attribute>
+            <attribute id="0x0075" name="Engineering Units" type="enum16" required="o" access="rw"></attribute>
+            <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
+        </server>
+        <client>
+        </client>
 	</cluster>
 	<cluster id="000f" name="Binary Input (Basic)">
-		<description>The Binary Input (Basic) cluster provides an interface for reading the value of a binary measurement and accessing various characteristics of that measurement. The cluster is typically used to implement a sensor that measures a two-state physical quantity.
-		</description>
+		<description>The Binary Input (Basic) cluster provides an interface for reading the value of a binary measurement and accessing various characteristics of that measurement. The cluster is typically used to implement a sensor that measures a two-state physical quantity.</description>
 		<server>
-			<attribute id="0x001c" name="Description" type="cstring" access="rw" required="o"></attribute>
+			<attribute id="0x0004" name="Active Text" type="cstring" required="o" access="rw" default=""></attribute>
+            <attribute id="0x001c" name="Description" type="cstring" access="rw" required="o"></attribute>
+            <attribute id="0x002e" name="Inactive Text" type="cstring" required="o" access="rw" default=""></attribute>
 			<attribute id="0x0051" name="Out of Service" type="bool" default="0" access="rw" required="m"></attribute>
-			<attribute id="0x0055" name="Present Value" type="bool" default="0" access="rw" required="m"></attribute>
-			<attribute id="0x0067" name="Reliabillity" type="enum8" default="0" access="r" required="o"></attribute>
-			<attribute id="0x006F" name="Status Flags" type="bmp8" default="0" access="r" required="m">
+            <attribute id="0x0054" name="Polarity" type="enum8" required="o" access="r"></attribute>
+                <value name="Normal" value="0"></value>
+                <value name="Reverse" value="1"></value>
+			</attribute>
+            <attribute id="0x0055" name="Present Value" type="bool" default="0" access="rw" required="m"></attribute>
+			<attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0"></attribute>
+                <value name="No fault detected" value="0"></value>
+                <value name="No sensor" value="1"></value>
+                <value name="Over range" value="2"></value>
+                <value name="Under range" value="3"></value>
+                <value name="Open loop" value="4"></value>
+                <value name="Shorted loop" value="5"></value>
+                <value name="No output" value="6"></value>
+                <value name="Unreliable other" value="7"></value>
+                <value name="Process error" value="8"></value>
+                <value name="Multi state fault" value="9"></value>
+                <value name="Configuration error" value="10"></value>
+			</attribute>
+            <attribute id="0x006F" name="Status Flags" type="bmp8" default="0" access="r" required="m">
 				<value name="In Alarm" value="0x01"></value>
 				<value name="Fault" value="0x02"></value>
 				<value name="Overidden" value="0x04"></value>
 				<value name="Out of Service" value="0x08"></value>
 			</attribute>
+            <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
 		</server>
 		<client>
 		</client>
-	<!-- TODO -->
 	</cluster>
 	<cluster id="0010" name="Binary Output (Basic)">
-	<description></description>
-	<!-- TODO -->
+	<description>The Binary Output (Basic) cluster provides an interface for setting the value of a binary output, and accessing various characteristics of that value.</description>
+        <server>
+            <attribute id="0x0004" name="Active Text" type="cstring" required="o" access="rw" default=""></attribute>
+            <attribute id="0x001c" name="Description" type="cstring" required="o" access="rw" default=""></attribute>
+            <attribute id="0x002e" name="Inactive Text" type="cstring" required="o" access="rw" default=""></attribute>
+            <attribute id="0x0042" name="Min Off Time" type="u32" required="o" access="rw" default="0xffffffff"></attribute>
+            <attribute id="0x0043" name="Min On Time" type="u32" required="o" access="rw" default="0xffffffff"></attribute>
+            <attribute id="0x0051" name="Out of service" type="bool" required="m" access="rw" default="0"></attribute>
+            <attribute id="0x0054" name="Polarity" type="enum8" required="o" access="r"></attribute>
+                <value name="Normal" value="0"></value>
+                <value name="Reverse" value="1"></value>
+            </attribute>
+            <attribute id="0x0055" name="Present value" type="bool" required="m" access="rw"></attribute>
+            <attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0"></attribute>
+                <value name="No fault detected" value="0"></value>
+                <value name="No sensor" value="1"></value>
+                <value name="Over range" value="2"></value>
+                <value name="Under range" value="3"></value>
+                <value name="Open loop" value="4"></value>
+                <value name="Shorted loop" value="5"></value>
+                <value name="No output" value="6"></value>
+                <value name="Unreliable other" value="7"></value>
+                <value name="Process error" value="8"></value>
+                <value name="Multi state fault" value="9"></value>
+                <value name="Configuration error" value="10"></value>
+            </attribute>
+            <attribute id="0x0068" name="Relinquish Default" type="bool" required="o" access="rw"></attribute>
+            <attribute id="0x006f" name="Status flags" type="bmp8" required="m" access="r" default="0">
+                <value name="In Alarm" value="0x01"></value>
+                <value name="Fault" value="0x02"></value>
+                <value name="Overidden" value="0x04"></value>
+                <value name="Out of Service" value="0x08"></value>
+            </attribute>
+            <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
+        </server>
+        <client>
+        </client>
 	</cluster>
 	<cluster id="0011" name="Binary Value (Basic)">
-	<description></description>
-	<!-- TODO -->
+	<description>The Binary Value (Basic) cluster provides an interface for setting a binary value, typically used as a control system parameter, and accessing various characteristics of that value.</description>
+        <server>
+            <attribute id="0x0004" name="Active Text" type="cstring" required="o" access="rw" default=""></attribute>
+            <attribute id="0x001c" name="Description" type="cstring" required="o" access="rw" default=""></attribute>
+            <attribute id="0x002e" name="Inactive Text" type="cstring" required="o" access="rw" default=""></attribute>
+            <attribute id="0x0042" name="Min Off Time" type="u32" required="o" access="rw" default="0xffffffff"></attribute>
+            <attribute id="0x0043" name="Min On Time" type="u32" required="o" access="rw" default="0xffffffff"></attribute>
+            <attribute id="0x0051" name="Out of service" type="bool" required="m" access="rw" default="0"></attribute>
+            <attribute id="0x0055" name="Present value" type="bool" required="m" access="rw"></attribute>
+            <attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0"></attribute>
+                <value name="No fault detected" value="0"></value>
+                <value name="No sensor" value="1"></value>
+                <value name="Over range" value="2"></value>
+                <value name="Under range" value="3"></value>
+                <value name="Open loop" value="4"></value>
+                <value name="Shorted loop" value="5"></value>
+                <value name="No output" value="6"></value>
+                <value name="Unreliable other" value="7"></value>
+                <value name="Process error" value="8"></value>
+                <value name="Multi state fault" value="9"></value>
+                <value name="Configuration error" value="10"></value>
+            </attribute>
+            <attribute id="0x0068" name="Relinquish Default" type="bool" required="o" access="rw"></attribute>
+            <attribute id="0x006f" name="Status flags" type="bmp8" required="m" access="r" default="0">
+                <value name="In Alarm" value="0x01"></value>
+                <value name="Fault" value="0x02"></value>
+                <value name="Overidden" value="0x04"></value>
+                <value name="Out of Service" value="0x08"></value>
+            </attribute>
+            <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
+        </server>
+        <client>
+        </client>
 	</cluster>
 	<cluster id="0x0012" name="Multistate Input (Basic)">
-		<description>Provides an interface for reading the value of a multistate measurement
-and accessing various characteristics of that measurement. The cluster is typically used to implement a sensor
-that measures a physical quantity that can take on one of a number of discrete states.</description>
+		<description>Provides an interface for reading the value of a multistate measurement and accessing various characteristics of that measurement. The cluster is typically used to implement a sensor that measures a physical quantity that can take on one of a number of discrete states.</description>
 		<server>
-			<attribute id="0x004a" type="u16" name="Number of states" required="m" access="rw" default="0"></attribute>
+			<attribute id="0x001c" name="Description" type="cstring" required="o" access="rw" default=""></attribute>
+            <attribute id="0x004a" type="u16" name="Number of states" required="m" access="rw" default="0"></attribute>
 			<attribute id="0x0051" type="bool" name="Out of service" required="m" access="rw" default="0"></attribute>
 			<attribute id="0x0055" type="u16" name="Present value" required="m" access="rw" default="0"></attribute>
+            <attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0"></attribute>
+                <value name="No fault detected" value="0"></value>
+                <value name="No sensor" value="1"></value>
+                <value name="Over range" value="2"></value>
+                <value name="Under range" value="3"></value>
+                <value name="Open loop" value="4"></value>
+                <value name="Shorted loop" value="5"></value>
+                <value name="No output" value="6"></value>
+                <value name="Unreliable other" value="7"></value>
+                <value name="Process error" value="8"></value>
+                <value name="Multi state fault" value="9"></value>
+                <value name="Configuration error" value="10"></value>
+            </attribute>
 			<attribute id="0x006f" type="bmp8" name="Status flags" required="m" access="r" default="0">
 				<value name="In Alarm" value="0x01"></value>
 				<value name="Fault" value="0x02"></value>
 				<value name="Overidden" value="0x04"></value>
 				<value name="Out of Service" value="0x08"></value>
 			</attribute>
+            <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
 		</server>
         <client>
         </client>
-	<!-- TODO -->
 	</cluster>
 	<cluster id="0013" name="Multistate Output (Basic)">
-  	<description></description>
-    <server>
-      <attribute id="0x004a" type="u16" name="Number of states" required="m" access="rw" default="0"></attribute>
-      <attribute id="0x0051" type="bool" name="Out of service" required="m" access="rw" default="0"></attribute>
-      <attribute id="0x0055" type="u16" name="Present value" required="m" access="rw" default="0"></attribute>
-      <attribute id="0x006f" type="bmp8" name="Status flags" required="m" access="r" default="0">
-        <value name="In Alarm" value="0x01"></value>
-        <value name="Fault" value="0x02"></value>
-        <value name="Overidden" value="0x04"></value>
-        <value name="Out of Service" value="0x08"></value>
-      </attribute>
-    </server>
-    <client>
-    </client>
-	<!-- TODO -->
+  	<description>The Multistate Output (Basic) cluster provides an interface for setting the value of an output that can take one of a number of discrete values, and accessing characteristics of that value.</description>
+        <server>
+            <attribute id="0x001c" name="Description" type="cstring" required="o" access="rw" default=""></attribute>
+            <attribute id="0x004a" type="u16" name="Number of states" required="m" access="rw" default="0"></attribute>
+            <attribute id="0x0051" type="bool" name="Out of service" required="m" access="rw" default="0"></attribute>
+            <attribute id="0x0055" type="u16" name="Present value" required="m" access="rw" default="0"></attribute>
+            <attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0"></attribute>
+                <value name="No fault detected" value="0"></value>
+                <value name="No sensor" value="1"></value>
+                <value name="Over range" value="2"></value>
+                <value name="Under range" value="3"></value>
+                <value name="Open loop" value="4"></value>
+                <value name="Shorted loop" value="5"></value>
+                <value name="No output" value="6"></value>
+                <value name="Unreliable other" value="7"></value>
+                <value name="Process error" value="8"></value>
+                <value name="Multi state fault" value="9"></value>
+                <value name="Configuration error" value="10"></value>
+            </attribute>
+            <attribute id="0x0068" name="Relinquish Default" type="u16" required="o" access="rw"></attribute>
+            <attribute id="0x006f" type="bmp8" name="Status flags" required="m" access="r" default="0">
+                <value name="In Alarm" value="0x01"></value>
+                <value name="Fault" value="0x02"></value>
+                <value name="Overidden" value="0x04"></value>
+                <value name="Out of Service" value="0x08"></value>
+            </attribute>
+            <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
+        </server>
+        <client>
+        </client>
 	</cluster>
 	<cluster id="0014" name="Multistate Value (Basic)">
-	<description></description>
-	<!-- TODO -->
+	<description>The Multistate Value (Basic) cluster provides an interface for setting a multistate value, typically used as a control system parameter, and accessing characteristics of that value.</description>
+        <server>
+            <attribute id="0x001c" name="Description" type="cstring" required="o" access="rw" default=""></attribute>
+            <attribute id="0x004a" type="u16" name="Number of states" required="m" access="rw" default="0"></attribute>
+            <attribute id="0x0051" type="bool" name="Out of service" required="m" access="rw" default="0"></attribute>
+            <attribute id="0x0055" type="u16" name="Present value" required="m" access="rw" default="0"></attribute>
+            <attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0"></attribute>
+                <value name="No fault detected" value="0"></value>
+                <value name="No sensor" value="1"></value>
+                <value name="Over range" value="2"></value>
+                <value name="Under range" value="3"></value>
+                <value name="Open loop" value="4"></value>
+                <value name="Shorted loop" value="5"></value>
+                <value name="No output" value="6"></value>
+                <value name="Unreliable other" value="7"></value>
+                <value name="Process error" value="8"></value>
+                <value name="Multi state fault" value="9"></value>
+                <value name="Configuration error" value="10"></value>
+            </attribute>
+            <attribute id="0x0068" name="Relinquish Default" type="u16" required="o" access="rw"></attribute>
+            <attribute id="0x006f" type="bmp8" name="Status flags" required="m" access="r" default="0">
+                <value name="In Alarm" value="0x01"></value>
+                <value name="Fault" value="0x02"></value>
+                <value name="Overidden" value="0x04"></value>
+                <value name="Out of Service" value="0x08"></value>
+            </attribute>
+            <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
+        </server>
+        <client>
+        </client>
 	</cluster>
 	<cluster id="0015" name="Commissioning">
 	<description>Attributes and commands for commissioning and managing a ZigBee device.</description>

--- a/general.xml
+++ b/general.xml
@@ -831,7 +831,7 @@
             <attribute id="0x0045" name="Min Present Value" type="float" required="o" access="rw"></attribute>
 			<attribute id="0x0051" name="Out of service" type="bool" required="m" access="rw" default="0"></attribute>
 			<attribute id="0x0055" name="Present value" type="float" required="m" access="rw" default="0"></attribute>
-            <attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0"></attribute>
+            <attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0">
                 <value name="No fault detected" value="0"></value>
                 <value name="No sensor" value="1"></value>
                 <value name="Over range" value="2"></value>
@@ -866,7 +866,7 @@
             <attribute id="0x0045" name="Min Present Value" type="float" required="o" access="rw"></attribute>
             <attribute id="0x0051" name="Out of service" type="bool" required="m" access="rw" default="0"></attribute>
             <attribute id="0x0055" name="Present value" type="float" required="m" access="rw" default="0"></attribute>
-            <attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0"></attribute>
+            <attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0">
                 <value name="No fault detected" value="0"></value>
                 <value name="No sensor" value="1"></value>
                 <value name="Over range" value="2"></value>
@@ -900,7 +900,7 @@
             <attribute id="0x001c" name="Description" type="cstring" required="o" access="rw"></attribute>
             <attribute id="0x0051" name="Out of service" type="bool" required="m" access="rw" default="0"></attribute>
             <attribute id="0x0055" name="Present value" type="float" required="m" access="rw" default="0"></attribute>
-            <attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0"></attribute>
+            <attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0">
                 <value name="No fault detected" value="0"></value>
                 <value name="No sensor" value="1"></value>
                 <value name="Over range" value="2"></value>
@@ -933,12 +933,12 @@
             <attribute id="0x001c" name="Description" type="cstring" access="rw" required="o"></attribute>
             <attribute id="0x002e" name="Inactive Text" type="cstring" required="o" access="rw" default=""></attribute>
 			<attribute id="0x0051" name="Out of Service" type="bool" default="0" access="rw" required="m"></attribute>
-            <attribute id="0x0054" name="Polarity" type="enum8" required="o" access="r"></attribute>
+            <attribute id="0x0054" name="Polarity" type="enum8" required="o" access="r">
                 <value name="Normal" value="0"></value>
                 <value name="Reverse" value="1"></value>
 			</attribute>
             <attribute id="0x0055" name="Present Value" type="bool" default="0" access="rw" required="m"></attribute>
-			<attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0"></attribute>
+			<attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0">
                 <value name="No fault detected" value="0"></value>
                 <value name="No sensor" value="1"></value>
                 <value name="Over range" value="2"></value>
@@ -971,12 +971,12 @@
             <attribute id="0x0042" name="Min Off Time" type="u32" required="o" access="rw" default="0xffffffff"></attribute>
             <attribute id="0x0043" name="Min On Time" type="u32" required="o" access="rw" default="0xffffffff"></attribute>
             <attribute id="0x0051" name="Out of service" type="bool" required="m" access="rw" default="0"></attribute>
-            <attribute id="0x0054" name="Polarity" type="enum8" required="o" access="r"></attribute>
+            <attribute id="0x0054" name="Polarity" type="enum8" required="o" access="r">
                 <value name="Normal" value="0"></value>
                 <value name="Reverse" value="1"></value>
             </attribute>
             <attribute id="0x0055" name="Present value" type="bool" required="m" access="rw"></attribute>
-            <attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0"></attribute>
+            <attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0">
                 <value name="No fault detected" value="0"></value>
                 <value name="No sensor" value="1"></value>
                 <value name="Over range" value="2"></value>
@@ -1011,7 +1011,7 @@
             <attribute id="0x0043" name="Min On Time" type="u32" required="o" access="rw" default="0xffffffff"></attribute>
             <attribute id="0x0051" name="Out of service" type="bool" required="m" access="rw" default="0"></attribute>
             <attribute id="0x0055" name="Present value" type="bool" required="m" access="rw"></attribute>
-            <attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0"></attribute>
+            <attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0">
                 <value name="No fault detected" value="0"></value>
                 <value name="No sensor" value="1"></value>
                 <value name="Over range" value="2"></value>
@@ -1043,7 +1043,7 @@
             <attribute id="0x004a" type="u16" name="Number of states" required="m" access="rw" default="0"></attribute>
 			<attribute id="0x0051" type="bool" name="Out of service" required="m" access="rw" default="0"></attribute>
 			<attribute id="0x0055" type="u16" name="Present value" required="m" access="rw" default="0"></attribute>
-            <attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0"></attribute>
+            <attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0">
                 <value name="No fault detected" value="0"></value>
                 <value name="No sensor" value="1"></value>
                 <value name="Over range" value="2"></value>
@@ -1074,7 +1074,7 @@
             <attribute id="0x004a" type="u16" name="Number of states" required="m" access="rw" default="0"></attribute>
             <attribute id="0x0051" type="bool" name="Out of service" required="m" access="rw" default="0"></attribute>
             <attribute id="0x0055" type="u16" name="Present value" required="m" access="rw" default="0"></attribute>
-            <attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0"></attribute>
+            <attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0">
                 <value name="No fault detected" value="0"></value>
                 <value name="No sensor" value="1"></value>
                 <value name="Over range" value="2"></value>
@@ -1106,7 +1106,7 @@
             <attribute id="0x004a" type="u16" name="Number of states" required="m" access="rw" default="0"></attribute>
             <attribute id="0x0051" type="bool" name="Out of service" required="m" access="rw" default="0"></attribute>
             <attribute id="0x0055" type="u16" name="Present value" required="m" access="rw" default="0"></attribute>
-            <attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0"></attribute>
+            <attribute id="0x0067" name="Reliabillity" type="enum8" required="o" access="rw" default="0">
                 <value name="No fault detected" value="0"></value>
                 <value name="No sensor" value="1"></value>
                 <value name="Over range" value="2"></value>

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -578,6 +578,25 @@ static const Sensor::ButtonMap sunricherCCTMap[] = {
     { Sensor::ModeNone,             0x00, 0x0000, 0x00, 0,    0,                                           nullptr }
 };
 
+static const Sensor::ButtonMap rgbgenie5121Map[] = {
+//    mode                          ep    cluster cmd   param button                                       name
+    // On button
+    { Sensor::ModeScenes,           0x01, 0x0006, 0x01, 0,    S_BUTTON_1 + S_BUTTON_ACTION_SHORT_RELEASED, "On" },
+    // Off button
+    { Sensor::ModeScenes,           0x01, 0x0006, 0x00, 0,    S_BUTTON_2 + S_BUTTON_ACTION_SHORT_RELEASED, "Off" },
+    // Dim up
+    { Sensor::ModeScenes,           0x01, 0x0008, 0x05, 0,    S_BUTTON_3 + S_BUTTON_ACTION_HOLD, "Move up (with on/off)" },
+    { Sensor::ModeScenes,           0x01, 0x0008, 0x07, 0,    S_BUTTON_3 + S_BUTTON_ACTION_LONG_RELEASED, "Stop_ (with on/off)" },
+    // Dim down
+    { Sensor::ModeScenes,           0x01, 0x0008, 0x05, 1,    S_BUTTON_4 + S_BUTTON_ACTION_HOLD, "Move down (with on/off)" },
+    { Sensor::ModeScenes,           0x01, 0x0008, 0x07, 1,    S_BUTTON_4 + S_BUTTON_ACTION_LONG_RELEASED, "Stop_ (with on/off)" },
+    // Scene button
+    { Sensor::ModeScenes,           0x01, 0x0005, 0x05, 1,    S_BUTTON_5 + S_BUTTON_ACTION_SHORT_RELEASED, "Recall scene 1" },
+    { Sensor::ModeScenes,           0x01, 0x0005, 0x04, 1,    S_BUTTON_5 + S_BUTTON_ACTION_LONG_RELEASED, "Store scene 1" },
+    // end
+    { Sensor::ModeNone,             0x00, 0x0000, 0x00, 0,    0,                                           nullptr }
+};
+
 static const Sensor::ButtonMap sunricherMap[] = {
 //    mode                          ep    cluster cmd   param button                                       name
     // 1st On button
@@ -1300,6 +1319,7 @@ const Sensor::ButtonMap *Sensor::buttonMap()
         {
             if      (modelid.startsWith(QLatin1String("ZGRC-KEY"))) { m_buttonMap = sunricherCCTMap; }
             else if (modelid.startsWith(QLatin1String("ZG2833K"))) { m_buttonMap = sunricherMap; }
+            else if (modelid.startsWith(QLatin1String("RGBgenie ZB-5121"))) { m_buttonMap = rgbgenie5121Map; }
         }
         else if (manufacturer == QLatin1String("Bitron Home"))
         {


### PR DESCRIPTION
- Added initial support for Sercomm open/close sensor SZ-DWS04 (#2722)
- Prevent lumi.plug.mmeu01 creating wrong sensors in rare cases (#2583)
- Update for LifeControl MCLH-08 environmental sensor
- Refactor IAS zone enrollment
- Added initial support for RGBgenie ZB-5121 (#2732)
- Enhancements for RGBgenie ZB-5001 (#1256)
- Added initial support for Centralite 3323-G contact sensor (#2783)
- Allow binding for Xiaomi Mijia Smart Light Sensor lumi.sen_ill.mgl01 (#2300)

According to Zigbee spec (07-5123-06-zigbee-cluster-library-specification.pdf, 8.2.2.2.3 Implementation Guidelines), writing the IAS CIE address is mandatory to be done first in the enrollment process. Apparently, not much end devices seem to adhere to that, as an enrollment request is fired very early from those devices.
However, some devices (e.g. Sercomm siren) stick to the specs and require the CIE write before, otherwise they do not earn status enrolled. The refactor should be more robust adhering to the procedure and also consider "orphan" sensors (a device with an IAS sensors gets reset, in those cases, the sensor is already available).
Tested with Sercomm siren, Heiman and Develco smoke detector.