### PR TITLE
Bugfixes and enhancements

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1130,14 +1130,14 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq.reportableChange16bit = 50;
             
             ConfigureReportingRequest rq2;
-            rq2.dataType = deCONZ::Zcl16BitBitMap;
+            rq2.dataType = deCONZ::Zcl8BitUint;
             rq2.attributeId = 0x0008;        // Pi heating demand
-            rq2.minInterval = 300;
+            rq2.minInterval = 60;
             rq2.maxInterval = 43200;
-            rq2.reportableChange16bit = 1;
+            rq2.reportableChange8bit = 1;
             
             ConfigureReportingRequest rq3;
-            rq3.dataType = deCONZ::Zcl16BitBitMap;
+            rq3.dataType = deCONZ::Zcl16BitInt;
             rq3.attributeId = 0x0012;        // Occupied heating setpoint
             rq3.minInterval = 1;
             rq3.maxInterval = 43200;
@@ -1148,17 +1148,16 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq4.attributeId = 0x4000;        // eTRV Open Window detection
             rq4.minInterval = 60;
             rq4.maxInterval = 43200;
-            rq4.reportableChange16bit = 0xffff;
+            rq4.reportableChange8bit = 0xff;
             
             ConfigureReportingRequest rq5;
-            rq5.dataType = deCONZ::Zcl8BitEnum;
+            rq5.dataType = deCONZ::ZclBoolean;
             rq5.attributeId = 0x4012;        // Mounting mode active
             rq5.minInterval = 1;
-            rq5.maxInterval = 0;
-            rq5.reportableChange16bit = 0xffff;
+            rq5.maxInterval = 43200;
+            rq5.reportableChange8bit = 0xff;
             
-            return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4}) ||
-                   sendConfigureReportingRequest(bt, {rq5});
+            return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4, rq5});
         }
 
         else

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2184,7 +2184,8 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId() == QLatin1String("Bell") ||
         // Sonoff
         sensor->modelId() == QLatin1String("MS01") ||
-        sensor->modelId() == QLatin1String("TH01"))
+        sensor->modelId() == QLatin1String("TH01") ||
+        sensor->modelId() == QLatin1String("DS01"))
     {
         deviceSupported = true;
         if (!sensor->node()->nodeDescriptor().receiverOnWhenIdle() ||

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1046,7 +1046,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq6.reportableChange24bit = 1;   // recommended value
             rq6.manufacturerCode = VENDOR_JENNIC;
 
-            return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4}) ||
+            return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4}) || // Use OR because of manuf. specific attributes
                    sendConfigureReportingRequest(bt, {rq5, rq6});
         }
         else if (sensor && sensor->modelId() == QLatin1String("Zen-01")) // Zen
@@ -1083,10 +1083,9 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq5.attributeId = 0x001C;        // Thermostat mode
             rq5.minInterval = 1;
             rq5.maxInterval = 600;
-            rq5.reportableChange16bit = 0xffff;
+            rq5.reportableChange16bit = 0xff;
 
-            return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4}) ||
-                   sendConfigureReportingRequest(bt, {rq5});
+            return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4, rq5});
         }
         else if ((sensor && sensor->modelId() == QLatin1String("SLR2")) || // Hive
                  (sensor && sensor->modelId().startsWith(QLatin1String("TH112")))) // Sinope
@@ -1098,18 +1097,18 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq.reportableChange16bit = 10;
 
             ConfigureReportingRequest rq3;
-            rq3.dataType = deCONZ::Zcl16BitBitMap;
+            rq3.dataType = deCONZ::Zcl16BitInt;
             rq3.attributeId = 0x0012;        // Occupied heating setpoint
             rq3.minInterval = 1;
             rq3.maxInterval = 600;
-            rq3.reportableChange16bit = 0xffff;
+            rq3.reportableChange16bit = 50;
 
             ConfigureReportingRequest rq4;
             rq4.dataType = deCONZ::Zcl8BitEnum;
             rq4.attributeId = 0x001C;        // Thermostat mode
             rq4.minInterval = 1;
             rq4.maxInterval = 600;
-            rq4.reportableChange16bit = 0xffff;
+            rq4.reportableChange16bit = 0xff;
 
             ConfigureReportingRequest rq2;
             rq2.dataType = deCONZ::Zcl16BitBitMap;
@@ -1149,6 +1148,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq4.minInterval = 60;
             rq4.maxInterval = 43200;
             rq4.reportableChange8bit = 0xff;
+            rq4.manufacturerCode = VENDOR_DANFOSS;
             
             ConfigureReportingRequest rq5;
             rq5.dataType = deCONZ::ZclBoolean;
@@ -1156,8 +1156,10 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq5.minInterval = 1;
             rq5.maxInterval = 43200;
             rq5.reportableChange8bit = 0xff;
+            rq5.manufacturerCode = VENDOR_DANFOSS;
             
-            return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4, rq5});
+            return sendConfigureReportingRequest(bt, {rq, rq2, rq3}) || // Use OR because of manuf. specific attributes
+                   sendConfigureReportingRequest(bt, {rq4, rq5});
         }
 
         else

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1822,6 +1822,9 @@ void DeRestPluginPrivate::checkLightBindingsForAttributeReporting(LightNode *lig
         else if (lightNode->manufacturer() == QLatin1String("Sercomm Corp."))
         {
         }
+        else if (lightNode->manufacturer() == QLatin1String("NIKO NV"))
+        {
+        }
         else
         {
             return;

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2183,7 +2183,8 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         // Sage
         sensor->modelId() == QLatin1String("Bell") ||
         // Sonoff
-        sensor->modelId() == QLatin1String("MS01"))
+        sensor->modelId() == QLatin1String("MS01") ||
+        sensor->modelId() == QLatin1String("TH01"))
     {
         deviceSupported = true;
         if (!sensor->node()->nodeDescriptor().receiverOnWhenIdle() ||

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1077,8 +1077,16 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq4.minInterval = 1;
             rq4.maxInterval = 600;
             rq4.reportableChange16bit = 0xffff;
+            
+            ConfigureReportingRequest rq5;
+            rq5.dataType = deCONZ::Zcl8BitEnum;
+            rq5.attributeId = 0x001C;        // Thermostat mode
+            rq5.minInterval = 1;
+            rq5.maxInterval = 600;
+            rq5.reportableChange16bit = 0xffff;
 
-            return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4});
+            return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4}) ||
+                   sendConfigureReportingRequest(bt, {rq5});
         }
         else if ((sensor && sensor->modelId() == QLatin1String("SLR2")) || // Hive
                  (sensor && sensor->modelId().startsWith(QLatin1String("TH112")))) // Sinope

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1303,7 +1303,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         if (sensor && (sensor->modelId() == QLatin1String("SmartPlug") ||      // Heiman
                        sensor->modelId() == QLatin1String("SKHMP30-I1") ||     // GS smart plug
                        sensor->modelId().startsWith(QLatin1String("E13-")) ||  // Sengled PAR38 Bulbs
-                       sensor->modelId().startsWith(QLatin1String("Connected s")))) // Niko smart socket
+                       sensor->modelId() == QLatin1String("Connected socket outlet"))) // Niko smart socket
         {
             rq.reportableChange48bit = 10; // 0.001 kWh (1 Wh)
         }
