### PR TITLE
Samsung multi sensor

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -923,8 +923,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
 
         const Sensor *sensor = dynamic_cast<Sensor *>(bt.restNode);
 
-        if (sensor->type() == QLatin1String("ZHAVibration") && sensor->modelId() == QLatin1String("multi")) // FIXME: check if this also applies to other Samjin sensors
-        // if (bt.restNode->node()->nodeDescriptor().manufacturerCode() == VENDOR_SAMJIN)
+        if (sensor->type() == QLatin1String("ZHAVibration") && sensor->modelId().startsWith(QLatin1String("multi")))
         {
             // Only configure periodic reports, as events are already sent though zone status change notification commands
             rq.minInterval = 300;
@@ -1160,6 +1159,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         else if (sensor && (sensor->modelId() == QLatin1String("Motion Sensor-A") ||
                             sensor->modelId() == QLatin1String("tagv4") ||
                             sensor->modelId() == QLatin1String("motionv4") ||
+                            sensor->modelId() == QLatin1String("multiv4") ||
                             sensor->modelId() == QLatin1String("RFDL-ZB-MS") ||
                             sensor->modelId() == QLatin1String("Zen-01")))
         {
@@ -1439,7 +1439,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         }
 
         // based on https://github.com/SmartThingsCommunity/SmartThingsPublic/blob/master/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
-        if (sensor->type() == QLatin1String("ZHAVibration") && sensor->modelId() == QLatin1String("multi"))
+        if (sensor->type() == QLatin1String("ZHAVibration") && sensor->modelId().startsWith(QLatin1String("multi")))
         {
             rq.dataType = deCONZ::Zcl16BitInt;
             rq.attributeId = 0x0012; // acceleration x
@@ -1949,10 +1949,10 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         // SmartThings
         sensor->modelId().startsWith(QLatin1String("tagv4")) ||
         sensor->modelId().startsWith(QLatin1String("motionv4")) ||
-        (sensor->manufacturer() == QLatin1String("Samjin") && sensor->modelId() == QLatin1String("button")) ||
+        sensor->modelId() == QLatin1String("button") ||
         (sensor->manufacturer() == QLatin1String("Samjin") && sensor->modelId() == QLatin1String("motion")) ||
-        (sensor->manufacturer() == QLatin1String("Samjin") && sensor->modelId() == QLatin1String("multi")) ||
-        (sensor->manufacturer() == QLatin1String("Samjin") && sensor->modelId() == QLatin1String("water")) ||
+        sensor->modelId().startsWith(QLatin1String("multi")) ||
+        sensor->modelId() == QLatin1String("water") ||
         (sensor->manufacturer() == QLatin1String("Samjin") && sensor->modelId() == QLatin1String("outlet")) ||
         // Bitron
         sensor->modelId().startsWith(QLatin1String("902010")) ||
@@ -2242,7 +2242,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         }
         else if (*i == SAMJIN_CLUSTER_ID)
         {
-            if (sensor->modelId() == QLatin1String("multi"))
+            if (sensor->modelId().startsWith(QLatin1String("multi")))
             {
                 val = sensor->getZclValue(*i, 0x0012); // Acceleration X
             }

--- a/database.cpp
+++ b/database.cpp
@@ -3128,6 +3128,9 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             else if (sensor.fingerPrint().hasInCluster(SAMJIN_CLUSTER_ID))
             {
                 clusterId = clusterId ? clusterId : SAMJIN_CLUSTER_ID;
+                item = sensor.addItem(DataTypeInt16, RStateOrientationX);
+                item = sensor.addItem(DataTypeInt16, RStateOrientationY);
+                item = sensor.addItem(DataTypeInt16, RStateOrientationZ);
             }
             item = sensor.addItem(DataTypeBool, RStateVibration);
             item->setValue(false);
@@ -3138,14 +3141,6 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 item = sensor.addItem(DataTypeInt16, RStateOrientationZ);
                 item = sensor.addItem(DataTypeUInt16, RStateTiltAngle);
                 item = sensor.addItem(DataTypeUInt16, RStateVibrationStrength);
-            }
-            else  if (sensor.modelId().startsWith(QLatin1String("multi")))
-            {
-                item = sensor.addItem(DataTypeInt16, RStateOrientationX);
-                item = sensor.addItem(DataTypeInt16, RStateOrientationY);
-                item = sensor.addItem(DataTypeInt16, RStateOrientationZ);
-                item = sensor.addItem(DataTypeUInt16, RConfigDuration);
-                item->setValue(0);
             }
         }
         else if (sensor.type().endsWith(QLatin1String("Water")))

