### PR TITLE
Re-enable setting `ct` for IKEA CWS light.

### DIFF
--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -653,7 +653,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
                 }
             }
         }
-        else if (param == "ct"  && taskRef.lightNode->item(RStateCt))
+        else if (param == "ct"  && (taskRef.lightNode->item(RStateCt) || taskRef.lightNode->manufacturerCode() == VENDOR_IKEA)) // FIXME workaround for IKEA CWS
         {
             paramOk = true;
             hasCmd = true;


### PR DESCRIPTION
Re-enable setting `ct` for IKEA CWS light, even though the light doesn't support it.  See #2798 and discussion with @manup in #general on Discord.

Note that it would also be possible once again, to set `ct` on IKEA dimmable lights.  Not sure how the code would react to this.