@@ -1355,6 +1355,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         if (sensor && (sensor->modelId() == QLatin1String("SmartPlug") ||   // Heiman
                        sensor->modelId() == QLatin1String("SKHMP30-I1") ||  // GS smart plug
                        sensor->modelId() == QLatin1String("SZ-ESW01-AU") || // Sercomm / Telstra smart plug
+                       sensor->modelId() == QLatin1String("Connected socket outlet") || // Niko smart socket
                        sensor->modelId().startsWith(QLatin1String("ROB_200")) || // ROBB Smarrt micro dimmer
                        sensor->modelId().startsWith(QLatin1String("Micro Smart Dimmer")) || // Sunricher Micro Smart Dimmer
                        sensor->modelId().startsWith(QLatin1String("lumi.plug.maeu")))) // Xiaomi Aqara ZB3.0 smart plug
@@ -1382,7 +1383,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         }
         else if (sensor && (sensor->modelId().startsWith(QLatin1String("ROB_200")) || // ROBB Smarrt micro dimmer
                             sensor->modelId().startsWith(QLatin1String("Micro Smart Dimmer")) || // Sunricher Micro Smart Dimmer
-                            sensor->modelId().startsWith(QLatin1String("Connected s")) || // Niko smart socket
+                            sensor->modelId() == QLatin1String("Connected socket outlet") || // Niko smart socket
                             sensor->modelId().startsWith(QLatin1String("TH112")))) // Sinope Thermostats
         {
             rq2.reportableChange16bit = 10; // 1 V
@@ -1400,7 +1401,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         if (sensor && (sensor->modelId() == QLatin1String("SP 120") ||           // innr
                        sensor->modelId() == QLatin1String("DoubleSocket50AU") || // Aurora
                        sensor->modelId() == QLatin1String("SZ-ESW01-AU") ||      // Sercomm / Telstra smart plug
-                       sensor->modelId().startsWith(QLatin1String("Connected s")) || // Niko smart socket
+                       sensor->modelId() == QLatin1String("Connected socket outlet") || // Niko smart socket
                        sensor->modelId() == QLatin1String("TS0121")))            // Tuya / Blitzwolf
         {
             rq3.reportableChange16bit = 100; // 0.1 A

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1120,6 +1120,47 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             
             return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4});
         }
+
+        else if (sensor && sensor->modelId() == QLatin1String("eTVR0100")) // Danfoss Ally
+        {
+            rq.dataType = deCONZ::Zcl16BitInt;
+            rq.attributeId = 0x0000;       // local temperature
+            rq.minInterval = 60;
+            rq.maxInterval = 3600;
+            rq.reportableChange16bit = 50;
+            
+            ConfigureReportingRequest rq2;
+            rq2.dataType = deCONZ::Zcl16BitBitMap;
+            rq2.attributeId = 0x0008;        // Pi heating demand
+            rq2.minInterval = 300;
+            rq2.maxInterval = 43200;
+            rq2.reportableChange16bit = 1;
+            
+            ConfigureReportingRequest rq3;
+            rq3.dataType = deCONZ::Zcl16BitBitMap;
+            rq3.attributeId = 0x0012;        // Occupied heating setpoint
+            rq3.minInterval = 1;
+            rq3.maxInterval = 43200;
+            rq3.reportableChange16bit = 1;
+            
+            ConfigureReportingRequest rq4;
+            rq4.dataType = deCONZ::Zcl8BitEnum;
+            rq4.attributeId = 0x4000;        // eTRV Open Window detection
+            rq4.minInterval = 60;
+            rq4.maxInterval = 43200;
+            rq4.reportableChange16bit = 0xffff;
+            
+            ConfigureReportingRequest rq5;
+            rq5.dataType = deCONZ::Zcl8BitEnum;
+            rq5.attributeId = 0x4012;        // Mounting mode active
+            rq5.minInterval = 1;
+            rq5.maxInterval = 0;
+            rq5.reportableChange16bit = 0xffff;
+            
+            return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4}) ||
+                   sendConfigureReportingRequest(bt, {rq5});
+        }
+
         else
         {
             rq.dataType = deCONZ::Zcl16BitInt;
@@ -1193,6 +1234,12 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq.minInterval = 900;        // value used by Hue bridge
             rq.maxInterval = 900;        // value used by Hue bridge
             rq.reportableChange8bit = 4; // value used by Hue bridge
+        }
+        else if (sensor && sensor->modelId() == QLatin1String("eTVR0100")) // Danfoss Ally
+        {
+            rq.minInterval = 3600;         // Vendor defaults
+            rq.maxInterval = 43200;        // Vendor defaults
+            rq.reportableChange8bit = 2;   // Vendor defaults
         }
         else if (sensor && (sensor->manufacturer().startsWith(QLatin1String("Climax")) ||
                             sensor->modelId().startsWith(QLatin1String("902010/23"))))
@@ -2185,7 +2232,10 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         // Sonoff
         sensor->modelId() == QLatin1String("MS01") ||
         sensor->modelId() == QLatin1String("TH01") ||
-        sensor->modelId() == QLatin1String("DS01"))
+        sensor->modelId() == QLatin1String("DS01") ||
+        // Danfoss
+        sensor->modelId() == QLatin1String("eTVR0100")
+        )
     {
         deviceSupported = true;
         if (!sensor->node()->nodeDescriptor().receiverOnWhenIdle() ||

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1121,7 +1121,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4});
         }
 
