### PR TITLE
REST-API plugin dialog: Cleanup network entries and read binding table keyboard shortcut

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -123,7 +123,10 @@ bool DeRestPluginPrivate::readBindingTable(RestNodeBase *node, quint8 startIndex
     Resource *r = dynamic_cast<Resource*>(node);
 
     // whitelist
-    if (checkMacVendor(node->address(), VENDOR_DDEL))
+    if (node->mgmtBindSupported())
+    {
+    }
+    else if (checkMacVendor(node->address(), VENDOR_DDEL))
     {
     }
     else if (checkMacVendor(node->address(), VENDOR_UBISYS))

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -16777,7 +16777,7 @@ QDialog *DeRestPlugin::createDialog()
 {
     if (!m_w)
     {
-        m_w = new DeRestWidget(0);
+        m_w = new DeRestWidget(nullptr, this);
     }
 
     return m_w;

--- a/de_web_plugin.h
+++ b/de_web_plugin.h
@@ -68,11 +68,12 @@ Q_SIGNALS:
     void nodeUpdated(quint64 extAddress, QString key, QString value);
 
 private:
-    QTimer *m_idleTimer;
-    QTimer *m_readAttributesTimer;
+    QTimer *m_idleTimer = nullptr;
+    QTimer *m_readAttributesTimer = nullptr;
     State m_state;
-    DeRestWidget *m_w;
-    DeRestPluginPrivate *d;
+    friend class DeRestWidget;
+    DeRestWidget *m_w = nullptr;
+    DeRestPluginPrivate *d = nullptr;
 };
 
 #endif // REST_PLUGIN_H

--- a/de_web_widget.cpp
+++ b/de_web_widget.cpp
@@ -41,7 +41,9 @@ DeRestWidget::DeRestWidget(QWidget *parent) :
         QString name = ifi->humanReadableName();
 
         // filter
-        if (name.contains("vm", Qt::CaseInsensitive) ||
+        if (name.contains("br-", Qt::CaseInsensitive) ||
+            name.contains("docker", Qt::CaseInsensitive) ||
+            name.contains("vm", Qt::CaseInsensitive) ||
             name.contains("virtual", Qt::CaseInsensitive) ||
             name.contains("loop", Qt::CaseInsensitive))
         {

--- a/de_web_widget.h
+++ b/de_web_widget.h
@@ -12,25 +12,32 @@
 #define DE_WEB_WIDGET_H
 
 #include <QDialog>
+#include <deconz.h>
 
 namespace Ui {
 class DeWebWidget;
 }
+
+class DeRestPlugin;
 
 class DeRestWidget : public QDialog
 {
     Q_OBJECT
     
 public:
-    explicit DeRestWidget(QWidget *parent);
+    explicit DeRestWidget(QWidget *parent, DeRestPlugin *_plugin);
     ~DeRestWidget();
     bool pluginActive() const;
 
-public Q_SLOTS:
+private Q_SLOTS:
+    void readBindingTableTriggered();
+    void nodeEvent(const deCONZ::NodeEvent &event);
 
 private:
     void showEvent(QShowEvent *);
-    Ui::DeWebWidget *ui;
+    deCONZ::Address m_selectedNodeAddress;
+    Ui::DeWebWidget *ui = nullptr;
+    DeRestPlugin *plugin = nullptr;
 };
 
 #endif // DE_WEB_WIDGET_H

--- a/de_web_widget.ui
+++ b/de_web_widget.ui
@@ -53,7 +53,7 @@
    <item>
     <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>Click on the link to open the WebApp in your browser.</string>
+      <string>Click on the link to open the Phoscon App in your browser.</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
* Don't list bridge and docker network interfaces
* Rename WebApp to Phoscon App
* Add keyboard shortcut Ctrl+B to read the binding table of the selected node