### PR TITLE
Implement setting/clearing thermostat schedule

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -8377,9 +8377,6 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                     }
                     else if (event.clusterId() == TIME_CLUSTER_ID)
                     {
-                        // FIXME: value returned for utc attributes is #seconds since 1970-01-01 ?!
-                        static const QDateTime epochUtc = QDateTime(QDate(1970, 1, 1), QTime(0, 0), Qt::UTC);
-
                         bool updated = false;
 
                         for (;ia != enda; ++ia)
@@ -8434,8 +8431,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                               {
                                   i->setZclValue(updateType, event.endpoint(), event.clusterId(), ia->id(), ia->numericValue());
                               }
-                              QDateTime time = epochUtc.addSecs(ia->numericValue().u32); // FIXME
-                              // QDateTime time = epoch.addSecs(ia->numericValue().u32);
+                              QDateTime time = epoch.addSecs(ia->numericValue().u32);
                               ResourceItem *item = i->item(RStateLastSet);
                               if (item && item->toVariant().toDateTime().toMSecsSinceEpoch() != time.toMSecsSinceEpoch())
                               {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -9327,7 +9327,7 @@ bool DeRestPluginPrivate::processZclAttributes(Sensor *sensorNode)
         task.req.setSrcEndpoint(getSrcEndpoint(sensorNode, task.req));
         task.req.setDstAddressMode(deCONZ::ApsExtAddress);
 
-        if (addTaskThermostatSetAndGetSchedule(task, ""))
+        if (addTaskThermostatGetSchedule(task))
         {
             sensorNode->clearRead(READ_THERMOSTAT_SCHEDULE);
             processed++;

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1696,13 +1696,13 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
     {
         return;
     }
-    
+
     //Make 2 fakes device for tuya stuff
     if (node->nodeDescriptor().manufacturerCode() == VENDOR_EMBER)
     {
         const deCONZ::SimpleDescriptor *sd = &node->simpleDescriptors()[0];
         bool hasTuyaCluster = false;
-        
+
         if (sd && (sd->deviceId() == DEV_ID_SMART_PLUG) && (node->simpleDescriptors().size() < 2) && ((node->address().ext() & 0xffffff0000000000ULL ) == silabs3MacPrefix))
         {
 
@@ -1710,13 +1710,13 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
             {
                 if (sd->inClusters()[c].id() == TUYA_CLUSTER_ID) { hasTuyaCluster = true; }
             }
-            
-            if (hasTuyaCluster) 
+
+            if (hasTuyaCluster)
             {
                 DBG_Printf(DBG_INFO, "Tuya : Creating 2 Fake Endpoints\n");
 
                 //Ok it's the good device, make 2 clones with differents endpoints
-                
+
                 //Note for me, to remove later
                 //sudo cp /usr/share/deCONZ/plugins/libde_rest_plugin.so /usr/share/deCONZ/plugins/libde_rest_plugin2.so
 
@@ -1734,7 +1734,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
 
                 sd1.setEndpoint(0x02);
                 sd2.setEndpoint(0x03);
-                
+
                 //remove useless cluster
                 if (false)
                 {
@@ -3886,7 +3886,7 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                 {
                     quint8 level = zclFrame.payload().at(0);
                     ok = buttonMap->zclParam0 == level;
-                    
+
                 }
             }
             else if (ind.clusterId() == LEVEL_CLUSTER_ID &&
@@ -4072,7 +4072,7 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                     }
             }
             else if ((ind.clusterId() == COLOR_CLUSTER_ID) &&
-                     (zclFrame.commandId() == 0x4b) && 
+                     (zclFrame.commandId() == 0x4b) &&
                      sensor->modelId().startsWith(QLatin1String("ZBT-CCTSwitch-D0001")) )
             {
                 quint8 pl0 = zclFrame.payload().isEmpty() ? 0 : zclFrame.payload().at(0);
@@ -4182,7 +4182,7 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
         }
         buttonMap++;
     }
-    
+
     //Remember last command id
     if (sensor->modelId().startsWith(QLatin1String("ZBT-CCTSwitch-D0001"))) // LDS remote
     {
@@ -4776,7 +4776,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     }
                 }
                     break;
-                    
+
                 case TUYA_CLUSTER_ID:
                 {
                     if ((modelId == QLatin1String("kud7u2l")) ||
@@ -5739,15 +5739,15 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             if (sensorNode.modelId() == QLatin1String("SLR2") ||            // Hive
                 sensorNode.modelId() == QLatin1String("SLR1b") ||           // Hive
                 sensorNode.modelId().startsWith(QLatin1String("TH112")) ||  // Sinope
-                sensorNode.modelId() == QLatin1String("kud7u2l") ||         // tuya 
+                sensorNode.modelId() == QLatin1String("kud7u2l") ||         // tuya
                 sensorNode.modelId() == QLatin1String("GbxAXL2") ||         // tuya
                 sensorNode.modelId() == QLatin1String("TS0601") ||           //tuya
                 sensorNode.modelId() == QLatin1String("Zen-01") )           // Zen
             {
                 sensorNode.addItem(DataTypeString, RConfigMode);
             }
-            
-            if (sensorNode.modelId() == QLatin1String("kud7u2l") || // tuya 
+
+            if (sensorNode.modelId() == QLatin1String("kud7u2l") || // tuya
                 sensorNode.modelId() == QLatin1String("GbxAXL2") || // tuya
                 sensorNode.modelId() == QLatin1String("TS0601") ) //tuya
             {
@@ -5755,7 +5755,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                 sensorNode.addItem(DataTypeBool, RStateLowBattery);
             }
 
-            if (sensorNode.modelId() == QLatin1String("kud7u2l") || // tuya 
+            if (sensorNode.modelId() == QLatin1String("kud7u2l") || // tuya
                 sensorNode.modelId() == QLatin1String("TS0601") ) //tuya
             {
                 sensorNode.addItem(DataTypeString, RConfigPreset);
@@ -8390,8 +8390,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 {
                                     i->setZclValue(updateType, event.endpoint(), event.clusterId(), ia->id(), ia->numericValue());
                                 }
-                                QDateTime time = epochUtc.addSecs(ia->numericValue().u32); // FIXME
-                                // QDateTime time = epoch.addSecs(ia->numericValue().u32);
+                                QDateTime time = epoch.addSecs(ia->numericValue().u32);
                                 ResourceItem *item = i->item(RStateUtc);
                                 if (item && item->toVariant().toDateTime().toMSecsSinceEpoch() != time.toMSecsSinceEpoch())
                                 {
@@ -15587,10 +15586,10 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
                  sensor->modelId().startsWith(QLatin1String("ZGRC-KEY")))  // Sunricher remote
         {
             quint8 lastEndpoint;
-            
+
             if (sensor->modelId() == QLatin1String("ZGRC-KEY-012")) { lastEndpoint = 0x05; }
             else { lastEndpoint = 0x04; }
-            
+
             ResourceItem *item = sensor->item(RConfigGroup);
             if (!item)
             {
@@ -18156,7 +18155,7 @@ void DeRestPluginPrivate::pollNextDevice()
     {
         for (LightNode &l : nodes)
         {
-            if (l.isAvailable() && l.state() == LightNode::StateNormal)
+            if (l.isAvailable() && l.address().ext() != gwDeviceAddress.ext() && l.state() == LightNode::StateNormal)
             {
                 pollNodes.push_back(&l);
             }

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1051,6 +1051,7 @@ public:
     int deleteSensor(const ApiRequest &req, ApiResponse &rsp);
     int changeSensorConfig(const ApiRequest &req, ApiResponse &rsp);
     int changeSensorState(const ApiRequest &req, ApiResponse &rsp);
+    int changeThermostatSchedule(const ApiRequest &req, ApiResponse &rsp);
     int createSensor(const ApiRequest &req, ApiResponse &rsp);
     int getGroupIdentifiers(const ApiRequest &req, ApiResponse &rsp);
     int recoverSensor(const ApiRequest &req, ApiResponse &rsp);
@@ -1389,7 +1390,8 @@ public:
     bool addTaskWindowCoveringCalibrate(TaskItem &task, int WindowCoveringType);
     bool addTaskUbisysConfigureSwitch(TaskItem &taskRef);
     bool addTaskThermostatCmd(TaskItem &task, uint8_t cmd, int8_t setpoint, const QString &schedule, uint8_t daysToReturn);
-    bool addTaskThermostatSetAndGetSchedule(TaskItem &task, const QString &sched);
+    bool addTaskThermostatGetSchedule(TaskItem &task);
+    bool addTaskThermostatSetTransitions(TaskItem &task, quint8 weekDays, const QString &transitions);
     bool addTaskThermostatReadWriteAttribute(TaskItem &task, uint8_t readOrWriteCmd, uint16_t mfrCode, uint16_t attrId, uint8_t attrType, uint32_t attrValue);
     bool addTaskThermostatWriteAttributeList(TaskItem &task, uint16_t mfrCode, QMap<quint16, quint32> &AttributeList );
     bool addTaskControlModeCmd(TaskItem &task, uint8_t cmdId, int8_t mode);

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1399,7 +1399,7 @@ public:
     bool addTaskWindowCoveringSetAttr(TaskItem &task, uint16_t mfrCode, uint16_t attrId, uint8_t attrType, uint16_t attrValue);
     bool addTaskWindowCoveringCalibrate(TaskItem &task, int WindowCoveringType);
     bool addTaskUbisysConfigureSwitch(TaskItem &taskRef);
-    bool addTaskThermostatCmd(TaskItem &task, uint16_t mfrCode, uint8_t cmd, int8_t setpoint, const QString &schedule, uint8_t daysToReturn);
+    bool addTaskThermostatCmd(TaskItem &task, uint16_t mfrCode, uint8_t cmd, int16_t setpoint, const QString &schedule, uint8_t daysToReturn);
     bool addTaskThermostatGetSchedule(TaskItem &task);
     bool addTaskThermostatSetTransitions(TaskItem &task, quint8 weekDays, const QString &transitions);
     bool addTaskThermostatReadWriteAttribute(TaskItem &task, uint8_t readOrWriteCmd, uint16_t mfrCode, uint16_t attrId, uint8_t attrType, uint32_t attrValue);

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1399,9 +1399,10 @@ public:
     bool addTaskWindowCoveringSetAttr(TaskItem &task, uint16_t mfrCode, uint16_t attrId, uint8_t attrType, uint16_t attrValue);
     bool addTaskWindowCoveringCalibrate(TaskItem &task, int WindowCoveringType);
     bool addTaskUbisysConfigureSwitch(TaskItem &taskRef);
-    bool addTaskThermostatCmd(TaskItem &task, uint16_t mfrCode, uint8_t cmd, int16_t setpoint, const QString &schedule, uint8_t daysToReturn);
+    bool addTaskThermostatCmd(TaskItem &task, uint16_t mfrCode, uint8_t cmd, int16_t setpoint, uint8_t daysToReturn);
     bool addTaskThermostatGetSchedule(TaskItem &task);
-    bool addTaskThermostatSetTransitions(TaskItem &task, quint8 weekDays, const QString &transitions);
+    bool addTaskThermostatSetWeeklySchedule(TaskItem &task, quint8 weekdays, const QString &transitions);
+    void updateThermostatSchedule(Sensor *sensor, quint8 newWeekdays, QString &transitions);
     bool addTaskThermostatReadWriteAttribute(TaskItem &task, uint8_t readOrWriteCmd, uint16_t mfrCode, uint16_t attrId, uint8_t attrType, uint32_t attrValue);
     bool addTaskThermostatWriteAttributeList(TaskItem &task, uint16_t mfrCode, QMap<quint16, quint32> &AttributeList );
     bool addTaskControlModeCmd(TaskItem &task, uint8_t cmdId, int8_t mode);

--- a/thermostat.cpp
+++ b/thermostat.cpp
@@ -171,7 +171,7 @@ bool DeRestPluginPrivate::deserialiseThermostatTransitions(const QString &s, QVa
     for (const QString &entry : list)
     {
         QStringList attributes = entry.split("|");
-        if (attributes.size != 2)
+        if (attributes.size() != 2)
         {
             transitions->clear();
             return false;
@@ -218,7 +218,7 @@ bool DeRestPluginPrivate::deserialiseThermostatSchedule(const QString &s, QVaria
         QVariantMap map;
         QStringList attributes = entry.split("/");
         QVariantList list;
-        if (attributes.size != 2 || !deserialiseThermostatTransitions(attributes[1], &list))
+        if (attributes.size() != 2 || !deserialiseThermostatTransitions(attributes[1], &list))
         {
             schedule->clear();
             return false;

--- a/thermostat.cpp
+++ b/thermostat.cpp
@@ -171,6 +171,11 @@ bool DeRestPluginPrivate::deserialiseThermostatTransitions(const QString &s, QVa
     for (const QString &entry : list)
     {
         QStringList attributes = entry.split("|");
+        if (attributes.size != 2)
+        {
+            transitions->clear();
+            return false;
+        }
         QVariantMap map;
         map[QLatin1String("localtime")] = "T" + attributes[0];
         map[QLatin1String("heatsetpoint")] = attributes[1].toInt();
@@ -213,8 +218,9 @@ bool DeRestPluginPrivate::deserialiseThermostatSchedule(const QString &s, QVaria
         QVariantMap map;
         QStringList attributes = entry.split("/");
         QVariantList list;
-        if (!deserialiseThermostatTransitions(attributes[1], &list))
+        if (attributes.size != 2 || !deserialiseThermostatTransitions(attributes[1], &list))
         {
+            schedule->clear();
             return false;
         }
         (*schedule)["W" + attributes[0]] = list;


### PR DESCRIPTION
- Implement POST and DELETE for `/sensors/`_id_`/config/schedule/W`_bbb_, see #2393;
- Added sanity checks when reading the serialised schedule from the database, to prevent segmentation faults, see #2393;
- Fixed handling of `utc` attributes for `ZHATime`, now that core returns number of seconds since 2000/01/01 instead of since 1970/01/01;
- Stop trying to poll the gateway device.  Gateway now no longer issues route requests for itself (NWK 0x0000).
