### PR TITLE
Store/restore source routes in database

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2016-2020 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -95,6 +95,10 @@ void DeRestPluginPrivate::checkDbUserVersion()
         updated = upgradeDbToUserVersion6();
     }
     else if (userVersion == 6)
+    {
+        updated = upgradeDbToUserVersion7();
+    }
+    else if (userVersion == 7)
     {
         // latest version
     }
@@ -250,8 +254,7 @@ bool DeRestPluginPrivate::setDbUserVersion(int userVersion)
 
     DBG_Printf(DBG_INFO, "DB write sqlite user_version %d\n", userVersion);
 
-    QString sql;
-    sql = QString("PRAGMA user_version = %1").arg(userVersion);
+    const auto sql = QString("PRAGMA user_version = %1").arg(userVersion);
 
     errmsg = NULL;
     rc = sqlite3_exec(db, qPrintable(sql), NULL, NULL, &errmsg);
@@ -376,9 +379,6 @@ bool DeRestPluginPrivate::upgradeDbToUserVersion2()
 /*! Upgrades database to user_version 6. */
 bool DeRestPluginPrivate::upgradeDbToUserVersion6()
 {
-    int rc;
-    char *errmsg;
-
     DBG_Printf(DBG_INFO, "DB upgrade to user_version 6\n");
 
     // create tables
@@ -410,22 +410,247 @@ bool DeRestPluginPrivate::upgradeDbToUserVersion6()
 
     for (int i = 0; sql[i] != nullptr; i++)
     {
-        errmsg = nullptr;
-        rc = sqlite3_exec(db, sql[i], nullptr, nullptr, &errmsg);
+        char *errmsg = nullptr;
+        int rc = sqlite3_exec(db, sql[i], nullptr, nullptr, &errmsg);
+
+        if (rc != SQLITE_OK)
+        {
+            bool fatalError = true;
+            if (errmsg)
+            {
+                if (strstr(errmsg, "duplicate column name")) // harmless
+                {
+                    fatalError = false;
+                }
+                else
+                {
+                    DBG_Printf(DBG_ERROR_L2, "SQL exec failed: %s, error: %s (%d)\n", sql[i], errmsg, rc);
+                }
+                sqlite3_free(errmsg);
+            }
+
+            if (fatalError)
+            {
+                return false;
+            }
+        }
+    }
+
+    return setDbUserVersion(6);
+}
+
+/*! Upgrades database to user_version 7. */
+bool DeRestPluginPrivate::upgradeDbToUserVersion7()
+{
+    DBG_Printf(DBG_INFO, "DB upgrade to user_version 7\n");
+
+    /*
+       The 'source_routes' table references 'devices' so that entries are
+       automatically deleted if the destination node is removed.
+       Inserting an entry with an existing uuid will automatically replace the old row.
+
+       The 'source_route_hops' table also references 'devices' so that
+       entries for a hop get deleted when the respective node is removed.
+       In this case the source route entry still exists but the source_routes.hops
+       count won't match the number of source_route_hops entries anymore.
+     */
+
+    // create tables
+    const char *sql[] = {
+        "CREATE TABLE IF NOT EXISTS source_routes ("
+        " uuid TEXT PRIMARY KEY ON CONFLICT REPLACE,"
+        " dest_device_id INTEGER REFERENCES devices(id) ON DELETE CASCADE,"
+        " route_order INTEGER NOT NULL,"
+        " hops INTEGER NOT NULL,"  // to track number of entries which should be in 'source_route_relays'
+        " timestamp INTEGER NOT NULL)",
+
+        "CREATE TABLE if NOT EXISTS source_route_hops ("
+        " source_route_uuid TEXT REFERENCES source_routes(uuid) ON DELETE CASCADE,"
+        " hop_device_id INTEGER REFERENCES devices(id) ON DELETE CASCADE,"
+        " hop INTEGER NOT NULL)",
+        nullptr
+    };
+
+    for (int i = 0; sql[i] != nullptr; i++)
+    {
+        char *errmsg = nullptr;
+        int rc = sqlite3_exec(db, sql[i], nullptr, nullptr, &errmsg);
 
         if (rc != SQLITE_OK)
         {
             if (errmsg)
             {
-                DBG_Printf(DBG_ERROR_L2, "SQL exec failed: %s, error: %s (%d)\n", sql[i], errmsg, rc);
+                DBG_Printf(DBG_ERROR_L2, "SQL exec failed: %s, error: %s (%d), line: %d\n", sql[i], errmsg, rc, __LINE__);
                 sqlite3_free(errmsg);
             }
             return false;
         }
     }
 
-    return setDbUserVersion(6);
+    return setDbUserVersion(7);
 }
