### PR TITLE
Add initial support for Owon AC201 Thermostat [02]

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1249,7 +1249,14 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq4.maxInterval = 600;
             rq4.reportableChange8bit = 0xff;
 
-            return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4});
+            ConfigureReportingRequest rq5;
+            rq5.dataType = deCONZ::Zcl8BitEnum;
+            rq5.attributeId = 0x0045;        // AC Louvers Position
+            rq5.minInterval = 1;
+            rq5.maxInterval = 600;
+            rq5.reportableChange8bit = 0xff;
+
+            return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4, rq5});
         }
         else if ( (sensor && sensor->modelId() == QLatin1String("eTRV0100")) || // Danfoss Ally
                   (sensor && sensor->modelId() == QLatin1String("TRV001")) )    // Hive TRV

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1220,7 +1220,37 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
 
             return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4});
         }
+        else if (sensor && sensor->modelId() == QLatin1String("AC201")) // OWON AC201 Thermostat
+        {
+            rq.dataType = deCONZ::Zcl16BitInt;
+            rq.attributeId = 0x0000;         // Local Temperature
+            rq.minInterval = 1;
+            rq.maxInterval = 600;
+            rq.reportableChange16bit = 50;
 
+            ConfigureReportingRequest rq2;
+            rq2.dataType = deCONZ::Zcl16BitInt;
+            rq2.attributeId = 0x0011;        // Occupied cooling setpoint
+            rq2.minInterval = 1;
+            rq2.maxInterval = 600;
+            rq2.reportableChange16bit = 50;
+
+            ConfigureReportingRequest rq3;
+            rq3.dataType = deCONZ::Zcl16BitInt;
+            rq3.attributeId = 0x0012;        // Occupied heating setpoint
+            rq3.minInterval = 1;
+            rq3.maxInterval = 600;
+            rq3.reportableChange16bit = 50;
+
+            ConfigureReportingRequest rq4;
+            rq4.dataType = deCONZ::Zcl8BitEnum;
+            rq4.attributeId = 0x001C;        // Thermostat mode
+            rq4.minInterval = 1;
+            rq4.maxInterval = 600;
+            rq4.reportableChange8bit = 0xff;
+
+            return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4});
+        }
         else if ( (sensor && sensor->modelId() == QLatin1String("eTRV0100")) || // Danfoss Ally
                   (sensor && sensor->modelId() == QLatin1String("TRV001")) )    // Hive TRV
         {
@@ -1370,6 +1400,20 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq.maxInterval = 43200;
             rq.reportableChange16bit = 0xffff;
             rq.manufacturerCode = VENDOR_DANFOSS;
+            return sendConfigureReportingRequest(bt, {rq});
+        }
+    }
+    else if (bt.binding.clusterId == FAN_CONTROL_CLUSTER_ID)
+    {
+        Sensor *sensor = dynamic_cast<Sensor *>(bt.restNode);
+
+        if (sensor && sensor->modelId() == QLatin1String("AC201"))    // OWON AC201 Thermostat
+        {
+            rq.dataType = deCONZ::Zcl8BitEnum;
+            rq.attributeId = 0x0000;        // Fan mode
+            rq.minInterval = 1;
+            rq.maxInterval = 600;
+            rq.reportableChange8bit = 0xff;
             return sendConfigureReportingRequest(bt, {rq});
         }
     }
