### PR TITLE
Enhancements and fixes

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2247,7 +2247,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId().startsWith(QLatin1String("ROB_200")) ||
         // Sunricher
         sensor->modelId().startsWith(QLatin1String("Micro Smart Dimmer")) ||
-        sensor->modelId().startsWith(QLatin1String("451270")) ||
+        sensor->modelId().startsWith(QLatin1String("45127")) ||
         // EcoDim
         sensor->modelId().startsWith(QLatin1String("ED-1001")) ||
         // Plugwise

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1242,6 +1242,12 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq.maxInterval = 43200;        // Vendor defaults
             rq.reportableChange8bit = 2;   // Vendor defaults
         }
+        else if (sensor && (sensor->modelId().startsWith(QLatin1String("ED-1001")))) // EcoDim switches
+        {
+            rq.minInterval = 3600;
+            rq.maxInterval = 43200;
+            rq.reportableChange8bit = 1;
+        }
         else if (sensor && (sensor->manufacturer().startsWith(QLatin1String("Climax")) ||
                             sensor->modelId().startsWith(QLatin1String("902010/23"))))
         {

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2254,6 +2254,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         // Sunricher
         sensor->modelId().startsWith(QLatin1String("Micro Smart Dimmer")) ||
         sensor->modelId().startsWith(QLatin1String("45127")) ||
+        sensor->modelId().startsWith(QLatin1String("ZG2835")) ||
         // EcoDim
         sensor->modelId().startsWith(QLatin1String("ED-1001")) ||
         // Namron
@@ -2911,7 +2912,9 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
         srcEndpoints.push_back(sensor->fingerPrint().endpoint);
     }
     // Linkind 1 key Remote Control / ZS23000178
-    else if (sensor->modelId().startsWith(QLatin1String("ZBT-DIMSwitch")))
+    // SR-ZG2835 Zigbee Rotary Switch
+    else if (sensor->modelId().startsWith(QLatin1String("ZBT-DIMSwitch")) ||
+             sensor->modelId().startsWith(QLatin1String("ZG2835")))
     {
         clusters.push_back(ONOFF_CLUSTER_ID);
         clusters.push_back(LEVEL_CLUSTER_ID);
@@ -3042,7 +3045,8 @@ void DeRestPluginPrivate::checkSensorGroup(Sensor *sensor)
         sensor->modelId().startsWith(QLatin1String("902010/23")) || // bitron remote
         sensor->modelId().startsWith(QLatin1String("Bell")) || // Sage doorbell sensor
         sensor->modelId().startsWith(QLatin1String("ZBT-DIMSwitch")) || // Linkind 1 key Remote Control / ZS23000178
-        sensor->modelId().startsWith(QLatin1String("WB01"))) // Sonoff SNZB-01
+        sensor->modelId().startsWith(QLatin1String("WB01")) || // Sonoff SNZB-01
+        sensor->modelId().startsWith(QLatin1String("ZG2835"))) // SR-ZG2835 Zigbee Rotary Switch
     {
 
     }

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2265,6 +2265,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         // Sage
         sensor->modelId() == QLatin1String("Bell") ||
         // Sonoff
+        sensor->modelId() == QLatin1String("WB01") ||
         sensor->modelId() == QLatin1String("MS01") ||
         sensor->modelId() == QLatin1String("TH01") ||
         sensor->modelId() == QLatin1String("DS01") ||
@@ -2714,7 +2715,9 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
         srcEndpoints.push_back(sensor->fingerPrint().endpoint);
     }
     // IKEA Trådfri on/off switch
-    else if (sensor->modelId().startsWith(QLatin1String("TRADFRI on/off switch")))
+    // Sonoff SNZB-01
+    else if (sensor->modelId().startsWith(QLatin1String("TRADFRI on/off switch")) ||
+             sensor->modelId().startsWith(QLatin1String("WB01")))
     {
         clusters.push_back(ONOFF_CLUSTER_ID);
         srcEndpoints.push_back(sensor->fingerPrint().endpoint);
@@ -3038,7 +3041,8 @@ void DeRestPluginPrivate::checkSensorGroup(Sensor *sensor)
         // sensor->modelId().startsWith(QLatin1String("SYMFONISK")) ||
         sensor->modelId().startsWith(QLatin1String("902010/23")) || // bitron remote
         sensor->modelId().startsWith(QLatin1String("Bell")) || // Sage doorbell sensor
-        sensor->modelId().startsWith(QLatin1String("ZBT-DIMSwitch"))) // Linkind 1 key Remote Control / ZS23000178
+        sensor->modelId().startsWith(QLatin1String("ZBT-DIMSwitch")) || // Linkind 1 key Remote Control / ZS23000178
+        sensor->modelId().startsWith(QLatin1String("WB01"))) // Sonoff SNZB-01
     {
 
     }

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1900,6 +1900,9 @@ void DeRestPluginPrivate::checkLightBindingsForAttributeReporting(LightNode *lig
         else if (lightNode->manufacturer() == QLatin1String("NIKO NV"))
         {
         }
+        else if (lightNode->manufacturer() == QLatin1String("Sunricher"))
+        {
+        }
         else
         {
             return;

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2816,7 +2816,8 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
         srcEndpoints.push_back(0x07);
         srcEndpoints.push_back(0x08);
     }
-    else if (sensor->modelId().startsWith(QLatin1String("ICZB-RM")))
+    else if (sensor->modelId().startsWith(QLatin1String("ICZB-RM")) ||
+             sensor->modelId().startsWith(QLatin1String("ZGRC-KEY-013")))
     {
         clusters.push_back(ONOFF_CLUSTER_ID);
         clusters.push_back(LEVEL_CLUSTER_ID);
@@ -2897,7 +2898,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
         srcEndpoints.push_back(sensor->fingerPrint().endpoint);
     }
     // RGBgenie remote control
-    else if (sensor->modelId().startsWith(QLatin1String("ZGRC-KEY")))
+    else if (sensor->modelId().startsWith(QLatin1String("ZGRC-KEY-012")))
     {
         clusters.push_back(ONOFF_CLUSTER_ID);
         clusters.push_back(LEVEL_CLUSTER_ID);

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1242,7 +1242,8 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq.maxInterval = 43200;        // Vendor defaults
             rq.reportableChange8bit = 2;   // Vendor defaults
         }
-        else if (sensor && (sensor->modelId().startsWith(QLatin1String("ED-1001")))) // EcoDim switches
+        else if (sensor && (sensor->modelId().startsWith(QLatin1String("ED-1001")) || // EcoDim switches
+                            sensor->modelId().startsWith(QLatin1String("45127"))))    // Namron switches
         {
             rq.minInterval = 3600;
             rq.maxInterval = 43200;
@@ -2255,6 +2256,8 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId().startsWith(QLatin1String("45127")) ||
         // EcoDim
         sensor->modelId().startsWith(QLatin1String("ED-1001")) ||
+        // Namron
+        sensor->modelId().startsWith(QLatin1String("45127")) ||
         // Plugwise
         sensor->modelId().startsWith(QLatin1String("160-01")) ||
         // Niko
@@ -2816,7 +2819,8 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
         srcEndpoints.push_back(0x03);
         srcEndpoints.push_back(0x04);
     }
-    else if (sensor->modelId().startsWith(QLatin1String("ED-1001")))
+    else if (sensor->modelId().startsWith(QLatin1String("ED-1001")) ||
+             sensor->modelId().startsWith(QLatin1String("45127")))
     {
         clusters.push_back(ONOFF_CLUSTER_ID);
         clusters.push_back(LEVEL_CLUSTER_ID);

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2907,6 +2907,13 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
         clusters.push_back(LEVEL_CLUSTER_ID);
         srcEndpoints.push_back(sensor->fingerPrint().endpoint);
     }
+    // Linkind 1 key Remote Control / ZS23000178
+    else if (sensor->modelId().startsWith(QLatin1String("ZBT-DIMSwitch")))
+    {
+        clusters.push_back(ONOFF_CLUSTER_ID);
+        clusters.push_back(LEVEL_CLUSTER_ID);
+        srcEndpoints.push_back(sensor->fingerPrint().endpoint);
+    }
     else
     {
         return false;
@@ -3030,7 +3037,8 @@ void DeRestPluginPrivate::checkSensorGroup(Sensor *sensor)
         sensor->modelId().startsWith(QLatin1String("TRADFRI wireless dimmer")) ||
         // sensor->modelId().startsWith(QLatin1String("SYMFONISK")) ||
         sensor->modelId().startsWith(QLatin1String("902010/23")) || // bitron remote
-        sensor->modelId().startsWith(QLatin1String("Bell"))) // Sage doorbell sensor
+        sensor->modelId().startsWith(QLatin1String("Bell")) || // Sage doorbell sensor
+        sensor->modelId().startsWith(QLatin1String("ZBT-DIMSwitch"))) // Linkind 1 key Remote Control / ZS23000178
     {
 
     }

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1412,7 +1412,8 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
                        sensor->modelId() == QLatin1String("Connected socket outlet") || // Niko smart socket
                        sensor->modelId().startsWith(QLatin1String("ROB_200")) || // ROBB Smarrt micro dimmer
                        sensor->modelId().startsWith(QLatin1String("Micro Smart Dimmer")) || // Sunricher Micro Smart Dimmer
