### PR TITLE
WIP: ci(actions): adds auto building of the REST plugin

### DIFF
--- a/.github/workflows/compile-rest-plugin.yml
+++ b/.github/workflows/compile-rest-plugin.yml
@@ -1,0 +1,30 @@
+name: Compile the REST plugin
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: |
+        wget -O - http://phoscon.de/apt/deconz.pub.key | sudo apt-key add -
+        sudo sh -c "echo 'deb [arch=amd64] http://phoscon.de/apt/deconz \
+            $(lsb_release -cs) main' > \
+            /etc/apt/sources.list.d/deconz.list"
+        sudo apt update
+        sudo apt install -y deconz deconz-dev
+
+    - name: Compile the plugin
+      run: |
+        qmake && make -j2
+        cp ../libde_rest_plugin.so $HOME
+
+    - name: Upload libde_rest_plugin.so
+      uses: actions/upload-artifact@v2
+      with:
+        name: libde_rest_plugin.so.zip
+        path: '~/libde_rest_plugin.so'


### PR DESCRIPTION
This adds an auto building of the `libde_rest_plugin.so` plugin and stores it with GitHub actions. This simplifies testing changes because users do not need to build it themselves and can just download an always up to date nightly version (of course at their own risk)

Some screenhots attached:
![Anmerkung 2020-05-12 180713](https://user-images.githubusercontent.com/838003/81717914-abeb7300-946a-11ea-8679-a0fe1ce17269.jpg)

![Anmerkung 2020-05-12 180639](https://user-images.githubusercontent.com/838003/81717930-aee66380-946a-11ea-875f-3edcee802e42.jpg)
