### PR TITLE
Added initial support for different version of RGBgenie ZB-5001

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2912,7 +2912,8 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
         srcEndpoints.push_back(0x08);
     }
     else if (sensor->modelId().startsWith(QLatin1String("ICZB-RM")) ||
-             sensor->modelId().startsWith(QLatin1String("ZGRC-KEY-013")))
+             sensor->modelId().startsWith(QLatin1String("ZGRC-KEY-013")) ||
+             sensor->modelId().startsWith(QLatin1String("RGBgenie ZB-5001")))
     {
         clusters.push_back(ONOFF_CLUSTER_ID);
         clusters.push_back(LEVEL_CLUSTER_ID);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -3620,10 +3620,11 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
             Event e(RSensors, REventValidGroup, sensor->id());
             enqueueEvent(e);
         }
-        else if (sensor->modelId().startsWith(QLatin1String("ICZB-RM")) || // icasa remote
-                 sensor->modelId().startsWith(QLatin1String("ZGRC-KEY")) ||// Sunricher remote
-                 sensor->modelId().startsWith(QLatin1String("ED-1001")) || // EcoDim switches
-                 sensor->modelId().startsWith(QLatin1String("45127")))     // Namron switches
+        else if (sensor->modelId().startsWith(QLatin1String("ICZB-RM")) ||          // icasa remote
+                 sensor->modelId().startsWith(QLatin1String("ZGRC-KEY")) ||         // Sunricher remote
+                 sensor->modelId().startsWith(QLatin1String("ED-1001")) ||          // EcoDim switches
+                 sensor->modelId().startsWith(QLatin1String("45127")) ||            // Namron switches
+                 sensor->modelId().startsWith(QLatin1String("RGBgenie ZB-5001")))   // RGBGenie remote
         {
             if (gids.length() != 5 && sensor->modelId().startsWith(QLatin1String("ZGRC-KEY-012"))) // 5 controller endpoints: 0x01, 0x02, 0x03, 0x04, 0x05
             {

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -1527,6 +1527,7 @@ const Sensor::ButtonMap *Sensor::buttonMap()
             else if (modelid.startsWith(QLatin1String("ZG2833K"))) { m_buttonMap = sunricherMap; }
             else if (modelid.startsWith(QLatin1String("ZG2835"))) { m_buttonMap = sunricherMap; }
             else if (modelid.startsWith(QLatin1String("ZGRC-KEY-013"))) { m_buttonMap = icasaRemoteMap; }
+            else if (modelid.startsWith(QLatin1String("RGBgenie ZB-5001"))) { m_buttonMap = icasaRemoteMap; }
         }
         else if (manufacturer == QLatin1String("RGBgenie"))
         {


### PR DESCRIPTION
Apparently, this is a different version of the remote. As it has different manufacturer name and modelID, it will be recognized during pairing, but would not issue any button events (#1256).