### PR TITLE
Show battery icons in deCONZ GUI based on ResourceItem battery state

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -7002,6 +7002,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     enqueueEvent(e);
                                     enqueueEvent(Event(RSensors, RStateLastUpdated, i->id()));
                                     updateSensorEtag(&*i);
+                                    q_ptr->nodeUpdated(i->address().ext(), QLatin1String(item->descriptor().suffix), QString::number(bat));
                                     continue;
                                 }
 
@@ -7042,6 +7043,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     item->setValue(bat);
                                     Event e(RSensors, RConfigBattery, i->id(), item);
                                     enqueueEvent(e);
+                                    q_ptr->nodeUpdated(i->address().ext(), QLatin1String(item->descriptor().suffix), QString::number(bat));
                                 }
 
                                 updateSensorEtag(&*i);
@@ -7134,6 +7136,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     item->setValue(static_cast<quint8>(bat));
                                     Event e(RSensors, RConfigBattery, i->id(), item);
                                     enqueueEvent(e);
+                                    q_ptr->nodeUpdated(i->address().ext(), QLatin1String(item->descriptor().suffix), QString::number(bat));
                                 }
                                 updateSensorEtag(&*i);
                             }
@@ -11597,6 +11600,7 @@ void DeRestPluginPrivate::handleZclAttributeReportIndicationXiaomiSpecial(const 
 
                 item->setValue(quint8(bat));
                 enqueueEvent(Event(RSensors, RConfigBattery, sensor.id(), item));
+                q_ptr->nodeUpdated(sensor.address().ext(), QLatin1String(item->descriptor().suffix), QString::number(bat));
 
                 if (item->lastSet() == item->lastChanged())
                 {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4449,6 +4449,17 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     pushSensorInfoToCore(&*i);
                 }
 
+                auto *item = i->item(RStateBattery);
+                if (!item)
+                {
+                    item = i->item(RConfigBattery);
+                }
+
+                if (item && item->toNumber() > 0)
+                {
+                    q_ptr->nodeUpdated(i->address().ext(), QLatin1String(item->descriptor().suffix), QString::number(item->toNumber()));
+                }
+
                 checkSensorNodeReachable(&*i, event);
             }
         }


### PR DESCRIPTION
This supersed battery state icons used via ZDP PowerDescriptor, which most often don't work.