### PR TITLE
Optimize poll manager to consider only avaliable attributes

### DIFF
--- a/poll_manager.cpp
+++ b/poll_manager.cpp
@@ -403,18 +403,7 @@ void PollManager::pollTimerFired()
     {
         clusterId = METERING_CLUSTER_ID;
         attributes.push_back(0x0000); // Current Summation Delivered
-        item = r->item(RAttrModelId);
-        if (item &&
-            !item->toString().startsWith(QLatin1String("SP 120")) &&  // Attribute is not available
-            !item->toString().startsWith(QLatin1String("lumi.plug.ma")) &&
-            !item->toString().startsWith(QLatin1String("ZB-ONOFFPlug-D0005")) &&
-            !item->toString().startsWith(QLatin1String("TS0121")) &&
-            !item->toString().startsWith(QLatin1String("BQZ10-AU")) &&
-            !item->toString().startsWith(QLatin1String("ROB_200")) &&
-            item->toString() != QLatin1String("Plug-230V-ZB3.0"))
-        {
-            attributes.push_back(0x0400); // Instantaneous Demand
-        }
+        attributes.push_back(0x0400); // Instantaneous Demand
     }
     else if (suffix == RStatePower)
     {
@@ -486,29 +475,6 @@ void PollManager::pollTimerFired()
     size_t fresh = 0;
     const int reportWaitTime = 360;
     const int reportWaitTimeXAL = 60 * 30;
-    for (quint16 attrId : attributes)
-    {
-        // force polling after node becomes reachable, since reporting might not be active
-//        if (dtReachable < reportWaitTime)
-//        {
-//            break;
-//        }
-
-        NodeValue &val = restNode->getZclValue(clusterId, attrId);
-
-        if (lightNode && lightNode->manufacturerCode() == VENDOR_IKEA && val.timestamp.isValid())
-        {
-            fresh++; // rely on reporting for ikea lights
-        }
-        else if (val.timestampLastReport.isValid() && val.timestampLastReport.secsTo(now) < reportWaitTime)
-        {
-            fresh++;
-        }
-        else if (lightNode && lightNode->manufacturerCode() == VENDOR_XAL && val.timestamp.isValid() && val.timestamp.secsTo(now) < reportWaitTimeXAL)
-        {
-            fresh++; // rely on reporting for XAL lights
-        }
-    }
 
     // check that cluster exists on endpoint
     if (clusterId != 0xffff)
@@ -517,11 +483,43 @@ void PollManager::pollTimerFired()
         deCONZ::SimpleDescriptor sd;
         if (restNode->node()->copySimpleDescriptor(pitem.endpoint, &sd) == 0)
         {
-            for (const auto &cl : sd.inClusters())
+            for (const auto &cl : sd.inClusters())  // Loop through clusters
             {
                 if (cl.id() == clusterId)
                 {
                     found = true;
+                    
+                    std::vector<quint16> check;
+
+                    for (const deCONZ::ZclAttribute &attr : cl.attributes())    // Loop through cluster attributes
+                    {
+                        for (quint16 attrId : attributes)   // Loop through poll candidates
+                        {
+                            // discard attributes which are not be available
+                            if (attrId == attr.id() && attr.isAvailable())
+                            {
+                                check.push_back(attr.id());     // Only use available attributes
+
+                                NodeValue &val = restNode->getZclValue(clusterId, attrId);
+
+                                if (lightNode && lightNode->manufacturerCode() == VENDOR_IKEA && val.timestamp.isValid())
+                                {
+                                    fresh++; // rely on reporting for ikea lights
+                                }
+                                else if (val.timestampLastReport.isValid() && val.timestampLastReport.secsTo(now) < reportWaitTime)
+                                {
+                                    fresh++;
+                                }
+                                else if (lightNode && lightNode->manufacturerCode() == VENDOR_XAL && val.timestamp.isValid() && val.timestamp.secsTo(now) < reportWaitTimeXAL)
+                                {
+                                    fresh++; // rely on reporting for XAL lights
+                                }
+
+                            }
+                        }
+                    }
+
+                    attributes = check;     // reassign filtered attributes
                     break;
                 }
             }


### PR DESCRIPTION
When cluster to be polled is found, extend the check to also determine if an attribute is available. If not, they get discarded (mainly applicable for instantaneous demand attribute on simple metering cluster). Also, freshness of values is only checked on available attributes now.