### PR TITLE
Fix network permit join set after deCONZ start

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -1151,18 +1151,6 @@ static int sqliteLoadConfigCallback(void *user, int ncols, char **colval , char 
             }
         }
     }
-    else if (strcmp(colval[0], "permitjoin") == 0)
-    {
-        if (!val.isEmpty())
-        {
-            uint seconds = val.toUInt(&ok);
-            if (ok && (seconds <= 255))
-            {
-                d->setPermitJoinDuration(seconds);
-                d->gwConfig["permitjoin"] = (double)seconds;
-            }
-        }
-    }
     else if (strcmp(colval[0], "networkopenduration") == 0)
     {
         if (!val.isEmpty())
@@ -4363,7 +4351,6 @@ void DeRestPluginPrivate::saveDb()
     // dump config
     if (saveDatabaseItems & DB_CONFIG)
     {
-        gwConfig["permitjoin"] = (double)gwPermitJoinDuration;
         gwConfig["networkopenduration"] = (double)gwNetworkOpenDuration;
         gwConfig["timeformat"] = gwTimeFormat;
         gwConfig["timezone"] = gwTimezone;


### PR DESCRIPTION
This could happen when permit join value > 0 was stored in the database and
restored after application startup. In my setup this caused invalid light nodes created from devices which where actually sensors and switches.

This PR removes database store/restore of the permit join value which must be set
to 0 on each startup and can only be set by REST-API.