-                       sensor->modelId().startsWith(QLatin1String("lumi.plug.maeu")))) // Xiaomi Aqara ZB3.0 smart plug
+                       sensor->modelId().startsWith(QLatin1String("lumi.plug.maeu")) || // Xiaomi Aqara ZB3.0 smart plug
+                       sensor->modelId().startsWith(QLatin1String("lumi.switch.b1naus01")))) // Xiaomi ZB3.0 Smart Wall Switch
         {
             rq.reportableChange16bit = 10; // 1 W
         }
@@ -1844,6 +1845,9 @@ void DeRestPluginPrivate::checkLightBindingsForAttributeReporting(LightNode *lig
         else if (lightNode->manufacturerCode() == VENDOR_SINOPE)
         {
         }
+        else if (lightNode->manufacturerCode() == VENDOR_XIAOMI)
+        {
+        }
         else if (lightNode->modelId().startsWith(QLatin1String("SP ")))
         {
         }
@@ -2217,6 +2221,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         // Xiaomi
         sensor->modelId().startsWith(QLatin1String("lumi.plug.maeu01")) ||
         sensor->modelId().startsWith(QLatin1String("lumi.sen_ill.mgl01")) ||
+        sensor->modelId().startsWith(QLatin1String("lumi.switch.b1naus01")) ||
         // iris
         sensor->modelId().startsWith(QLatin1String("1116-S")) ||
         sensor->modelId().startsWith(QLatin1String("1117-S")) ||

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1083,7 +1083,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq5.attributeId = 0x001C;        // Thermostat mode
             rq5.minInterval = 1;
             rq5.maxInterval = 600;
-            rq5.reportableChange16bit = 0xff;
+            rq5.reportableChange8bit = 0xff;
 
             return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4, rq5});
         }
@@ -1108,7 +1108,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq4.attributeId = 0x001C;        // Thermostat mode
             rq4.minInterval = 1;
             rq4.maxInterval = 600;
-            rq4.reportableChange16bit = 0xff;
+            rq4.reportableChange8bit = 0xff;
 
             ConfigureReportingRequest rq2;
             rq2.dataType = deCONZ::Zcl16BitBitMap;

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2887,6 +2887,9 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
         clusters.push_back(LEVEL_CLUSTER_ID);
         srcEndpoints.push_back(0x01);
         srcEndpoints.push_back(0x02);
+        srcEndpoints.push_back(0x03);
+        srcEndpoints.push_back(0x04);
+        srcEndpoints.push_back(0x05);
     }
     // Sage doorbell sensor
     else if (sensor->modelId().startsWith(QLatin1String("Bell")))

--- a/database.cpp
+++ b/database.cpp
@@ -3405,6 +3405,10 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 item = sensor.addItem(DataTypeBool, RStateLowBattery);
                 // don't set value -> null until reported
             }
+            else if (sensor.modelId() == QLatin1String("lumi.sensor_natgas"))
+            {
+                // Don't expose battery resource item for this device
+            }
             else if (!sensor.type().endsWith(QLatin1String("Battery")))
             {
                 item = sensor.addItem(DataTypeUInt8, RConfigBattery);

--- a/database.cpp
+++ b/database.cpp
@@ -3130,6 +3130,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     (!sensor.modelId().startsWith(QLatin1String("BQZ10-AU"))) &&
                     (!sensor.modelId().startsWith(QLatin1String("ROB_200"))) &&
                     (sensor.modelId() != QLatin1String("Plug-230V-ZB3.0")) &&
+                    (sensor.modelId() != QLatin1String("lumi.switch.b1naus01")) &&
                     (sensor.modelId() != QLatin1String("Connected socket outlet")))
                 {
                     item = sensor.addItem(DataTypeInt16, RStatePower);
@@ -3159,7 +3160,8 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     // hasVoltage = false;
                 }
                 else if (sensor.modelId() == QLatin1String("ZB-ONOFFPlug-D0005") ||
-                         sensor.modelId() == QLatin1String("Plug-230V-ZB3.0"))
+                         sensor.modelId() == QLatin1String("Plug-230V-ZB3.0") ||
+                         sensor.modelId() == QLatin1String("lumi.switch.b1naus01"))
                 {
                     hasVoltage = false;
                 }
@@ -3341,6 +3343,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 !sensor.modelId().startsWith(QLatin1String("lumi.plug")) &&
                 sensor.modelId() != QLatin1String("lumi.curtain") &&
                 sensor.modelId() != QLatin1String("lumi.sensor_natgas") &&
+                sensor.modelId() != QLatin1String("lumi.switch.b1naus01") &&
                 !sensor.modelId().startsWith(QLatin1String("lumi.relay.c")) &&
                 !sensor.type().endsWith(QLatin1String("Battery")))
             {

--- a/database.cpp
+++ b/database.cpp
@@ -3144,6 +3144,8 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             else if (sensor.fingerPrint().hasInCluster(ANALOG_INPUT_CLUSTER_ID))
             {
                 clusterId = clusterId ? clusterId : ANALOG_INPUT_CLUSTER_ID;
+                item = sensor.addItem(DataTypeUInt64, RStateConsumption);
+                item->setValue(0);
             }
         }
         else if (sensor.type().endsWith(QLatin1String("Power")))