-        else if (sensor && sensor->modelId() == QLatin1String("eTVR0100")) // Danfoss Ally
+        else if (sensor && sensor->modelId() == QLatin1String("eTRV0100")) // Danfoss Ally
         {
             rq.dataType = deCONZ::Zcl16BitInt;
             rq.attributeId = 0x0000;       // local temperature
@@ -1235,7 +1235,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq.maxInterval = 900;        // value used by Hue bridge
             rq.reportableChange8bit = 4; // value used by Hue bridge
         }
-        else if (sensor && sensor->modelId() == QLatin1String("eTVR0100")) // Danfoss Ally
+        else if (sensor && sensor->modelId() == QLatin1String("eTRV0100")) // Danfoss Ally
         {
             rq.minInterval = 3600;         // Vendor defaults
             rq.maxInterval = 43200;        // Vendor defaults
@@ -2254,7 +2254,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId() == QLatin1String("TH01") ||
         sensor->modelId() == QLatin1String("DS01") ||
         // Danfoss
-        sensor->modelId() == QLatin1String("eTVR0100")
+        sensor->modelId() == QLatin1String("eTRV0100")
         )
     {
         deviceSupported = true;

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2181,7 +2181,9 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         // Niko
         sensor->modelId() == QLatin1String("Connected socket outlet") ||
         // Sage
-        sensor->modelId() == QLatin1String("Bell"))
+        sensor->modelId() == QLatin1String("Bell") ||
+        // Sonoff
+        sensor->modelId() == QLatin1String("MS01"))
     {
         deviceSupported = true;
         if (!sensor->node()->nodeDescriptor().receiverOnWhenIdle() ||

--- a/database.cpp
+++ b/database.cpp
@@ -3124,12 +3124,18 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             if (sensor.fingerPrint().hasInCluster(METERING_CLUSTER_ID))
             {
                 clusterId = clusterId ? clusterId : METERING_CLUSTER_ID;
+                if (sensor.modelId() != QLatin1String("160-01"))
+                {
+                    item = sensor.addItem(DataTypeUInt64, RStateConsumption);
+                    item->setValue(0);
+                }
                 if ((sensor.modelId() != QLatin1String("SP 120")) &&
                     (sensor.modelId() != QLatin1String("ZB-ONOFFPlug-D0005")) &&
                     (sensor.modelId() != QLatin1String("TS0121")) &&
                     (!sensor.modelId().startsWith(QLatin1String("BQZ10-AU"))) &&
                     (!sensor.modelId().startsWith(QLatin1String("ROB_200"))) &&
-                    (sensor.modelId() != QLatin1String("Plug-230V-ZB3.0")))
+                    (sensor.modelId() != QLatin1String("Plug-230V-ZB3.0")) &&
+                    (sensor.modelId() != QLatin1String("Connected socket outlet")))
                 {
                     item = sensor.addItem(DataTypeInt16, RStatePower);
                     item->setValue(0);
@@ -3138,11 +3144,6 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             else if (sensor.fingerPrint().hasInCluster(ANALOG_INPUT_CLUSTER_ID))
             {
                 clusterId = clusterId ? clusterId : ANALOG_INPUT_CLUSTER_ID;
-            }
-            if (sensor.modelId() != QLatin1String("160-01"))
-            {
-                item = sensor.addItem(DataTypeUInt64, RStateConsumption);
-                item->setValue(0);
             }
         }
         else if (sensor.type().endsWith(QLatin1String("Power")))

--- a/database.cpp
+++ b/database.cpp
@@ -3226,6 +3226,10 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 {
                     sensor.addItem(DataTypeString, RConfigMode);
                 }
+                if (sensor.modelId() == QLatin1String("eTVR0100"))
+                {
+                    sensorNode.addItem(DataTypeUInt8, RStateValve);
+                }
                 
                 if (sensor.modelId().startsWith(QLatin1String("SPZB"))) // Eurotronic Spirit
                 {

--- a/database.cpp
+++ b/database.cpp
@@ -3226,10 +3226,6 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 {
                     sensor.addItem(DataTypeString, RConfigMode);
                 }
-                if (sensor.modelId() == QLatin1String("eTVR0100"))
-                {
-                    sensorNode.addItem(DataTypeUInt8, RStateValve);
-                }
                 
                 if (sensor.modelId().startsWith(QLatin1String("SPZB"))) // Eurotronic Spirit
                 {
@@ -3241,6 +3237,10 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 }
                 else if (sensor.modelId() == QLatin1String("Zen-01"))
                 {
+                }
+                else if (sensor.modelId() == QLatin1String("eTVR0100"))
+                {
+                    sensorNode.addItem(DataTypeUInt8, RStateValve);
                 }
                 else
                 {

--- a/database.cpp
+++ b/database.cpp
@@ -3238,7 +3238,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 else if (sensor.modelId() == QLatin1String("Zen-01"))
                 {
                 }
-                else if (sensor.modelId() == QLatin1String("eTVR0100"))
+                else if (sensor.modelId() == QLatin1String("eTRV0100"))
                 {
                     sensor.addItem(DataTypeUInt8, RStateValve);
                 }

--- a/database.cpp
+++ b/database.cpp
@@ -3240,7 +3240,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 }
                 else if (sensor.modelId() == QLatin1String("eTVR0100"))
                 {
-                    sensorNode.addItem(DataTypeUInt8, RStateValve);
+                    sensor.addItem(DataTypeUInt8, RStateValve);
                 }
                 else
                 {

--- a/database.cpp
+++ b/database.cpp
@@ -3241,6 +3241,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 else if (sensor.modelId() == QLatin1String("eTRV0100"))
                 {
                     sensor.addItem(DataTypeUInt8, RStateValve);
+                    sensor.addItem(DataTypeString, RStateWindowOpen);
                 }
                 else
                 {

--- a/database.cpp
+++ b/database.cpp
@@ -3219,8 +3219,9 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 sensor.addItem(DataTypeInt16, RConfigHeatSetpoint);    // Heating set point
                 sensor.addItem(DataTypeBool, RStateOn);           // Heating on/off
                 
-                if (sensor.modelId() == QLatin1String("SLR2") || //Hive 
-                    sensor.modelId().startsWith(QLatin1String("TH112")) ) // Sinope
+                if (sensor.modelId() == QLatin1String("SLR2") ||           // Hive 
+                    sensor.modelId().startsWith(QLatin1String("TH112")) || // Sinope
+                    sensor.modelId() == QLatin1String("Zen-01"))           // Zen
                 {
                     sensor.addItem(DataTypeString, RConfigMode);
                 }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5523,6 +5523,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             else if (modelId == QLatin1String("eTRV0100"))
             {
                 sensorNode.addItem(DataTypeUInt8, RStateValve);
+                sensorNode.addItem(DataTypeString, RStateWindowOpen);
             }
             else
             {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -100,6 +100,7 @@ const quint64 silabs5MacPrefix    = 0x842e140000000000ULL;
 const quint64 embertecMacPrefix   = 0x848e960000000000ULL;
 const quint64 silabsMacPrefix     = 0x90fd9f0000000000ULL;
 const quint64 zhejiangMacPrefix   = 0xb0ce180000000000ULL;
+const quint64 silabs7MacPrefix    = 0xbc33ac0000000000ULL;
 const quint64 silabs2MacPrefix    = 0xcccccc0000000000ULL;
 const quint64 silabs3MacPrefix    = 0xec1bbd0000000000ULL;
 const quint64 energyMiMacPrefix   = 0xd0cf5e0000000000ULL;
@@ -5434,8 +5435,9 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             sensorNode.addItem(DataTypeInt16, RConfigHeatSetpoint);    // Heating set point
             sensorNode.addItem(DataTypeBool, RStateOn);           // Heating on/off
             
-            if (sensorNode.modelId() == QLatin1String("SLR2") || //Hive
-                sensorNode.modelId().startsWith(QLatin1String("TH112")) ) // Sinope
+            if (sensorNode.modelId() == QLatin1String("SLR2") ||            // Hive
+                sensorNode.modelId().startsWith(QLatin1String("TH112")) ||  // Sinope
+                sensorNode.modelId() == QLatin1String("Zen-01"))            // Zen
             {
                 sensorNode.addItem(DataTypeString, RConfigMode);
             }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -7525,7 +7525,8 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     i->modelId().startsWith(QLatin1String("E13-")) ||    // Sengled PAR38 Bulbs
                                     i->modelId() == QLatin1String("Connected socket outlet")) // Niko smart socket
                                 {
-                                    consumption += 5; consumption /= 10; // 0.1 Wh -> Wh
+                                    //consumption += 5; consumption /= 10; // 0.1 Wh -> Wh
+                                    consumption = static_cast<quint64>(round((double)consumption / 10.0)); // 0.1 Wh -> Wh
                                 }
                                 else if (i->modelId() == QLatin1String("SP 120") ||            // innr
                                          i->modelId() == QLatin1String("Plug-230V-ZB3.0") ||   // Immax
@@ -7535,12 +7536,14 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 }
                                 else if (i->modelId().startsWith(QLatin1String("SZ-ESW01"))) // Sercomm / Telstra smart plug
                                 {
-                                    consumption /= 1000;
+                                    //consumption /= 1000;
+                                    consumption = static_cast<quint64>(round((double)consumption / 1000.0)); // -> Wh
                                 }
                                 else if (i->modelId().startsWith(QLatin1String("ROB_200")) ||            // ROBB Smarrt micro dimmer
                                          i->modelId().startsWith(QLatin1String("Micro Smart Dimmer")))   // Sunricher Micro Smart Dimmer
                                 {
-                                    consumption /= 3600;
+                                    //consumption /= 3600;
+                                    consumption = static_cast<quint64>(round((double)consumption / 3600.0)); // -> Wh
                                 }
 
                                 if (item)
@@ -7567,11 +7570,13 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     i->modelId().startsWith(QLatin1String("SKHMP30")) ||// GS smart plug
                                     i->modelId().startsWith(QLatin1String("160-01")))   // Plugwise smart plug
                                 {
-                                    power += 5; power /= 10; // 0.1 W -> W
+                                    //power += 5; power /= 10; // 0.1 W -> W
+                                    power = static_cast<qint32>(round((double)power / 10.0)); // 0.1W -> W
                                 }
                                 else if (i->modelId().startsWith(QLatin1String("SZ-ESW01"))) // Sercomm / Telstra smart plug
                                 {
-                                    power /= 1000;
+                                    //power /= 1000;
+                                    power = static_cast<qint32>(round((double)power / 1000.0)); // -> W
                                 }
 
                                 if (item)
@@ -7619,27 +7624,27 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                         i->modelId().startsWith(QLatin1String("SKHMP30")) || // GS smart plug
                                         i->modelId().startsWith(QLatin1String("ROB_200")) || // ROBB Smarrt micro dimmer
                                         i->modelId().startsWith(QLatin1String("Micro Smart Dimmer")) || // Sunricher Micro Smart Dimmer
-                                        i->modelId().startsWith(QLatin1String("lumi.plug.maeu"))) // Xiaomi Aqara ZB3.0 smart plug
+                                        i->modelId().startsWith(QLatin1String("lumi.plug.maeu")) || // Xiaomi Aqara ZB3.0 smart plug
+                                        i->modelId() == QLatin1String("RICI01") ||           // LifeControl Smart Plug
+                                        i->modelId().startsWith(QLatin1String("outlet")) ||  // Samsung SmartThings IM6001-OTP/IM6001-OTP01
+                                        i->modelId().startsWith(QLatin1String("3200-S")))    // Samsung/Centralite smart outlet
                                     {
-                                        power += 5; power /= 10; // 0.1W -> W
+                                        //power += 5; power /= 10; // 0.1W -> W
+                                        power = static_cast<qint16>(round((double)power / 10.0)); // 0.1W -> W
                                     }
                                     else if (i->modelId().startsWith(QLatin1String("Plug")) && i->manufacturer() == QLatin1String("OSRAM")) // OSRAM
                                     {
                                         power = power == 28000 ? 0 : power / 10;
                                     }
-                                    else if (i->modelId() == QLatin1String("RICI01") ||           // LifeControl Smart Plug
-                                             i->modelId().startsWith(QLatin1String("outlet")) ||  // Samsung SmartThings IM6001-OTP/IM6001-OTP01
-                                             i->modelId().startsWith(QLatin1String("3200-S")))    // Samsung/Centralite smart outlet
-                                    {
-                                        power /= 10; // 0.1W -> W
-                                    }
                                     else if (i->modelId().startsWith(QLatin1String("SZ-ESW01"))) // Sercomm / Telstra smart plug
                                     {
-                                        power *= 128; power /= 1000;
+                                        //power *= 128; power /= 1000;
+                                        power = static_cast<qint16>(round(((double)power * 128) / 1000.0));
                                     }
                                     else if (i->modelId() == QLatin1String("Connected socket outlet")) // Niko smart socket
                                     {
-                                        power *= 1123; power /= 10000;
+                                        //power *= 1123; power /= 10000;
+                                        power = static_cast<qint16>(round(((double)power * 1123) / 10000.0));
                                     }
                                     else if (i->modelId().startsWith(QLatin1String("lumi.relay.c2acn"))) // Xiaomi relay
                                     {
@@ -7668,7 +7673,8 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                         i->modelId().startsWith(QLatin1String("SMRZB-33")) || // Develco smart relay
                                         i->modelId().startsWith(QLatin1String("SKHMP30")))    // GS smart plug
                                     {
-                                        voltage += 50; voltage /= 100; // 0.01V -> V
+                                        //voltage += 50; voltage /= 100; // 0.01V -> V
+                                        voltage = static_cast<quint16>(round((double)voltage / 100.0)); // 0.01V -> V
                                     }
                                     else if (i->modelId() == QLatin1String("RICI01") ||           // LifeControl Smart Plug
                                              i->modelId().startsWith(QLatin1String("outlet")) ||  // Samsung SmartThings IM6001-OTP/IM6001-OTP01
@@ -7678,11 +7684,13 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                              i->modelId() == QLatin1String("Connected socket outlet") || // Niko smart socket
                                              i->modelId().startsWith(QLatin1String("TH112"))) // Sinope Thermostats
                                     {
-                                        voltage /= 10; // 0.1V -> V
+                                        //voltage /= 10; // 0.1V -> V
+                                        voltage = static_cast<quint16>(round((double)voltage / 10.0)); // 0.1V -> V
                                     }
                                     else if (i->modelId().startsWith(QLatin1String("SZ-ESW01"))) // Sercomm / Telstra smart plug
                                     {
-                                        voltage /= 125; // -> V
+                                        //voltage /= 125; // -> V
+                                        voltage = static_cast<quint16>(round((double)voltage / 125.0)); // -> V
                                     }
                                     item->setValue(voltage); // in V
                                     enqueueEvent(Event(RSensors, RStateVoltage, i->id(), item));

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -7523,7 +7523,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     i->modelId().startsWith(QLatin1String("PSMP5_")) ||  // Climax
                                     i->modelId().startsWith(QLatin1String("SKHMP30")) || // GS smart plug
                                     i->modelId().startsWith(QLatin1String("E13-")) ||    // Sengled PAR38 Bulbs
-                                    i->modelId().startsWith(QLatin1String("Connected s"))) // Niko smart socket
+                                    i->modelId() == QLatin1String("Connected socket outlet")) // Niko smart socket
                                 {
                                     consumption += 5; consumption /= 10; // 0.1 Wh -> Wh
                                 }
