### PR TITLE
Fix for Aqara Opple switches and Ikea wireless dimmer

### DIFF
--- a/button_maps.json
+++ b/button_maps.json
@@ -262,7 +262,7 @@
         "ikeaDimmerMap": {
             "modelids": ["TRADFRI wireless dimmer"],
             "map": [
-                [4, "0x01", "LEVEL_CONTROL", "MOVE_TO_LEVEL_WITH_ON_OFF", "255", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "Move to level 255 (with on/off)"],
+                [4, "0x01", "LEVEL_CONTROL", "MOVE_TO_LEVEL_WITH_ON_OFF", "0xFF", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "Move to level 255 (with on/off)"],
                 [4, "0x01", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "0", "S_BUTTON_2", "S_BUTTON_ACTION_SHORT_RELEASED", "Move up (with on/off)"],
                 [4, "0x01", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "0", "0", "0", "Stop_ up (with on/off)"],
                 [4, "0x01", "LEVEL_CONTROL", "MOVE", "1", "S_BUTTON_3", "S_BUTTON_ACTION_SHORT_RELEASED", "Move down"],
@@ -700,38 +700,38 @@
             ]
         },
         "aqaraOpple6Map": {
-            "modelids": ["86opcn01"],
+            "modelids": ["lumi.remote.b286opcn01", "lumi.remote.b486opcn01", "lumi.remote.b686opcn01"],
             "map": [
                 [1, "0x01", "MULTISTATE_INPUT", "0x0a", "0", "S_BUTTON_1", "S_BUTTON_ACTION_HOLD", "Off hold"],
                 [1, "0x01", "MULTISTATE_INPUT", "0x0a", "1", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "Off press"],
                 [1, "0x01", "MULTISTATE_INPUT", "0x0a", "2", "S_BUTTON_1", "S_BUTTON_ACTION_DOUBLE_PRESS", "Off double press"],
                 [1, "0x01", "MULTISTATE_INPUT", "0x0a", "3", "S_BUTTON_1", "S_BUTTON_ACTION_TREBLE_PRESS", "Off triple press"],
-                [1, "0x01", "MULTISTATE_INPUT", "0x0a", "255", "S_BUTTON_1", "S_BUTTON_ACTION_LONG_RELEASED", "Off long released"],
+                [1, "0x01", "MULTISTATE_INPUT", "0x0a", "0xFF", "S_BUTTON_1", "S_BUTTON_ACTION_LONG_RELEASED", "Off long released"],
                 [1, "0x02", "MULTISTATE_INPUT", "0x0a", "0", "S_BUTTON_2", "S_BUTTON_ACTION_HOLD", "On hold"],
                 [1, "0x02", "MULTISTATE_INPUT", "0x0a", "1", "S_BUTTON_2", "S_BUTTON_ACTION_SHORT_RELEASED", "On press"],
                 [1, "0x02", "MULTISTATE_INPUT", "0x0a", "2", "S_BUTTON_2", "S_BUTTON_ACTION_DOUBLE_PRESS", "On double press"],
                 [1, "0x02", "MULTISTATE_INPUT", "0x0a", "3", "S_BUTTON_2", "S_BUTTON_ACTION_TREBLE_PRESS", "On triple press"],
-                [1, "0x02", "MULTISTATE_INPUT", "0x0a", "255", "S_BUTTON_2", "S_BUTTON_ACTION_LONG_RELEASED", "On long released"],
+                [1, "0x02", "MULTISTATE_INPUT", "0x0a", "0xFF", "S_BUTTON_2", "S_BUTTON_ACTION_LONG_RELEASED", "On long released"],
                 [1, "0x03", "MULTISTATE_INPUT", "0x0a", "0", "S_BUTTON_3", "S_BUTTON_ACTION_HOLD", "Dim down hold"],
                 [1, "0x03", "MULTISTATE_INPUT", "0x0a", "1", "S_BUTTON_3", "S_BUTTON_ACTION_SHORT_RELEASED", "Dim down press"],
                 [1, "0x03", "MULTISTATE_INPUT", "0x0a", "2", "S_BUTTON_3", "S_BUTTON_ACTION_DOUBLE_PRESS", "Dim down double press"],
                 [1, "0x03", "MULTISTATE_INPUT", "0x0a", "3", "S_BUTTON_3", "S_BUTTON_ACTION_TREBLE_PRESS", "Dim down triple press"],
-                [1, "0x03", "MULTISTATE_INPUT", "0x0a", "255", "S_BUTTON_3", "S_BUTTON_ACTION_LONG_RELEASED", "Dim down long released"],
+                [1, "0x03", "MULTISTATE_INPUT", "0x0a", "0xFF", "S_BUTTON_3", "S_BUTTON_ACTION_LONG_RELEASED", "Dim down long released"],
                 [1, "0x04", "MULTISTATE_INPUT", "0x0a", "0", "S_BUTTON_4", "S_BUTTON_ACTION_HOLD", "Dim up hold"],
                 [1, "0x04", "MULTISTATE_INPUT", "0x0a", "1", "S_BUTTON_4", "S_BUTTON_ACTION_SHORT_RELEASED", "Dim up press"],
                 [1, "0x04", "MULTISTATE_INPUT", "0x0a", "2", "S_BUTTON_4", "S_BUTTON_ACTION_DOUBLE_PRESS", "Dim up double press"],
                 [1, "0x04", "MULTISTATE_INPUT", "0x0a", "3", "S_BUTTON_4", "S_BUTTON_ACTION_TREBLE_PRESS", "Dim up triple press"],
-                [1, "0x04", "MULTISTATE_INPUT", "0x0a", "255", "S_BUTTON_4", "S_BUTTON_ACTION_LONG_RELEASED", "Dim up long released"],
+                [1, "0x04", "MULTISTATE_INPUT", "0x0a", "0xFF", "S_BUTTON_4", "S_BUTTON_ACTION_LONG_RELEASED", "Dim up long released"],
                 [1, "0x05", "MULTISTATE_INPUT", "0x0a", "0", "S_BUTTON_5", "S_BUTTON_ACTION_HOLD", "Color warm hold"],
                 [1, "0x05", "MULTISTATE_INPUT", "0x0a", "1", "S_BUTTON_5", "S_BUTTON_ACTION_SHORT_RELEASED", "Color warm press"],
                 [1, "0x05", "MULTISTATE_INPUT", "0x0a", "2", "S_BUTTON_5", "S_BUTTON_ACTION_DOUBLE_PRESS", "Color warm double press"],
                 [1, "0x05", "MULTISTATE_INPUT", "0x0a", "3", "S_BUTTON_5", "S_BUTTON_ACTION_TREBLE_PRESS", "Color warm triple press"],
-                [1, "0x05", "MULTISTATE_INPUT", "0x0a", "255", "S_BUTTON_5", "S_BUTTON_ACTION_LONG_RELEASED", "Color warm long released"],
+                [1, "0x05", "MULTISTATE_INPUT", "0x0a", "0xFF", "S_BUTTON_5", "S_BUTTON_ACTION_LONG_RELEASED", "Color warm long released"],
                 [1, "0x06", "MULTISTATE_INPUT", "0x0a", "0", "S_BUTTON_6", "S_BUTTON_ACTION_HOLD", "Color cold hold"],
                 [1, "0x06", "MULTISTATE_INPUT", "0x0a", "1", "S_BUTTON_6", "S_BUTTON_ACTION_SHORT_RELEASED", "Color cold press"],
                 [1, "0x06", "MULTISTATE_INPUT", "0x0a", "2", "S_BUTTON_6", "S_BUTTON_ACTION_DOUBLE_PRESS", "Color cold double press"],
                 [1, "0x06", "MULTISTATE_INPUT", "0x0a", "3", "S_BUTTON_6", "S_BUTTON_ACTION_TREBLE_PRESS", "Color cold triple press"],
-                [1, "0x06", "MULTISTATE_INPUT", "0x0a", "255", "S_BUTTON_6", "S_BUTTON_ACTION_LONG_RELEASED", "Color cold long released"]
+                [1, "0x06", "MULTISTATE_INPUT", "0x0a", "0xFF", "S_BUTTON_6", "S_BUTTON_ACTION_LONG_RELEASED", "Color cold long released"]
             ]
         },
         "legrandShutterSwitchRemote": {


### PR DESCRIPTION
For the Opple switches (and presumably also the wireless dimmer), any button event x0003 was missing due to an incorrect value conversion. Additionally, the dedicated Opple model IDs have been added.