### PR TITLE
Hampton Bay fan module

### DIFF
--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1273,8 +1273,10 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
     // state.speed
     if (hasSpeed)
     {
+        TaskItem task;
+        copyTaskReq(taskRef, task);
         const quint16 cluster = FAN_CONTROL_CLUSTER_ID;
-        const quint16 attrId = 0x0000; // Fan Mode
+        const quint16 attr = 0x0000; // Fan Mode
         const quint8 type = deCONZ::Zcl8BitEnum;
         const quint8 value = targetSpeed;
 
@@ -1312,7 +1314,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
 
         // FIXME: Use following code once ZclAttribute has been fixed.
 
-        // deCONZ::ZclAttribute attr(attrId, type, "speed", deCONZ::ZclReadWrite, true);
+        // deCONZ::ZclAttribute attr(0x0000, type, "speed", deCONZ::ZclReadWrite, true);
         // attr.setValue(value);
         // ok = writeAttribute(taskRef.lightNode, taskRef.lightNode->haEndpoint().endpoint(), cluster, attr);
 
@@ -1627,7 +1629,7 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
 
             // FIXME: Use following code once ZclAttribute has been fixed.
 
-            // deCONZ::ZclAttribute attr(attr, type, "value", deCONZ::ZclReadWrite, true);
+            // deCONZ::ZclAttribute attr(0x0055, type, "value", deCONZ::ZclReadWrite, true);
             // attr.setValue(QVariant(value));
             // ok = writeAttribute(taskRef.lightNode, taskRef.lightNode->haEndpoint().endpoint(), cluster, attr);
         }

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1273,23 +1273,22 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
     // state.speed
     if (hasSpeed)
     {
-        TaskItem task;
-        copyTaskReq(taskRef, task);
         const quint16 cluster = FAN_CONTROL_CLUSTER_ID;
         const quint16 attrId = 0x0000; // Fan Mode
         const quint8 type = deCONZ::Zcl8BitEnum;
+        const quint64 speed = targetSpeed;
 
         deCONZ::ZclAttribute attr(attrId, type, "speed", deCONZ::ZclReadWrite, true);
-        attr.setValue((quint64) targetSpeed);
+        attr.setValue(speed);
         ok = writeAttribute(taskRef.lightNode, taskRef.lightNode->haEndpoint().endpoint(), cluster, attr);
-        if (addTask(task))
+        if (ok)
         {
             QVariantMap rspItem;
             QVariantMap rspItemState;
             rspItemState[QString("/lights/%1/state/speed").arg(id)] = map["speed"];
             rspItem["success"] = rspItemState;
             rsp.list.append(rspItem);
-            taskToLocalData(task);
+            // Rely on attribute reporting to update state.speed
         }
         else
         {


### PR DESCRIPTION
Workaround for broken `deCONZ::ZclAttribute`: doesn't support `Zcl8BitEnum` either, see #932.