### PR TITLE
Add support for OSRAM Lightify 'Switch Mini' and 'Switch 4x' remotes

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1170,7 +1170,8 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq.reportableChange8bit = 0;
         }
         else if (sensor && (sensor->modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
-                            sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY"))) ) // Osram 4 button remote
+                            sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+                            sensor->modelId().startsWith(QLatin1String("Switch-LIGHTIFY"))) ) // Osram 4 button remote
         {
             rq.attributeId = 0x0020;
             rq.minInterval = 21600;
@@ -1934,6 +1935,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         // OSRAM
         sensor->modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
         sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+        sensor->modelId().startsWith(QLatin1String("Switch-LIGHTIFY")) || // Osram 4 button remote
         // Keen Home
         sensor->modelId().startsWith(QLatin1String("SV01-")) ||
         // Trust ZPIR-8000
@@ -2103,8 +2105,9 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         }
     }
     
-    if (sensor->modelId().startsWith(QLatin1String("Lightify Switch Mini")) || // Osram 3 button remote
-        sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) ) // Osram 4 button remote
+    if (sensor->modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
+        sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+        sensor->modelId().startsWith(QLatin1String("Switch-LIGHTIFY")) ) // Osram 4 button remote
     {
         // Make bind only for endpoint 01
         if (sensor->fingerPrint().endpoint != 0x01)
@@ -2185,8 +2188,9 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
                      sensor->modelId() == QLatin1String("MOSZB-130") ||
                      sensor->modelId() == QLatin1String("FLSZB-110") ||
                      sensor->modelId() == QLatin1String("Zen-01") ||
-                     sensor->modelId() == QLatin1String("Lightify Switch Mini") ||  // Osram 3 button remote
-                     sensor->modelId() == QLatin1String("Switch 4x EU-LIGHTIFY") || // Osram 4 button remote
+                     sensor->modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
+                     sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+                     sensor->modelId().startsWith(QLatin1String("Switch-LIGHTIFY")) || // Osram 4 button remote
                      sensor->modelId() == QLatin1String("Remote switch") ||
                      sensor->modelId() == QLatin1String("Shutters central remote switch") ||
                      sensor->modelId() == QLatin1String("Double gangs remote switch") ||
@@ -2544,7 +2548,8 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
         srcEndpoints.push_back(0x03);
     }
     // OSRAM 4 button remote
