### PR TITLE
Quick & dirty support of Window Covering groups

### DIFF
--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -654,7 +654,8 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
                 }
             }
         }
-        else if (param == "ct"  && (taskRef.lightNode->item(RStateCt) || taskRef.lightNode->manufacturerCode() == VENDOR_IKEA)) // FIXME workaround for IKEA CWS
+        else if (param == "ct") // FIXME workaround for lights that support color tempeature, but API doesn't expose ct.
+        // else if (param == "ct"  && (taskRef.lightNode->item(RStateCt))
         {
             paramOk = true;
             hasCmd = true;


### PR DESCRIPTION
This PR adds support for `{"open": true}` and `{"open": false}` to a PUT to a group `action`, to generate _Window Covering_ cluster commands _Open_ and _Close_ to the group.  No checks whatsoever, that the group actually contains a _Windows Covering_ device.  Also, `open` is not exposed in the `action` object.

Works brilliantly with my `lumi.curtain` - haven't had a failed attempt yet (where unicast commands fails regularly due to routing issues).  Doesn't seem to work for my FYRTUR - not sure why the open/close controller works just fine.  Both FYRTUR and the controller have the same parent, though: a Hue light.