### PR TITLE
Fix SEGV in poll manager

### DIFF
--- a/poll_manager.cpp
+++ b/poll_manager.cpp
@@ -275,7 +275,7 @@ void PollManager::pollTimerFired()
         pitem.items.clear(); // all done
     }
 
-    if (suffix == RStateOn)
+    if (suffix == RStateOn && lightNode)
     {
         item = r->item(RAttrModelId);
 
@@ -283,7 +283,7 @@ void PollManager::pollTimerFired()
         {
             //Thoses devices haven't cluster 0006, and use Cluster specific
         }
-        else if (lightNode && lightNode->manufacturerCode() != VENDOR_XIAOMI) // reports
+        else if (lightNode->manufacturerCode() != VENDOR_XIAOMI) // reports
         {
             clusterId = ONOFF_CLUSTER_ID;
             attributes.push_back(0x0000); // onOff


### PR DESCRIPTION
lightNode pointer wasn't guarded to check for nullptr in RStateOn handler.
Issue: https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3427