--- a/database.cpp
+++ b/database.cpp
@@ -3144,8 +3144,6 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             else if (sensor.fingerPrint().hasInCluster(ANALOG_INPUT_CLUSTER_ID))
             {
                 clusterId = clusterId ? clusterId : ANALOG_INPUT_CLUSTER_ID;
-                item = sensor.addItem(DataTypeUInt64, RStateConsumption);
-                item->setValue(0);
             }
         }
         else if (sensor.type().endsWith(QLatin1String("Power")))

--- a/database.cpp
+++ b/database.cpp
@@ -3124,11 +3124,6 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             if (sensor.fingerPrint().hasInCluster(METERING_CLUSTER_ID))
             {
                 clusterId = clusterId ? clusterId : METERING_CLUSTER_ID;
-                if (sensor.modelId() != QLatin1String("160-01"))
-                {
-                    item = sensor.addItem(DataTypeUInt64, RStateConsumption);
-                    item->setValue(0);
-                }
                 if ((sensor.modelId() != QLatin1String("SP 120")) &&
                     (sensor.modelId() != QLatin1String("ZB-ONOFFPlug-D0005")) &&
                     (sensor.modelId() != QLatin1String("TS0121")) &&
@@ -3144,6 +3139,11 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             else if (sensor.fingerPrint().hasInCluster(ANALOG_INPUT_CLUSTER_ID))
             {
                 clusterId = clusterId ? clusterId : ANALOG_INPUT_CLUSTER_ID;
+            }
+            if (sensor.modelId() != QLatin1String("160-01"))
+            {
+                item = sensor.addItem(DataTypeUInt64, RStateConsumption);
+                item->setValue(0);
             }
         }
         else if (sensor.type().endsWith(QLatin1String("Power")))

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -307,6 +307,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_LEGRAND, "DIN power consumption module", legrandMacPrefix }, // Legrand DIN power consumption module
     { VENDOR_NETVOX, "Z809AE3R", netvoxMacPrefix }, // Netvox smartplug
     { VENDOR_LDS, "ZB-ONOFFPlug-D0005", silabs2MacPrefix }, // Samsung SmartPlug 2019 (7A-PL-Z-J3)
+    { VENDOR_LDS, "ZBT-DIMSwitch", silabs2MacPrefix }, // Linkind 1 key Remote Control / ZS23000178
     { VENDOR_PHYSICAL, "outletv4", stMacPrefix }, // Samsung SmartThings plug (IM6001-OTP)
     { VENDOR_EMBER, "RH3040", konkeMacPrefix }, // Tuyatec motion sensor
     { VENDOR_NONE, "RH3001", ikea2MacPrefix }, // Tuyatec door/window sensor

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4367,7 +4367,8 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                              modelId.startsWith(QLatin1String("HESZB-120")) ||        // Develco heat detector
                              modelId.startsWith(QLatin1String("SF2")) ||              // ORVIBO (Heiman) smoke sensor
                              modelId.startsWith(QLatin1String("lumi.sensor_smoke")) || // Xiaomi Mi smoke sensor
