### PR TITLE
Changed Link button not pressed message

### DIFF
--- a/authorisation.cpp
+++ b/authorisation.cpp
@@ -121,7 +121,7 @@ bool DeRestPluginPrivate::allowedToCreateApikey(const ApiRequest &req, ApiRespon
     }
 
     rsp.httpStatus = HttpStatusForbidden;
-    rsp.list.append(errorToMap(ERR_LINK_BUTTON_NOT_PRESSED, "/", "link button not pressed"));
+    rsp.list.append(errorToMap(ERR_LINK_BUTTON_NOT_PRESSED, "/", "Authenticate button not pressed"));
     return false;
 }
 


### PR DESCRIPTION
The "link button not pressed" error on API is kinda confusing as it is called "authenticate" in Phoscon. This change makes that easier.