@@ -2060,6 +2104,9 @@ void DeRestPluginPrivate::checkLightBindingsForAttributeReporting(LightNode *lig
         else if (lightNode->manufacturerCode() == VENDOR_SINOPE)
         {
         }
+        else if (lightNode->manufacturerCode() == VENDOR_OWON)
+        {
+        }
         else if (lightNode->manufacturerCode() == VENDOR_XIAOMI)
         {
         }
@@ -2522,6 +2569,8 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId() == QLatin1String("Connected socket outlet") ||
         // Sage
         sensor->modelId() == QLatin1String("Bell") ||
+        // Owon
+        sensor->modelId() == QLatin1String("AC201") ||
         // Sonoff
         sensor->modelId() == QLatin1String("WB01") ||
         sensor->modelId() == QLatin1String("MS01") ||
@@ -2768,6 +2817,10 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         {
             val = sensor->getZclValue(*i, 0x0000); // Local temperature
         }
+        else if (*i == FAN_CONTROL_CLUSTER_ID)
+        {
+            val = sensor->getZclValue(*i, 0x0000); // Fan mode
+        }
         else if (*i == THERMOSTAT_UI_CONFIGURATION_CLUSTER_ID)
         {
             val = sensor->getZclValue(*i, 0x0001); // Keypad lockout
@@ -2838,6 +2891,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         case BASIC_CLUSTER_ID:
         case BINARY_INPUT_CLUSTER_ID:
         case THERMOSTAT_CLUSTER_ID:
+        case FAN_CONTROL_CLUSTER_ID:
         case THERMOSTAT_UI_CONFIGURATION_CLUSTER_ID:
         case DIAGNOSTICS_CLUSTER_ID:
         case APPLIANCE_EVENTS_AND_ALERTS_CLUSTER_ID:

--- a/database.cpp
+++ b/database.cpp
@@ -3565,6 +3565,12 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     sensor.addItem(DataTypeBool, RConfigLocked);
                     sensor.addItem(DataTypeBool, RConfigMountingMode);
                 }
+                else if (sensor.modelId() == QLatin1String("AC201")) // OWON AC201 Thermostat
+                {
+                    sensor.addItem(DataTypeInt16, RConfigCoolSetpoint);
+                    sensor.addItem(DataTypeString, RConfigMode);
+                    sensor.addItem(DataTypeString, RConfigFanMode);
+                }
                 else
                 {
                     sensor.addItem(DataTypeBool, RConfigScheduleOn);

--- a/database.cpp
+++ b/database.cpp
@@ -3570,6 +3570,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     sensor.addItem(DataTypeInt16, RConfigCoolSetpoint);
                     sensor.addItem(DataTypeString, RConfigMode);
                     sensor.addItem(DataTypeString, RConfigFanMode);
+                    sensor.addItem(DataTypeString, RConfigSwingMode);
                 }
                 else
                 {

--- a/de_web.pro
+++ b/de_web.pro
@@ -127,6 +127,7 @@ SOURCES  = authorisation.cpp \
            de_otau.cpp \
            event.cpp \
            event_queue.cpp \
+           fan_control.cpp \
            firmware_update.cpp \
            gateway.cpp \
            gateway_scanner.cpp \

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -91,6 +91,7 @@ const quint64 deMacPrefix         = 0x00212e0000000000ULL;
 const quint64 keenhomeMacPrefix   = 0x0022a30000000000ULL;
 const quint64 zenMacPrefix        = 0x0024460000000000ULL;
 const quint64 heimanMacPrefix     = 0x0050430000000000ULL;
+const quint64 davicomMacPrefix    = 0x00606e0000000000ULL;
 const quint64 xiaomiMacPrefix     = 0x04cf8c0000000000ULL;
 const quint64 konkeMacPrefix      = 0x086bd70000000000ULL;
 const quint64 ikea2MacPrefix      = 0x14b4570000000000ULL;
@@ -290,6 +291,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_EMBER, "Super TR", emberMacPrefix }, // Elko Thermostat
     { VENDOR_EMBER, "ElkoDimmer", emberMacPrefix }, // Elko dimmer
     { VENDOR_ATMEL, "Thermostat", ecozyMacPrefix }, // eCozy Thermostat
+    { VENDOR_OWON, "AC201", davicomMacPrefix }, // OWON AC201 Thermostat
     { VENDOR_STELPRO, "ST218", xalMacPrefix }, // Stelpro Thermostat
     { VENDOR_STELPRO, "STZB402", xalMacPrefix }, // Stelpro baseboard thermostat
     { VENDOR_STELPRO, "SORB", xalMacPrefix }, // Stelpro Orleans Fan
@@ -836,6 +838,10 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
 
         case DIAGNOSTICS_CLUSTER_ID:
             handleDiagnosticsClusterIndication(ind, zclFrame);
+            break;
+
+        case FAN_CONTROL_CLUSTER_ID:
+            handleFanControlClusterIndication(ind, zclFrame);
             break;
 
         default:
@@ -3166,6 +3172,7 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
                     }
                 }
             }
