### PR TITLE
Discovery service improvements

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -473,8 +473,8 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
 
     // set some default might be overwritten by database
     gwAnnounceInterval = ANNOUNCE_INTERVAL;
-    gwAnnounceUrl = "http://dresden-light.appspot.com/discover";
-    inetDiscoveryManager = 0;
+    gwAnnounceUrl = "https://phoscon.de/discover";
+    inetDiscoveryManager = nullptr;
 
     webhookManager = new QNetworkAccessManager(this);
     connect(webhookManager, SIGNAL(finished(QNetworkReply*)),

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -340,7 +340,7 @@
 #define VENDOR_C2DF         0xC2DF
 #define VENDOR_PHILIO       0xFFA0
 
-#define ANNOUNCE_INTERVAL 10 // minutes default announce interval
+#define ANNOUNCE_INTERVAL 45 // minutes default announce interval
 
 #define MAX_NODES 200
 #define MAX_SENSORS 1000

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -1077,7 +1077,7 @@ void DeRestPluginPrivate::configToMap(const ApiRequest &req, QVariantMap &map)
     }
     else
     {
-        map["gateway"] = "192.168.178.1";
+        map["gateway"] = "0.0.0.0";
     }
 }
 

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -375,6 +375,13 @@ void DeRestPluginPrivate::initNetworkInfo()
                     continue;
                 }
 
+                if ((ipv4 & 0xFFFF0000ul) == 0xA9FE0000ul)
+                {
+                    // link local ip
+                    // 169.254.0.0 - 169.254.255.255
+                    continue;
+                }
+
                 QString mac = i->hardwareAddress().toLower();
                 gwMAC = mac;
                 if (gwLANBridgeId) {


### PR DESCRIPTION
* Replace Google App Engine endpoint by https://phoscon.de/discover.
* Raise default announce interval from 10 to 45 minutes.
* Don't use link local IPv4 addresses (169.254.x.x) as internal IP address.
* Duplicated and too old entries are now fixed in the server (not this PR).