@@ -7637,7 +7637,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     {
                                         power *= 128; power /= 1000;
                                     }
-                                    else if (i->modelId().startsWith(QLatin1String("Connected s"))) // Niko smart socket
+                                    else if (i->modelId() == QLatin1String("Connected socket outlet")) // Niko smart socket
                                     {
                                         power *= 1123; power /= 10000;
                                     }
@@ -7675,7 +7675,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                              i->modelId() == QLatin1String("EMIZB-13") ||         // Develco EMI
                                              i->modelId().startsWith(QLatin1String("ROB_200")) || // ROBB Smarrt micro dimmer
                                              i->modelId().startsWith(QLatin1String("Micro Smart Dimmer")) || // Sunricher Micro Smart Dimmer
-                                             i->modelId().startsWith(QLatin1String("Connected s")) || // Niko smart socket
+                                             i->modelId() == QLatin1String("Connected socket outlet") || // Niko smart socket
                                              i->modelId().startsWith(QLatin1String("TH112"))) // Sinope Thermostats
                                     {
                                         voltage /= 10; // 0.1V -> V
@@ -7710,7 +7710,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                         i->modelId() == QLatin1String("TS0121") ||            // Tuya smart plug
                                         i->modelId().startsWith(QLatin1String("ROB_200")) ||  // ROBB Smarrt micro dimmer
                                         i->modelId().startsWith(QLatin1String("Micro Smart Dimmer")) || // Sunricher Micro Smart Dimmer
-                                        i->modelId().startsWith(QLatin1String("Connected s")) || // Niko smart socket
+                                        i->modelId() == QLatin1String("Connected socket outlet") || // Niko smart socket
                                         i->modelId().startsWith(QLatin1String("S1")) || // Ubisys S1/S1-R
                                         i->modelId().startsWith(QLatin1String("S2")) || // Ubisys S2/S2-R
                                         i->modelId().startsWith(QLatin1String("J1")) || // Ubisys J1/J1-R

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -341,6 +341,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_NONE, "MS01", tiMacPrefix }, // Sonoff SNZB-03
     { VENDOR_NONE, "TH01", tiMacPrefix }, // Sonoff SNZB-02
     { VENDOR_NONE, "DS01", tiMacPrefix }, // Sonoff SNZB-04