+            // This code can potentially be removed here and covered by fan_control.cpp
             else if (ic->id() == FAN_CONTROL_CLUSTER_ID && (event.clusterId() == FAN_CONTROL_CLUSTER_ID))
             {
                 std::vector<deCONZ::ZclAttribute>::const_iterator ia = ic->attributes().begin();
@@ -6072,6 +6079,12 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                 sensorNode.addItem(DataTypeBool, RConfigDisplayFlipped);
                 sensorNode.addItem(DataTypeBool, RConfigLocked);
                 sensorNode.addItem(DataTypeBool, RConfigMountingMode);
+            }
+            else if (modelId == QLatin1String("AC201")) // OWON AC201 Thermostat
+            {
+                sensorNode.addItem(DataTypeInt16, RConfigCoolSetpoint);
+                sensorNode.addItem(DataTypeString, RConfigMode);
+                sensorNode.addItem(DataTypeString, RConfigFanMode);
             }
             else
             {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6085,6 +6085,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                 sensorNode.addItem(DataTypeInt16, RConfigCoolSetpoint);
                 sensorNode.addItem(DataTypeString, RConfigMode);
                 sensorNode.addItem(DataTypeString, RConfigFanMode);
+                sensorNode.addItem(DataTypeString, RConfigSwingMode);
             }
             else
             {

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -316,6 +316,7 @@
 #define VENDOR_BOSCH        0x1133
 #define VENDOR_DDEL         0x1135
 #define VENDOR_WAXMAN       0x113B
+#define VENDOR_OWON         0x113C
 #define VENDOR_LUTRON       0x1144
 #define VENDOR_ZEN          0x1158
 #define VENDOR_KEEN_HOME    0x115B
@@ -553,6 +554,8 @@ inline bool checkMacVendor(quint64 addr, quint16 vendor)
         case VENDOR_OSRAM_STACK:
             return prefix == osramMacPrefix ||
                    prefix == heimanMacPrefix;
+        case VENDOR_OWON:
+            return prefix == davicomMacPrefix;
         case VENDOR_PHILIPS:
             return prefix == philipsMacPrefix;
         case VENDOR_PLUGWISE_BV:
@@ -1433,6 +1436,7 @@ public:
     bool addTaskControlModeCmd(TaskItem &task, uint8_t cmdId, int8_t mode);
     bool addTaskSyncTime(Sensor *sensor);
     bool addTaskThermostatUiConfigurationReadWriteAttribute(TaskItem &task, uint8_t readOrWriteCmd, uint16_t attrId, uint8_t attrType, uint32_t attrValue, uint16_t mfrCode=0);
+    bool addTaskFanControlReadWriteAttribute(TaskItem &task, uint8_t readOrWriteCmd, uint16_t attrId, uint8_t attrType, uint32_t attrValue, uint16_t mfrCode=0);
 
     void handleGroupClusterIndication(TaskItem &task, const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleSceneClusterIndication(TaskItem &task, const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
@@ -1462,6 +1466,7 @@ public:
     void handleThermostatUiConfigurationClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleTimeClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleDiagnosticsClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
+    void handleFanControlClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void sendTimeClusterResponse(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleBasicClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void sendBasicClusterResponse(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -434,6 +434,7 @@ extern const quint64 macPrefixMask;
 
 extern const quint64 celMacPrefix;
 extern const quint64 bjeMacPrefix;
+extern const quint64 davicomMacPrefix;
 extern const quint64 deMacPrefix;
 extern const quint64 emberMacPrefix;
 extern const quint64 embertecMacPrefix;

--- a/fan_control.cpp
+++ b/fan_control.cpp
@@ -76,21 +76,21 @@ void DeRestPluginPrivate::handleFanControlClusterIndication(const deCONZ::ApsDat
                 if (sensor->modelId() == QLatin1String("AC201"))    // Owon
                 {
                     qint8 mode = attr.numericValue().u8;
-                    QString mode_set;
+                    QString modeSet;
 
-                    mode_set = QString("off");
-                    if ( mode == 0x00 ) { mode_set = QString("off"); }
-                    if ( mode == 0x01 ) { mode_set = QString("low"); }
-                    if ( mode == 0x02 ) { mode_set = QString("medium"); }
-                    if ( mode == 0x03 ) { mode_set = QString("high"); }
-                    if ( mode == 0x04 ) { mode_set = QString("on"); }
-                    if ( mode == 0x05 ) { mode_set = QString("auto"); }
-                    if ( mode == 0x06 ) { mode_set = QString("smart"); }
+                    modeSet = QLatin1String("off");
+                    if ( mode == 0x00 ) { modeSet = QLatin1String("off"); }
+                    if ( mode == 0x01 ) { modeSet = QLatin1String("low"); }
+                    if ( mode == 0x02 ) { modeSet = QLatin1String("medium"); }
+                    if ( mode == 0x03 ) { modeSet = QLatin1String("high"); }
+                    if ( mode == 0x04 ) { modeSet = QLatin1String("on"); }
+                    if ( mode == 0x05 ) { modeSet = QLatin1String("auto"); }
+                    if ( mode == 0x06 ) { modeSet = QLatin1String("smart"); }
 
                     item = sensor->item(RConfigFanMode);
-                    if (item && !item->toString().isEmpty() && item->toString() != mode_set)
+                    if (item && !item->toString().isEmpty() && item->toString() != modeSet)
                     {
-                        item->setValue(mode_set);
+                        item->setValue(modeSet);
                         enqueueEvent(Event(RSensors, RConfigFanMode, sensor->id(), item));
                         configUpdated = true;
                     }
@@ -158,24 +158,24 @@ bool DeRestPluginPrivate::addTaskFanControlReadWriteAttribute(TaskItem &task, ui
     QDataStream stream(&task.zclFrame.payload(), QIODevice::WriteOnly);
     stream.setByteOrder(QDataStream::LittleEndian);
 
-    stream << (quint16) attrId;
+    stream << static_cast<quint16>(attrId);
 
     if (readOrWriteCmd == deCONZ::ZclWriteAttributesId)
     {
-        stream << (quint8) attrType;
+        stream << static_cast<quint8>(attrType);
         if (attrType == deCONZ::Zcl8BitEnum || attrType == deCONZ::Zcl8BitInt || attrType == deCONZ::Zcl8BitBitMap)
         {
-            stream << (quint8) attrValue;
+            stream << static_cast<quint8>(attrValue);
         }
         else if (attrType == deCONZ::Zcl16BitInt || attrType == deCONZ::Zcl16BitBitMap)
         {
-            stream << (quint16) attrValue;
+            stream << static_cast<quint16>(attrValue);
         }
         else if (attrType == deCONZ::Zcl24BitUint)
         {
-            stream << (qint8) (attrValue & 0xFF);
-            stream << (qint8) ((attrValue >> 8) & 0xFF);
-            stream << (qint8) ((attrValue >> 16) & 0xFF);
+            stream << static_cast<qint8>(attrValue & 0xFF);
+            stream << static_cast<qint8>((attrValue >> 8) & 0xFF);
+            stream << static_cast<qint8>((attrValue >> 16) & 0xFF);
         }
         else
         {

--- a/fan_control.cpp
+++ b/fan_control.cpp
@@ -1,0 +1,194 @@
+#include "de_web_plugin.h"
+#include "de_web_plugin_private.h"
+
+/*! Handle packets related to the ZCL Fan control cluster.
+    \param ind the APS level data indication containing the ZCL packet
+    \param zclFrame the actual ZCL frame which holds the Thermostat cluster command or attribute
+ */
+void DeRestPluginPrivate::handleFanControlClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame)
+{
+    Sensor *sensor = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), ind.srcEndpoint());
+
+    if (!sensor)
+    {
+        DBG_Printf(DBG_INFO, "No sensor found for 0x%016llX, endpoint: 0x%08X\n", ind.srcAddress().ext(), ind.srcEndpoint());
+        return;
+    }
+
+    // Currently only intended for thermostats. Might change later...
+    if (sensor->type() != QLatin1String("ZHAThermostat"))
+    {
+        return;
+    }
+
+    QDataStream stream(zclFrame.payload());
+    stream.setByteOrder(QDataStream::LittleEndian);
+
+    bool isReadAttr = false;
+    bool isReporting = false;
+    if (zclFrame.isProfileWideCommand() && zclFrame.commandId() == deCONZ::ZclReadAttributesResponseId)
+    {
+        isReadAttr = true;
+    }
+    if (zclFrame.isProfileWideCommand() && zclFrame.commandId() == deCONZ::ZclReportAttributesId)
+    {
+        isReporting = true;
+    }
+
+    // Read ZCL reporting and ZCL Read Attributes Response
+    if (isReadAttr || isReporting)
+    {
+        const NodeValue::UpdateType updateType = isReadAttr ? NodeValue::UpdateByZclRead : NodeValue::UpdateByZclReport;
+
+        bool configUpdated = false;
+        bool stateUpdated = false;
+
+        while (!stream.atEnd())
+        {
+            quint16 attrId;
+            quint8 attrTypeId;
+
+            stream >> attrId;
+            if (isReadAttr)
+            {
+                quint8 status;
+                stream >> status;  // Read Attribute Response status
+                if (status != deCONZ::ZclSuccessStatus)
+                {
+                    continue;
+                }
+            }
+            stream >> attrTypeId;
+
+            deCONZ::ZclAttribute attr(attrId, attrTypeId, QLatin1String(""), deCONZ::ZclRead, false);
+
+            if (!attr.readFromStream(stream))
+            {
+                continue;
+            }
+
+            ResourceItem *item = nullptr;
+
+            switch (attrId)
+            {
+            case 0x0000: // Fan mode
+            {
+                if (sensor->modelId() == QLatin1String("AC201"))    // Owon
+                {
+                    qint8 mode = attr.numericValue().u8;
+                    QString mode_set;
+
+                    mode_set = QString("off");
+                    if ( mode == 0x00 ) { mode_set = QString("off"); }
+                    if ( mode == 0x01 ) { mode_set = QString("low"); }
+                    if ( mode == 0x02 ) { mode_set = QString("medium"); }
+                    if ( mode == 0x03 ) { mode_set = QString("high"); }
+                    if ( mode == 0x04 ) { mode_set = QString("on"); }
+                    if ( mode == 0x05 ) { mode_set = QString("auto"); }
+                    if ( mode == 0x06 ) { mode_set = QString("smart"); }
+
+                    item = sensor->item(RConfigFanMode);
+                    if (item && !item->toString().isEmpty() && item->toString() != mode_set)
+                    {
+                        item->setValue(mode_set);
+                        enqueueEvent(Event(RSensors, RConfigFanMode, sensor->id(), item));
+                        configUpdated = true;
+                    }
+                }
+                sensor->setZclValue(updateType, ind.srcEndpoint(), FAN_CONTROL_CLUSTER_ID, attrId, attr.numericValue());
+            }
+                break;
+
+            default:
+                break;
+            }
+        }
+
+        if (stateUpdated)
+        {
+            sensor->updateStateTimestamp();
+            enqueueEvent(Event(RSensors, RStateLastUpdated, sensor->id()));
+        }
+
+        if (configUpdated || stateUpdated)
+        {
+            updateEtag(sensor->etag);
+            updateEtag(gwConfigEtag);
+            sensor->setNeedSaveDatabase(true);
+            queSaveDb(DB_SENSORS, DB_SHORT_SAVE_DELAY);
+        }
+    }
+}
+
+/*! Write Attribute on fan control cluster.
+   \param task - the task item
+   \param attrId
+   \param attrType
+   \param attrValue
+   \return true - on success
+           false - on error
+ */
+bool DeRestPluginPrivate::addTaskFanControlReadWriteAttribute(TaskItem &task, uint8_t readOrWriteCmd, uint16_t attrId, uint8_t attrType, uint32_t attrValue, uint16_t mfrCode)
+{
+    if (readOrWriteCmd != deCONZ::ZclReadAttributesId && readOrWriteCmd != deCONZ::ZclWriteAttributesId)
+    {
+        DBG_Printf(DBG_INFO, "Thermostat invalid parameter readOrWriteCmd %d\n", readOrWriteCmd);
+        return false;
+    }
+
+    task.taskType = TaskThermostat;
+
+    task.req.setClusterId(FAN_CONTROL_CLUSTER_ID);
+    task.req.setProfileId(HA_PROFILE_ID);
+
+    task.zclFrame.payload().clear();
+    task.zclFrame.setSequenceNumber(zclSeq++);
+    task.zclFrame.setCommandId(readOrWriteCmd);
+    task.zclFrame.setFrameControl(deCONZ::ZclFCProfileCommand |
+            deCONZ::ZclFCDirectionClientToServer |
+            deCONZ::ZclFCDisableDefaultResponse);
+
+    if (mfrCode != 0x0000)
+    {
+        task.zclFrame.setFrameControl(task.zclFrame.frameControl() | deCONZ::ZclFCManufacturerSpecific);
+        task.zclFrame.setManufacturerCode(mfrCode);
+    }
+
+    // payload
+    QDataStream stream(&task.zclFrame.payload(), QIODevice::WriteOnly);
+    stream.setByteOrder(QDataStream::LittleEndian);
+
+    stream << (quint16) attrId;
+
+    if (readOrWriteCmd == deCONZ::ZclWriteAttributesId)
+    {
+        stream << (quint8) attrType;
+        if (attrType == deCONZ::Zcl8BitEnum || attrType == deCONZ::Zcl8BitInt || attrType == deCONZ::Zcl8BitBitMap)
+        {
+            stream << (quint8) attrValue;
+        }
+        else if (attrType == deCONZ::Zcl16BitInt || attrType == deCONZ::Zcl16BitBitMap)
+        {
+            stream << (quint16) attrValue;
+        }
+        else if (attrType == deCONZ::Zcl24BitUint)
+        {
+            stream << (qint8) (attrValue & 0xFF);
+            stream << (qint8) ((attrValue >> 8) & 0xFF);
+            stream << (qint8) ((attrValue >> 16) & 0xFF);
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    { // ZCL frame
+        task.req.asdu().clear(); // cleanup old request data if there is any
+        QDataStream stream(&task.req.asdu(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+        task.zclFrame.writeToStream(stream);
+    }
+
+    return addTask(task);
+}

--- a/general.xml
+++ b/general.xml
@@ -1722,22 +1722,60 @@ Note: It does not clear or delete previous weekly schedule programming configura
 						<value name="Fan 3rd Stage State On" value="6"></value>
 					</attribute>
 				</attribute-set>
-        <attribute-set id="0x0030" description="Thermostat Setpoint Change Tracking">
-          <attribute id="0x0030" name="Setpoint Change Source" type="enum8" access="r" required="o">
-            <value name="Manual" value="0"></value>
-            <value name="Schedule" value="1"></value>
-            <value name="Zigbee" value="2"></value>
-          </attribute>
-          <attribute id="0x0031" name="Setpoint Change Amount" type="s16" access="r" required="o" default="0x8000"/>
-          <attribute id="0x0032" name="Setpoint Change Timestamp" type="utc" access="r" required="o" default="0"/>
-        </attribute-set>
+				<attribute-set id="0x0030" description="Thermostat Setpoint Change Tracking">
+					<attribute id="0x0030" name="Setpoint Change Source" type="enum8" access="r" required="o">
+						<value name="Manual" value="0"></value>
+						<value name="Schedule" value="1"></value>
+						<value name="Zigbee" value="2"></value>
+					</attribute>
+					<attribute id="0x0031" name="Setpoint Change Amount" type="s16" access="r" required="o" default="0x8000"/>
+					<attribute id="0x0032" name="Setpoint Change Timestamp" type="utc" access="r" required="o" default="0"/>
+				</attribute-set>
+
+				<attribute-set id="0x0040" description="AC Information">
+					<attribute id="0x0040" name="AC Type" type="enum8" access="rw" required="o">
+						<value name="Cooling and Fixed Speed" value="1"></value>
+						<value name="Heat Pump and Fixed Speed" value="2"></value>
+						<value name="Cooling and Inverter" value="3"></value>
+						<value name="Heat Pump and Inverter" value="4"></value>
+					</attribute>
+					<attribute id="0x0041" name="AC Capacity" type="u16" access="rw" required="o" default="0x00"/>
+					<attribute id="0x0042" name="AC Refrigerant Type" type="enum8" access="rw" required="o" default="0x00">
+						<value name="R22" value="1"></value>
+						<value name="R410a" value="2"></value>
+						<value name="R407c" value="3"></value>
+					</attribute>
+					<attribute id="0x0043" name="AC Compressor Type" type="enum8" access="rw" required="o" default="0x00">
+						<value name="T1, Max working ambient 43 oC" value="1"></value>
+						<value name="T2, Max working ambient 35 oC" value="2"></value>
+						<value name="T3, Max working ambient 52 oC" value="3"></value>
+					</attribute>
+					<attribute id="0x0044" name="AC Error Code" type="bmp32" access="rw" required="o" default="0x00000000">
+						<value name="Compressor Failure or Refrigerant Leakage" value="0"></value>
+						<value name="Room Temperature Sensor Failure" value="1"></value>
+						<value name="Outdoor Temperature Sensor Failure" value="2"></value>
+						<value name="Indoor Coil Temperature Sensor Failure" value="3"></value>
+						<value name="Fan Failure" value="4"></value>
+					</attribute>
+					<attribute id="0x0045" name="AC Louver Position" type="enum8" access="rw" required="o" default="0x00">
+						<value name="Fully Closed" value="1"></value>
+						<value name="Fully Open" value="2"></value>
+						<value name="Quarter Open" value="3"></value>
+						<value name="Half Open" value="4"></value>
+						<value name="Three Quarters Open" value="5"></value>
+					</attribute>
+					<attribute id="0x0046" name="AC Coil Temperature" type="s16" access="r" required="o"/>
+					<attribute id="0x0047" name="AC Capacity Format" type="enum8" access="rw" required="o" default="0x00">
+						<value name="BTUh" value="0"></value>
+					</attribute>
+				</attribute-set>
         
-        <attribute-set id="0x0080" description="eCozy" mfcode="0x1014">
-          <attribute id="0x0080" name="Unknown" type="s16" access="r" required="o"/>
-          <attribute id="0x0081" name="Unknown" type="s16" access="r" required="o"/>
-          <attribute id="0x0082" name="Unknown (Heat Setpoint?)" type="s16" access="r" required="o"/>
-        </attribute-set>
-        
+				<attribute-set id="0x0080" description="eCozy" mfcode="0x1014">
+					<attribute id="0x0080" name="Unknown" type="s16" access="r" required="o"/>
+					<attribute id="0x0081" name="Unknown" type="s16" access="r" required="o"/>
+					<attribute id="0x0082" name="Unknown (Heat Setpoint?)" type="s16" access="r" required="o"/>
+				</attribute-set>
+
 		<!-- ELKO specific -->
 		<attribute-set id="0x0400" description="ELKO specific" mfcode="0x1002">
 			<attribute id="0x0401" name="Unknown" type="u16" access="rw" required="m"></attribute>

--- a/resource.cpp
+++ b/resource.cpp
@@ -149,6 +149,7 @@ const char *RConfigSensitivity = "config/sensitivity";
 const char *RConfigSensitivityMax = "config/sensitivitymax";
 const char *RConfigSunriseOffset = "config/sunriseoffset";
 const char *RConfigSunsetOffset = "config/sunsetoffset";
+const char *RConfigSwingMode = "config/swingmode";
 const char *RConfigTemperature = "config/temperature";
 const char *RConfigTemperatureMeasurement = "config/temperaturemeasurement";
 const char *RConfigTholdDark = "config/tholddark";
@@ -306,6 +307,7 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, RConfigSensitivityMax));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeInt8, RConfigSunriseOffset, -120, 120));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeInt8, RConfigSunsetOffset, -120, 120));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RConfigSwingMode));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeInt16, RConfigTemperature, -27315, 32767));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RConfigTemperatureMeasurement));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigTholdDark, 0, 0xfffe));