+
+#if DECONZ_LIB_VERSION >= 0x010E00
+/*! Stores a source route.
+    Any existing source route with the same uuid will be replaced automatically.
+ */
+void DeRestPluginPrivate::storeSourceRoute(const deCONZ::SourceRoute &sourceRoute)
+{
+    DBG_Assert(sourceRoute.hops().size() > 1);
+
+    if (sourceRoute.hops().size() <= 1)
+    {
+        return; // at least two hops (incl. destination)
+    }
+
+    openDb();
+    DBG_Assert(db);
+    if (!db)
+    {
+        return;
+    }
+
+    QString sql = QString("INSERT INTO source_routes (uuid,dest_device_id,route_order,hops,timestamp)"
+                          " SELECT '%1', (SELECT id FROM devices WHERE mac = '%2'), %3, %4, strftime('%s','now');")
+                          .arg(sourceRoute.uuid())
+                          .arg(generateUniqueId(sourceRoute.hops().back().ext(), 0, 0))
+                          .arg(sourceRoute.order())
+                          .arg(sourceRoute.hops().size());
+
+    for (size_t i = 0; i < sourceRoute.hops().size(); i++)
+    {
+        sql += QString("INSERT INTO source_route_hops (source_route_uuid, hop_device_id, hop)"
+                       " SELECT '%1', (SELECT id FROM devices WHERE mac = '%2'), %3;")
+                .arg(sourceRoute.uuid())
+                .arg(generateUniqueId(sourceRoute.hops().at(i).ext(), 0, 0))
+                .arg(i);
+    }
+
+    char *errmsg = nullptr;
+    int rc = sqlite3_exec(db, sql.toUtf8().constData(), NULL, NULL, &errmsg);
+
+    if (rc != SQLITE_OK)
+    {
+        if (errmsg)
+        {
+            DBG_Printf(DBG_ERROR, "DB sqlite3_exec failed: %s, error: %s, line: %d\n", qPrintable(sql), errmsg, __LINE__);
+            sqlite3_free(errmsg);
+        }
+    }
+
+    closeDb();
+}
+
+/*! Deletes the source route with \p uuid. */
+void DeRestPluginPrivate::deleteSourceRoute(const QString &uuid)
+{
+    DBG_Assert(!uuid.isEmpty());
+
+    openDb();
+    DBG_Assert(db);
+    if (!db)
+    {
+        return;
+    }
+
+    char *errmsg = nullptr;
+    const auto sql = QString("DELETE FROM source_routes WHERE uuid = '%1'").arg(uuid);
+    int rc = sqlite3_exec(db, sql.toUtf8().constData(), NULL, NULL, &errmsg);
+
+    if (rc != SQLITE_OK)
+    {
+        if (errmsg)
+        {
+            DBG_Printf(DBG_ERROR, "DB sqlite3_exec failed: %s, error: %s, line: %d\n", qPrintable(sql), errmsg, __LINE__);
+            sqlite3_free(errmsg);
+        }
+    }
+
+    closeDb();
+}
+
+/*! Restores and activates all source routes in core. */
+void DeRestPluginPrivate::restoreSourceRoutes()
+{
+    openDb();
+    DBG_Assert(db);
+    if (!db)
+    {
+        return;
+    }
+
+    const auto loadSourceRoutesCallback = [](void *user, int ncols, char **colval , char **) -> int
+    {
+        auto *sourceRoutes = static_cast<std::vector<deCONZ::SourceRoute>*>(user);
+        DBG_Assert(sourceRoutes);
+        DBG_Assert(ncols == 3);
+        // TODO verify number of hops in colval[2]
+        sourceRoutes->push_back(deCONZ::SourceRoute(colval[0], QString(colval[1]).toInt(), {}));
+        return 0;
+    };
+
+    char *errmsg = nullptr;
+    std::vector<deCONZ::SourceRoute> sourceRoutes;
+    const char *sql = "SELECT uuid, route_order, hops FROM source_routes";
+
+    int rc = sqlite3_exec(db, sql, loadSourceRoutesCallback, &sourceRoutes, &errmsg);
+
+    if (rc != SQLITE_OK)
+    {
+        if (errmsg)
+        {
+            DBG_Printf(DBG_ERROR, "sqlite3_exec %s, error: %s, line: %d\n", qPrintable(sql), errmsg, __LINE__);
+            sqlite3_free(errmsg);
+            errmsg = nullptr;
+        }
+    }
+
+    const auto loadHopsCallback = [](void *user, int ncols, char **colval , char **) -> int
+    {
+        auto *hops = static_cast<std::vector<deCONZ::Address>*>(user);
+        DBG_Assert(hops);
+        DBG_Assert(ncols == 2);
+
+        const auto mac = QString("0x%1").arg(colval[0]).remove(':');
+        // TODO make use of 'hop' in colval[1]
+
+        bool ok = false;
+        deCONZ::Address addr;
+        addr.setExt(static_cast<uint64_t>(mac.toULongLong(&ok, 16)));
+
+        if (ok)
+        {
+            hops->push_back(addr);
+        }
+
+        return 0;
+    };
+
+    for (auto &sr : sourceRoutes)
+    {
+        std::vector<deCONZ::Address> hops;
+        const auto sql = QString("SELECT mac, hop FROM source_route_hops INNER JOIN devices WHERE hop_device_id = devices.id AND source_route_uuid = '%1';").arg(sr.uuid());
+
+        rc = sqlite3_exec(db, qPrintable(sql), loadHopsCallback, &hops, &errmsg);
+
+        if (rc != SQLITE_OK)
+        {
+            if (errmsg)
+            {
+                DBG_Printf(DBG_ERROR, "sqlite3_exec %s, error: %s, line: %d\n", qPrintable(sql), errmsg, __LINE__);
+                sqlite3_free(errmsg);
+                errmsg = nullptr;
+            }
+        }
+        else if (apsCtrl && hops.size() > 1) // at least two items
+        {
+            apsCtrl->activateSourceRoute(deCONZ::SourceRoute(sr.uuid(), sr.order(), hops));
+        }
+    }
+
+    closeDb();
+}
+#endif // DECONZ_LIB_VERSION >= 0x010E00
 
 /*! Puts a new top level device entry in the db (mac address) or refreshes nwk address.
 */

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -561,6 +561,12 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
     connect(apsCtrl, SIGNAL(nodeEvent(deCONZ::NodeEvent)),
             this, SLOT(nodeEvent(deCONZ::NodeEvent)));
 