-    else if (sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) )
+    else if (sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || 
+             sensor->modelId().startsWith(QLatin1String("Switch-LIGHTIFY")) )
     {
         clusters.push_back(ONOFF_CLUSTER_ID);
         clusters.push_back(LEVEL_CLUSTER_ID);
@@ -2804,11 +2809,13 @@ void DeRestPluginPrivate::checkSensorGroup(Sensor *sensor)
     {
         //Make group but without uniqueid
     }
-    else if (sensor->modelId().startsWith(QLatin1String("Lightify Switch Mini")) || // Osram 3 button remote
-             sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) ) // Osram 4 button remote
+    else if (sensor->modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
+             sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+             sensor->modelId().startsWith(QLatin1String("Switch-LIGHTIFY")) ) // Osram 4 button remote
     {
         quint8 maxEp = 0x03;
-        if (sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")))
+        if (sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || 
+            sensor->modelId().startsWith(QLatin1String("Switch-LIGHTIFY")) )
         {
             maxEp = 0x04;
         }

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1171,6 +1171,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         }
         else if (sensor && (sensor->modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
                             sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+                            sensor->modelId().startsWith(QLatin1String("Switch 4x-LIGHTIFY")) || // Osram 4 button remote
                             sensor->modelId().startsWith(QLatin1String("Switch-LIGHTIFY"))) ) // Osram 4 button remote
         {
             rq.attributeId = 0x0020;
@@ -1935,6 +1936,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         // OSRAM
         sensor->modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
         sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+        sensor->modelId().startsWith(QLatin1String("Switch 4x-LIGHTIFY")) || // Osram 4 button remote
         sensor->modelId().startsWith(QLatin1String("Switch-LIGHTIFY")) || // Osram 4 button remote
         // Keen Home
         sensor->modelId().startsWith(QLatin1String("SV01-")) ||
@@ -2107,6 +2109,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
     
     if (sensor->modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
         sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+        sensor->modelId().startsWith(QLatin1String("Switch 4x-LIGHTIFY")) || // Osram 4 button remote
         sensor->modelId().startsWith(QLatin1String("Switch-LIGHTIFY")) ) // Osram 4 button remote
     {
         // Make bind only for endpoint 01
@@ -2190,6 +2193,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
                      sensor->modelId() == QLatin1String("Zen-01") ||
                      sensor->modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
                      sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+                     sensor->modelId().startsWith(QLatin1String("Switch 4x-LIGHTIFY")) || // Osram 4 button remote
                      sensor->modelId().startsWith(QLatin1String("Switch-LIGHTIFY")) || // Osram 4 button remote
                      sensor->modelId() == QLatin1String("Remote switch") ||
                      sensor->modelId() == QLatin1String("Shutters central remote switch") ||
@@ -2549,6 +2553,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
     }
     // OSRAM 4 button remote
     else if (sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || 
+             sensor->modelId().startsWith(QLatin1String("Switch 4x-LIGHTIFY")) || 
              sensor->modelId().startsWith(QLatin1String("Switch-LIGHTIFY")) )
     {
         clusters.push_back(ONOFF_CLUSTER_ID);
@@ -2811,10 +2816,12 @@ void DeRestPluginPrivate::checkSensorGroup(Sensor *sensor)
     }
     else if (sensor->modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
              sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+             sensor->modelId().startsWith(QLatin1String("Switch 4x-LIGHTIFY")) || // Osram 4 button remote
              sensor->modelId().startsWith(QLatin1String("Switch-LIGHTIFY")) ) // Osram 4 button remote
     {
         quint8 maxEp = 0x03;
         if (sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || 
+            sensor->modelId().startsWith(QLatin1String("Switch 4x-LIGHTIFY")) || 
             sensor->modelId().startsWith(QLatin1String("Switch-LIGHTIFY")) )
         {
             maxEp = 0x04;

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1172,9 +1172,9 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         else if (sensor && (sensor->modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
                             sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY"))) ) // Osram 4 button remote
         {
-            rq.attributeId = 0x0020;    // battery voltage
-            rq.minInterval = 3600;      // 1 hour
-            rq.maxInterval = 3600;      // 1 hour
+            rq.attributeId = 0x0020;
+            rq.minInterval = 21600;
+            rq.maxInterval = 21600;
             rq.reportableChange8bit = 0;
         }
         else if (sensor && (sensor->modelId().startsWith(QLatin1String("SMSZB-120")) || // Develco smoke sensor

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5666,16 +5666,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                         sensorNode.enableRead(READ_BATTERY);
                         queryTime = queryTime.addSecs(1);
                     }
-                } 
-                else if (sensorNode.modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
-                         sensorNode.modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
-                         sensorNode.modelId().startsWith(QLatin1String("Switch-LIGHTIFY")) ) // Osram 4 button remote
-                )
-                {
-                    sensorNode.setNextReadTime(READ_BATTERY, queryTime);
-                    sensorNode.setLastRead(READ_BATTERY, idleTotalCounter);
-                    sensorNode.enableRead(READ_BATTERY);
-                    queryTime = queryTime.addSecs(1);
                 }
             }
         }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -209,6 +209,7 @@ static const SupportedDevice supportedDevices[] = {
     // { VENDOR_OSRAM_STACK, "Plug", osramMacPrefix }, // OSRAM plug - exposed only as light
     { VENDOR_OSRAM, "Lightify Switch Mini", emberMacPrefix }, // Osram 3 button remote
     { VENDOR_OSRAM, "Switch 4x EU-LIGHTIFY", emberMacPrefix }, // Osram 4 button remote
+    { VENDOR_OSRAM, "Switch-LIGHTIFY", emberMacPrefix }, // Osram 4 button remote
     { VENDOR_OSRAM_STACK, "CO_", heimanMacPrefix }, // Heiman CO sensor
     { VENDOR_OSRAM_STACK, "DOOR_", heimanMacPrefix }, // Heiman door/window sensor - older model
     { VENDOR_OSRAM_STACK, "PIR_", heimanMacPrefix }, // Heiman motion sensor
@@ -742,8 +743,9 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
                     else if (sensorNode->modelId().startsWith("C4") || // ubisys
                              sensorNode->modelId().startsWith("RC 110") || // innr RC 110
                              sensorNode->modelId().startsWith("ICZB-RM") || // icasa remote
-                             sensorNode->modelId().startsWith(QLatin1String("Lightify Switch Mini")) || // Osram 3 button remote
-                             sensorNode->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) ) // Osram 4 button remote
+                             sensorNode->modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
+                             sensorNode->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+                             sensorNode->modelId().startsWith(QLatin1String("Switch-LIGHTIFY")) ) // Osram 4 button remote
                     {
                         sensorNode = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), 0x01);
                     }
@@ -3393,8 +3395,9 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
     {
         checkReporting = true;
     }