--- a/resource.cpp
+++ b/resource.cpp
@@ -119,6 +119,7 @@ const char *RConfigCoolSetpoint = "config/coolsetpoint";
 const char *RConfigDelay = "config/delay";
 const char *RConfigDisplayFlipped = "config/displayflipped";
 const char *RConfigDuration = "config/duration";
+const char *RConfigFanMode = "config/fanmode";
 const char *RConfigGroup = "config/group";
 const char *RConfigHeatSetpoint = "config/heatsetpoint";
 const char *RConfigHostFlags = "config/hostflags";
@@ -275,6 +276,7 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigDelay));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, RConfigDisplayFlipped));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigDuration));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, RConfigFanMode, 0, 6));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RConfigGroup));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeInt16, RConfigHeatSetpoint, 500, 3200));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt32, RConfigHostFlags));

--- a/resource.cpp
+++ b/resource.cpp
@@ -276,7 +276,7 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigDelay));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, RConfigDisplayFlipped));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigDuration));
-    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, RConfigFanMode, 0, 6));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RConfigFanMode));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RConfigGroup));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeInt16, RConfigHeatSetpoint, 500, 3200));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt32, RConfigHostFlags));

--- a/resource.h
+++ b/resource.h
@@ -157,6 +157,7 @@ extern const char *RConfigSensitivity;
 extern const char *RConfigSensitivityMax;
 extern const char *RConfigSunriseOffset;
 extern const char *RConfigSunsetOffset;