+    { VENDOR_DANFOSS, "eTRV0100", silabs2MacPrefix }, // Danfoss Ally thermostat
 
     { 0, nullptr, 0 }
 };
@@ -5445,11 +5446,14 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             
             if (sensorNode.modelId() == QLatin1String("SLR2") ||            // Hive
                 sensorNode.modelId().startsWith(QLatin1String("TH112")) ||  // Sinope
-                sensorNode.modelId() == QLatin1String("Zen-01"))            // Zen
+                sensorNode.modelId() == QLatin1String("Zen-01") ||          // Zen
             {
                 sensorNode.addItem(DataTypeString, RConfigMode);
             }
-            
+            if (modelId == QLatin1String("eTVR0100"))
+            {
+                sensorNode.addItem(DataTypeUInt8, RStateValve);
+            }            
             if (modelId.startsWith(QLatin1String("SPZB"))) // Eurotronic Spirit
             {
                 sensorNode.addItem(DataTypeUInt8, RStateValve);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -338,6 +338,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_PLUGWISE_BV, "160-01", emberMacPrefix }, // Plugwise smart plug
     { VENDOR_NIKO_NV, "Connected socket outlet", konkeMacPrefix }, // Niko smart socket 170-33505
     { VENDOR_ATMEL, "Bell", dishMacPrefix }, // Sage doorbell sensor
