### PR TITLE
Firmware update improvements

### DIFF
--- a/de_web.pro
+++ b/de_web.pro
@@ -6,13 +6,6 @@ TARGET = $$qtLibraryTarget($$TARGET)
 
 DEFINES += DECONZ_DLLSPEC=Q_DECL_IMPORT
 
-unix:contains(QMAKE_HOST.arch, armv6l) {
-    DEFINES += ARCH_ARM ARCH_ARMV6
-}
-unix:contains(QMAKE_HOST.arch, armv7l) {
-    DEFINES += ARCH_ARM ARCH_ARMV7
-}
-
 QMAKE_CXXFLAGS += -Wno-attributes \
                   -Wno-psabi \
                   -Wall

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -28,11 +28,6 @@
 #include <QSettings>
 #include <queue>
 #include <cmath>
-#ifdef ARCH_ARM
-  #include <unistd.h>
-  #include <sys/reboot.h>
-  #include <errno.h>
-#endif
 #include "colorspace.h"
 #include "de_web_plugin.h"
 #include "de_web_plugin_private.h"
@@ -41,6 +36,11 @@
 #include "json.h"
 #include "poll_manager.h"
 #include "rest_devices.h"
+#ifdef ARCH_ARM
+  #include <unistd.h>
+  #include <sys/reboot.h>
+  #include <errno.h>
+#endif
 
 DeRestPluginPrivate *plugin;
 

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -38,6 +38,11 @@
 #include <math.h>
 #include "websocket_server.h"
 
+#if defined(Q_OS_LINUX) && !defined(Q_PROCESSOR_X86)
+  // Workaround to detect ARM and AARCH64 in older Qt versions.
+  #define ARCH_ARM
+#endif
+
 /*! JSON generic error message codes */
 #define ERR_UNAUTHORIZED_USER          1
 #define ERR_INVALID_JSON               2

--- a/firmware_update.cpp
+++ b/firmware_update.cpp
@@ -118,6 +118,8 @@ void DeRestPluginPrivate::updateFirmware()
     updateEtag(gwConfigEtag);
     fwUpdateTimer->start(250);
 
+    DBG_Printf(DBG_INFO, "exec: %s %s\n", qPrintable(bin), qPrintable(fwProcessArgs.join(' ')));
+
     fwProcess->start(bin, fwProcessArgs);
 }
 
@@ -593,10 +595,13 @@ void DeRestPluginPrivate::checkFirmwareDevices()
 #if DECONZ_LIB_VERSION >= 0x010A00
     if (devConnected > 0 && !ttyPath.isEmpty())
     {
-        fwProcessArgs << "-d" << ttyPath << "-t" << "30"; // GCFFlasher >= 3.x
         if (!serialNumber.isEmpty())
         {
             fwProcessArgs << "-s" << serialNumber; // GCFFlasher >= 3.2
+        }
+        else
+        {
+            fwProcessArgs << "-d" << ttyPath; // GCFFlasher >= 3.x
         }
     }
     else

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -28,12 +28,7 @@
 #include "gateway.h"
 #ifdef Q_OS_LINUX
   #include <unistd.h>
-#ifdef ARCH_ARM
-  #include <sys/reboot.h>
   #include <sys/time.h>
-  #include <signal.h>
-  #include <errno.h>
-#endif
 #endif // Q_OS_LINUX
 
 /*! Constructor. */
@@ -411,7 +406,7 @@ void DeRestPluginPrivate::initNetworkInfo()
 /*! Init WiFi parameters if necessary. */
 void DeRestPluginPrivate::initWiFi()
 {
-#if !defined(ARCH_ARMV6) && !defined (ARCH_ARMV7)
+#if !defined(ARCH_ARM)
     gwWifi = QLatin1String("not-available");
     return;
 #else
@@ -526,7 +521,7 @@ void DeRestPluginPrivate::initWiFi()
     }
 
     queSaveDb(DB_CONFIG, DB_SHORT_SAVE_DELAY);
-#endif // ARCH_ARMV6, ARCH_ARMV7
+#endif
 }
 
 /*! Handle deCONZ::ApsController::configurationChanged() event.
@@ -959,7 +954,7 @@ void DeRestPluginPrivate::configToMap(const ApiRequest &req, QVariantMap &map)
         // since api version 1.2.1
         map["apiversion"] = QLatin1String(GW_SW_VERSION);
         map["system"] = "other";
-#if defined(ARCH_ARMV6) || defined (ARCH_ARMV7)
+#ifdef ARCH_ARM
 #ifdef Q_OS_LINUX
         map["system"] = "linux-gw";
 #endif
@@ -2821,9 +2816,6 @@ int DeRestPluginPrivate::configureWifi(const ApiRequest &req, ApiResponse &rsp)
 
         updateEtag(gwConfigEtag);
         queSaveDb(DB_CONFIG | DB_SYNC, DB_SHORT_SAVE_DELAY);
-#ifdef ARCH_ARM
-        //kill(gwWifiPID, SIGUSR1);
-#endif
     }
 
     QVariantMap rspItem;


### PR DESCRIPTION
* Fix detection of ARM and AARCH64 platform.
* Don't disable update on headless desktop Linux based on DISPLAY environment variable.
* Don't use sudo when EUID is 0 (root user).
* Enable firmware update via Phoscon App again.
* GCFFlasher 3.14 now checks that after flashing the application firmware is up and running, and if not will retry the update process.