-    else if (sensor->modelId().startsWith(QLatin1String("Lightify Switch Mini")) || // Osram 3 button remote
-             sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")))  // Osram 4 button remote
+    else if (sensor->modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
+             sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+             sensor->modelId().startsWith(QLatin1String("Switch-LIGHTIFY")) ) // Osram 4 button remote
     {
         checkReporting = true;
         checkClientCluster = true;
@@ -3784,8 +3787,9 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
             else if (ind.clusterId() == COLOR_CLUSTER_ID && (zclFrame.commandId() == 0x01 ) )  // Move hue command
             {
                 // Only used by Osram devices currently
-                if (sensor->modelId().startsWith(QLatin1String("Lightify Switch Mini")) || // Osram 3 button remote
-                    sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) ) // Osram 4 button remote
+                if (sensor->modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
+                    sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+                    sensor->modelId().startsWith(QLatin1String("Switch-LIGHTIFY")) ) // Osram 4 button remote
                 {
                     quint8 pl0 = zclFrame.payload().isEmpty() ? 0 : zclFrame.payload().at(0);
                     if (buttonMap->zclParam0 != pl0)
@@ -4091,8 +4095,9 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     {
                         // ignore second endpoint
                     }
-                    else if (modelId.startsWith(QLatin1String("Lightify Switch Mini")) || // Osram 3 button remote
-                             modelId.startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) ) // Osram 4 button remote
+                    else if (modelId.startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
+                             modelId.startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+                             modelId.startsWith(QLatin1String("Switch-LIGHTIFY")) ) // Osram 4 button remote
                     {
                         // Don't create entry for this cluster
                     }
@@ -4485,8 +4490,9 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     {
                         fpPresenceSensor.outClusters.push_back(ci->id());
                     }
-                    else if (modelId.startsWith(QLatin1String("Lightify Switch Mini")) || // Osram 3 button remote
-                             modelId.startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) ) // Osram 4 button remote
+                    else if (modelId.startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
+                             modelId.startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+                             modelId.startsWith(QLatin1String("Switch-LIGHTIFY")) ) // Osram 4 button remote
                     {
                         // Only create entry for endpoint 0x01
                         fpSwitch.outClusters.push_back(ci->id());
@@ -4573,8 +4579,9 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                 fpSwitch.endpoint = 2;
             }
             
-            if (modelId.startsWith(QLatin1String("Lightify Switch Mini")) || // Osram 3 button remote
-                modelId.startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) ) // Osram 4 button remote
+            if (modelId.startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
+                modelId.startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+                modelId.startsWith(QLatin1String("Switch-LIGHTIFY")) ) // Osram 4 button remote
             {
                 sensor = getSensorNodeForAddress(node->address().ext());
                 if (sensor && sensor->deletedState() != Sensor::StateNormal)
@@ -5646,7 +5653,9 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             else if (*ci == POWER_CONFIGURATION_CLUSTER_ID)
             {
                 //This device make a Rejoin every time, you trigger it, it's the only moment where you can read attribute.
-                if (sensorNode.modelId() == QLatin1String("Remote switch") || sensorNode.modelId() == QLatin1String("Shutters central remote switch") || sensorNode.modelId() == QLatin1String("Double gangs remote switch") )
+                if (sensorNode.modelId() == QLatin1String("Remote switch") || 
+                    sensorNode.modelId() == QLatin1String("Shutters central remote switch") || 
+                    sensorNode.modelId() == QLatin1String("Double gangs remote switch") )
                 {
                     //Ask for battery but only every day max
                     //int diff = idleTotalCounter - sensorNode.lastRead(READ_BATTERY);
@@ -5657,6 +5666,16 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                         sensorNode.enableRead(READ_BATTERY);
                         queryTime = queryTime.addSecs(1);
                     }
+                } 
+                else if (sensorNode.modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
+                         sensorNode.modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+                         sensorNode.modelId().startsWith(QLatin1String("Switch-LIGHTIFY")) ) // Osram 4 button remote
+                )
+                {
+                    sensorNode.setNextReadTime(READ_BATTERY, queryTime);
+                    sensorNode.setLastRead(READ_BATTERY, idleTotalCounter);
+                    sensorNode.enableRead(READ_BATTERY);
+                    queryTime = queryTime.addSecs(1);
                 }
             }
         }
@@ -6244,8 +6263,9 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     i->modelId().startsWith(QLatin1String("lumi.sen_ill")) || // Xiaomi ZB3.0 light sensor
                                     i->modelId().startsWith(QLatin1String("SZ-DWS04"))   || // Sercomm open/close sensor
                                     i->modelId().startsWith(QLatin1String("Tripper")) || // Quirky Tripper (Sercomm) open/close
