### PR TITLE
Adding release schedule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ The Phoscon App is a browser based web application and supports lights, sensors 
 
 ### Release Schedule
 
-deCONZ is having a beta release at the 15th day of the month in which the beta of last month becomes stable. Pull requests done before the 10th of the month, are getting included in the next beta (if there are no issues ofcourse!). 
-Current Beta: 2.05.80 
-Current Stable: 2.05.78
+deCONZ is having a beta release at the 15th day of the month in which the beta of last month becomes stable. Pull requests done before the 10th of the month, are getting included in the next beta (if there are no issues ofcourse!).  Stable release would be around the 1st - 5th of the month after latest beta. 
+Current Beta: 2.05.81 
+Current Stable: 2.05.81
 
-
+Next Beta: 2.05.82 expected at the 15th of October. 
+Next Stable: 2.05.82 expected in week 45 (2th to 8th of November)
 
 Installation
 ============

--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ The Phoscon App is a browser based web application and supports lights, sensors 
 
 ### Release Schedule
 
-deCONZ is having a beta release at the 15th day of the month in which the beta of last month becomes stable. 
+deCONZ is having a beta release at the 15th day of the month in which the beta of last month becomes stable. Pull requests done before the 10th of the month, are getting included in the next beta (if there are no issues ofcourse!). 
 Current Beta: 2.05.80 
 Current Stable: 2.05.78
+
+
 
 Installation
 ============

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ The Phoscon App is a browser based web application and supports lights, sensors 
 ### Release Schedule
 
 deCONZ is having a beta release at the 15th day of the month in which the beta of last month becomes stable. Pull requests done before the 10th of the month, are getting included in the next beta (if there are no issues ofcourse!).  Stable release would be around the 1st - 5th of the month after latest beta. 
-Current Beta: 2.05.81 
+Current Beta: 2.05.82
 Current Stable: 2.05.81
 
-Next Beta: 2.05.82 expected at the 15th of October. 
-Next Stable: 2.05.82 expected in week 45 (2th to 8th of November)
+Next Beta: 2.05.84 expected at the 15th of October. 
+Next Stable: 2.05.83 expected in week 45 (2th to 8th of November)
 
 Installation
 ============

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ deCONZ is having a beta release at the 15th day of the month in which the beta o
 Current Beta: 2.05.82
 Current Stable: 2.05.81
 
-Next Beta: 2.05.84 expected at the 15th of October. 
-Next Stable: 2.05.83 expected in week 45 (2th to 8th of November)
+Next Beta: 2.05.85 expected at the 15th of October. 
+Next Stable: 2.05.84 expected at 8th October (minor fixes and new firmware files)
 
 Installation
 ============

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ For community based support with deCONZ or Phoscon, please visit the [deCONZ Dis
 The Phoscon App is a browser based web application and supports lights, sensors and switches. For more information and screenshots visit the [Phoscon App Documentation](https://phoscon.de/app/doc?ref=gh).
 
 
+### Release Schedule
+
+deCONZ is having a beta release at the 15th day of the month in which the beta of last month becomes stable. 
+Current Beta: 2.05.80 
+Current Stable: 2.05.78
+
 Installation
 ============
 
@@ -117,4 +123,5 @@ The following libraries are used by the plugin:
 License
 =======
 The plugin is available as open source and licensed under the BSD (3-Clause) license.
+
 


### PR DESCRIPTION
@manup as per now: .78 is latest stable. Can we make .80 stable in the next release of the beta 81?

Just so we have a even roster?
