### PR TITLE
Fixes

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6315,6 +6315,11 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             item = sensorNode.addItem(DataTypeUInt8, RConfigPending);
         }
     }
+    else if (modelId.startsWith(QLatin1String("Super TR")) ||
+             modelId.startsWith(QLatin1String("ElkoDimmer")))
+    {
+        sensorNode.setManufacturer("ELKO");
+    }
     else if (node->nodeDescriptor().manufacturerCode() == VENDOR_EMBER ||
              node->nodeDescriptor().manufacturerCode() == VENDOR_HEIMAN)
     {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -16830,13 +16830,18 @@ void DeRestPlugin::idleTimerFired()
                                 val = sensorNode->getZclValue(*ci, 0x0029); // heating operation state
                             }
 
-                            if (sensorNode->modelId().startsWith(QLatin1String("SPZB")) ||   // Eurotronic Spirit
-                                sensorNode->modelId().startsWith(QLatin1String("SLT2")) ||   // Hive Active Heating Thermostat
-                                sensorNode->modelId().startsWith(QLatin1String("SLR2")) ||   // Hive Active Heating Receiver 2 channel
-                                sensorNode->modelId().startsWith(QLatin1String("SLR1b")) ||  // Hive Active Heating Receiver 1 channel
-                                sensorNode->modelId().startsWith(QLatin1String("TRV001")) || // Hive TRV
-                                sensorNode->modelId().startsWith(QLatin1String("TH112")) ||  // Sinope devices
-                                sensorNode->modelId().startsWith(QLatin1String("eTRV0100"))) // Danfoss Ally
+                            if (sensorNode->modelId().startsWith(QLatin1String("SPZB")) ||      // Eurotronic Spirit
+                                sensorNode->modelId().startsWith(QLatin1String("SLT2")) ||      // Hive Active Heating Thermostat
+                                sensorNode->modelId().startsWith(QLatin1String("SLR2")) ||      // Hive Active Heating Receiver 2 channel
+                                sensorNode->modelId().startsWith(QLatin1String("SLR1b")) ||     // Hive Active Heating Receiver 1 channel
+                                sensorNode->modelId().startsWith(QLatin1String("TRV001")) ||    // Hive TRV
+                                sensorNode->modelId().startsWith(QLatin1String("TH112")) ||     // Sinope devices
+                                sensorNode->modelId().startsWith(QLatin1String("eTRV0100")) ||  // Danfoss Ally
+                                sensorNode->modelId().startsWith(QLatin1String("Super TR")) ||  // Elko
+                                sensorNode->modelId().startsWith(QLatin1String("AC201")) ||     // Owon
+                                sensorNode->modelId().startsWith(QLatin1String("SORB")) ||      // Stelpro Orleans
+                                sensorNode->modelId().startsWith(QLatin1String("3157100")) ||   // Centralite pearl
+                                sensorNode->modelId().startsWith(QLatin1String("902010/32")))   // Bitron
                             {
                                 // supports reporting, no need to read attributes
                             }

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1385,7 +1385,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                         {
                             bool data = map[pi.key()].toBool();
 
-                            if (addTaskThermostatUiConfigurationReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, 0x0412, deCONZ::ZclBoolean, data))
+                            if (addTaskThermostatReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, 0x0412, deCONZ::ZclBoolean, data))
                             {
                                 updated = true;
                             }
@@ -1483,7 +1483,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
 
                             if (mode < 4 && mode != 2)
                             {
-                                if (addTaskThermostatUiConfigurationReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, 0x0403, deCONZ::Zcl8BitEnum, mode))
+                                if (addTaskThermostatReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, 0x0403, deCONZ::Zcl8BitEnum, mode))
                                 {
                                     updated = true;
                                 }
@@ -1499,7 +1499,10 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                     }
                     else
                     {
-                        rspItemState[QString("Error : unknown Window open setting for %1").arg(sensor->modelId())] = map[pi.key()];
+                        rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/sensors/%1/config/%2").arg(id).arg(pi.key()).toHtmlEscaped(),
+                                                   QString("invalid value, %1, for parameter %2").arg(map[pi.key()].toString()).arg(pi.key()).toHtmlEscaped()));
+                        rsp.httpStatus = HttpStatusBadRequest;
+                        return REQ_READY_SEND;
                     }
                 }
                 else if ((rid.suffix == RConfigWindowOpen) && (sensor->modelId().startsWith(QLatin1String("kud7u2l")) ||

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1385,7 +1385,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                         {
                             bool data = map[pi.key()].toBool();
 
-                            if (addTaskThermostatReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, 0x0412, deCONZ::ZclBoolean, data))
+                            if (addTaskThermostatReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, 0, 0x0412, deCONZ::ZclBoolean, data))
                             {
                                 updated = true;
                             }
@@ -1483,7 +1483,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
 
                             if (mode < 4 && mode != 2)
                             {
-                                if (addTaskThermostatReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, 0x0403, deCONZ::Zcl8BitEnum, mode))
+                                if (addTaskThermostatReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, 0, 0x0403, deCONZ::Zcl8BitEnum, mode))
                                 {
                                     updated = true;
                                 }

--- a/thermostat.cpp
+++ b/thermostat.cpp
@@ -476,7 +476,7 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
                     sensor->modelId().startsWith(QLatin1String("SLR1b")) ||  // Hive
                     sensor->modelId().startsWith(QLatin1String("TH112")) ||  // Sinope
                     sensor->modelId().startsWith(QLatin1String("Zen-01")) || // Zen
-                    sensor->modelId().startsWith(QLatin1String("Super")))    // ELKO
+                    sensor->modelId().startsWith(QLatin1String("Super TR")))    // ELKO
                 {
                     qint8 mode = attr.numericValue().s8;
                     QString mode_set;
@@ -604,9 +604,9 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
                     quint8 mode = attr.numericValue().u8;
                     QString mode_set;
 
-                    if ( mode == 0x00 ) { mode_set = QString("Air sensor"); }
-                    if ( mode == 0x01 ) { mode_set = QString("Floor sensor"); }
-                    if ( mode == 0x03 ) { mode_set = QString("Floor protection"); }
+                    if ( mode == 0x00 ) { mode_set = QString("air sensor"); }
+                    if ( mode == 0x01 ) { mode_set = QString("floor sensor"); }
+                    if ( mode == 0x03 ) { mode_set = QString("floor protection"); }
                     
                     item = sensor->item(RConfigTemperatureMeasurement);
 
@@ -1121,7 +1121,7 @@ bool DeRestPluginPrivate::addTaskThermostatReadWriteAttribute(TaskItem &task, ui
     if (readOrWriteCmd == deCONZ::ZclWriteAttributesId)
     {
         stream << (quint8) attrType;
-        if (attrType == deCONZ::Zcl8BitEnum || attrType == deCONZ::Zcl8BitInt || attrType == deCONZ::Zcl8BitBitMap)
+        if (attrType == deCONZ::Zcl8BitEnum || attrType == deCONZ::Zcl8BitInt || attrType == deCONZ::Zcl8BitBitMap || attrType == deCONZ::ZclBoolean)
         {
             stream << (quint8) attrValue;
         }


### PR DESCRIPTION
- Fix setting temperature mode and child lock for Elko Super TR thermostat
- Prevent polling for further thermostats, thereby relying on reporting for the follwing thermostats: Elko Super TR, Owon AC201, Stelpro Orleans Fan SORB, Centralite pearl 3157100, Bitron 902010/32