+    { VENDOR_NONE, "MS01", tiMacPrefix }, // Sonoff SNZB-03
 
     { 0, nullptr, 0 }
 };
@@ -4291,7 +4292,8 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                              modelId.startsWith(QLatin1String("SN10ZW")) ||           // ORVIBO motion sensor
                              modelId.startsWith(QLatin1String("MOSZB-130")) ||        // Develco motion sensor
                              modelId == QLatin1String("4in1-Sensor-ZB3.0") ||         // Immax NEO ZB3.0 4 in 1 sensor E13-A21
-                             modelId == QLatin1String("E13-A21"))                     // Sengled E13-A21 PAR38 bulp with motion sensor
+                             modelId == QLatin1String("E13-A21") ||                   // Sengled E13-A21 PAR38 bulp with motion sensor
+                             modelId == QLatin1String("MS01"))                        // Sonoff SNZB-03
                     {
                         fpPresenceSensor.inClusters.push_back(ci->id());
                     }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5383,7 +5383,10 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             if ((modelId != QLatin1String("SP 120")) &&
                 (modelId != QLatin1String("ZB-ONOFFPlug-D0005")) &&
                 (modelId != QLatin1String("TS0121")) &&
-                (modelId != QLatin1String("Plug-230V-ZB3.0")))
+                (!modelId.startsWith(QLatin1String("BQZ10-AU"))) &&
+                (!modelId.startsWith(QLatin1String("ROB_200"))) &&
+                (modelId != QLatin1String("Plug-230V-ZB3.0")) &&
+                (modelId != QLatin1String("Connected socket outlet")))
             {
                 item = sensorNode.addItem(DataTypeInt16, RStatePower);
             }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5520,7 +5520,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             else if (modelId == QLatin1String("Zen-01"))
             {
             }
-            else if (modelId == QLatin1String("eTVR0100"))
+            else if (modelId == QLatin1String("eTRV0100"))
             {
                 sensorNode.addItem(DataTypeUInt8, RStateValve);
             }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5450,10 +5450,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             {
                 sensorNode.addItem(DataTypeString, RConfigMode);
             }
-            if (modelId == QLatin1String("eTVR0100"))
-            {
-                sensorNode.addItem(DataTypeUInt8, RStateValve);
-            }            
+                        
             if (modelId.startsWith(QLatin1String("SPZB"))) // Eurotronic Spirit
             {
                 sensorNode.addItem(DataTypeUInt8, RStateValve);
@@ -5464,6 +5461,10 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             }
             else if (modelId == QLatin1String("Zen-01"))
             {
+            }
+            else if (modelId == QLatin1String("eTVR0100"))
+            {
+                sensorNode.addItem(DataTypeUInt8, RStateValve);
             }
             else
             {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -339,6 +339,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_NIKO_NV, "Connected socket outlet", konkeMacPrefix }, // Niko smart socket 170-33505
     { VENDOR_ATMEL, "Bell", dishMacPrefix }, // Sage doorbell sensor
     { VENDOR_NONE, "MS01", tiMacPrefix }, // Sonoff SNZB-03
+    { VENDOR_NONE, "TH01", tiMacPrefix }, // Sonoff SNZB-02
 
     { 0, nullptr, 0 }
 };

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -340,6 +340,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_ATMEL, "Bell", dishMacPrefix }, // Sage doorbell sensor
     { VENDOR_NONE, "MS01", tiMacPrefix }, // Sonoff SNZB-03
     { VENDOR_NONE, "TH01", tiMacPrefix }, // Sonoff SNZB-02
+    { VENDOR_NONE, "DS01", tiMacPrefix }, // Sonoff SNZB-04
 
     { 0, nullptr, 0 }
 };
@@ -4281,7 +4282,8 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                              modelId.startsWith(QLatin1String("902010/21")) ||        // Bitron door/window sensor
                              modelId.startsWith(QLatin1String("WISZB-120")) ||        // Develco door/window sensor
                              modelId.startsWith(QLatin1String("ZHMS101")) ||          // Wattle (Develco) door/window sensor
-                             modelId == QLatin1String("E1D-G73"))                     // Sengled contact sensor
+                             modelId == QLatin1String("E1D-G73") ||                   // Sengled contact sensor
+                             modelId == QLatin1String("DS01"))                        // Sonoff SNZB-04
                     {
                         fpOpenCloseSensor.inClusters.push_back(ci->id());
                     }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5446,7 +5446,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             
             if (sensorNode.modelId() == QLatin1String("SLR2") ||            // Hive
                 sensorNode.modelId().startsWith(QLatin1String("TH112")) ||  // Sinope
-                sensorNode.modelId() == QLatin1String("Zen-01") ||          // Zen
+                sensorNode.modelId() == QLatin1String("Zen-01"))            // Zen
             {
                 sensorNode.addItem(DataTypeString, RConfigMode);
             }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5669,6 +5669,10 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
     {
         sensorNode.setManufacturer("Heiman");
     }
