### PR TITLE
Add Lupus temperature sensor

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -323,6 +323,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_NONE, "RH3001", ikea2MacPrefix }, // Tuyatec door/window sensor
     { VENDOR_EMBER, "RH3001", silabs3MacPrefix }, // Tuya/Blitzwolf BW-IS2 door/window sensor
     { VENDOR_NONE, "RH3052", emberMacPrefix }, // Tuyatec temperature sensor
+    { VENDOR_NONE, "RH3052", konkeMacPrefix }, // Tuyatec/Lupus temperature sensor
     { VENDOR_EMBER, "TS0201", silabs3MacPrefix }, // Tuya/Blitzwolf temperature and humidity sensor
     { VENDOR_NONE, "TS0204", silabs3MacPrefix }, // Tuya gas sensor
     { VENDOR_NONE, "TS0121", silabs3MacPrefix }, // Tuya/Blitzwolf smart plug


### PR DESCRIPTION
This PR adds the Tuya/Lupus mini temperature sensor with a changed MAC vendor ID and resolves #3263.