--- a/database.cpp
+++ b/database.cpp
@@ -3139,7 +3139,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 item = sensor.addItem(DataTypeUInt16, RStateTiltAngle);
                 item = sensor.addItem(DataTypeUInt16, RStateVibrationStrength);
             }
-            else  if (sensor.modelId() == QLatin1String("multi") && sensor.manufacturer() == QLatin1String("Samjin"))
+            else  if (sensor.modelId().startsWith(QLatin1String("multi")))
             {
                 item = sensor.addItem(DataTypeInt16, RStateOrientationX);
                 item = sensor.addItem(DataTypeInt16, RStateOrientationY);
@@ -3190,7 +3190,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     return 0;
                     // hasVoltage = false;
                 }
-                else if (sensor.modelId() == QLatin1String("ZB-ONOFFPlug-D0005") || 
+                else if (sensor.modelId() == QLatin1String("ZB-ONOFFPlug-D0005") ||
                          sensor.modelId() == QLatin1String("Plug-230V-ZB3.0"))
                 {
                     hasVoltage = false;
@@ -3392,9 +3392,8 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
 
         if (sensor.fingerPrint().hasInCluster(IAS_ZONE_CLUSTER_ID))
         {
-          if ((sensor.manufacturer() == QLatin1String("Samjin") &&
-              (sensor.modelId() == QLatin1String("button") || sensor.modelId() == QLatin1String("multi") || sensor.modelId() == QLatin1String("water"))) ||
-              (sensor.manufacturer() == QLatin1String("CentraLite") && sensor.modelId() == QLatin1String("Motion Sensor-A")))
+          if (sensor.modelId() == QLatin1String("button") || sensor.modelId().startsWith(QLatin1String("multi")) || sensor.modelId() == QLatin1String("water") ||
+              sensor.modelId() == QLatin1String("Motion Sensor-A"))
             {
                 // no support for some IAS Zone flags
             }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2534,6 +2534,11 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
 
                         if (!item)
                         {
+                            if (lightNode->modelId() == QLatin1String("FB56-ZCW08KU1.1"))
+                            {
+                                // Feibit color light exposes color temperature, but doesn't support it, see #2733.
+                                continue;
+                            }
                             item = lightNode->addItem(DataTypeUInt16, RStateCt);
                             DBG_Assert(item != 0);
                         }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5067,6 +5067,9 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
         else if (sensorNode.fingerPrint().hasInCluster(SAMJIN_CLUSTER_ID))
         {
             clusterId = SAMJIN_CLUSTER_ID;
+            item = sensorNode.addItem(DataTypeInt16, RStateOrientationX);
+            item = sensorNode.addItem(DataTypeInt16, RStateOrientationY);
+            item = sensorNode.addItem(DataTypeInt16, RStateOrientationZ);
         }
         item = sensorNode.addItem(DataTypeBool, RStateVibration);
         item->setValue(false);
@@ -5396,15 +5399,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
     else if (node->nodeDescriptor().manufacturerCode() == VENDOR_SAMJIN)
     {
         sensorNode.setManufacturer("Samjin");
-
-        if (sensorNode.type() == QLatin1String("ZHAVibration"))
-        {
-            item = sensorNode.addItem(DataTypeInt16, RStateOrientationX);
-            item = sensorNode.addItem(DataTypeInt16, RStateOrientationY);
-            item = sensorNode.addItem(DataTypeInt16, RStateOrientationZ);
-            item = sensorNode.addItem(DataTypeUInt16, RConfigDuration);
-            item->setValue(0);
-        }
 
         if (fingerPrint.hasInCluster(IAS_ZONE_CLUSTER_ID)) // POLL_CONTROL_CLUSTER_ID
         {
@@ -6629,7 +6623,6 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                     else if (event.clusterId() == SAMJIN_CLUSTER_ID)
                     {
                         bool updated = false;
-                        bool vibration = false;
 
                         for (;ia != enda; ++ia)
                         {
@@ -6640,8 +6633,29 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 continue;
                             }
 
+                            if (ia->id() == 0x0010) // active
+                            {
+                                if (updateType != NodeValue::UpdateInvalid)
+                                {
+                                    i->setZclValue(updateType, event.endpoint(), event.clusterId(), ia->id(), ia->numericValue());
+                                    pushZclValueDb(event.node()->address().ext(), event.endpoint(), event.clusterId(), ia->id(), ia->numericValue().u8);
+                                }
 
-                            if (ia->id() == 0x0012) // accelerate x
+                                ResourceItem *item = i->item(RStateVibration);
+                                if (item)
+                                {
+                                    const bool vibration = ia->numericValue().u8 == 0x01;
+                                    item->setValue(vibration);
+                                    updated = true;
+
+                                    if (item->lastSet() == item->lastChanged())
+                                    {
+                                        Event e(RSensors, item->descriptor().suffix, i->id(), item);
+                                        enqueueEvent(e);
+                                    }
+                                }
+                            }
+                            else if (ia->id() == 0x0012) // accelerate x
                             {
                                 if (updateType != NodeValue::UpdateInvalid)
                                 {
@@ -6660,7 +6674,6 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     {
                                         Event e(RSensors, item->descriptor().suffix, i->id(), item);
                                         enqueueEvent(e);
-                                        vibration = true;
                                     }
                                 }
                             }
@@ -6683,7 +6696,6 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     {
                                         Event e(RSensors, item->descriptor().suffix, i->id(), item);
                                         enqueueEvent(e);
-                                        vibration = true;
                                     }
                                 }
                             }
@@ -6706,7 +6718,6 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     {
                                         Event e(RSensors, item->descriptor().suffix, i->id(), item);
                                         enqueueEvent(e);
-                                        vibration = true;
                                     }
                                 }
                             }
@@ -6714,24 +6725,6 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
 
                         if (updated)
                         {
-                            if (vibration)
-                            {
-                                {
-                                    ResourceItem *item = i->item(RStateVibration);
-                                    if (item)
-                                    {
-                                        item->setValue(true);
-                                        enqueueEvent(Event(RSensors, RStateVibration, i->id(), item));
-
-                                        // prepare to set vibration to false automatically
-                                        ResourceItem *item2 = i->item(RConfigDuration);
-                                        if (item2 && item2->toNumber() > 0)
-                                        {
-                                          i->durationDue = item->lastSet().addSecs(item2->toNumber());
-                                        }
-                                    }
-                                }
-                            }
                             i->setNeedSaveDatabase(true);
                             i->updateStateTimestamp();
                             enqueueEvent(Event(RSensors, RStateLastUpdated, i->id()));

--- a/general.xml
+++ b/general.xml
@@ -2271,7 +2271,7 @@ controller device, that supports a keypad and LCD screen.</description>
 			<client>
 			</client>
 		</cluster>
-		
+
 		<cluster id="0x0501" name="IAS ACE">
 			<description>The IAS ACE cluster defines an interface to the functionality of any Ancillary Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE device can access a IAS CIE device and manipulate the IAS system, on behalf of a level-2 user.</description>
 			<server>
@@ -2492,7 +2492,7 @@ controller device, that supports a keypad and LCD screen.</description>
 				</command>
 			</client>
 		</cluster>
-		
+
 		<cluster id="0x0502" name="IAS WD">
 			<description>The IAS WD cluster provides an interface to the functionality of any Warning Device equipment of the IAS system. Using this cluster, a ZigBee enabled CIE device can access a ZigBee enabled IAS WD device and issue alarm warning indications (siren, strobe lighting, etc.) when a system alarm condition is detected.</description>
 			<server>
@@ -2970,8 +2970,19 @@ Fil pilote > Off=0001 - On=0002</description>
 		</cluster>
 
 		<!-- Samjin -->
+    <cluster id="0xfc02" name="Samjin" mfcode="0x110a">
+			<description>Samjin manufacturer-specifc cluster for SmartThings multi sensor.</description>
+			<server>
+				<attribute id="0x0000" name="Unknown" type="u8" mfcode="0x110a" default="0" access="r" required="m"> </attribute>
+				<attribute id="0x0012" name="Acceleration X" type="s16" mfcode="0x110a" default="0" access="r" required="m"> </attribute>
+				<attribute id="0x0013" name="Acceleration Y" type="s16" mfcode="0x110a" default="0" access="r" required="m"> </attribute>
+				<attribute id="0x0014" name="Acceleration Z" type="s16" mfcode="0x110a" default="0" access="r" required="m"> </attribute>
+			</server>
+			<client>
+			</client>
+		</cluster>
 		<cluster id="0xfc02" name="Samjin" mfcode="0x1241">
-			<description>Attributes and commands.</description>
+			<description>Samjin manufacturer-specifc cluster for SmartThings multi sensor.</description>
 			<server>
 				<attribute id="0x0000" name="Unknown" type="u8" mfcode="0x1241" default="0" access="r" required="m"> </attribute>
 				<attribute id="0x0012" name="Acceleration X" type="s16" mfcode="0x1241" default="0" access="r" required="m"> </attribute>
@@ -3046,7 +3057,7 @@ Fil pilote > Off=0001 - On=0002</description>
 			<client>
 			</client>
 		</cluster>
-		
+
 		<!-- INNR -->
 		<cluster id="0xfc82" name="innr" mfcode="0x1166">
 			<description>innr specific attributes.</description>

--- a/general.xml
+++ b/general.xml
@@ -2974,7 +2974,7 @@ Fil pilote > Off=0001 - On=0002</description>
 			<description>Samjin manufacturer-specifc cluster for SmartThings multi sensor.</description>
 			<server>
         <attribute id="0x0000" name="Motion Threshold Multiplier" type="u8" mfcode="0x104e" default="0" access="rw" required="m"> </attribute>
-        <attribute id="0x0001" name="Motion Threshold" type="u16" mfcode="0x104e" default="0" access="rw" required="m"> </attribute>
+        <attribute id="0x0002" name="Motion Threshold" type="u16" mfcode="0x104e" default="0" access="rw" required="m"> </attribute>
         <attribute id="0x0010" name="Active" type="bmp8" mfcode="0x104e" default="0" access="r" required="m">
           <value name="Active" value="0"></value>
         </attribute>
@@ -2989,7 +2989,7 @@ Fil pilote > Off=0001 - On=0002</description>
 			<description>Samjin manufacturer-specifc cluster for SmartThings multi sensor.</description>
 			<server>
         <attribute id="0x0000" name="Motion Threshold Multiplier" type="u8" mfcode="0x110a" default="0" access="rw" required="m"> </attribute>
-        <attribute id="0x0001" name="Motion Threshold" type="u16" mfcode="0x110a" default="0" access="rw" required="m"> </attribute>
+        <attribute id="0x0002" name="Motion Threshold" type="u16" mfcode="0x110a" default="0" access="rw" required="m"> </attribute>
         <attribute id="0x0010" name="Active" type="bmp8" mfcode="0x110a" default="0" access="r" required="m">
           <value name="Active" value="0"></value>
         </attribute>
@@ -3004,7 +3004,6 @@ Fil pilote > Off=0001 - On=0002</description>
 			<description>Samjin manufacturer-specifc cluster for SmartThings multi sensor.</description>
 			<server>
 				<attribute id="0x0000" name="Motion Threshold Multiplier" type="u8" mfcode="0x1241" default="0" access="rw" required="m"> </attribute>
-        <attribute id="0x0001" name="Motion Threshold" type="u16" mfcode="0x1241" default="0" access="rw" required="m"> </attribute>
         <attribute id="0x0010" name="Active" type="bmp8" mfcode="0x1241" default="0" access="r" required="m">
           <value name="Active" value="0"></value>
         </attribute>

--- a/general.xml
+++ b/general.xml
@@ -2970,10 +2970,29 @@ Fil pilote > Off=0001 - On=0002</description>
 		</cluster>
 
 		<!-- Samjin -->
+    <cluster id="0xfc02" name="Samjin" mfcode="0x104e">
+			<description>Samjin manufacturer-specifc cluster for SmartThings multi sensor.</description>
+			<server>
+        <attribute id="0x0000" name="Motion Threshold Multiplier" type="u8" mfcode="0x104e" default="0" access="rw" required="m"> </attribute>
+        <attribute id="0x0001" name="Motion Threshold" type="u16" mfcode="0x104e" default="0" access="rw" required="m"> </attribute>
+        <attribute id="0x0010" name="Active" type="bmp8" mfcode="0x104e" default="0" access="r" required="m">
+          <value name="Active" value="0"></value>
+        </attribute>
+				<attribute id="0x0012" name="Acceleration X" type="s16" mfcode="0x104e" default="0" access="r" required="m"> </attribute>
+				<attribute id="0x0013" name="Acceleration Y" type="s16" mfcode="0x104e" default="0" access="r" required="m"> </attribute>
+				<attribute id="0x0014" name="Acceleration Z" type="s16" mfcode="0x104e" default="0" access="r" required="m"> </attribute>
+			</server>
+			<client>
+			</client>
+		</cluster>
     <cluster id="0xfc02" name="Samjin" mfcode="0x110a">
 			<description>Samjin manufacturer-specifc cluster for SmartThings multi sensor.</description>
 			<server>
-				<attribute id="0x0000" name="Unknown" type="u8" mfcode="0x110a" default="0" access="r" required="m"> </attribute>
+        <attribute id="0x0000" name="Motion Threshold Multiplier" type="u8" mfcode="0x110a" default="0" access="rw" required="m"> </attribute>
+        <attribute id="0x0001" name="Motion Threshold" type="u16" mfcode="0x110a" default="0" access="rw" required="m"> </attribute>
+        <attribute id="0x0010" name="Active" type="bmp8" mfcode="0x110a" default="0" access="r" required="m">
+          <value name="Active" value="0"></value>
+        </attribute>
 				<attribute id="0x0012" name="Acceleration X" type="s16" mfcode="0x110a" default="0" access="r" required="m"> </attribute>
 				<attribute id="0x0013" name="Acceleration Y" type="s16" mfcode="0x110a" default="0" access="r" required="m"> </attribute>
 				<attribute id="0x0014" name="Acceleration Z" type="s16" mfcode="0x110a" default="0" access="r" required="m"> </attribute>
@@ -2984,7 +3003,11 @@ Fil pilote > Off=0001 - On=0002</description>
 		<cluster id="0xfc02" name="Samjin" mfcode="0x1241">
 			<description>Samjin manufacturer-specifc cluster for SmartThings multi sensor.</description>
 			<server>
-				<attribute id="0x0000" name="Unknown" type="u8" mfcode="0x1241" default="0" access="r" required="m"> </attribute>
+				<attribute id="0x0000" name="Motion Threshold Multiplier" type="u8" mfcode="0x1241" default="0" access="rw" required="m"> </attribute>
+        <attribute id="0x0001" name="Motion Threshold" type="u16" mfcode="0x1241" default="0" access="rw" required="m"> </attribute>
+        <attribute id="0x0010" name="Active" type="bmp8" mfcode="0x1241" default="0" access="r" required="m">
+          <value name="Active" value="0"></value>
+        </attribute>
 				<attribute id="0x0012" name="Acceleration X" type="s16" mfcode="0x1241" default="0" access="r" required="m"> </attribute>
 				<attribute id="0x0013" name="Acceleration Y" type="s16" mfcode="0x1241" default="0" access="r" required="m"> </attribute>
 				<attribute id="0x0014" name="Acceleration Z" type="s16" mfcode="0x1241" default="0" access="r" required="m"> </attribute>

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -2266,7 +2266,7 @@ void DeRestPluginPrivate::checkSensorStateTimerFired()
                         enqueueEvent(Event(RSensors, RStateLastUpdated, sensor->id()));
                     }
                 }
-                else if (!item && (sensor->modelId() == QLatin1String("lumi.vibration.aq1") || sensor->modelId() == QLatin1String("multi")) && sensor->type() == QLatin1String("ZHAVibration"))
+                else if (!item && (sensor->modelId().startsWith(QLatin1String("lumi.vibration")) || sensor->modelId().startsWith(QLatin1String("multi"))) && sensor->type() == QLatin1String("ZHAVibration"))
                 {
                     item = sensor->item(RStateVibration);
                     if (item && item->toBool())

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -2266,7 +2266,7 @@ void DeRestPluginPrivate::checkSensorStateTimerFired()
                         enqueueEvent(Event(RSensors, RStateLastUpdated, sensor->id()));
                     }
                 }
