### PR TITLE
Schlage Connect Smart Deadbolt B3468 Support

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1817,6 +1817,11 @@ void DeRestPluginPrivate::checkLightBindingsForAttributeReporting(LightNode *lig
         {
             DBG_Printf(DBG_INFO, "Binding DanaLock\n");
         }
+        // Schlage support
+        else if (lightNode->manufacturerCode() == VENDOR_SCHLAGE)
+        {
+            DBG_Printf(DBG_INFO, "Binding Schlage\n");
+        }
         else if (lightNode->manufacturerCode() == VENDOR_IKEA)
         {
         }
@@ -2136,6 +2141,8 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId().startsWith(QLatin1String("FLS-NB")) ||
         // Danalock support
         sensor->modelId().startsWith(QLatin1String("V3")) ||
+        // Schlage support
+        sensor->modelId().startsWith(QLatin1String("BE468")) ||
         // SmartThings
         sensor->modelId().startsWith(QLatin1String("tagv4")) ||
         sensor->modelId().startsWith(QLatin1String("motionv4")) ||

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -109,6 +109,7 @@ const quint64 xalMacPrefix        = 0xf8f0050000000000ULL;
 const quint64 lutronMacPrefix     = 0xffff000000000000ULL;
 // Danalock support
 const quint64 danalockMacPrefix   = 0x000b570000000000ULL; // note: same as ikeaMacPrefix
+const quint64 schlageMacPrefix    = 0xd0cf5e0000000000ULL;
 
 struct SupportedDevice {
     quint16 vendorId;
@@ -1654,7 +1655,9 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
         node->nodeDescriptor().manufacturerCode() == VENDOR_IKEA || // IKEA FYRTUR and KADRILJ smart binds
         node->nodeDescriptor().manufacturerCode() == VENDOR_THIRD_REALITY || // Third Reality smart light switch
         // Danalock support. The vendor ID (0x115c) needs to defined and whitelisted, as it's battery operated
-        node->nodeDescriptor().manufacturerCode() == VENDOR_DANALOCK) // Danalock Door Lock
+        node->nodeDescriptor().manufacturerCode() == VENDOR_DANALOCK || // Danalock Door Lock
+        // Schlage support. The vendor ID (0x1236) needs to defined and whitelisted, as it's battery operated
+        node->nodeDescriptor().manufacturerCode() == VENDOR_SCHLAGE)
     {
         // whitelist
     }

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -292,6 +292,7 @@
 #define VENDOR_NYCE         0x10B9
 #define VENDOR_UBISYS       0x10F2
 #define VENDOR_DANALOCK     0x115C
+#define VENDOR_SCHLAGE      0x1236 // Used by Schlage Locks
 #define VENDOR_BEGA         0x1105
 #define VENDOR_PHYSICAL     0x110A // Used by SmartThings
 #define VENDOR_OSRAM        0x110C
@@ -457,6 +458,7 @@ extern const quint64 ecozyMacPrefix;
 extern const quint64 zhejiangMacPrefix;
 // Danalock support
 extern const quint64 danalockMacPrefix;
+extern const quint64 schlageMacPrefix;
 
 inline bool checkMacVendor(quint64 addr, quint16 vendor)
 {
@@ -572,6 +574,8 @@ inline bool checkMacVendor(quint64 addr, quint16 vendor)
             return prefix == computimeMacPrefix;
         case VENDOR_DANALOCK:
             return prefix == danalockMacPrefix;
+        case VENDOR_SCHLAGE:
+            return prefix == schlageMacPrefix;
         default:
             return false;
     }

--- a/light_node.cpp
+++ b/light_node.cpp
@@ -108,6 +108,7 @@ void LightNode::setManufacturerCode(uint16_t code)
         case VENDOR_HEIMAN:  name = QLatin1String("Heiman"); break;
         case VENDOR_KEEN_HOME: name = QLatin1String("Keen Home Inc"); break;
         case VENDOR_DANALOCK: name = QLatin1String("Danalock"); break;
+        case VENDOR_SCHLAGE: name = QLatin1String("Schlage"); break;
         case VENDOR_DEVELCO: name = QLatin1String("Develco Products A/S"); break;
         case VENDOR_NETVOX:   name = QLatin1String("netvox"); break;
         default:


### PR DESCRIPTION
Using the Danalock v3 code update as base, updated to support Schlage Connect Smart Deadbolt B3468.

Tested and working with my lock.