+extern const char *RConfigSwingMode;
 extern const char *RConfigTemperature;
 extern const char *RConfigTemperatureMeasurement;
 extern const char *RConfigTholdDark;

--- a/resource.h
+++ b/resource.h
@@ -127,6 +127,7 @@ extern const char *RConfigCoolSetpoint;
 extern const char *RConfigDelay;
 extern const char *RConfigDisplayFlipped;
 extern const char *RConfigDuration;
+extern const char *RConfigFanMode;
 extern const char *RConfigGroup;
 extern const char *RConfigHeatSetpoint;
 extern const char *RConfigHostFlags;

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1250,7 +1250,8 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                              sensor->modelId() == QLatin1String("SLR1b") ||           // Hive
                              sensor->modelId().startsWith(QLatin1String("TH112")) ||  // Sinope
                              sensor->modelId().startsWith(QLatin1String("Zen-01")) || // Zen
-                             sensor->modelId().startsWith(QLatin1String("SORB")))     // Stelpro Orleans Fan
+                             sensor->modelId().startsWith(QLatin1String("SORB")) ||   // Stelpro Orleans Fan
+                             sensor->modelId().startsWith(QLatin1String("AC201")))    // OWON
                     {
 
                         QString modeSet = map[pi.key()].toString();

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1571,6 +1571,51 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                         rspItemState[QString("Error : unknown Window open setting for %1").arg(sensor->modelId())] = map[pi.key()];
                     }
                 }
