### PR TITLE
Disable reporting of SwBuildId for IKEA lights

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -704,7 +704,8 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt, const s
         if (val.clusterId == bt.binding.clusterId)
         {
             // value exists
-            if (val.timestampLastReport.isValid() &&
+            if (rq.maxInterval != 0xffff && // disable reporting
+                val.timestampLastReport.isValid() &&
                 val.timestampLastReport.secsTo(now) < qMin((rq.maxInterval * 3), 1800))
             {
                 DBG_Printf(DBG_INFO, "skip configure report for cluster: 0x%04X attr: 0x%04X of node 0x%016llX (seems to be active)\n",
@@ -1864,9 +1865,9 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
 
         NodeValue &val = bt.restNode->getZclValue(BASIC_CLUSTER_ID, 0x4000, bt.binding.srcEndpoint);
 
-        if (val.timestampLastReport.isValid() && (val.timestampLastReport.secsTo(now) < val.maxInterval * 1.5))
+        if (val.timestampLastReport.isValid() && (val.timestampLastReport.secsTo(now) > val.maxInterval * 1.5))
         {
-            return false;
+            return false; // reporting this attribute might be already disabled
         }
 
         // already configured? wait for report ...
@@ -1878,7 +1879,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq.dataType = deCONZ::ZclCharacterString;
         rq.attributeId = 0x4000; // sw build id
         rq.minInterval = 0;   // value used by IKEA gateway
-        rq.maxInterval = 1800;   // value used by IKEA gateway
+        rq.maxInterval = 0xffff; // disable reporting to prevent group casts
 
         return sendConfigureReportingRequest(bt, {rq});
     }

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -4420,3 +4420,29 @@ void DeRestPluginPrivate::bindingTableReaderTimerFired()
         bindingTableReaderTimer->start();
     }
 }
+
+/*! Add a binding task to the queue and prevent double entries.
+    \param bindingTask - the binding task
+    \return true - when enqueued
+ */
+bool DeRestPluginPrivate::queueBindingTask(const BindingTask &bindingTask)
+{
+    if (!apsCtrl || apsCtrl->networkState() != deCONZ::InNetwork)
+    {
+        return false;
+    }
+
+    const std::list<BindingTask>::const_iterator i = std::find(bindingQueue.begin(), bindingQueue.end(), bindingTask);
+
+    if (i == bindingQueue.end())
+    {
+        DBG_Printf(DBG_INFO_L2, "queue binding task for 0x%016llX, cluster 0x%04X\n", bindingTask.binding.srcAddress, bindingTask.binding.clusterId);
+        bindingQueue.push_back(bindingTask);
+    }
+    else
+    {
+        DBG_Printf(DBG_INFO, "discard double entry in binding queue (size: %u) for for 0x%016llX, cluster 0x%04X\n", bindingQueue.size(), bindingTask.binding.srcAddress, bindingTask.binding.clusterId);
+    }
+
+    return true;
+}

--- a/rest_rules.cpp
+++ b/rest_rules.cpp
@@ -957,32 +957,6 @@ int DeRestPluginPrivate::deleteRule(const ApiRequest &req, ApiResponse &rsp)
     return REQ_READY_SEND;
 }
 
-/*! Add a binding task to the queue and prevent double entries.
-    \param bindingTask - the binding task
-    \return true - when enqueued
- */
-bool DeRestPluginPrivate::queueBindingTask(const BindingTask &bindingTask)
-{
-    if (!apsCtrl || apsCtrl->networkState() != deCONZ::InNetwork)
-    {
-        return false;
-    }
-
-    const std::list<BindingTask>::const_iterator i = std::find(bindingQueue.begin(), bindingQueue.end(), bindingTask);
-
-    if (i == bindingQueue.end())
-    {
-        DBG_Printf(DBG_INFO_L2, "queue binding task for 0x%016llX, cluster 0x%04X\n", bindingTask.binding.srcAddress, bindingTask.binding.clusterId);
-        bindingQueue.push_back(bindingTask);
-    }
-    else
-    {
-        DBG_Printf(DBG_INFO, "discard double entry in binding queue (size: %u) for for 0x%016llX, cluster 0x%04X\n", bindingQueue.size(), bindingTask.binding.srcAddress, bindingTask.binding.clusterId);
-    }
-
-    return true;
-}
-
 /*! Starts verification that the ZigBee bindings of a rule are present
     on the source device.
     \param rule the rule to verify


### PR DESCRIPTION
IKEA lights add a implicit bindings of Basic Cluster for each group they are in including default group 0xfff0. For some lights there are up to 4 Basic Cluster bindings (perhaps even more). deCONZ additionally adds a unicast binding. The group bindings can't be removed as the result status asserts "No Entry".

The attribute was configured to report every 30 minutes, resulting in multiple group casts which is quite heavy and might cause negative side effects. As a side note Xiaomi mains powered switches also have the default group 0xfff0, it's not clear yet if they are related.

This PR disabled reporting of attribute 0x4000 and falls back to simple ZCL read attribute command.