+    else if (modelId.startsWith(QLatin1String("451270")))
+    {
+        sensorNode.setManufacturer("Namron AS");
+    }
     else if (node->nodeDescriptor().manufacturerCode() == VENDOR_LGE)
     {
         sensorNode.setManufacturer("LG Electronics");

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -7303,7 +7303,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 {
                                     if (i->type() == QLatin1String("ZHAPower"))
                                     {
-                                        qint16 power = ia->numericValue().real;
+                                        qint16 power = static_cast<qint16>(round(ia->numericValue().real));
                                         ResourceItem *item = i->item(RStatePower);
 
                                         if (item)

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -426,6 +426,7 @@ extern const quint64 silabs3MacPrefix;
 extern const quint64 silabs4MacPrefix;
 extern const quint64 silabs5MacPrefix;
 extern const quint64 silabs6MacPrefix;
+extern const quint64 silabs7MacPrefix;
 extern const quint64 instaMacPrefix;
 extern const quint64 boschMacPrefix;
 extern const quint64 jennicMacPrefix;
@@ -481,7 +482,8 @@ inline bool checkMacVendor(quint64 addr, quint16 vendor)
             return prefix == emberMacPrefix ||
                    prefix == konkeMacPrefix ||
                    prefix == silabs3MacPrefix ||
-                   prefix == silabs5MacPrefix;
+                   prefix == silabs5MacPrefix ||
+                   prefix == silabs7MacPrefix;
         case VENDOR_EMBERTEC:
             return prefix == embertecMacPrefix;
         case VENDOR_DDEL:

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -323,6 +323,7 @@
 #define VENDOR_DSR          0x1234
 #define VENDOR_HANGZHOU_IMAGIC 0x123B
 #define VENDOR_SAMJIN       0x1241
+#define VENDOR_DANFOSS      0x1246
 #define VENDOR_NIKO_NV      0x125F
 #define VENDOR_KONKE        0x1268
 #define VENDOR_OSRAM_STACK  0xBBAA
@@ -478,6 +479,8 @@ inline bool checkMacVendor(quint64 addr, quint16 vendor)
             return prefix == bjeMacPrefix;
         case VENDOR_CENTRALITE:
             return prefix == emberMacPrefix;
+        case VENDOR_DANFOSS:
+            return prefix == silabs2MacPrefix;
         case VENDOR_EMBER:
             return prefix == emberMacPrefix ||
                    prefix == konkeMacPrefix ||

--- a/general.xml
+++ b/general.xml
@@ -3396,8 +3396,8 @@ Fil pilote > Off=0001 - On=0002</description>
 				<attribute id="0x0102" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
 				<attribute id="0x0103" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
 				<attribute id="0x0104" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0200" name="Unknown" type="u32" mfcode="0x125f" access="w" required="m"> </attribute>
-				<attribute id="0x0201" name="Connected to power since" type="u48" mfcode="0x125f" access="rw" required="m"> </attribute>
+				<attribute id="0x0200" name="Connected to power since" type="u32" mfcode="0x125f" access="r" required="m"> </attribute>
+				<attribute id="0x0201" name="Unknown" type="u48" mfcode="0x125f" access="rw" required="m"> </attribute>
 				<attribute id="0x0202" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
 				<attribute id="0x0300" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
 				<attribute id="0x0301" name="Unknown" type="bmp8" mfcode="0x125f" access="rw" required="m"> </attribute>

--- a/general.xml
+++ b/general.xml
@@ -290,6 +290,7 @@
 		<description>Attributes and commands for putting a device into Identification mode (e.g. flashing a light)</description>
 		<server>
 			<attribute id="0000" name="Identify Time" type="u16" access="rw" default="0x0000" range="0x0000,0xfff" required="m"></attribute>
+			<attribute id="0x4000" name="Identification button" type="bool" default="0x00" access="r" required="m" mfcode="0x1246"></attribute>
 			<command id="00" dir="recv" name="Identify" required="m">
 				<description>Start or stop the device identifying itself.</description>
 				<payload>
@@ -1717,6 +1718,36 @@ Note: It does not clear or delete previous weekly schedule programming configura
 						<value name="Fan 3rd Stage State On" value="6"></value>
 					</attribute>
 				</attribute-set>
+                
+                <!-- Danfoss manufacturer specific -->
+                <attribute-set id="0x4000" description="Danfoss specific">
+					<attribute id="0x4000" name="eTRV Open Window Detection" type="enum8" default="0x00" access="r" required="m" mfcode="0x1246">
+						<value name="Closed" value="0x01"></value>
+						<value name="Hold" value="0x02"></value>
+						<value name="Open" value="0x03"></value>
+						<value name="Windows open from external, but detected closed" value="0x04"></value>
+					</attribute>
+                    <attribute id="0x4003" name="External Open Window Detected" type="bool" default="0x00" access="rw" required="m" mfcode="0x1246"></attribute>
+                    <attribute id="0x4010" name="Exercise day of week" type="enum8" default="0x04" access="rw" required="m" mfcode="0x1246">
+						<value name="Sunday" value="0x00"></value>
+						<value name="Monday" value="0x01"></value>
+						<value name="Tuesday" value="0x02"></value>
+						<value name="Wednesday" value="0x03"></value>
+						<value name="Thursday" value="0x04"></value>
+						<value name="Friday" value="0x05"></value>
+						<value name="Saturday" value="0x06"></value>
+						<value name="Undefined" value="0x07"></value>
+					</attribute>
+                    <attribute id="0x4011" name="Exercise trigger time" type="u16" default="660" access="rw" required="m" mfcode="0x1246"></attribute>
+                    <attribute id="0x4012" name="Mounting mode active" type="bool" default="0x01" access="r" required="m" mfcode="0x1246"></attribute>
+                    <attribute id="0x4013" name="Mounting mode control" type="bool" access="rw" required="m" mfcode="0x1246"></attribute>
+                    <attribute id="0x4014" name="eTRV Orientation" type="bool" default="0x00" access="rw" required="m" mfcode="0x1246"></attribute>
+                    <attribute id="0x4015" name="External Measured Room Sensor" type="s16" access="r" required="m" mfcode="0x1246"></attribute>
+                    <attribute id="0x4020" name="Control algorithm scale factor" type="u8" default="1" access="rw" required="m" mfcode="0x1246"></attribute>
+                    <attribute id="0x4030" name="Heat Available" type="bool" default="0x01" access="rw" required="m" mfcode="0x1246"></attribute>
+                    <attribute id="0x4031" name="Heat Supply Request " type="bool" access="r" required="m" mfcode="0x1246"></attribute>
+                </attribute-set>
+                
 				<!-- Eurotronic manufacturer specific -->
 				<attribute-set id="0x4000" description="Eurotronic">
 					<attribute id="0x4000" name="TRV Mode" type="enum8" default="0x02" access="rw" required="m" mfcode="0x1037">
@@ -1802,6 +1833,10 @@ controller device, that supports a keypad and LCD screen.</description>
 				<attribute id="0x0002" name="Schedule Programming Visibility" type="enum8" access="rw"  range="0x00,0x01" default="0x00" required="o">
 					<value name="Local schedule programming enabled" value="0x00"></value>
 					<value name="Local schedule programming disabled" value="0x01"></value>
+				</attribute>
+                <attribute id="0x4000" name="Viewing Direction" type="enum8" access="rw" range="0x00,0x01" default="0x00" required="o" mfcode="0x1246">
+					<value name="Viewing direction 1" value="0x00"></value>
+					<value name="Viewing direction 2" value="0x01"></value>
 				</attribute>
 			</server>
 			<client>
@@ -2391,6 +2426,7 @@ controller device, that supports a keypad and LCD screen.</description>
 						<attribute id="0x011c" name="Last Message LQI" type="u8" access="r" required="o" default="0x00"></attribute>
 						<attribute id="0x011d" name="Last Message RSSI" type="s8" access="r" required="o" default="0x00"></attribute>
 					</attribute-set>
+                    <attribute id="0x4000" name="SW error code" type="map16" access="rw" default="0" required="o" mfcode="0x1246"></attribute>
 				</server>
 				<client>
 				</client>

--- a/resource.cpp
+++ b/resource.cpp
@@ -91,6 +91,7 @@ const char *RStateVibration = "state/vibration";
 const char *RStateVibrationStrength = "state/vibrationstrength";
 const char *RStateVoltage = "state/voltage";
 const char *RStateWater = "state/water";
+const char *RStateWindowOpen = "state/windowopen";
 const char *RStateX = "state/x";
 const char *RStateY = "state/y";
 
@@ -234,6 +235,7 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RStateVibrationStrength));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RStateVoltage));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, RStateWater));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RStateWindowOpen));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RStateX));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RStateY));
 