-                                    i->modelId().startsWith(QLatin1String("Lightify Switch Mini")) || // Osram 3 button remote
-                                    i->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) ) // Osram 4 button remote
+                                    i->modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
+                                    i->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+                                    i->modelId().startsWith(QLatin1String("Switch-LIGHTIFY")) ) // Osram 4 button remote
                                 {  }
                                 else
                                 {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -209,6 +209,7 @@ static const SupportedDevice supportedDevices[] = {
     // { VENDOR_OSRAM_STACK, "Plug", osramMacPrefix }, // OSRAM plug - exposed only as light
     { VENDOR_OSRAM, "Lightify Switch Mini", emberMacPrefix }, // Osram 3 button remote
     { VENDOR_OSRAM, "Switch 4x EU-LIGHTIFY", emberMacPrefix }, // Osram 4 button remote
+    { VENDOR_OSRAM, "Switch 4x-LIGHTIFY", emberMacPrefix }, // Osram 4 button remote
     { VENDOR_OSRAM, "Switch-LIGHTIFY", emberMacPrefix }, // Osram 4 button remote
     { VENDOR_OSRAM_STACK, "CO_", heimanMacPrefix }, // Heiman CO sensor
     { VENDOR_OSRAM_STACK, "DOOR_", heimanMacPrefix }, // Heiman door/window sensor - older model
@@ -745,6 +746,7 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
                              sensorNode->modelId().startsWith("ICZB-RM") || // icasa remote
                              sensorNode->modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
                              sensorNode->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+                             sensorNode->modelId().startsWith(QLatin1String("Switch 4x-LIGHTIFY")) || // Osram 4 button remote
                              sensorNode->modelId().startsWith(QLatin1String("Switch-LIGHTIFY")) ) // Osram 4 button remote
                     {
                         sensorNode = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), 0x01);