-                             modelId.startsWith(QLatin1String("TS0204")))             // Tuya gas sensor
+                             modelId.startsWith(QLatin1String("TS0204")) ||           // Tuya gas sensor
+                             modelId.startsWith(QLatin1String("MOT003")))             // Hive motion sensor
                     {
                         // Gas sensor detects combustable gas, so fire is more appropriate than CO.
                         fpFireSensor.inClusters.push_back(ci->id());

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -791,6 +791,7 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
                     else if (sensorNode->modelId().startsWith("C4") || // ubisys
                              sensorNode->modelId().startsWith("RC 110") || // innr RC 110
                              sensorNode->modelId().startsWith("ICZB-RM") || // icasa remote
+                             sensorNode->modelId().startsWith("ZGRC-KEY") || // Sunricher remote
                              sensorNode->modelId().startsWith("ED-1001") || // EcoDim switches
                              sensorNode->modelId().startsWith("45127") || // Namron switches
                              sensorNode->modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
@@ -3393,12 +3394,8 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
         checkReporting = true;
         checkClientCluster = true;
     }
-    else if (sensor->modelId().startsWith(QLatin1String("ICZB-RM"))) // icasa remote
-    {
-        checkReporting = true;
-        checkClientCluster = true;
-    }
-    else if (sensor->modelId().startsWith(QLatin1String("RGBGenie ZB-5")) || // RGBGenie remote control
+    else if (sensor->modelId().startsWith(QLatin1String("ICZB-RM")) || // icasa remote
+             sensor->modelId().startsWith(QLatin1String("RGBGenie ZB-5")) || // RGBGenie remote control
              sensor->modelId().startsWith(QLatin1String("ZGRC-KEY")))        // RGBGenie ZB-5001
     {
         checkReporting = true;
@@ -3496,16 +3493,23 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
             enqueueEvent(e);
         }
         else if (sensor->modelId().startsWith(QLatin1String("ICZB-RM")) || // icasa remote
+                 sensor->modelId().startsWith(QLatin1String("ZGRC-KEY")) ||// Sunricher remote
                  sensor->modelId().startsWith(QLatin1String("ED-1001")) || // EcoDim switches
                  sensor->modelId().startsWith(QLatin1String("45127")))     // Namron switches
         {
-            // 4 controller endpoints: 0x01, 0x02, 0x03, 0x04
-            if (gids.length() != 4)
+            if (gids.length() != 5 && sensor->modelId().startsWith(QLatin1String("ZGRC-KEY-012"))) // 5 controller endpoints: 0x01, 0x02, 0x03, 0x04, 0x05
+            {
+                // initialise list of groups: one for each endpoint
+                gids = QStringList();
+                gids << "0" << "0" << "0" << "0" << "0";
+            }
+            else if (gids.length() != 4) // 4 controller endpoints: 0x01, 0x02, 0x03, 0x04
             {
                 // initialise list of groups: one for each endpoint
                 gids = QStringList();
                 gids << "0" << "0" << "0" << "0";
             }
+            else 
 
             // check group corresponding to source endpoint
             int i = ind.srcEndpoint();
@@ -4702,6 +4706,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     }
                     else if (modelId.startsWith(QLatin1String("RC 110")) ||  // innr RC 110
                              modelId.startsWith(QLatin1String("ICZB-RM")) || // icasa remote
+                             modelId.startsWith(QLatin1String("ZGRC-KEY")) || // Sunricher remote
                              modelId.startsWith(QLatin1String("ED-1001")) || // EcoDim switches
                              modelId.startsWith(QLatin1String("ED-1001")))   // Namron switches
                     {
@@ -15169,8 +15174,12 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
             }
             checkSensorBindingsForClientClusters(sensor);
         }
-        else if (sensor->modelId().startsWith(QLatin1String("ICZB-RM"))) // icasa remote
+        else if (sensor->modelId().startsWith(QLatin1String("ICZB-RM")) || // icasa remote
+                 sensor->modelId().startsWith(QLatin1String("ZGRC-KEY"))   // Sunricher remote
         {
+            if (sensor->modelId() == QLatin1String("ZGRC-KEY-012")) { quint8 lastEndpoint = 0x05; }
+            else { quint8 lastEndpoint = 0x04; }
+            
             ResourceItem *item = sensor->item(RConfigGroup);
             if (!item)
             {
@@ -15179,7 +15188,7 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
                 QString gid;
                 Group *group;
 
-                for (quint8 endpoint = 0x01; endpoint <= 0x04; endpoint++)
+                for (quint8 endpoint = 0x01; endpoint <= lastEndpoint; endpoint++)
                 {
                     group = addGroup();
                     gid = group->id();

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -209,7 +209,8 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_XIAOMI, "lumi.remote.b486opcn01", xiaomiMacPrefix }, // Xiaomi Aqara Opple WXCJKG12LM
     { VENDOR_XIAOMI, "lumi.remote.b686opcn01", xiaomiMacPrefix }, // Xiaomi Aqara Opple WXCJKG13LM
     { VENDOR_XIAOMI, "lumi.sen_ill.mgl01", xiaomiMacPrefix }, // Xiaomi ZB3.0 light sensor
-    { VENDOR_XIAOMI, "lumi.plug", xiaomiMacPrefix }, // Xiaomi Xiaomi smart plugs (router)
+    { VENDOR_XIAOMI, "lumi.plug", xiaomiMacPrefix }, // Xiaomi smart plugs (router)
+    { VENDOR_XIAOMI, "lumi.switch.b1naus01", xiaomiMacPrefix }, // Xiaomi Aqara ZB3.0 Smart Wall Switch Single Rocker
     // { VENDOR_XIAOMI, "lumi.curtain", jennicMacPrefix}, // Xiaomi curtain controller (router) - exposed only as light
     { VENDOR_UBISYS, "C4", ubisysMacPrefix },
     { VENDOR_UBISYS, "D1", ubisysMacPrefix },
@@ -5445,6 +5446,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                 (!modelId.startsWith(QLatin1String("BQZ10-AU"))) &&
                 (!modelId.startsWith(QLatin1String("ROB_200"))) &&
                 (modelId != QLatin1String("Plug-230V-ZB3.0")) &&
+                (modelId != QLatin1String("lumi.switch.b1naus01")) &&
                 (modelId != QLatin1String("Connected socket outlet")))
             {
                 item = sensorNode.addItem(DataTypeInt16, RStatePower);
@@ -5465,6 +5467,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             if ( (!modelId.startsWith(QLatin1String("Plug"))) &&
                  (!modelId.startsWith(QLatin1String("ZB-ONOFFPlug-D0005"))) &&
                  (modelId != QLatin1String("Plug-230V-ZB3.0")) &&
+                 (modelId != QLatin1String("lumi.switch.b1naus01")) &&
                  (node->nodeDescriptor().manufacturerCode() != VENDOR_LEGRAND) ) // OSRAM and Legrand plug don't have theses options
             {
                 item = sensorNode.addItem(DataTypeUInt16, RStateVoltage);
@@ -5703,6 +5706,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             !sensorNode.modelId().startsWith(QLatin1String("lumi.relay.c")) &&
             sensorNode.modelId() != QLatin1String("lumi.curtain") &&
             sensorNode.modelId() != QLatin1String("lumi.sensor_natgas") &&
+            sensorNode.modelId() != QLatin1String("lumi.switch.b1naus01") &&
             !sensorNode.type().endsWith(QLatin1String("Battery")))
         {
             sensorNode.addItem(DataTypeUInt8, RConfigBattery);
@@ -7703,7 +7707,8 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                         i->modelId().startsWith(QLatin1String("lumi.plug.maeu")) || // Xiaomi Aqara ZB3.0 smart plug
                                         i->modelId() == QLatin1String("RICI01") ||           // LifeControl Smart Plug
                                         i->modelId().startsWith(QLatin1String("outlet")) ||  // Samsung SmartThings IM6001-OTP/IM6001-OTP01
-                                        i->modelId().startsWith(QLatin1String("3200-S")))    // Samsung/Centralite smart outlet
+                                        i->modelId().startsWith(QLatin1String("3200-S")) ||    // Samsung/Centralite smart outlet
+                                        i->modelId().startsWith(QLatin1String("lumi.switch.b1naus01"))) // Xiaomi ZB3.0 Smart Wall Switch
                                     {
                                         //power += 5; power /= 10; // 0.1W -> W
                                         power = static_cast<qint16>(round((double)power / 10.0)); // 0.1W -> W

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -149,6 +149,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_NONE, "902010/23", tiMacPrefix }, // Bitron: remote control
     { VENDOR_NONE, "902010/24", tiMacPrefix }, // Bitron: smoke detector
     { VENDOR_NONE, "902010/25", tiMacPrefix }, // Bitron: smart plug
+    { VENDOR_NONE, "902010/29", tiMacPrefix }, // Bitron: Outdoor siren
     { VENDOR_BITRON, "902010/32", emberMacPrefix }, // Bitron: thermostat
     { VENDOR_DDEL, "Lighting Switch", deMacPrefix },
     { VENDOR_DDEL, "Scene Switch", deMacPrefix },
@@ -4387,7 +4388,8 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                         fpWaterSensor.inClusters.push_back(ci->id());
                     }
                     else if (modelId == QLatin1String("WarningDevice") ||               // Heiman siren
-                             modelId == QLatin1String("SZ-SRN12N"))                     // Sercomm siren
+                             modelId == QLatin1String("SZ-SRN12N") ||                   // Sercomm siren
+                             modelId == QLatin1String("902010/29"))                     // Bitron outdoor siren
                     {
                         fpAlarmSensor.inClusters.push_back(ci->id());
                     }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -785,6 +785,8 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
                     else if (sensorNode->modelId().startsWith("C4") || // ubisys
                              sensorNode->modelId().startsWith("RC 110") || // innr RC 110
                              sensorNode->modelId().startsWith("ICZB-RM") || // icasa remote
+                             sensorNode->modelId().startsWith("ED-1001") || // EcoDim switches
+                             sensorNode->modelId().startsWith("45127") || // Namron switches
                              sensorNode->modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
                              sensorNode->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
                              sensorNode->modelId().startsWith(QLatin1String("Switch 4x-LIGHTIFY")) || // Osram 4 button remote
@@ -3487,7 +3489,9 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
             Event e(RSensors, REventValidGroup, sensor->id());
             enqueueEvent(e);
         }
-        else if (sensor->modelId().startsWith(QLatin1String("ICZB-RM"))) // icasa remote
+        else if (sensor->modelId().startsWith(QLatin1String("ICZB-RM")) || // icasa remote
+                 sensor->modelId().startsWith(QLatin1String("ED-1001")) || // EcoDim switches
+                 sensor->modelId().startsWith(QLatin1String("45127")))     // Namron switches
         {
             // 4 controller endpoints: 0x01, 0x02, 0x03, 0x04
             if (gids.length() != 4)
@@ -4687,8 +4691,10 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     {
                         fpSwitch.outClusters.push_back(ci->id());
                     }
-                    else if (modelId.startsWith(QLatin1String("RC 110")) || // innr RC 110
-                             modelId.startsWith(QLatin1String("ICZB-RM"))) // icasa remote
+                    else if (modelId.startsWith(QLatin1String("RC 110")) ||  // innr RC 110
+                             modelId.startsWith(QLatin1String("ICZB-RM")) || // icasa remote
+                             modelId.startsWith(QLatin1String("ED-1001")) || // EcoDim switches
+                             modelId.startsWith(QLatin1String("ED-1001")))   // Namron switches
                     {
                         if (i->endpoint() == 0x01) // create sensor only for first endpoint
                         {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -319,6 +319,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_NONE, "TS0121", silabs3MacPrefix }, // Tuya/Blitzwolf smart plug
     { VENDOR_EMBER, "TS0121", silabs3MacPrefix }, // Tuya/Blitzwolf smart plug
     { VENDOR_EMBER, "TS0302", silabs3MacPrefix }, // Tuya curtain switch
+    { VENDOR_EMBER, "TS0207", silabs3MacPrefix }, // Tuya water leak sensor
     { VENDOR_AURORA, "DoubleSocket50AU", jennicMacPrefix }, // Aurora AOne Double Socket UK
     { VENDOR_COMPUTIME, "SP600", computimeMacPrefix }, // Salus smart plug
     { VENDOR_HANGZHOU_IMAGIC, "1116-S", energyMiMacPrefix }, // iris contact sensor v3
@@ -4387,8 +4388,9 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                              modelId.startsWith(QLatin1String("Water")) ||            // Heiman water sensor (newer model)
                              modelId.startsWith(QLatin1String("lumi.sensor_wleak")) || // Xiaomi Aqara flood sensor
                              modelId.startsWith(QLatin1String("WL4200S")) ||          // Sinope Water Leak detector
-                             modelId.startsWith(QLatin1String("3315")) ||              // Centralite water sensor
-                             modelId.startsWith(QLatin1String("FLSZB-110")))          // Develco Water Leak detector
+                             modelId.startsWith(QLatin1String("3315")) ||             // Centralite water sensor
+                             modelId.startsWith(QLatin1String("FLSZB-110")) ||        // Develco Water Leak detector
+                             modelId.startsWith(QLatin1String("TS0207")))             // Tuya water leak sensor
                     {
                         fpWaterSensor.inClusters.push_back(ci->id());
                     }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -329,8 +329,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_ALERTME, "SLP2b", computimeMacPrefix }, // Hive  plug
     { VENDOR_ALERTME, "SLR2", computimeMacPrefix }, // Hive   Heating Receiver
     { VENDOR_ALERTME, "SLT2", computimeMacPrefix }, // Hive thermostat