-                else if (!item && (sensor->modelId().startsWith(QLatin1String("lumi.vibration")) || sensor->modelId().startsWith(QLatin1String("multi"))) && sensor->type() == QLatin1String("ZHAVibration"))
+                else if (!item && sensor->modelId().startsWith(QLatin1String("lumi.vibration")) && sensor->type() == QLatin1String("ZHAVibration"))
                 {
                     item = sensor->item(RStateVibration);
                     if (item && item->toBool())

--- a/zcl_tasks.cpp
+++ b/zcl_tasks.cpp
@@ -389,9 +389,6 @@ bool DeRestPluginPrivate::addTaskSetColorTemperature(TaskItem &task, uint16_t ct
         bool supportsXy = colorCaps && colorCaps->toNumber() & 0x0008;
         bool supportsCt = colorCaps && colorCaps->toNumber() & 0x0010;
         bool useXy = supportsXy && !supportsCt;
-        // IKEA lights need to use "xy" because move to color temperature is broken and
-        // won't update x,y values resulting in broken scenes.
-        useXy = useXy || task.lightNode->manufacturerCode() == VENDOR_IKEA;
 
         if (useXy)
         {


### PR DESCRIPTION
See #1848, #1264

See SmartThings [groovy](https://github.com/SmartThingsCommunity/SmartThingsPublic/blob/master/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy) file.

- Update `general.xml` with additional attributed for 0xFC02 (Samjin) cluster and add cluster for SmartThings (Physical) and Centralite manufacturer codes;
- Sensor actually exposes _Active_ attribute (0x0010) for `state.vibration`, so use that to reset vibration.  Remove `config.duration` and automatic reset by REST API plugin;
- Adjust attribute reporting;
- Add support for 2016 model `multiv4` by `SmartThings` (untested);
- Add support for vibration for Centralite variant (untested).

Additional bug fixes:
- Don't expose `state.ct` for Feibit color light. It exposes color temperature, but doesn't support it, see #2733.
- Remove unholy hack to set colour temperature for IKEA lights as `xy`, see #2507.