--- a/resource.h
+++ b/resource.h
@@ -106,6 +106,7 @@ extern const char *RStateVibration;
 extern const char *RStateVibrationStrength;
 extern const char *RStateVoltage;
 extern const char *RStateWater;
+extern const char *RStateWindowOpen;
 extern const char *RStateX;
 extern const char *RStateY;
 

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1100,8 +1100,9 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                         }
                         rspItem["success"] = rspItemState;
                     }
-                    else if (sensor->modelId() == QLatin1String("SLR2") || //Hive
-                             sensor->modelId().startsWith(QLatin1String("TH112")) ) // Sinope
+                    else if (sensor->modelId() == QLatin1String("SLR2") ||            //Hive
+                             sensor->modelId().startsWith(QLatin1String("TH112")) ||  // Sinope
+                             sensor->modelId().startsWith(QLatin1String("Zen-01")))   // Zen
                     {
 
                         QString mode_set = map[pi.key()].toString();

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -879,8 +879,9 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                             rspItem["success"] = rspItemState;
                         }
                         
-                        else if (sensor->modelId() == QLatin1String("SLR2") || //Hive
-                                 sensor->modelId().startsWith(QLatin1String("TH112")) ) // Sinope
+                        else if (sensor->modelId() == QLatin1String("SLR2") ||            // Hive
+                                 sensor->modelId().startsWith(QLatin1String("TH112")) ||  // Sinope
+                                 sensor->modelId() == QLatin1String("Zen-01"))            // Zen
                         {
                             QString mode_set = map[pi.key()].toString();
                             quint8 mode = 0x00;

--- a/thermostat.cpp
+++ b/thermostat.cpp
@@ -313,6 +313,32 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
             // manufacturerspecific reported by Eurotronic SPZB0001
             // https://eurotronic.org/wp-content/uploads/2019/01/Spirit_ZigBee_BAL_web_DE_view_V9.pdf
             case 0x4000: // enum8 (0x30): value 0x02, TRV mode
+            {
+                if (zclFrame.manufacturerCode() == VENDOR_JENNIC)
+                {
+                }
+                else if (zclFrame.manufacturerCode() == VENDOR_DANFOSS)
+                {
+                    qint8 windowmode = attr.numericValue().s8;
+                    QString windowmode_set;
+                   
+                    if ( windowmode == 0x01 ) { windowmode_set = QString("Closed"); }
+                    if ( windowmode == 0x02 ) { windowmode_set = QString("Hold"); }
+                    if ( windowmode == 0x03 ) { windowmode_set = QString("Open"); }
+                    if ( windowmode == 0x04 ) { windowmode_set = QString("Open (external), closed (internal)"); }
+
+                    item = sensor->item(RStateWindowOpen);
+                    if (item && item->toString() != windowmode_set)
+                    {
+                        item->setValue(windowmode_set);
+                        enqueueEvent(Event(RSensors, RStateWindowOpen, sensor->id(), item));
+                        configUpdated = true;
+                    }
+                }
+                sensor->setZclValue(updateType, ind.srcEndpoint(), THERMOSTAT_CLUSTER_ID, attrId, attr.numericValue());
+            }
+                break;
+            
             case 0x4001: // U8 (0x20): value 0x00, valve position
             case 0x4002: // U8 (0x20): value 0x00, errors
             {

--- a/thermostat.cpp
+++ b/thermostat.cpp
@@ -252,8 +252,9 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
                 
             case 0x001C: // System Mode
             {
-                if (sensor->modelId().startsWith(QLatin1String("SLR2")) || //Hive
-                    sensor->modelId().startsWith(QLatin1String("TH112")) ) // Sinope
+                if (sensor->modelId().startsWith(QLatin1String("SLR2")) ||  // Hive
+                    sensor->modelId().startsWith(QLatin1String("TH112")) || // Sinope
+                    sensor->modelId().startsWith(QLatin1String("Zen-01")))  // Zen
                 {
                     qint8 mode = attr.numericValue().s8;
                     QString mode_set;


### PR DESCRIPTION
- Expose system mode for Zen-01 thermostat
- Added additional mac prefix
- Appropriately round Xiaomi power values
- Adjusted Niko 170-33505 power reporting interval
- Appropriately round all power, voltage and consumption values
- Set manufacturer name to Namron AS for all devices starting with 451270
- Enable light bindings for Niko devices
- Corrected Niko specific attribute name in general.xml
- Added initial support for Sonoff SNZB-03 (MS01) (#2991)
- Added initial support for Sonoff SNZB-02 (TH01) (#3037)
- Added initial support for Sonoff SNZB-04 (DS01) (#3036)
- Updates to prevent exposure of power for consumption sensors
- Added initial support for Danfoss Ally (eTRV0100) (#2983)