-    { VENDOR_SUNRICHER, "4512703", silabs2MacPrefix }, // Namron 4-ch remote controller
-    { VENDOR_SUNRICHER, "451270", silabs2MacPrefix }, // Namron 1/4-ch remote controller
+    { VENDOR_SUNRICHER, "45127", silabs2MacPrefix }, // Namron 1/2/4-ch remote controller
     { VENDOR_SENGLED_OPTOELEC, "E13-", zhejiangMacPrefix }, // Sengled PAR38 Bulbs
     { VENDOR_SENGLED_OPTOELEC, "E1D-", zhejiangMacPrefix }, // Sengled contact sensor
     { VENDOR_JENNIC, "Plug-230V-ZB3.0", silabs2MacPrefix }, // Immax NEO ZB3.0 smart plug
@@ -5742,7 +5741,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
     {
         sensorNode.setManufacturer("Heiman");
     }
-    else if (modelId.startsWith(QLatin1String("451270")))
+    else if (modelId.startsWith(QLatin1String("45127")))
     {
         sensorNode.setManufacturer("Namron AS");
     }
@@ -6421,7 +6420,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                         i->modelId().startsWith(QLatin1String("ZGRC-KEY")) || //  Sunricher wireless CCT remote
                                         i->modelId().startsWith(QLatin1String("ZG2833K")) || // Sunricher remote controller
                                         i->modelId().startsWith(QLatin1String("SV01-")) || // Keen Home vent
-                                        i->modelId().startsWith(QLatin1String("451270")) || // Namron 1/4-ch remote controller
+                                        i->modelId().startsWith(QLatin1String("45127")) || // Namron 1/2/4-ch remote controller
                                         i->modelId().startsWith(QLatin1String("RGBgenie ZB-5")) || // RGBgenie remote control
                                         i->modelId().startsWith(QLatin1String("VOC_Sensor"))) // LifeControl Enviroment sensor
                                     {
@@ -6459,7 +6458,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                         i->modelId().startsWith(QLatin1String("ZGRC-KEY")) || // Sunricher wireless CCT remote
                                         i->modelId().startsWith(QLatin1String("ZG2833K")) || // Sunricher remote controller
                                         i->modelId().startsWith(QLatin1String("SV01-")) || // Keen Home vent
-                                        i->modelId().startsWith(QLatin1String("451270")) || // Namron 1/4-ch remote controller
+                                        i->modelId().startsWith(QLatin1String("45127")) || // Namron 1/2/4-ch remote controller
                                         i->modelId().startsWith(QLatin1String("RGBgenie ZB-5")) || // RGBgenie remote control
                                         i->modelId().startsWith(QLatin1String("VOC_Sensor"))) // LifeControl Enviroment sensor
                                     {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5215,6 +5215,10 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             sensorNode.addItem(DataTypeBool, RStateLowBattery);
             // don't set value -> null until reported
         }
+        else if (sensorNode.modelId() == QLatin1String("lumi.sensor_natgas"))
+        {
+            // Don't expose battery resource item for this device
+        }
         else if (!sensorNode.type().endsWith(QLatin1String("Battery")))
         {
             sensorNode.addItem(DataTypeUInt8, RConfigBattery);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -3509,7 +3509,6 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                 gids = QStringList();
                 gids << "0" << "0" << "0" << "0";
             }
-            else 
 
             // check group corresponding to source endpoint
             int i = ind.srcEndpoint();
@@ -15175,10 +15174,12 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
             checkSensorBindingsForClientClusters(sensor);
         }
         else if (sensor->modelId().startsWith(QLatin1String("ICZB-RM")) || // icasa remote
-                 sensor->modelId().startsWith(QLatin1String("ZGRC-KEY"))   // Sunricher remote
+                 sensor->modelId().startsWith(QLatin1String("ZGRC-KEY")))  // Sunricher remote
         {
-            if (sensor->modelId() == QLatin1String("ZGRC-KEY-012")) { quint8 lastEndpoint = 0x05; }
-            else { quint8 lastEndpoint = 0x04; }
+            quint8 lastEndpoint;
+            
+            if (sensor->modelId() == QLatin1String("ZGRC-KEY-012")) { lastEndpoint = 0x05; }
+            else { lastEndpoint = 0x04; }
             
             ResourceItem *item = sensor->item(RConfigGroup);
             if (!item)

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -345,6 +345,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_PLUGWISE_BV, "160-01", emberMacPrefix }, // Plugwise smart plug
     { VENDOR_NIKO_NV, "Connected socket outlet", konkeMacPrefix }, // Niko smart socket 170-33505
     { VENDOR_ATMEL, "Bell", dishMacPrefix }, // Sage doorbell sensor
+    { VENDOR_NONE, "WB01", tiMacPrefix }, // Sonoff SNZB-01
     { VENDOR_NONE, "MS01", tiMacPrefix }, // Sonoff SNZB-03
     { VENDOR_NONE, "TH01", tiMacPrefix }, // Sonoff SNZB-02
     { VENDOR_NONE, "DS01", tiMacPrefix }, // Sonoff SNZB-04

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -211,7 +211,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_XIAOMI, "lumi.remote.b686opcn01", xiaomiMacPrefix }, // Xiaomi Aqara Opple WXCJKG13LM
     { VENDOR_XIAOMI, "lumi.sen_ill.mgl01", xiaomiMacPrefix }, // Xiaomi ZB3.0 light sensor
     { VENDOR_XIAOMI, "lumi.plug", xiaomiMacPrefix }, // Xiaomi smart plugs (router)