+                else if (rid.suffix == RConfigFanMode)
+                {
+                    if (map[pi.key()].type() == QVariant::String && map[pi.key()].toString().size() <= 6)
+                    {
+                        if (sensor->modelId() == QLatin1String("AC201"))
+                        {
+                            QString modeSet = map[pi.key()].toString();
+                            quint8 mode = 0;
+
+                            if (modeSet == "off") { mode = 0x00; }
+                            else if (modeSet == "low") { mode = 0x01; }
+                            else if (modeSet == "medium") { mode = 0x02; }
+                            else if (modeSet == "high") { mode = 0x03; }
+                            else if (modeSet == "on") { mode = 0x04; }
+                            else if (modeSet == "auto") { mode = 0x05; }
+                            else if (modeSet == "smart") { mode = 0x06; }
+                            else
+                            {
+                                rspItemState[QString("error unknown fan mode for %1").arg(sensor->modelId())] = map[pi.key()];
+                            }
+
+                            if (mode < 7)
+                            {
+                                if (addTaskFanControlReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, 0x0000, deCONZ::Zcl8BitEnum, mode))
+                                {
+                                    updated = true;
+                                }
+                                else
+                                {
+                                    rsp.list.append(errorToMap(ERR_ACTION_ERROR, QString("/sensors/%1/config/%2").arg(id).arg(pi.key()).toHtmlEscaped(),
+                                                               QString("Could not set attribute")));
+                                    rsp.httpStatus = HttpStatusBadRequest;
+                                    return REQ_READY_SEND;
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/sensors/%1/config/%2").arg(id).arg(pi.key()).toHtmlEscaped(),
+                                                   QString("invalid value, %1, for parameter %2").arg(map[pi.key()].toString()).arg(pi.key()).toHtmlEscaped()));
+                        rsp.httpStatus = HttpStatusBadRequest;
+                        return REQ_READY_SEND;
+                    }
+                }
             }
         }
 

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1619,6 +1619,56 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                 }
             }
         }