@@ -3397,6 +3399,7 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
     }
     else if (sensor->modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
              sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+             sensor->modelId().startsWith(QLatin1String("Switch 4x-LIGHTIFY")) || // Osram 4 button remote
              sensor->modelId().startsWith(QLatin1String("Switch-LIGHTIFY")) ) // Osram 4 button remote
     {
         checkReporting = true;
@@ -3789,6 +3792,7 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                 // Only used by Osram devices currently
                 if (sensor->modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
                     sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+                    sensor->modelId().startsWith(QLatin1String("Switch 4x-LIGHTIFY")) || // Osram 4 button remote
                     sensor->modelId().startsWith(QLatin1String("Switch-LIGHTIFY")) ) // Osram 4 button remote
                 {
                     quint8 pl0 = zclFrame.payload().isEmpty() ? 0 : zclFrame.payload().at(0);
@@ -4097,6 +4101,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     }
                     else if (modelId.startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
                              modelId.startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+                             modelId.startsWith(QLatin1String("Switch 4x-LIGHTIFY")) || // Osram 4 button remote
                              modelId.startsWith(QLatin1String("Switch-LIGHTIFY")) ) // Osram 4 button remote
                     {
                         // Don't create entry for this cluster
@@ -4492,6 +4497,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     }
                     else if (modelId.startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
                              modelId.startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+                             modelId.startsWith(QLatin1String("Switch 4x-LIGHTIFY")) || // Osram 4 button remote
                              modelId.startsWith(QLatin1String("Switch-LIGHTIFY")) ) // Osram 4 button remote
                     {
                         // Only create entry for endpoint 0x01
@@ -4581,6 +4587,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
             
             if (modelId.startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
                 modelId.startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+                modelId.startsWith(QLatin1String("Switch 4x-LIGHTIFY")) || // Osram 4 button remote
                 modelId.startsWith(QLatin1String("Switch-LIGHTIFY")) ) // Osram 4 button remote
             {
                 sensor = getSensorNodeForAddress(node->address().ext());
@@ -6255,6 +6262,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     i->modelId().startsWith(QLatin1String("Tripper")) || // Quirky Tripper (Sercomm) open/close
                                     i->modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
                                     i->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+                                    i->modelId().startsWith(QLatin1String("Switch 4x-LIGHTIFY")) || // Osram 4 button remote
                                     i->modelId().startsWith(QLatin1String("Switch-LIGHTIFY")) ) // Osram 4 button remote
                                 {  }
                                 else

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -161,21 +161,21 @@ static const Sensor::ButtonMap osramMiniRemoteMap[] = {
 static const Sensor::ButtonMap osram4ButRemoteMap[] = {
     // mode               ep    cluster cmd   param    button                                       name
     // Button upper-left
-    { Sensor::ModeScenes, 0x01, 0x0006, 0x01, 0x00,    S_BUTTON_1 + S_BUTTON_ACTION_HOLD,           "UL press short" },
-    { Sensor::ModeScenes, 0x01, 0x0008, 0x05, 0x00,    S_BUTTON_1 + S_BUTTON_ACTION_SHORT_RELEASED, "UL long press" },
-    { Sensor::ModeScenes, 0x01, 0x0008, 0x03, 0x00,    S_BUTTON_1 + S_BUTTON_ACTION_LONG_RELEASED,  "UL press release" },
+    { Sensor::ModeScenes, 0x01, 0x0008, 0x05, 0x00,    S_BUTTON_1 + S_BUTTON_ACTION_SHORT_RELEASED, "UL short press" },
+    { Sensor::ModeScenes, 0x01, 0x0006, 0x01, 0x00,    S_BUTTON_1 + S_BUTTON_ACTION_HOLD,           "UL long press" },
+    { Sensor::ModeScenes, 0x01, 0x0008, 0x03, 0x00,    S_BUTTON_1 + S_BUTTON_ACTION_LONG_RELEASED,  "UL long release" },
     // Button upper-right
-    { Sensor::ModeScenes, 0x02, 0x0300, 0x4C, 0x01,    S_BUTTON_2 + S_BUTTON_ACTION_LONG_RELEASED,  "UR short press" },
-    { Sensor::ModeScenes, 0x02, 0x0300, 0x03, 0xFE,    S_BUTTON_2 + S_BUTTON_ACTION_HOLD,           "UR press long" },
-    { Sensor::ModeScenes, 0x02, 0x0300, 0x01, 0x00,    S_BUTTON_2 + S_BUTTON_ACTION_LONG_RELEASED,  "UR press Release" },
+    { Sensor::ModeScenes, 0x02, 0x0300, 0x4C, 0x01,    S_BUTTON_2 + S_BUTTON_ACTION_SHORT_RELEASED, "UR short press" },
+    { Sensor::ModeScenes, 0x02, 0x0300, 0x03, 0xFE,    S_BUTTON_2 + S_BUTTON_ACTION_HOLD,           "UR long press" },
+    { Sensor::ModeScenes, 0x02, 0x0300, 0x01, 0x00,    S_BUTTON_2 + S_BUTTON_ACTION_LONG_RELEASED,  "UR long release" },
     // Button lower-left 
     { Sensor::ModeScenes, 0x03, 0x0006, 0x00, 0x00,    S_BUTTON_3 + S_BUTTON_ACTION_SHORT_RELEASED, "LL short press" },
-    { Sensor::ModeScenes, 0x03, 0x0008, 0x01, 0x01,    S_BUTTON_3 + S_BUTTON_ACTION_HOLD,           "LL press long" },
-    { Sensor::ModeScenes, 0x03, 0x0008, 0x03, 0x01,    S_BUTTON_3 + S_BUTTON_ACTION_LONG_RELEASED,  "LL press release" },
+    { Sensor::ModeScenes, 0x03, 0x0008, 0x01, 0x01,    S_BUTTON_3 + S_BUTTON_ACTION_HOLD,           "LL long press" },
+    { Sensor::ModeScenes, 0x03, 0x0008, 0x03, 0x01,    S_BUTTON_3 + S_BUTTON_ACTION_LONG_RELEASED,  "LL long release" },
     // Button lower-right 
     { Sensor::ModeScenes, 0x04, 0x0300, 0x4C, 0x03,    S_BUTTON_4 + S_BUTTON_ACTION_SHORT_RELEASED, "LR short press" },
-    { Sensor::ModeScenes, 0x04, 0x0300, 0x03, 0xFE,    S_BUTTON_4 + S_BUTTON_ACTION_HOLD,           "LR press long" },
-    { Sensor::ModeScenes, 0x04, 0x0300, 0x01, 0x00,    S_BUTTON_4 + S_BUTTON_ACTION_LONG_RELEASED,  "LR press release" },
+    { Sensor::ModeScenes, 0x04, 0x0300, 0x03, 0xFE,    S_BUTTON_4 + S_BUTTON_ACTION_HOLD,           "LR long press" },
+    { Sensor::ModeScenes, 0x04, 0x0300, 0x01, 0x00,    S_BUTTON_4 + S_BUTTON_ACTION_LONG_RELEASED,  "LR long release" },
     // end
     { Sensor::ModeNone,             0x00, 0x0000, 0x00, 0,    0,                                           nullptr }
 };

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -1324,6 +1324,7 @@ const Sensor::ButtonMap *Sensor::buttonMap()
         {
             if      (modelid.startsWith(QLatin1String("Lightify Switch Mini"))) { m_buttonMap = osramMiniRemoteMap; }
             else if (modelid.startsWith(QLatin1String("Switch 4x EU-LIGHTIFY"))) { m_buttonMap = osram4ButRemoteMap; }
+            else if (modelid.startsWith(QLatin1String("Switch-LIGHTIFY"))) { m_buttonMap = osram4ButRemoteMap; }
         }
         else if (manufacturer == QLatin1String("ubisys"))
         {

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -158,6 +158,7 @@ static const Sensor::ButtonMap osramMiniRemoteMap[] = {
     { Sensor::ModeNone,   0x00, 0x0000, 0x00,    0,    0,                                           nullptr }
 };
 
+// OSRAM 'Switch 4x EU-LIGHTIFY' and Switch 4x-LIGHTIFY'
 static const Sensor::ButtonMap osram4ButRemoteMap[] = {
     // mode               ep    cluster cmd   param    button                                       name
     // Button upper-left
@@ -177,7 +178,30 @@ static const Sensor::ButtonMap osram4ButRemoteMap[] = {
     { Sensor::ModeScenes, 0x04, 0x0300, 0x03, 0xFE,    S_BUTTON_4 + S_BUTTON_ACTION_HOLD,           "LR long press" },
     { Sensor::ModeScenes, 0x04, 0x0300, 0x01, 0x00,    S_BUTTON_4 + S_BUTTON_ACTION_LONG_RELEASED,  "LR long release" },
     // end
-    { Sensor::ModeNone,             0x00, 0x0000, 0x00, 0,    0,                                           nullptr }
+    { Sensor::ModeNone,   0x00, 0x0000, 0x00,    0,    0,                                           nullptr }
+};
+
+// OSRAM 'Switch-LIGHTIFY'
+static const Sensor::ButtonMap osram4ButRemoteMap2[] = {
+    // mode               ep    cluster cmd   param    button                                       name
+    // Button upper-left
+    { Sensor::ModeScenes, 0x01, 0x0006, 0x01, 0x00,    S_BUTTON_1 + S_BUTTON_ACTION_SHORT_RELEASED, "UL short press" },
+    { Sensor::ModeScenes, 0x01, 0x0008, 0x05, 0x00,    S_BUTTON_1 + S_BUTTON_ACTION_HOLD,           "UL long press" },
+    { Sensor::ModeScenes, 0x01, 0x0008, 0x03, 0x00,    S_BUTTON_1 + S_BUTTON_ACTION_LONG_RELEASED,  "UL long release" },
+    // Button upper-right
+    { Sensor::ModeScenes, 0x02, 0x0300, 0x4C, 0x01,    S_BUTTON_2 + S_BUTTON_ACTION_SHORT_RELEASED, "UR short press" },
+    { Sensor::ModeScenes, 0x02, 0x0300, 0x01, 0x01,    S_BUTTON_2 + S_BUTTON_ACTION_HOLD,           "UR long press" },
+    { Sensor::ModeScenes, 0x02, 0x0300, 0x47, 0x00,    S_BUTTON_2 + S_BUTTON_ACTION_LONG_RELEASED,  "UR long release" },
+    // Button lower-left 
+    { Sensor::ModeScenes, 0x03, 0x0006, 0x00, 0x00,    S_BUTTON_3 + S_BUTTON_ACTION_SHORT_RELEASED, "LL short press" },
+    { Sensor::ModeScenes, 0x03, 0x0008, 0x01, 0x01,    S_BUTTON_3 + S_BUTTON_ACTION_HOLD,           "LL long press" },
+    { Sensor::ModeScenes, 0x03, 0x0008, 0x03, 0x01,    S_BUTTON_3 + S_BUTTON_ACTION_LONG_RELEASED,  "LL long release" },
+    // Button lower-right 
+    { Sensor::ModeScenes, 0x04, 0x0300, 0x4C, 0x03,    S_BUTTON_4 + S_BUTTON_ACTION_SHORT_RELEASED, "LR short press" },
+    { Sensor::ModeScenes, 0x04, 0x0300, 0x01, 0x03,    S_BUTTON_4 + S_BUTTON_ACTION_HOLD,           "LR long press" },
+    { Sensor::ModeScenes, 0x04, 0x0300, 0x47, 0x00,    S_BUTTON_4 + S_BUTTON_ACTION_LONG_RELEASED,  "LR long release" },
+    // end
+    { Sensor::ModeNone,   0x00, 0x0000, 0x00,    0,    0,                                           nullptr }
 };
 
 static const Sensor::ButtonMap ikeaDimmerMap[] = {
@@ -1322,9 +1346,10 @@ const Sensor::ButtonMap *Sensor::buttonMap()
         }
         else if (manufacturer.startsWith(QLatin1String("OSRAM")))
         {
-            if      (modelid.startsWith(QLatin1String("Lightify Switch Mini"))) { m_buttonMap = osramMiniRemoteMap; }
-            else if (modelid.startsWith(QLatin1String("Switch 4x EU-LIGHTIFY"))) { m_buttonMap = osram4ButRemoteMap; }
-            else if (modelid.startsWith(QLatin1String("Switch-LIGHTIFY"))) { m_buttonMap = osram4ButRemoteMap; }
+            if      (modelid.startsWith(QLatin1String("Lightify Switch Mini")))     { m_buttonMap = osramMiniRemoteMap; }
+            else if (modelid.startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")))    { m_buttonMap = osram4ButRemoteMap; }
+            else if (modelid.startsWith(QLatin1String("Switch 4x-LIGHTIFY")))       { m_buttonMap = osram4ButRemoteMap; }
+            else if (modelid.startsWith(QLatin1String("Switch-LIGHTIFY")))          { m_buttonMap = osram4ButRemoteMap2; }
         }
         else if (manufacturer == QLatin1String("ubisys"))
         {

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -161,8 +161,8 @@ static const Sensor::ButtonMap osramMiniRemoteMap[] = {
 static const Sensor::ButtonMap osram4ButRemoteMap[] = {
     // mode               ep    cluster cmd   param    button                                       name
     // Button upper-left
-    { Sensor::ModeScenes, 0x01, 0x0008, 0x05, 0x00,    S_BUTTON_1 + S_BUTTON_ACTION_SHORT_RELEASED, "UL short press" },
-    { Sensor::ModeScenes, 0x01, 0x0006, 0x01, 0x00,    S_BUTTON_1 + S_BUTTON_ACTION_HOLD,           "UL long press" },
+    { Sensor::ModeScenes, 0x01, 0x0006, 0x01, 0x00,    S_BUTTON_1 + S_BUTTON_ACTION_SHORT_RELEASED, "UL short press" },
+    { Sensor::ModeScenes, 0x01, 0x0008, 0x05, 0x00,    S_BUTTON_1 + S_BUTTON_ACTION_HOLD,           "UL long press" },
     { Sensor::ModeScenes, 0x01, 0x0008, 0x03, 0x00,    S_BUTTON_1 + S_BUTTON_ACTION_LONG_RELEASED,  "UL long release" },
     // Button upper-right
     { Sensor::ModeScenes, 0x02, 0x0300, 0x4C, 0x01,    S_BUTTON_2 + S_BUTTON_ACTION_SHORT_RELEASED, "UR short press" },

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -140,6 +140,46 @@ static const Sensor::ButtonMap ikeaRemoteMap[] = {
     { Sensor::ModeNone,             0x00, 0x0000, 0x00, 0,    0,                                           nullptr }
 };
 
+static const Sensor::ButtonMap osramMiniRemoteMap[] = {
+    // mode               ep    cluster cmd   param    button                                       name
+    // Button up
+    { Sensor::ModeScenes, 0x01, 0x0006, 0x01, 0x00,    S_BUTTON_1 + S_BUTTON_ACTION_SHORT_RELEASED, "Up short press" },
+    { Sensor::ModeScenes, 0x01, 0x0008, 0x05, 0x00,    S_BUTTON_1 + S_BUTTON_ACTION_HOLD,           "Up long press" },
+    { Sensor::ModeScenes, 0x01, 0x0008, 0x03, 0x00,    S_BUTTON_1 + S_BUTTON_ACTION_LONG_RELEASED,  "Up long release" },
+    // Button 0 (center)
+    { Sensor::ModeScenes, 0x03, 0x0300, 0x0A, 0x72,    S_BUTTON_3 + S_BUTTON_ACTION_SHORT_RELEASED, "0 short press" },
+    { Sensor::ModeScenes, 0x03, 0x0300, 0x03, 0xFE,    S_BUTTON_3 + S_BUTTON_ACTION_HOLD,           "0 long press" },
+    { Sensor::ModeScenes, 0x03, 0x0300, 0x01, 0x00,    S_BUTTON_3 + S_BUTTON_ACTION_LONG_RELEASED,  "0 long release" },
+    // Button down
+    { Sensor::ModeScenes, 0x02, 0x0006, 0x00, 0x00,    S_BUTTON_2 + S_BUTTON_ACTION_SHORT_RELEASED, "Down short press" },
+    { Sensor::ModeScenes, 0x02, 0x0008, 0x01, 0x01,    S_BUTTON_2 + S_BUTTON_ACTION_HOLD,           "Down long press" },
+    { Sensor::ModeScenes, 0x02, 0x0008, 0x03, 0x01,    S_BUTTON_2 + S_BUTTON_ACTION_LONG_RELEASED,  "Down long release" },
+    // end
+    { Sensor::ModeNone,   0x00, 0x0000, 0x00,    0,    0,                                           nullptr }
+};
+
+static const Sensor::ButtonMap osram4ButRemoteMap[] = {
+    // mode               ep    cluster cmd   param    button                                       name
+    // Button upper-left
+    { Sensor::ModeScenes, 0x01, 0x0006, 0x01, 0x00,    S_BUTTON_1 + S_BUTTON_ACTION_HOLD,           "UL press short" },
+    { Sensor::ModeScenes, 0x01, 0x0008, 0x05, 0x00,    S_BUTTON_1 + S_BUTTON_ACTION_SHORT_RELEASED, "UL long press" },
+    { Sensor::ModeScenes, 0x01, 0x0008, 0x03, 0x00,    S_BUTTON_1 + S_BUTTON_ACTION_LONG_RELEASED,  "UL press release" },
+    // Button upper-right
+    { Sensor::ModeScenes, 0x02, 0x0300, 0x4C, 0x01,    S_BUTTON_2 + S_BUTTON_ACTION_LONG_RELEASED,  "UR short press" },
+    { Sensor::ModeScenes, 0x02, 0x0300, 0x03, 0xFE,    S_BUTTON_2 + S_BUTTON_ACTION_HOLD,           "UR press long" },
+    { Sensor::ModeScenes, 0x02, 0x0300, 0x01, 0x00,    S_BUTTON_2 + S_BUTTON_ACTION_LONG_RELEASED,  "UR press Release" },
+    // Button lower-left 
+    { Sensor::ModeScenes, 0x03, 0x0006, 0x00, 0x00,    S_BUTTON_3 + S_BUTTON_ACTION_SHORT_RELEASED, "LL short press" },
+    { Sensor::ModeScenes, 0x03, 0x0008, 0x01, 0x01,    S_BUTTON_3 + S_BUTTON_ACTION_HOLD,           "LL press long" },
+    { Sensor::ModeScenes, 0x03, 0x0008, 0x03, 0x01,    S_BUTTON_3 + S_BUTTON_ACTION_LONG_RELEASED,  "LL press release" },
+    // Button lower-right 
+    { Sensor::ModeScenes, 0x04, 0x0300, 0x4C, 0x03,    S_BUTTON_4 + S_BUTTON_ACTION_SHORT_RELEASED, "LR short press" },
+    { Sensor::ModeScenes, 0x04, 0x0300, 0x03, 0xFE,    S_BUTTON_4 + S_BUTTON_ACTION_HOLD,           "LR press long" },
+    { Sensor::ModeScenes, 0x04, 0x0300, 0x01, 0x00,    S_BUTTON_4 + S_BUTTON_ACTION_LONG_RELEASED,  "LR press release" },
+    // end
+    { Sensor::ModeNone,             0x00, 0x0000, 0x00, 0,    0,                                           nullptr }
+};
+
 static const Sensor::ButtonMap ikeaDimmerMap[] = {
 //    mode                ep    cluster cmd   param button                                       name
     // on
@@ -1279,6 +1319,11 @@ const Sensor::ButtonMap *Sensor::buttonMap()
             else if (modelid.startsWith(QLatin1String("TRADFRI on/off switch"))) { m_buttonMap = ikeaOnOffMap; }
             else if (modelid.startsWith(QLatin1String("TRADFRI open/close remote"))) { m_buttonMap = ikeaOpenCloseMap; }
             else if (modelid.startsWith(QLatin1String("SYMFONISK"))) { m_buttonMap = ikeaSoundControllerMap; }
+        }
+        else if (manufacturer.startsWith(QLatin1String("OSRAM")))
+        {
+            if      (modelid.startsWith(QLatin1String("Lightify Switch Mini"))) { m_buttonMap = osramMiniRemoteMap; }
+            else if (modelid.startsWith(QLatin1String("Switch 4x EU-LIGHTIFY"))) { m_buttonMap = osram4ButRemoteMap; }
         }
         else if (manufacturer == QLatin1String("ubisys"))
         {


### PR DESCRIPTION
Added support for the [Osram Switch Mini+](https://www.ledvance.com/consumer/products/smart-home/smart-home-products-with-zigbee-technology/smart-home-components/smart-switch-mini/index.jsp) and [Osram 4x Button](https://www.amazon.com/Osram-Lightify-Intelligent-Flexible-Operation/dp/B00YSXBROI) in collaboration with @Smanar 

### Switch Mini
* Up short / long press
* Middle (0) short / long press
* Down short / long press
* Battery reporting

### 4x Button
* Upper-left short / long press
* Upper-right short / long press
* Lower-left short / long press
* Lower-right short / long press
* Battery reporting

resolves https://github.com/dresden-elektronik/deconz-rest-plugin/issues/294
resolves https://github.com/dresden-elektronik/deconz-rest-plugin/issues/374
resolves https://github.com/dresden-elektronik/deconz-rest-plugin/issues/1893
resolves https://github.com/dresden-elektronik/deconz-rest-plugin/issues/2082
resolves https://github.com/dresden-elektronik/deconz-rest-plugin/issues/2763