-    { VENDOR_XIAOMI, "lumi.switch.b1naus01", xiaomiMacPrefix }, // Xiaomi Aqara ZB3.0 Smart Wall Switch Single Rocker
+    { VENDOR_XIAOMI, "lumi.switch.b1naus01", xiaomiMacPrefix }, // Xiaomi Aqara ZB3.0 Smart Wall Switch Single Rocker WS-USC03
     // { VENDOR_XIAOMI, "lumi.curtain", jennicMacPrefix}, // Xiaomi curtain controller (router) - exposed only as light
     { VENDOR_UBISYS, "C4", ubisysMacPrefix },
     { VENDOR_UBISYS, "D1", ubisysMacPrefix },
@@ -310,6 +310,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_PHYSICAL, "outletv4", stMacPrefix }, // Samsung SmartThings plug (IM6001-OTP)
     { VENDOR_EMBER, "RH3040", konkeMacPrefix }, // Tuyatec motion sensor
     { VENDOR_NONE, "RH3001", ikea2MacPrefix }, // Tuyatec door/window sensor
+    { VENDOR_EMBER, "RH3001", silabs3MacPrefix }, // Tuya/Blitzwolf BW-IS2 door/window sensor
     { VENDOR_NONE, "RH3052", emberMacPrefix }, // Tuyatec temperature sensor
     { VENDOR_EMBER, "TS0201", silabs3MacPrefix }, // Tuya/Blitzwolf temperature and humidity sensor
     { VENDOR_NONE, "TS0204", silabs3MacPrefix }, // Tuya gas sensor
@@ -4347,7 +4348,8 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                              modelId.startsWith(QLatin1String("WISZB-120")) ||        // Develco door/window sensor
                              modelId.startsWith(QLatin1String("ZHMS101")) ||          // Wattle (Develco) door/window sensor
                              modelId == QLatin1String("E1D-G73") ||                   // Sengled contact sensor
-                             modelId == QLatin1String("DS01"))                        // Sonoff SNZB-04
+                             modelId == QLatin1String("DS01") ||                      // Sonoff SNZB-04
+                             modelId == QLatin1String("RH3001"))                      // Tuya/Blitzwolf BW-IS2 door/window sensor
                     {
                         fpOpenCloseSensor.inClusters.push_back(ci->id());
                     }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -16031,13 +16031,11 @@ void DeRestPlugin::idleTimerFired()
                         {
                             val = sensorNode->getZclValue(*ci, 0x0029); // heating state
 
-                            if (sensorNode->modelId().startsWith("SPZB")) // Eurotronic Spirit
-                            {
-                                // supports reporting, no need to read attributes
-                            }
-                            if (sensorNode->modelId().startsWith("SLT2") ||
-                                sensorNode->modelId().startsWith("SLR2") ||
-                                sensorNode->modelId().startsWith(QLatin1String("TH112")) ) // Sinope devices
+                            if (sensorNode->modelId().startsWith(QLatin1String("SPZB")) ||   // Eurotronic Spirit
+                                sensorNode->modelId().startsWith(QLatin1String("SLT2")) ||   // Hive Active Heating Thermostat
+                                sensorNode->modelId().startsWith(QLatin1String("SLR2")) ||   // Hive Active Heating Receiver
+                                sensorNode->modelId().startsWith(QLatin1String("TH112")) ||  // Sinope devices
+                                sensorNode->modelId().startsWith(QLatin1String("eTRV0100"))) // Danfoss Ally
                             {
                                 // supports reporting, no need to read attributes
                             }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -264,6 +264,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_SUNRICHER, "RGBgenie ZB-5", emberMacPrefix }, // RGBgenie remote control
     { VENDOR_SUNRICHER, "ROB_200", silabs3MacPrefix }, // Sunricher SR-ZG9040A built-in dimmer, whitelabeled by Robbshop
     { VENDOR_SUNRICHER, "Micro Smart Dimmer", silabs3MacPrefix }, // Sunricher SR-ZG9040A built-in dimmer
+    { VENDOR_SUNRICHER, "ZG2835", silabs6MacPrefix }, // SR-ZG2835 Zigbee Rotary Switch
     { VENDOR_JENNIC, "SPZB0001", jennicMacPrefix }, // Eurotronic thermostat
     { VENDOR_NONE, "RES001", tiMacPrefix }, // Hubitat environment sensor, see #1308
     { VENDOR_SINOPE, "WL4200S", sinopeMacPrefix}, // Sinope water sensor
@@ -6438,7 +6439,8 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                         i->modelId().startsWith(QLatin1String("SV01-")) || // Keen Home vent
                                         i->modelId().startsWith(QLatin1String("45127")) || // Namron 1/2/4-ch remote controller
                                         i->modelId().startsWith(QLatin1String("RGBgenie ZB-5")) || // RGBgenie remote control
-                                        i->modelId().startsWith(QLatin1String("VOC_Sensor"))) // LifeControl Enviroment sensor
+                                        i->modelId().startsWith(QLatin1String("VOC_Sensor")) || // LifeControl Enviroment sensor
+                                        i->modelId().startsWith(QLatin1String("ZG2835"))) // SR-ZG2835 Zigbee Rotary Switch
                                     {
                                         bat = ia->numericValue().u8;
                                     }
@@ -6476,7 +6478,8 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                         i->modelId().startsWith(QLatin1String("SV01-")) || // Keen Home vent
                                         i->modelId().startsWith(QLatin1String("45127")) || // Namron 1/2/4-ch remote controller
                                         i->modelId().startsWith(QLatin1String("RGBgenie ZB-5")) || // RGBgenie remote control
-                                        i->modelId().startsWith(QLatin1String("VOC_Sensor"))) // LifeControl Enviroment sensor
+                                        i->modelId().startsWith(QLatin1String("VOC_Sensor")) || // LifeControl Enviroment sensor
+                                        i->modelId().startsWith(QLatin1String("ZG2835"))) // SR-ZG2835 Zigbee Rotary Switch
                                     {
                                         bat = ia->numericValue().u8;
                                     }

--- a/general.xml
+++ b/general.xml
@@ -2426,7 +2426,9 @@ controller device, that supports a keypad and LCD screen.</description>
 						<attribute id="0x011c" name="Last Message LQI" type="u8" access="r" required="o" default="0x00"></attribute>
 						<attribute id="0x011d" name="Last Message RSSI" type="s8" access="r" required="o" default="0x00"></attribute>
 					</attribute-set>
-                    <attribute id="0x4000" name="SW error code" type="map16" access="rw" default="0" required="o" mfcode="0x1246"></attribute>
+					<attribute-set id="0x4000" description="Vendor specific attributes">
+						<attribute id="0x4000" name="SW error code" type="bmp16" access="rw" default="0" required="o" mfcode="0x1246"></attribute>
+					</attribute-set>
 				</server>
 				<client>
 				</client>