+        else if (rid.suffix == RConfigSwingMode)
+        {
+            if (map[pi.key()].type() == QVariant::String && map[pi.key()].toString().size() <= 19)
+            {
+                if (sensor->modelId() == QLatin1String("AC201"))
+                {
+                    QString modeSet = map[pi.key()].toString();
+                    quint8 mode = 0;
+
+                    if (modeSet == "fully closed") { mode = 0x01; }
+                    else if (modeSet == "fully open") { mode = 0x02; }
+                    else if (modeSet == "quarter open") { mode = 0x03; }
+                    else if (modeSet == "half open") { mode = 0x04; }
+                    else if (modeSet == "three quarters open") { mode = 0x05; }
+                    else
+                    {
+                        rspItemState[QString("error unknown swing mode for %1").arg(sensor->modelId())] = map[pi.key()];
+                    }
+
+                    if (mode > 0 && mode < 6)
+                    {   
+                        if (addTaskThermostatReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, 0x0000, 0x0045, deCONZ::Zcl8BitEnum, mode))
+                        {
+                            updated = true;
+                        }
+                        else
+                        {
+                            rsp.list.append(errorToMap(ERR_ACTION_ERROR, QString("/sensors/%1/config/%2").arg(id).arg(pi.key()).toHtmlEscaped(),
+                                                    QString("Could not set attribute")));
+                            rsp.httpStatus = HttpStatusBadRequest;
+                            return REQ_READY_SEND;
+                        }
+                    }
+                    else
+                    {
+                        rsp.list.append(errorToMap(ERR_ACTION_ERROR, QString("/sensors/%1/config/%2").arg(id).arg(pi.key()).toHtmlEscaped(),
+                                                QString("Could not set attribute")));
+                        rsp.httpStatus = HttpStatusBadRequest;
+                        return REQ_READY_SEND;
+                    }
+                }
+            }
+            else
+            {
+                rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/sensors/%1/config/%2").arg(id).arg(pi.key()).toHtmlEscaped(),
+                                           QString("invalid value, %1, for parameter %2").arg(map[pi.key()].toString()).arg(pi.key()).toHtmlEscaped()));
+                rsp.httpStatus = HttpStatusBadRequest;
+                return REQ_READY_SEND;
+            }
+        }
 
         if (!item)
         {

--- a/thermostat.cpp
+++ b/thermostat.cpp
@@ -612,6 +612,30 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
             }
                 break;
 