+#if DECONZ_LIB_VERSION >= 0x010E00
+    connect(apsCtrl, &deCONZ::ApsController::sourceRouteCreated, this, &DeRestPluginPrivate::storeSourceRoute);
+    connect(apsCtrl, &deCONZ::ApsController::sourceRouteDeleted, this, &DeRestPluginPrivate::deleteSourceRoute);
+    connect(apsCtrl, &deCONZ::ApsController::nodesRestored, this, &DeRestPluginPrivate::restoreSourceRoutes, Qt::QueuedConnection);
+#endif
+
     deCONZ::GreenPowerController *gpCtrl = deCONZ::GreenPowerController::instance();
 
     if (gpCtrl)

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1210,6 +1210,13 @@ public Q_SLOTS:
     void pushSensorInfoToCore(Sensor *sensor);
     void pollNextDevice();
 
+    // database
+#if DECONZ_LIB_VERSION >= 0x010E00
+    void storeSourceRoute(const deCONZ::SourceRoute &sourceRoute);
+    void deleteSourceRoute(const QString &uuid);
+    void restoreSourceRoutes();
+#endif
+
     // touchlink
     void touchlinkDisconnectNetwork();
     void checkTouchlinkNetworkDisconnected();
@@ -1481,6 +1488,7 @@ public:
     bool upgradeDbToUserVersion1();
     bool upgradeDbToUserVersion2();
     bool upgradeDbToUserVersion6();
+    bool upgradeDbToUserVersion7();
     void refreshDeviceDb(const deCONZ::Address &addr);
     void pushZdpDescriptorDb(quint64 extAddress, quint8 endpoint, quint16 type, const QByteArray &data);
     void pushZclValueDb(quint64 extAddress, quint8 endpoint, quint16 clusterId, quint16 attributeId, qint64 data);


### PR DESCRIPTION
Manual configuration of source routes is part of 2.05.81, this PR handles the related persistent storage of them.

There are two new tables:

1. The `source_routes` table references `devices` so that entries are automatically deleted if the destination node is removed.
Inserting an entry with an existing uuid will automatically replace the old row.

2. The 'source_route_hops' table also references 'devices' so that entries for a hop get deleted when the respective node is removed. In this case the source route entry still exists but the source_routes.hops count won't match the number of `source_route_hops` entries anymore.