### PR TITLE
Remove the don't close DB yet message

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -4923,7 +4923,6 @@ void DeRestPluginPrivate::closeDb()
     {
         if (ttlDataBaseConnection > idleTotalCounter)
         {
-            DBG_Printf(DBG_INFO, "don't close database yet, keep open for %d seconds\n", (ttlDataBaseConnection - idleTotalCounter));
             return;
         }
 


### PR DESCRIPTION
As discussed in dev channels, i figured we could remove the message:  don't close database yet, keep open for 900 seconds