+            case 0x0045: // AC Louvers Position
+            {
+                qint8 mode = attr.numericValue().s8;
+                QString mode_set;
+
+                mode_set = QString("fully closed");
+                if ( mode == 0x01 ) { mode_set = QString("fully closed"); }
+                if ( mode == 0x02 ) { mode_set = QString("fully open"); }
+                if ( mode == 0x03 ) { mode_set = QString("quarter open"); }
+                if ( mode == 0x04 ) { mode_set = QString("half open"); }
+                if ( mode == 0x05 ) { mode_set = QString("three quarters open"); }
+
+                item = sensor->item(RConfigSwingMode);
+                if (item && !item->toString().isEmpty() && item->toString() != mode_set)
+                {
+                    item->setValue(mode_set);
+                    enqueueEvent(Event(RSensors, RConfigSwingMode, sensor->id(), item));
+                    configUpdated = true;
+                }
+
+                sensor->setZclValue(updateType, ind.srcEndpoint(), THERMOSTAT_CLUSTER_ID, attrId, attr.numericValue());
+            }
+                break;
+
             case 0x0403: // Temperature measurement
             {
                 if (zclFrame.manufacturerCode() == VENDOR_EMBER && sensor->modelId().startsWith(QLatin1String("Super TR"))) // ELKO

--- a/thermostat.cpp
+++ b/thermostat.cpp
@@ -490,7 +490,8 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
                     sensor->modelId().startsWith(QLatin1String("SLR1b")) ||  // Hive
                     sensor->modelId().startsWith(QLatin1String("TH112")) ||  // Sinope
                     sensor->modelId().startsWith(QLatin1String("Zen-01")) || // Zen
-                    sensor->modelId().startsWith(QLatin1String("Super")))    // ELKO
+                    sensor->modelId().startsWith(QLatin1String("Super")) ||  // ELKO
+                    sensor->modelId().startsWith(QLatin1String("AC201")))    // OWON
                 {
                     qint8 mode = attr.numericValue().s8;
                     QString mode_set;

--- a/thermostat.cpp
+++ b/thermostat.cpp
@@ -614,19 +614,19 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
             case 0x0045: // AC Louvers Position
             {
                 qint8 mode = attr.numericValue().s8;
-                QString mode_set;
+                QString modeSet;
 
-                mode_set = QString("fully closed");
-                if ( mode == 0x01 ) { mode_set = QString("fully closed"); }
-                if ( mode == 0x02 ) { mode_set = QString("fully open"); }
-                if ( mode == 0x03 ) { mode_set = QString("quarter open"); }
-                if ( mode == 0x04 ) { mode_set = QString("half open"); }
-                if ( mode == 0x05 ) { mode_set = QString("three quarters open"); }
+                modeSet = QLatin1String("fully closed");
+                if ( mode == 0x01 ) { modeSet = QLatin1String("fully closed"); }
+                else if ( mode == 0x02 ) { modeSet = QLatin1String("fully open"); }
+                else if ( mode == 0x03 ) { modeSet = QLatin1String("quarter open"); }
+                else if ( mode == 0x04 ) { modeSet = QLatin1String("half open"); }
+                else if ( mode == 0x05 ) { modeSet = QLatin1String("three quarters open"); }
 
                 item = sensor->item(RConfigSwingMode);
-                if (item && !item->toString().isEmpty() && item->toString() != mode_set)
+                if (item && !item->toString().isEmpty() && item->toString() != modeSet)
                 {
-                    item->setValue(mode_set);
+                    item->setValue(modeSet);
                     enqueueEvent(Event(RSensors, RConfigSwingMode, sensor->id(), item));
                     configUpdated = true;
                 }


### PR DESCRIPTION
- Add initial support for Owon AC201 Thermostat
- Introduce `fan_control.cpp` to accomodate AC fan control for thermostats
- Introduce `RConfigFanMode` to set AC fan mode
- Introduce `RConfigSwingMode` to set AC louvers position