--- a/light_node.cpp
+++ b/light_node.cpp
@@ -534,7 +534,8 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
                     if (modelId() == QLatin1String("902010/24") ||   // Bitron Smoke Detector with siren
                         modelId() == QLatin1String("SMSZB-120") ||   // Develco Smoke Alarm with siren
                         modelId() == QLatin1String("HESZB-120") ||   // Develco heat sensor with siren
-                        modelId() == QLatin1String("FLSZB-110"))     // Develco water leak sensor with siren
+                        modelId() == QLatin1String("FLSZB-110") ||   // Develco water leak sensor with siren
+                        modelId() == QLatin1String("902010/29"))     // Bitron outdoor siren
                     {
                         removeItem(RStateOn);
                         ltype = QLatin1String("Warning device");

--- a/light_node.cpp
+++ b/light_node.cpp
@@ -478,52 +478,55 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
                 }
                 else if (i->id() == WINDOW_COVERING_CLUSTER_ID /*FIXME ubisys J1*/)
                 {
-                    QList<deCONZ::ZclCluster>::const_iterator ic = haEndpoint().inClusters().constBegin();
-                    std::vector<deCONZ::ZclAttribute>::const_iterator ia = ic->attributes().begin();
-                    std::vector<deCONZ::ZclAttribute>::const_iterator enda = ic->attributes().end();
-                    isWindowCovering = true;
-                    bool hasLift = true; // set default to lift
-                    bool hasTilt = false;
-                    for (;ia != enda; ++ia)
+                    if (modelId() != QLatin1String("lumi.light.aqcn02"))
                     {
-                        if (ia->id() == 0x0000)  // WindowCoveringType
+                        QList<deCONZ::ZclCluster>::const_iterator ic = haEndpoint().inClusters().constBegin();
+                        std::vector<deCONZ::ZclAttribute>::const_iterator ia = ic->attributes().begin();
+                        std::vector<deCONZ::ZclAttribute>::const_iterator enda = ic->attributes().end();
+                        isWindowCovering = true;
+                        bool hasLift = true; // set default to lift
+                        bool hasTilt = false;
+                        for (;ia != enda; ++ia)
                         {
-                            /*
-                             * Value Type                         Capabilities
-                             *  0    Roller Shade                 = Lift only
-                             *  1    Roller Shade two motors      = Lift only
-                             *  2    Roller Shade exterior        = Lift only
-                             *  3    Roller Shade two motors ext  = Lift only
-                             *  4    Drapery                      = Lift only
-                             *  5    Awning                       = Lift only
-                             *  6    Shutter                      = Tilt only
-                             *  7    Tilt Blind Lift only         = Tilt only
-                             *  8    Tilt Blind lift & tilt       = Lift & Tilt
-                             *  9    Projector Screen             = Lift only
-                             */
-                            uint8_t coveringType = ia->numericValue().u8;
-                            if (coveringType == 8 ) {
-                                hasTilt = true;
-                            }
-                            else if (coveringType == 6 || coveringType == 7)
+                            if (ia->id() == 0x0000)  // WindowCoveringType
                             {
-                                hasTilt = true;
-                                hasLift = false;
+                                /*
+                                 * Value Type                         Capabilities
+                                 *  0    Roller Shade                 = Lift only
+                                 *  1    Roller Shade two motors      = Lift only
+                                 *  2    Roller Shade exterior        = Lift only
+                                 *  3    Roller Shade two motors ext  = Lift only
+                                 *  4    Drapery                      = Lift only
+                                 *  5    Awning                       = Lift only
+                                 *  6    Shutter                      = Tilt only
+                                 *  7    Tilt Blind Lift only         = Tilt only
+                                 *  8    Tilt Blind lift & tilt       = Lift & Tilt
+                                 *  9    Projector Screen             = Lift only
+                                 */
+                                uint8_t coveringType = ia->numericValue().u8;
+                                if (coveringType == 8 ) {
+                                    hasTilt = true;
+                                }
+                                else if (coveringType == 6 || coveringType == 7)
+                                {
+                                    hasTilt = true;
+                                    hasLift = false;
+                                }
                             }
                         }
-                    }
-                    removeItem(RStateAlert);
-                    addItem(DataTypeBool, RStateOpen);
-                    // FIXME: removeItem(RStateOn);
-                    if (hasLift)
-                    {
-                        addItem(DataTypeUInt8, RStateLift);
-                        addItem(DataTypeUInt8, RStateBri); // FIXME: deprecate
-                    }
-                    if (hasTilt)
-                    {
-                        addItem(DataTypeUInt8, RStateTilt);
-                        addItem(DataTypeUInt8, RStateSat); // FIXME: deprecate
+                        removeItem(RStateAlert);
+                        addItem(DataTypeBool, RStateOpen);
+                        // FIXME: removeItem(RStateOn);
+                        if (hasLift)
+                        {
+                            addItem(DataTypeUInt8, RStateLift);
+                            addItem(DataTypeUInt8, RStateBri); // FIXME: deprecate
+                        }
+                        if (hasTilt)
+                        {
+                            addItem(DataTypeUInt8, RStateTilt);
+                            addItem(DataTypeUInt8, RStateSat); // FIXME: deprecate
+                        }
                     }
                 }
                 else if (i->id() == FAN_CONTROL_CLUSTER_ID) {

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1859,7 +1859,8 @@ int DeRestPluginPrivate::setWarningDeviceState(const ApiRequest &req, ApiRespons
         else if (alert == "select")
         {
             task.options = 0x17; // Warning mode 1 (burglar), Strobe, Very high sound
-            if (taskRef.lightNode->modelId() == QLatin1String("902010/24"))
+            if (taskRef.lightNode->modelId() == QLatin1String("902010/24") ||
+                taskRef.lightNode->modelId() == QLatin1String("902010/29"))
             {
                 task.options = 0x12;
             }
@@ -1868,7 +1869,8 @@ int DeRestPluginPrivate::setWarningDeviceState(const ApiRequest &req, ApiRespons
         else if (alert == "lselect")
         {
             task.options = 0x17; // Warning mode 1 (burglar), Strobe, Very high sound
-            if (taskRef.lightNode->modelId() == QLatin1String("902010/24"))
+            if (taskRef.lightNode->modelId() == QLatin1String("902010/24") ||
+                taskRef.lightNode->modelId() == QLatin1String("902010/29"))
             {
                 task.options = 0x12;
             }

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -1460,7 +1460,7 @@ const Sensor::ButtonMap *Sensor::buttonMap()
         }
         else if (manufacturer == QLatin1String("Namron AS"))
         {
-            if (modelid.startsWith(QLatin1String("451270"))) { m_buttonMap = sunricherMap; }
+            if (modelid.startsWith(QLatin1String("45127"))) { m_buttonMap = sunricherMap; }
         }
         else if (manufacturer == QLatin1String("Heiman"))
         {

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -607,6 +607,14 @@ static const Sensor::ButtonMap icasaRemoteMap[] = {
     { Sensor::ModeScenes,           0x04, 0x0006, 0x01, 0,    S_BUTTON_8 + S_BUTTON_ACTION_SHORT_RELEASED, "On" },
     { Sensor::ModeScenes,           0x04, 0x0008, 0x05, 0,    S_BUTTON_8 + S_BUTTON_ACTION_HOLD, "Move up (with on/off)" },
     { Sensor::ModeScenes,           0x04, 0x0008, 0x07, 0,    S_BUTTON_8 + S_BUTTON_ACTION_LONG_RELEASED, "Stop_ (with on/off)" },
+    // Off 5 button
+    { Sensor::ModeScenes,           0x05, 0x0006, 0x00, 0,    S_BUTTON_11 + S_BUTTON_ACTION_SHORT_RELEASED, "Off" },
+    { Sensor::ModeScenes,           0x05, 0x0008, 0x05, 1,    S_BUTTON_11 + S_BUTTON_ACTION_HOLD, "Move down (with on/off)" },
+    { Sensor::ModeScenes,           0x05, 0x0008, 0x07, 1,    S_BUTTON_11 + S_BUTTON_ACTION_LONG_RELEASED, "Stop_ (with on/off)" },
+    // On 5 button
+    { Sensor::ModeScenes,           0x05, 0x0006, 0x01, 0,    S_BUTTON_12 + S_BUTTON_ACTION_SHORT_RELEASED, "On" },
+    { Sensor::ModeScenes,           0x05, 0x0008, 0x05, 0,    S_BUTTON_12 + S_BUTTON_ACTION_HOLD, "Move up (with on/off)" },
+    { Sensor::ModeScenes,           0x05, 0x0008, 0x07, 0,    S_BUTTON_12 + S_BUTTON_ACTION_LONG_RELEASED, "Stop_ (with on/off)" },
     // end
     { Sensor::ModeNone,             0x00, 0x0000, 0x00, 0,    0,                                           nullptr }
 };
@@ -1455,9 +1463,10 @@ const Sensor::ButtonMap *Sensor::buttonMap()
         }
         else if (manufacturer == QLatin1String("Sunricher"))
         {
-            if      (modelid.startsWith(QLatin1String("ZGRC-KEY"))) { m_buttonMap = sunricherCCTMap; }
+            if      (modelid.startsWith(QLatin1String("ZGRC-KEY-012"))) { m_buttonMap = icasaRemoteMap; }
             else if (modelid.startsWith(QLatin1String("ZG2833K"))) { m_buttonMap = sunricherMap; }
             else if (modelid.startsWith(QLatin1String("ZG2835"))) { m_buttonMap = sunricherMap; }
+            else if (modelid.startsWith(QLatin1String("ZGRC-KEY-013"))) { m_buttonMap = icasaRemoteMap; }
         }
         else if (manufacturer == QLatin1String("RGBgenie"))
         {

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -1431,7 +1431,7 @@ const Sensor::ButtonMap *Sensor::buttonMap()
         }
         else if (manufacturer == QLatin1String("EcoDim"))
         {
-            if      (modelid.startsWith(QLatin1String("ED-1001"))) { m_buttonMap = icasaKeypadMap; }
+            if      (modelid.startsWith(QLatin1String("ED-1001"))) { m_buttonMap = icasaRemoteMap; }
         }
         else if (manufacturer == QLatin1String("Samjin"))
         {

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -1431,7 +1431,7 @@ const Sensor::ButtonMap *Sensor::buttonMap()
         }
         else if (manufacturer == QLatin1String("EcoDim"))
         {
-            if      (modelid.startsWith(QLatin1String("ED-1001"))) { m_buttonMap = icasaRemoteMap; }
+            if      (modelid.startsWith(QLatin1String("ED-1001"))) { m_buttonMap = sunricherMap; }
         }
         else if (manufacturer == QLatin1String("Samjin"))
         {

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -869,6 +869,14 @@ static const Sensor::ButtonMap sageMap[] = {
     { Sensor::ModeNone,             0x00, 0x0000, 0x00, 0,    0,                                           nullptr }
 };
 
+static const Sensor::ButtonMap sonoffOnOffMap[] = {
+//    mode                          ep    cluster cmd   param button                                       name
+    { Sensor::ModeScenes,           0x01, 0x0006, 0x01, 0,    S_BUTTON_1 + S_BUTTON_ACTION_SHORT_RELEASED, "On" },
+    { Sensor::ModeScenes,           0x01, 0x0006, 0x00, 0,    S_BUTTON_2 + S_BUTTON_ACTION_SHORT_RELEASED, "Off" },
+    // end
+    { Sensor::ModeNone,             0x00, 0x0000, 0x00, 0,    0,                                           nullptr }
+};
+
 /*! Returns a fingerprint as JSON string. */
 QString SensorFingerprint::toString() const
 {
@@ -1478,6 +1486,10 @@ const Sensor::ButtonMap *Sensor::buttonMap()
         else if (manufacturer == QLatin1String("lk"))
         {
             if (modelid == QLatin1String("ZBT-DIMSwitch")) { m_buttonMap = ikeaOnOffMap; }
+        }
+        else if (manufacturer == QLatin1String("eWeLink"))
+        {
+            if (modelid == QLatin1String("WB01")) { m_buttonMap = sonoffOnOffMap; }
         }
     }
 

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -1457,6 +1457,7 @@ const Sensor::ButtonMap *Sensor::buttonMap()
         {
             if      (modelid.startsWith(QLatin1String("ZGRC-KEY"))) { m_buttonMap = sunricherCCTMap; }
             else if (modelid.startsWith(QLatin1String("ZG2833K"))) { m_buttonMap = sunricherMap; }
+            else if (modelid.startsWith(QLatin1String("ZG2835"))) { m_buttonMap = sunricherMap; }
         }
         else if (manufacturer == QLatin1String("RGBgenie"))
         {

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -1475,6 +1475,10 @@ const Sensor::ButtonMap *Sensor::buttonMap()
         {
             if (modelid == QLatin1String("Bell")) { m_buttonMap = sageMap; }
         }
+        else if (manufacturer == QLatin1String("lk"))
+        {
+            if (modelid == QLatin1String("ZBT-DIMSwitch")) { m_buttonMap = ikeaOnOffMap; }
+        }
     }
 
     return m_buttonMap;

--- a/sensor.h
+++ b/sensor.h
@@ -50,6 +50,9 @@
 #define S_BUTTON_7   7000
 #define S_BUTTON_8   8000
 #define S_BUTTON_9   9000
+#define S_BUTTON_10  10000
+#define S_BUTTON_11  11000
+#define S_BUTTON_12  12000
 
 struct SensorFingerprint
 {


### PR DESCRIPTION
- Amended battery reporting for EcoDim switches
- Correct button map for EcoDim switches
- Prevent Danfoss Ally to be queried unnecessarily for heating state
- Fixed some reportable change values for thermostats
- Add additional group bindings for RGBgenie ZB-5001
- Whitelist Hive MOT003 as presence sensor
- Restore RStateConsumption for analog input cluster on DB load
- Corrected "SW error code" attribute in general.xml
- Also consider Namron 4512721 ZB3.0 switch as supported device
- Added initial support for Xiaomi Aqara ZB3.0 Smart Wall Switch Single Rocker (lumi.switch.b1naus01) (#3083)
- Expose EcoDim and Namron switches as single ZHASwitch resource
- Added initial support for Bitron outdoor siren 902010/29 (#3092)
- Update to properly recognize Tuya/Blitzwolf BW-IS2 door/window sensor
- Added initial support for Linkind 1 key Remote Control / ZS23000178 (#2321)
- Added initial support for Sonoff SNZB-01 (WB01) (#2990)
- Added initial support for SR-ZG2835/ROB_200-018-0 Rotary Switch (#3085)
- Prevent lumi.light.aqcn02 to expose windows covering resource items (#3048)
- Further additions for lumi.sensor_natgas to prevent exposure of battery resource item (#3111)
- Added initial support for Blitzwolf bw-is5 (TS0207) water leak sensor (#3067)
- Improvements for Sunricher ZGRC-KEY-013 and RGBGenie ZB-5001 remote controls. Both remotes are now exposed as single ZHASwitch resource. (#3125, #2857, #1256)