### PR TITLE
Tuya thermostat and switch improvements, Kwikset 914 smart lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ The Phoscon App is a browser based web application and supports lights, sensors 
 ### Release Schedule
 
 deCONZ is having a beta release at the 15th day of the month in which the beta of last month becomes stable. Pull requests done before the 10th of the month, are getting included in the next beta (if there are no issues ofcourse!).  Stable release would be around the 1st - 5th of the month after latest beta. 
-Current Beta: 2.05.83
-Current Stable: 2.05.84
+Current Beta: **2.05.85**
+Current Stable: **2.05.84**
 
-Next Beta: 2.05.85 expected at the 15th of October.  
-Next Stable: 2.05.86 expected at 8th November (minor fixes and new firmware files)
+Next Beta: **2.05.87** expected at the 15th of November.  
+Next Stable: **2.05.86** expected at 8th November.
 
 Installation
 ============

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ The Phoscon App is a browser based web application and supports lights, sensors 
 
 ### Release Schedule
 
-deCONZ is having a beta release at the 15th day of the month in which the beta of last month becomes stable. Pull requests done before the 10th of the month, are getting included in the next beta (if there are no issues ofcourse!).  Stable release would be around the 1st - 5th of the month after latest beta. 
-Current Beta: **2.05.85**
+deCONZ is having a beta release at the 15th day of the month in which the beta of last month becomes stable. Pull requests done before the 10th of the month, are getting included in the next beta (if there are no issues ofcourse!).  Stable release would be around the 1st - 5th of the month after latest beta.  
+
+Current Beta: **2.05.85**  
 Current Stable: **2.05.84**
 
 Next Beta: **2.05.87** expected at the 15th of November.  

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2422,6 +2422,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId().startsWith(QLatin1String("TS0202")) || // motion sensor, manu = _TYZB01_zwvaj5wy
         sensor->modelId().startsWith(QLatin1String("TS0043")) || // to test
         sensor->modelId().startsWith(QLatin1String("TS0041")) ||
+        sensor->modelId().startsWith(QLatin1String("TS0044")) ||
         // Tuyatec
         sensor->modelId().startsWith(QLatin1String("RH3040")) ||
         sensor->modelId().startsWith(QLatin1String("RH3001")) ||

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2421,6 +2421,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId().startsWith(QLatin1String("TS03")) ||
         sensor->modelId().startsWith(QLatin1String("TS0202")) || // motion sensor, manu = _TYZB01_zwvaj5wy
         sensor->modelId().startsWith(QLatin1String("TS0043")) || // to test
+        sensor->modelId().startsWith(QLatin1String("TS0041")) ||
         // Tuyatec
         sensor->modelId().startsWith(QLatin1String("RH3040")) ||
         sensor->modelId().startsWith(QLatin1String("RH3001")) ||

--- a/button_maps.json
+++ b/button_maps.json
@@ -668,7 +668,10 @@
                 [1, "0x02", "ONOFF", "0xfd", "2", "S_BUTTON_2", "S_BUTTON_ACTION_LONG_RELEASED", "B2 long"],
                 [1, "0x03", "ONOFF", "0xfd", "0", "S_BUTTON_3", "S_BUTTON_ACTION_SHORT_RELEASED", "B3 short"],
                 [1, "0x03", "ONOFF", "0xfd", "1", "S_BUTTON_3", "S_BUTTON_ACTION_DOUBLE_PRESS", "B3 double"],
-                [1, "0x03", "ONOFF", "0xfd", "2", "S_BUTTON_3", "S_BUTTON_ACTION_LONG_RELEASED", "B3 long"]
+                [1, "0x03", "ONOFF", "0xfd", "2", "S_BUTTON_3", "S_BUTTON_ACTION_LONG_RELEASED", "B3 long"],
+                [1, "0x04", "ONOFF", "0xfd", "0", "S_BUTTON_4", "S_BUTTON_ACTION_SHORT_RELEASED", "B4 short"],
+                [1, "0x04", "ONOFF", "0xfd", "1", "S_BUTTON_4", "S_BUTTON_ACTION_DOUBLE_PRESS", "B4 double"],
+                [1, "0x04", "ONOFF", "0xfd", "2", "S_BUTTON_4", "S_BUTTON_ACTION_LONG_RELEASED", "B4 long"]
             ]
         },
         "legrandSwitchRemote": {

--- a/database.cpp
+++ b/database.cpp
@@ -3505,7 +3505,8 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     sensor.modelId().startsWith(QLatin1String("TH112")) ||  // Sinope
                     sensor.modelId() == QLatin1String("GbxAXL2") ||         // Tuya
                     sensor.modelId() == QLatin1String("kud7u2l") ||         // Tuya
-                    sensor.modelId() == QLatin1String("TS0601") ||          // Tuya
+                   (sensor.manufacturer() == QLatin1String("_TZE200_ckud7u2l")) ||          // Tuya
+                   (sensor.manufacturer() == QLatin1String("_TZE200_aoclfnxz")) ||          // Tuya
                     sensor.modelId() == QLatin1String("Zen-01") )           // Zen
                 {
                     sensor.addItem(DataTypeString, RConfigMode);
@@ -3521,7 +3522,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
 
                 if (sensor.modelId() == QLatin1String("kud7u2l") || // Tuya
                     sensor.modelId() == QLatin1String("GbxAXL2") || // Tuya
-                    sensor.modelId() == QLatin1String("TS0601") )   // Tuya
+                   (sensor.manufacturer() == QLatin1String("_TZE200_ckud7u2l")) )   // Tuya
                 {
                     sensor.addItem(DataTypeUInt8, RStateValve);
                     item = sensor.addItem(DataTypeBool, RStateLowBattery);
@@ -3530,10 +3531,19 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 
                 if (sensor.modelId() == QLatin1String("kud7u2l") || // Tuya
                     sensor.modelId() == QLatin1String("eaxp72v") || // Tuya
-                    sensor.modelId() == QLatin1String("TS0601") )   // Tuya
+                   (sensor.manufacturer() == QLatin1String("_TZE200_ckud7u2l")) ||  // Tuya
+                   (sensor.manufacturer() == QLatin1String("_TZE200_aoclfnxz")) )   // Tuya
                 {
                     sensor.addItem(DataTypeString, RConfigPreset);
                     sensor.addItem(DataTypeBool, RConfigLocked);
+                    sensor.addItem(DataTypeString, RConfigSchedule);
+                    sensor.addItem(DataTypeBool, RConfigSetValve);
+                }
+                
+                if (sensor.modelId() == QLatin1String("kud7u2l") || // Tuya
+                    sensor.modelId() == QLatin1String("eaxp72v") || // Tuya
+                   (sensor.manufacturer() == QLatin1String("_TZE200_ckud7u2l")) )   // Tuya
+                {
                     sensor.addItem(DataTypeBool, RConfigWindowOpen);
                 }
 
@@ -3567,11 +3577,16 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     sensor.addItem(DataTypeBool, RConfigDisplayFlipped);
                     sensor.addItem(DataTypeBool, RConfigLocked);
                     sensor.addItem(DataTypeBool, RConfigMountingMode);
+                    sensor.addItem(DataTypeString, RConfigSchedule);
+                    sensor.addItem(DataTypeBool, RConfigScheduleOn);
                 }
                 else
                 {
-                    sensor.addItem(DataTypeBool, RConfigScheduleOn);
-                    sensor.addItem(DataTypeString, RConfigSchedule);
+                    if (!sensor.modelId().isEmpty())
+                    {
+                        sensor.addItem(DataTypeBool, RConfigScheduleOn);
+                        sensor.addItem(DataTypeString, RConfigSchedule);
+                    }
                 }
             }
         }

--- a/database.cpp
+++ b/database.cpp
@@ -3520,7 +3520,6 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 }
 
                 if (sensor.modelId() == QLatin1String("kud7u2l") || // Tuya
-                    sensor.modelId() == QLatin1String("eaxp72v") || // Tuya
                     sensor.modelId() == QLatin1String("GbxAXL2") || // Tuya
                     sensor.modelId() == QLatin1String("TS0601") )   // Tuya
                 {

--- a/database.cpp
+++ b/database.cpp
@@ -3531,17 +3531,29 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 
                 if (sensor.modelId() == QLatin1String("kud7u2l") || // Tuya
                     sensor.modelId() == QLatin1String("eaxp72v") || // Tuya
+                    sensor.modelId() == QLatin1String("fvq6avy") || // Tuya
+                    sensor.modelId() == QLatin1String("88teujp") || // Tuya
                    (sensor.manufacturer() == QLatin1String("_TZE200_ckud7u2l")) ||  // Tuya
                    (sensor.manufacturer() == QLatin1String("_TZE200_aoclfnxz")) )   // Tuya
                 {
                     sensor.addItem(DataTypeString, RConfigPreset);
                     sensor.addItem(DataTypeBool, RConfigLocked);
-                    sensor.addItem(DataTypeString, RConfigSchedule);
                     sensor.addItem(DataTypeBool, RConfigSetValve);
                 }
                 
                 if (sensor.modelId() == QLatin1String("kud7u2l") || // Tuya
+                    sensor.modelId() == QLatin1String("fvq6avy") || // Tuya
+                    sensor.modelId() == QLatin1String("88teujp") || // Tuya
+                   (sensor.manufacturer() == QLatin1String("_TZE200_ckud7u2l")) ||  // Tuya
+                   (sensor.manufacturer() == QLatin1String("_TZE200_aoclfnxz")) )   // Tuya
+                {
+                    sensor.addItem(DataTypeString, RConfigSchedule);
+                }
+                
+                if (sensor.modelId() == QLatin1String("kud7u2l") || // Tuya
                     sensor.modelId() == QLatin1String("eaxp72v") || // Tuya
+                    sensor.modelId() == QLatin1String("88teujp") || // Tuya
+                    sensor.modelId() == QLatin1String("fvq6avy") || // Tuya
                    (sensor.manufacturer() == QLatin1String("_TZE200_ckud7u2l")) )   // Tuya
                 {
                     sensor.addItem(DataTypeBool, RConfigWindowOpen);

--- a/database.cpp
+++ b/database.cpp
@@ -3506,7 +3506,6 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     sensor.modelId() == QLatin1String("GbxAXL2") ||         // Tuya
                     sensor.modelId() == QLatin1String("kud7u2l") ||         // Tuya
                     sensor.modelId() == QLatin1String("TS0601") ||          // Tuya
-                    sensor.modelId() == QLatin1String("eaxp72v") ||          // Tuya
                     sensor.modelId() == QLatin1String("Zen-01") )           // Zen
                 {
                     sensor.addItem(DataTypeString, RConfigMode);
@@ -3530,7 +3529,8 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     item->setValue(false);
                 }
                 
-                if (sensor.modelId() == QLatin1String("kud7u2l") || // Tuya 
+                if (sensor.modelId() == QLatin1String("kud7u2l") || // Tuya
+                    sensor.modelId() == QLatin1String("eaxp72v") || // Tuya
                     sensor.modelId() == QLatin1String("TS0601") )   // Tuya
                 {
                     sensor.addItem(DataTypeString, RConfigPreset);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6042,7 +6042,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
 
             if (sensorNode.modelId() == QLatin1String("kud7u2l") || // Tuya
                 sensorNode.modelId() == QLatin1String("GbxAXL2") || // Tuya
-                sensorNode.modelId() == QLatin1String("eaxp72v") || // Tuya
                 sensorNode.modelId() == QLatin1String("TS0601") )   // Tuya
             {
                 sensorNode.addItem(DataTypeUInt8, RStateValve);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6026,7 +6026,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                 sensorNode.modelId() == QLatin1String("kud7u2l") ||         // Tuya
                 sensorNode.modelId() == QLatin1String("GbxAXL2") ||         // Tuya
                 sensorNode.modelId() == QLatin1String("TS0601") ||          // Tuya
-                sensorNode.modelId() == QLatin1String("eaxp72v") ||          // Tuya
                 sensorNode.modelId() == QLatin1String("Zen-01") )           // Zen
             {
                 sensorNode.addItem(DataTypeString, RConfigMode);
@@ -6051,6 +6050,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             }
 
             if (sensorNode.modelId() == QLatin1String("kud7u2l") || // Tuya
+                sensorNode.modelId() == QLatin1String("eaxp72v") || // Tuya
                 sensorNode.modelId() == QLatin1String("TS0601") )   // Tuya
             {
                 sensorNode.addItem(DataTypeString, RConfigPreset);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -917,6 +917,16 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
                     {
                         sensorNode = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), 0x01);
                     }
+                    else if ((sensorNode->manufacturer() == QLatin1String("_TZ3000_bi6lpsew")) ||
+                        (sensorNode->manufacturer() == QLatin1String("_TZ3400_keyjhapk")) ||
+                        (sensorNode->manufacturer() == QLatin1String("_TYZB02_key8kk7r")) ||
+                        (sensorNode->manufacturer() == QLatin1String("_TZ3400_keyjqthh")) ||
+                        (sensorNode->manufacturer() == QLatin1String("_TZ3400_key8kk7r")) ||
+                        (sensorNode->manufacturer() == QLatin1String("_TZ3000_vp6clf9d")) ||
+                        (sensorNode->manufacturer() == QLatin1String("_TYZB02_keyjqthh")))
+                    {
+                        sensorNode = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), 0x01);
+                    }
                     else
                     {
                         sensorNode = 0; // not supported

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4627,6 +4627,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                         // For some device the Tuya cluster is sometime Invisible, so force device detection
                         if ((modelId == QLatin1String("kud7u2l")) ||
                            (modelId == QLatin1String("eaxp72v")) ||
+                           (manufacturer == QLatin1String("_TZE200_aoclfnxz")) ||
                            (modelId == QLatin1String("GbxAXL2")) )
                         {
                             fpThermostatSensor.inClusters.push_back(TUYA_CLUSTER_ID);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1756,7 +1756,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
     if (node->nodeDescriptor().manufacturerCode() == VENDOR_KEEN_HOME || // Keen Home Vent
         node->nodeDescriptor().manufacturerCode() == VENDOR_JENNIC || // Xiaomi lumi.ctrl_neutral1, lumi.ctrl_neutral2
         node->nodeDescriptor().manufacturerCode() == VENDOR_XIAOMI || // Xiaomi lumi.curtain.hagl04
-        node->nodeDescriptor().manufacturerCode() == VENDOR_EMBER) || // atsmart Z6-03 switch + Heiman plug + Tuya stuff
+        node->nodeDescriptor().manufacturerCode() == VENDOR_EMBER || // atsmart Z6-03 switch + Heiman plug + Tuya stuff
         (!node->nodeDescriptor().isNull() && node->nodeDescriptor().manufacturerCode() == VENDOR_NONE) || // Climax Siren
         node->nodeDescriptor().manufacturerCode() == VENDOR_DEVELCO || // Develco Smoke sensor with siren
         node->nodeDescriptor().manufacturerCode() == VENDOR_LDS || // Samsung SmartPlug 2019

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1756,11 +1756,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
     if (node->nodeDescriptor().manufacturerCode() == VENDOR_KEEN_HOME || // Keen Home Vent
         node->nodeDescriptor().manufacturerCode() == VENDOR_JENNIC || // Xiaomi lumi.ctrl_neutral1, lumi.ctrl_neutral2
         node->nodeDescriptor().manufacturerCode() == VENDOR_XIAOMI || // Xiaomi lumi.curtain.hagl04
-        ((node->nodeDescriptor().manufacturerCode() == VENDOR_EMBER) && (
-            ((node->address().ext() & 0xffffff0000000000ULL ) == 0x8841570000000000ULL) ||  // atsmart Z6-03 switch 
-            ((node->address().ext() & 0xffffff0000000000ULL ) == emberMacPrefix) ||         // Heiman plug
-            ((node->address().ext() & 0xffffff0000000000ULL ) == silabs7MacPrefix) ||       // Tuya Smart TRV HY369
-            ((node->address().ext() & 0xffffff0000000000ULL ) == silabs5MacPrefix) )) ||    // MOES Zigbee Radiator Actuator HY368
+        node->nodeDescriptor().manufacturerCode() == VENDOR_EMBER) || // atsmart Z6-03 switch + Heiman plug + Tuya stuff
         (!node->nodeDescriptor().isNull() && node->nodeDescriptor().manufacturerCode() == VENDOR_NONE) || // Climax Siren
         node->nodeDescriptor().manufacturerCode() == VENDOR_DEVELCO || // Develco Smoke sensor with siren
         node->nodeDescriptor().manufacturerCode() == VENDOR_LDS || // Samsung SmartPlug 2019

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4627,7 +4627,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                         // For some device the Tuya cluster is sometime Invisible, so force device detection
                         if ((modelId == QLatin1String("kud7u2l")) ||
                            (modelId == QLatin1String("eaxp72v")) ||
-                           (manufacturer == QLatin1String("_TZE200_aoclfnxz")) ||
                            (modelId == QLatin1String("GbxAXL2")) )
                         {
                             fpThermostatSensor.inClusters.push_back(TUYA_CLUSTER_ID);
@@ -4636,6 +4635,11 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                         {
                             fpTuyaSensor.inClusters.push_back(TUYA_CLUSTER_ID);
                         }
+                    }
+                    else if ((node->nodeDescriptor().manufacturerCode() == VENDOR_EMBER) &&
+                             (manufacturer == QLatin1String("_TZE200_aoclfnxz")) )
+                    {
+                        fpThermostatSensor.inClusters.push_back(TUYA_CLUSTER_ID);
                     }
                 }
                     break;

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -100,6 +100,7 @@ const quint64 samjinMacPrefix     = 0x286d970000000000ULL;
 const quint64 sinopeMacPrefix     = 0x500b910000000000ULL;
 const quint64 silabs6MacPrefix    = 0x588e810000000000ULL;
 const quint64 silabs4MacPrefix    = 0x680ae20000000000ULL;
+const quint64 silabs8MacPrefix    = 0x60a4230000000000ULL;
 const quint64 ecozyMacPrefix      = 0x70b3d50000000000ULL;
 const quint64 osramMacPrefix      = 0x8418260000000000ULL;
 const quint64 silabs5MacPrefix    = 0x842e140000000000ULL;
@@ -343,10 +344,14 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_EMBER, "TS0121", silabs3MacPrefix }, // Tuya/Blitzwolf smart plug
     { VENDOR_EMBER, "TS0302", silabs3MacPrefix }, // Tuya curtain switch
     { VENDOR_EMBER, "TS0041", silabs3MacPrefix }, // Tuya wireless switch
+    { VENDOR_EMBER, "TS0041", silabs5MacPrefix }, // Tuya wireless switch
+    { VENDOR_EMBER, "TS0042", silabs3MacPrefix }, // Tuya wireless switch
+    { VENDOR_EMBER, "TS0043", silabs3MacPrefix }, // Tuya wireless switch
+    { VENDOR_EMBER, "TS0043", silabs8MacPrefix }, // Tuya wireless switch
     { VENDOR_NONE, "kud7u2l", silabs3MacPrefix }, // Tuya Smart TRV HY369 Thermostatic Radiator Valve
     { VENDOR_NONE, "GbxAXL2", silabs3MacPrefix }, // Another Tuya Smart TRV Thermostatic Radiator Valve
     { VENDOR_EMBER, "TS0601", silabs7MacPrefix }, // Tuya Smart TRV HY369 Thermostatic Radiator Valve
-    { VENDOR_EMBER, "TS0601", silabs5MacPrefix }, // MOES Zigbee Radiator Actuator HY368
+    { VENDOR_EMBER, "TS0601", silabs5MacPrefix }, // MOES Zigbee Radiator Actuator HY368 / Moes Tuya Thermostat BTH-002
     { VENDOR_EMBER, "TS0207", silabs3MacPrefix }, // Tuya water leak sensor
     { VENDOR_NONE, "TS0202", silabs4MacPrefix }, // Tuya presence sensor
     { VENDOR_NONE, "0yu2xgi", silabs5MacPrefix }, // Tuya siren
@@ -391,7 +396,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_NONE, "DS01", tiMacPrefix }, // Sonoff SNZB-04
     { VENDOR_DANFOSS, "eTRV0100", silabs2MacPrefix }, // Danfoss Ally thermostat
     { VENDOR_LDS, "ZBT-CCTSwitch-D0001", silabs2MacPrefix }, // Leedarson remote control
-    { VENDOR_NONE, "SMARTCODE_CONVERT_GEN1", zenMacPrefix }, // Kwikset 914 ZigBee smart lock
+    { VENDOR_KWIKSET, "SMARTCODE_CONVERT_GEN1", zenMacPrefix }, // Kwikset 914 ZigBee smart lock
 
     { 0, nullptr, 0 }
 };
@@ -1768,6 +1773,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
         node->nodeDescriptor().manufacturerCode() == VENDOR_MMB || // Axis shade
         // Danalock support. The vendor ID (0x115c) needs to defined and whitelisted, as it's battery operated
         node->nodeDescriptor().manufacturerCode() == VENDOR_DANALOCK || // Danalock Door Lock
+        node->nodeDescriptor().manufacturerCode() == VENDOR_KWIKSET || // Kwikset 914 ZigBee smart lock
         // Schlage support. The vendor ID (0x1236) needs to defined and whitelisted, as it's battery operated
         node->nodeDescriptor().manufacturerCode() == VENDOR_SCHLAGE)
     {
@@ -1781,14 +1787,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
     bool hasTuyaCluster = false;
     QString manufacturer;
 
-    //using VENDOR_EMBER is too much, lot of enddevice use this manufacture and are not router, so using this black list
-    if ((node->nodeDescriptor().manufacturerCode() == VENDOR_EMBER) &&
-        ((node->address().ext() & 0xffffff0000000000ULL ) == silabs7MacPrefix) )
-    {
-        return;
-    }
-
-    //Make 2 fakes device for tuya stuff
+    //Make 2 fakes device for tuya switches
     if (node->nodeDescriptor().manufacturerCode() == VENDOR_EMBER)
     {
         const deCONZ::SimpleDescriptor *sd = &node->simpleDescriptors()[0];
@@ -1870,7 +1869,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
             else if ((i->inClusters()[c].id() == TUYA_CLUSTER_ID) && (node->macCapabilities() & deCONZ::MacDeviceIsFFD) ) { hasServerOnOff = true; }
             // Danalock support. The cluster needs to be defined and whitelisted by setting hasServerOnOff
             else if (node->nodeDescriptor().manufacturerCode() == VENDOR_DANALOCK && i->inClusters()[c].id() == DOOR_LOCK_CLUSTER_ID) { hasServerOnOff = true; }
-            else if (!node->nodeDescriptor().isNull() && node->nodeDescriptor().manufacturerCode() == VENDOR_NONE && i->inClusters()[c].id() == DOOR_LOCK_CLUSTER_ID) { hasServerOnOff = true; } //Kwikset 914 ZigBee smart lock
+            else if (node->nodeDescriptor().manufacturerCode() == VENDOR_KWIKSET && i->inClusters()[c].id() == DOOR_LOCK_CLUSTER_ID) { hasServerOnOff = true; } //Kwikset 914 ZigBee smart lock
             else if (i->inClusters()[c].id() == BASIC_CLUSTER_ID)
             {
                 std::vector<deCONZ::ZclAttribute>::const_iterator j = i->inClusters()[c].attributes().begin();
@@ -1987,7 +1986,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
 
 
         // For Tuya, we realy need manufacture Name, but can't use it to compare because of fonction setManufacturerCode() that put "Heiman",
-        if (!node->nodeDescriptor().isNull() && node->nodeDescriptor().manufacturerCode() == VENDOR_NONE && node->simpleDescriptors().size() == 1)
+        if (((!node->nodeDescriptor().isNull() && node->nodeDescriptor().manufacturerCode() == VENDOR_NONE) || (node->nodeDescriptor().manufacturerCode() == VENDOR_EMBER)) && (node->simpleDescriptors().size() == 1))
         {
             if (manufacturer.isEmpty())
             {
@@ -2033,6 +2032,20 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
                 (lightNode.manufacturer() == QLatin1String("_TYST11_jeaxp72v")) )
             {
                 hasServerOnOff = false;
+            }
+        }
+        if (node->nodeDescriptor().manufacturerCode() == VENDOR_EMBER)
+        {
+            //Tuya black list
+            //_TZE200_aoclfnxz is a thermostat
+            if (lightNode.manufacturer() == QLatin1String("_TZE200_aoclfnxz"))
+            {
+                hasServerOnOff = false;
+            }
+            //to test
+            if (lightNode.manufacturer() == QLatin1String("_TZE200_wmcdj3aq"))
+            {
+                hasServerOnOff = true;
             }
         }
 
@@ -2349,6 +2362,8 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
         //Add missing field for Tuya Device with tuya cluster
         // Window covering
         if ((lightNode.manufacturer() == QString("_TYST11_xu1rkty3")) ||
+            (lightNode.manufacturer() == QString("_TZE200_xuzcvlku")) ||
+            (lightNode.manufacturer() == QString("_TZE200_wmcdj3aq")) ||
             (lightNode.manufacturer() == QString("_TYST11_wmcdj3aq")) )
         {
             lightNode.addItem(DataTypeBool, RStateOpen);
@@ -4729,7 +4744,12 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     {
                         fpSwitch.inClusters.push_back(ci->id());
                     }
-                    else if (manufacturer == QLatin1String("_TZ3000_bi6lpsew"))
+                    else if ((manufacturer == QLatin1String("_TZ3000_bi6lpsew")) ||
+                             (manufacturer == QLatin1String("_TZ3400_keyjhapk")) ||
+                             (manufacturer == QLatin1String("_TYZB02_key8kk7r")) ||
+                             (manufacturer == QLatin1String("_TZ3400_keyjqthh")) ||
+                             (manufacturer == QLatin1String("_TZ3400_key8kk7r")) ||
+                             (manufacturer == QLatin1String("_TYZB02_keyjqthh")) )
                     {
                         fpSwitch.inClusters.push_back(ci->id());
                     }
@@ -4911,6 +4931,11 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     else if (((modelId.startsWith(QLatin1String("SLR2"))) || (modelId == QLatin1String("SLR1b")) ) && (i->endpoint() > 0x06 ))
                     {
                     }
+                    // Don't create entry for the door lock
+                    //else if (modelId == QLatin1String("SMARTCODE_CONVERT_GEN1"))
+                    else if (node->nodeDescriptor().manufacturerCode() == VENDOR_KWIKSET)
+                    {
+                    }
                     else
                     {
                         fpTemperatureSensor.inClusters.push_back(ci->id());
@@ -5035,6 +5060,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                 {
                     if ((modelId == QLatin1String("kud7u2l")) ||
                         (modelId == QLatin1String("GbxAXL2")) ||
+                        (manufacturer == QLatin1String("_TYST11_jeaxp72v")) ||
                         (manufacturer == QLatin1String("_TZE200_aoclfnxz")) ||
                         (manufacturer == QLatin1String("_TZE200_ckud7u2l")) )
                     {
@@ -6028,7 +6054,8 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                 sensorNode.modelId().startsWith(QLatin1String("TH112")) ||  // Sinope
                 sensorNode.modelId() == QLatin1String("kud7u2l") ||         // Tuya
                 sensorNode.modelId() == QLatin1String("GbxAXL2") ||         // Tuya
-                sensorNode.modelId() == QLatin1String("TS0601") ||          // Tuya
+               (sensorNode.manufacturer() == QLatin1String("_TZE200_ckud7u2l")) ||          // Tuya
+               (sensorNode.manufacturer() == QLatin1String("_TZE200_aoclfnxz")) ||          // Tuya
                 sensorNode.modelId() == QLatin1String("Zen-01") )           // Zen
             {
                 sensorNode.addItem(DataTypeString, RConfigMode);
@@ -6044,7 +6071,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
 
             if (sensorNode.modelId() == QLatin1String("kud7u2l") || // Tuya
                 sensorNode.modelId() == QLatin1String("GbxAXL2") || // Tuya
-                sensorNode.modelId() == QLatin1String("TS0601") )   // Tuya
+                (sensorNode.manufacturer() == QLatin1String("_TZE200_ckud7u2l")) )   // Tuya
             {
                 sensorNode.addItem(DataTypeUInt8, RStateValve);
                 item = sensorNode.addItem(DataTypeBool, RStateLowBattery);
@@ -6053,10 +6080,19 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
 
             if (sensorNode.modelId() == QLatin1String("kud7u2l") || // Tuya
                 sensorNode.modelId() == QLatin1String("eaxp72v") || // Tuya
-                sensorNode.modelId() == QLatin1String("TS0601") )   // Tuya
+               (sensorNode.manufacturer() == QLatin1String("_TZE200_aoclfnxz")) || 
+               (sensorNode.manufacturer() == QLatin1String("_TZE200_ckud7u2l")) )   // Tuya
             {
                 sensorNode.addItem(DataTypeString, RConfigPreset);
                 sensorNode.addItem(DataTypeBool, RConfigLocked);
+                sensorNode.addItem(DataTypeBool, RConfigSetValve);
+                sensorNode.addItem(DataTypeString, RConfigSchedule);
+            }
+
+            if (sensorNode.modelId() == QLatin1String("kud7u2l") || // Tuya
+                sensorNode.modelId() == QLatin1String("eaxp72v") || // Tuya
+               (sensorNode.manufacturer() == QLatin1String("_TZE200_ckud7u2l")) )   // Tuya
+            {
                 sensorNode.addItem(DataTypeBool, RConfigWindowOpen);
             }
 
@@ -6093,8 +6129,11 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             }
             else
             {
-                sensorNode.addItem(DataTypeBool, RConfigScheduleOn);
-                sensorNode.addItem(DataTypeString, RConfigSchedule);
+                if (!modelId.isEmpty())
+                {
+                    sensorNode.addItem(DataTypeBool, RConfigScheduleOn);
+                    sensorNode.addItem(DataTypeString, RConfigSchedule);
+                }
             }
         }
     }

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -297,6 +297,7 @@
 #define VENDOR_COMPUTIME    0x1078
 #define VENDOR_AXIS         0x1262 // Axis
 #define VENDOR_MMB          0x109a
+#define VENDOR_KWIKSET      0x1092
 #define VENDOR_NETVOX       0x109F
 #define VENDOR_NYCE         0x10B9
 #define VENDOR_UNIVERSAL2   0x10EF
@@ -446,6 +447,7 @@ extern const quint64 silabs4MacPrefix;
 extern const quint64 silabs5MacPrefix;
 extern const quint64 silabs6MacPrefix;
 extern const quint64 silabs7MacPrefix;
+extern const quint64 silabs8MacPrefix;
 extern const quint64 instaMacPrefix;
 extern const quint64 boschMacPrefix;
 extern const quint64 jennicMacPrefix;
@@ -1438,6 +1440,7 @@ public:
     void sendIasZoneEnrollResponse(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleIndicationSearchSensors(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     bool SendTuyaRequest(TaskItem &task, TaskType taskType , qint8 Dp_type, qint8 Dp_identifier , QByteArray data );
+    bool SendTuyaRequestThermostatSetWeeklySchedule(TaskItem &taskRef, quint8 weekdays , QString transitions );
     void handleCommissioningClusterIndication(TaskItem &task, const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleZdpIndication(const deCONZ::ApsDataIndication &ind);
     bool handleMgmtBindRspConfirm(const deCONZ::ApsDataConfirm &conf);

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -448,6 +448,7 @@ extern const quint64 silabs5MacPrefix;
 extern const quint64 silabs6MacPrefix;
 extern const quint64 silabs7MacPrefix;
 extern const quint64 silabs8MacPrefix;
+extern const quint64 silabs9MacPrefix;
 extern const quint64 instaMacPrefix;
 extern const quint64 boschMacPrefix;
 extern const quint64 jennicMacPrefix;
@@ -1440,7 +1441,7 @@ public:
     void sendIasZoneEnrollResponse(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleIndicationSearchSensors(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     bool SendTuyaRequest(TaskItem &task, TaskType taskType , qint8 Dp_type, qint8 Dp_identifier , QByteArray data );
-    bool SendTuyaRequestThermostatSetWeeklySchedule(TaskItem &taskRef, quint8 weekdays , QString transitions );
+    bool SendTuyaRequestThermostatSetWeeklySchedule(TaskItem &taskRef, quint8 weekdays , QString transitions , qint8 Dp_identifier);
     void handleCommissioningClusterIndication(TaskItem &task, const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleZdpIndication(const deCONZ::ApsDataIndication &ind);
     bool handleMgmtBindRspConfirm(const deCONZ::ApsDataConfirm &conf);

--- a/general.xml
+++ b/general.xml
@@ -547,25 +547,32 @@
 	<cluster id="0006" name="On/Off">
 		<description>Attributes and commands for switching devices between 'On' and 'Off' states.</description>
 		<server>
-						<attribute-set id="0x0000" description="OnOff state">
-							<attribute id="0000" name="OnOff" type="bool" access="r" default="0" required="m">
-									<value name="On" value="1"></value>
-									<value name="Off" value="0"></value>
-							</attribute>
-						</attribute-set>
-						<attribute-set id="0x4000" description="ZLL extensions">
-							<attribute id="0x4000" name="GlobalSceneControl" type="bool" access="r" default="0" required="o">
-							</attribute>
-							<attribute id="0x4001" name="OnTime" type="u16" access="r" default="0" required="o">
-							</attribute>
-							<attribute id="0x4002" name="OffWaitTime" type="u16" access="r" default="0" required="o">
-							</attribute>
-							<attribute id="0x4003" name="PowerOn OnOff" type="enum8" access="rw" default="0x01" required="o">
-                <value name="Off" value="0x00"></value>
-                <value name="On" value="0x01"></value>
-                <value name="Previous" value="0xff"></value>
-							</attribute>
-						</attribute-set>
+                <attribute-set id="0x0000" description="OnOff state">
+                    <attribute id="0000" name="OnOff" type="bool" access="r" default="0" required="m">
+                            <value name="On" value="1"></value>
+                            <value name="Off" value="0"></value>
+                    </attribute>
+                </attribute-set>
+                <attribute-set id="0x4000" description="ZLL extensions">
+                    <attribute id="0x4000" name="GlobalSceneControl" type="bool" access="r" default="0" required="o">
+                    </attribute>
+                    <attribute id="0x4001" name="OnTime" type="u16" access="r" default="0" required="o">
+                    </attribute>
+                    <attribute id="0x4002" name="OffWaitTime" type="u16" access="r" default="0" required="o">
+                    </attribute>
+                    <attribute id="0x4003" name="PowerOn OnOff" type="enum8" access="rw" default="0x01" required="o">
+                        <value name="Off" value="0x00"></value>
+                        <value name="On" value="0x01"></value>
+                        <value name="Previous" value="0xff"></value>
+					</attribute>
+				</attribute-set>
+                <attribute-set id="0x8001" description="Tuya special">
+                    <attribute id="0x8001" name="Light mode" type="enum8" default="0" required="m" access="r">
+                        <value name="Mode 1" value="0"></value>
+                        <value name="Mode 2" value="1"></value>
+                        <value name="Mode 3" value="2"></value>
+                    </attribute>
+                </attribute-set>
 
 			<command id="00" dir="recv" name="Off" required="m">
 				<description>On receipt of this command, a device shall enter its 'Off' state. This state is device dependent, but it is recommended that it is used for power off or similar functions.</description>
@@ -1588,6 +1595,16 @@ by the Poll Control Cluster Client.</description>
           </attribute>
           <attribute id="0x0018" name="Intermediate Setpoints – Lift" type="ostring" default="1,0x0000" access="rw" required="o"></attribute>
           <attribute id="0x0019" name="Intermediate Setpoints – Tilt" type="ostring" default="1,0x0000" access="rw" required="o"></attribute>
+        </attribute-set>
+        <attribute-set id="0xf001" description="Tuya Window Covering Setting">
+			<attribute id="0xf001" name="Calibration" type="enum8" default="0" required="m" access="r">
+				<value name="Start" value="0"></value>
+				<value name="End" value="1"></value>
+			</attribute>
+			<attribute id="0xf002" name="Motor Reversal" type="enum8" default="0" required="m" access="r">
+				<value name="Off" value="0"></value>
+				<value name="On" value="1"></value>
+			</attribute>
         </attribute-set>
         <command id="0x00" dir="recv" name="Up / Open" required="m"></command>
         <command id="0x01" dir="recv" name="Down / Close" required="m"></command>

--- a/light_node.cpp
+++ b/light_node.cpp
@@ -106,7 +106,7 @@ void LightNode::setManufacturerCode(uint16_t code)
         case VENDOR_OSRAM:   name = QLatin1String("OSRAM"); break;
         case VENDOR_UBISYS:  name = QLatin1String("ubisys"); break;
         case VENDOR_BUSCH_JAEGER:  name = QLatin1String("Busch-Jaeger"); break;
-        case VENDOR_EMBER:   // fall through
+        //case VENDOR_EMBER:   // fall through
         case VENDOR_HEIMAN:  name = QLatin1String("Heiman"); break;
         case VENDOR_KEEN_HOME: name = QLatin1String("Keen Home Inc"); break;
         case VENDOR_DANALOCK: name = QLatin1String("Danalock"); break;
@@ -539,6 +539,8 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
                 else if (i->id() == FAN_CONTROL_CLUSTER_ID) {
                     addItem(DataTypeUInt8, RStateSpeed);
                 }
+                //else if (i->id() == TUYA_CLUSTER_ID) {
+                //}
                 else if (i->id() == IAS_WD_CLUSTER_ID)
                 {
                     if (modelId() == QLatin1String("902010/24") ||   // Bitron Smoke Detector with siren

--- a/resource.cpp
+++ b/resource.cpp
@@ -132,6 +132,7 @@ const char *RConfigLocked = "config/locked";
 const char *RConfigLong = "config/long";
 const char *RConfigLevelMin = "config/levelmin";
 const char *RConfigMode = "config/mode";
+const char *RConfigSetValve = "config/setvalve";
 const char *RConfigMountingMode = "config/mountingmode";
 const char *RConfigOffset = "config/offset";
 const char *RConfigOn = "config/on";
@@ -284,6 +285,7 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, RConfigLedIndication));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeTime, RConfigLocalTime));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, RConfigLocked));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, RConfigSetValve));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RConfigLong));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, RConfigLevelMin));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RConfigMode));

--- a/resource.h
+++ b/resource.h
@@ -137,6 +137,7 @@ extern const char *RConfigLat;
 extern const char *RConfigLedIndication;
 extern const char *RConfigLocalTime;
 extern const char *RConfigLocked;
+extern const char *RConfigSetValve;
 extern const char *RConfigLong;
 extern const char *RConfigLevelMin;
 extern const char *RConfigMode;

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -547,6 +547,8 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
     {
         //window covering
         if ((taskRef.lightNode->manufacturer() == QLatin1String("_TYST11_wmcdj3aq")) ||
+            (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_xuzcvlku")) ||
+            (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_wmcdj3aq")) ||
             (taskRef.lightNode->manufacturer() == QLatin1String("_TYST11_xu1rkty3")) )
         {
             return setWindowCoveringState(req, rsp, taskRef, map);
@@ -1520,6 +1522,8 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
     }
     
     if ((taskRef.lightNode->manufacturer() == QLatin1String("_TYST11_wmcdj3aq")) ||
+        (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_xuzcvlku")) ||
+        (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_wmcdj3aq")) ||
         (taskRef.lightNode->manufacturer() == QLatin1String("_TYST11_xu1rkty3")) )
     {
         cluster = TUYA_CLUSTER_ID;
@@ -1708,7 +1712,8 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
     //Some device don't support lift, but third app can use it
     if (hasLift)
     {
-        if (taskRef.lightNode->manufacturer() == QLatin1String("_TYZB01_dazsid15"))
+        if ((taskRef.lightNode->manufacturer() == QLatin1String("_TYZB01_dazsid15")) ||
+            (taskRef.lightNode->modelId() == QLatin1String("FB56+CUR17SB2.2")) )
         {
             hasLift = false;
             hasOpen = true;
@@ -2344,6 +2349,55 @@ int DeRestPluginPrivate::setLightAttributes(const ApiRequest &req, ApiResponse &
         else
         {
             rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/lights/%1/reverse").arg(id), QString("invalid value, %1, for parameter reverse").arg(map["reverse"].toString())));
+            rsp.httpStatus = HttpStatusBadRequest;
+            return REQ_READY_SEND;
+        }
+    }
+
+    // Calibration command used for covering
+    if (map.contains("calibration"))
+    {
+
+        TaskItem taskRef;
+        taskRef.lightNode = getLightNodeForId(id);
+
+        if (!taskRef.lightNode || taskRef.lightNode->state() == LightNode::StateDeleted)
+        {
+            rsp.httpStatus = HttpStatusNotFound;
+            rsp.list.append(errorToMap(ERR_RESOURCE_NOT_AVAILABLE, QString("/lights/%1").arg(id), QString("resource, /lights/%1, not available").arg(id)));
+            return REQ_READY_SEND;
+        }
+
+        if (!taskRef.lightNode->isAvailable())
+        {
+            rsp.httpStatus = HttpStatusOk;
+            rsp.list.append(errorToMap(ERR_RESOURCE_NOT_AVAILABLE, QString("/lights/%1").arg(id), QString("resource, /lights/%1, not available").arg(id)));
+            return REQ_READY_SEND;
+        }
+
+        qint64 value = 0x00;
+        if (map["calibration"].toBool())
+        {
+            value = 0x01;
+        }
+        
+        deCONZ::ZclAttribute attr(0xf001, deCONZ::Zcl8BitEnum, "calibration", deCONZ::ZclReadWrite, true);
+        attr.setValue(value);
+
+        if (writeAttribute(taskRef.lightNode, taskRef.lightNode->haEndpoint().endpoint(), WINDOW_COVERING_CLUSTER_ID, attr))
+        {
+            QVariantMap rspItem;
+            QVariantMap rspItemState;
+            rspItemState[QString("/lights/%1/calibration").arg(id)] = map["calibration"];
+            rspItem["success"] = rspItemState;
+            rsp.list.append(rspItem);
+            rsp.etag = lightNode->etag;
+
+            return REQ_READY_SEND;
+        }
+        else
+        {
+            rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/lights/%1/calibration").arg(id), QString("invalid value, %1, for parameter calibration").arg(map["calibration"].toString())));
             rsp.httpStatus = HttpStatusBadRequest;
             return REQ_READY_SEND;
         }

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1144,8 +1144,8 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                             heatsetpoint = (int16_t)(heatsetpoint / 10);
                         }
                         
-                        data.append((qint8)((heatsetpoint >> 8) & 0xff));
-                        data.append((qint8)(heatsetpoint & 0xff));
+                        data.append(static_cast<qint8>((heatsetpoint >> 8) & 0xff));
+                        data.append(static_cast<qint8>(heatsetpoint & 0xff));
                         
                         if (SendTuyaRequest(task, TaskThermostat , DP_TYPE_VALUE , dp, data))
                         {
@@ -1666,8 +1666,8 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                             {
                                 data = QByteArray("\x01", 1);
                             }
-                            data.append((qint8)(setting[1].toUInt()));
-                            data.append((qint8)(setting[2].toUInt()));
+                            data.append(static_cast<qint8>(setting[1].toUInt()));
+                            data.append(static_cast<qint8>(setting[2].toUInt()));
 
                             if (SendTuyaRequest(task, TaskThermostat , DP_TYPE_RAW, 0x68, data))
                             {

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1324,6 +1324,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                 }
                 else if ((rid.suffix == RConfigPreset) && (sensor->modelId().startsWith(QLatin1String("kud7u2l")) ||
                                                            sensor->modelId().startsWith(QLatin1String("GbxAXL2")) ||
+                                                           sensor->modelId().startsWith(QLatin1String("eaxp72v")) ||
                                                            sensor->modelId().startsWith(QLatin1String("TS0601"))))
                 {
                     QByteArray data;
@@ -1351,7 +1352,9 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                 {
                     if (map[pi.key()].type() == QVariant::Bool)
                     {
-                        if (sensor->modelId().startsWith(QLatin1String("kud7u2l")) || sensor->modelId().startsWith(QLatin1String("GbxAXL2")) ||
+                        if (sensor->modelId().startsWith(QLatin1String("kud7u2l")) ||
+                            sensor->modelId().startsWith(QLatin1String("GbxAXL2")) ||
+                            sensor->modelId().startsWith(QLatin1String("eaxp72v")) ||
                             sensor->modelId().startsWith(QLatin1String("TS0601")))
                         {
                             QByteArray data = QByteArray("\x00", 1);

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1507,6 +1507,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                 }
                 else if ((rid.suffix == RConfigWindowOpen) && (sensor->modelId().startsWith(QLatin1String("kud7u2l")) ||
                                                            sensor->modelId().startsWith(QLatin1String("GbxAXL2")) ||
+                                                           sensor->modelId().startsWith(QLatin1String("eaxp72v")) ||
                                                            sensor->modelId().startsWith(QLatin1String("TS0601"))))
                 {
                     // Config on / off

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1002,8 +1002,10 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                     qint32 offset = (qint32)(round(map[pi.key()].toInt(&ok) / 10.0));
                     if (ok && (sensor->modelId().startsWith(QLatin1String("kud7u2l")) ||
                                sensor->modelId().startsWith(QLatin1String("GbxAXL2")) ||
+                               sensor->modelId().startsWith(QLatin1String("88teujp")) ||
                                sensor->modelId().startsWith(QLatin1String("eaxp72v")) ||
-                               (sensor->manufacturer() == QLatin1String("_TZE200_ckud7u2l")) ) ) // Tuya Smart TRV HY369 Thermostatic Radiator Valve
+                               sensor->modelId().startsWith(QLatin1String("fvq6avy")) ||
+                              (sensor->manufacturer() == QLatin1String("_TZE200_ckud7u2l")) ) ) // Tuya Smart TRV HY369 Thermostatic Radiator Valve
                     {
                         QByteArray data;
                         if (offset > 90) { offset = 90; }
@@ -1113,7 +1115,9 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                     }
                     else if (sensor->modelId().startsWith(QLatin1String("kud7u2l")) ||
                              sensor->modelId().startsWith(QLatin1String("GbxAXL2")) ||
+                             sensor->modelId().startsWith(QLatin1String("88teujp")) ||
                              sensor->modelId().startsWith(QLatin1String("eaxp72v")) ||
+                             sensor->modelId().startsWith(QLatin1String("fvq6avy")) ||
                             (sensor->manufacturer() == QLatin1String("_TZE200_aoclfnxz")) ||
                             (sensor->manufacturer() == QLatin1String("_TZE200_ckud7u2l")) )// Tuya Smart TRV HY369 Thermostatic Radiator Valve
                     {
@@ -1182,6 +1186,8 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                     }
                     else if ((sensor->modelId().startsWith(QLatin1String("kud7u2l"))) ||
                              (sensor->modelId().startsWith(QLatin1String("eaxp72v"))) ||
+                             (sensor->modelId().startsWith(QLatin1String("88teujp"))) ||
+                             (sensor->modelId().startsWith(QLatin1String("fvq6avy"))) ||
                              (sensor->manufacturer() == QLatin1String("_TZE200_ckud7u2l")) ) // Tuya Smart TRV HY369 Thermostatic Radiator Valve
                     {
                         QByteArray data;
@@ -1342,6 +1348,8 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                 }
                 else if ((rid.suffix == RConfigPreset) && (sensor->modelId().startsWith(QLatin1String("kud7u2l")) ||
                                                            sensor->modelId().startsWith(QLatin1String("GbxAXL2")) ||
+                                                           sensor->modelId().startsWith(QLatin1String("88teujp")) ||
+                                                           sensor->modelId().startsWith(QLatin1String("fvq6avy")) ||
                                                            sensor->modelId().startsWith(QLatin1String("eaxp72v")) ||
                                                           (sensor->manufacturer() == QLatin1String("_TZE200_ckud7u2l")) ))
                 {
@@ -1390,7 +1398,9 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                     {
                         if (sensor->modelId().startsWith(QLatin1String("kud7u2l")) ||
                             sensor->modelId().startsWith(QLatin1String("GbxAXL2")) ||
+                            sensor->modelId().startsWith(QLatin1String("fvq6avy")) ||
                             sensor->modelId().startsWith(QLatin1String("eaxp72v")) ||
+                            sensor->modelId().startsWith(QLatin1String("88teujp")) ||
                            (sensor->manufacturer() == QLatin1String("_TZE200_aoclfnxz")) ||
                            (sensor->manufacturer() == QLatin1String("_TZE200_ckud7u2l")) )
                         {
@@ -1586,6 +1596,8 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                 }
                 else if ((rid.suffix == RConfigWindowOpen) && (sensor->modelId().startsWith(QLatin1String("kud7u2l")) ||
                                                            sensor->modelId().startsWith(QLatin1String("GbxAXL2")) ||
+                                                           sensor->modelId().startsWith(QLatin1String("fvq6avy")) ||
+                                                           sensor->modelId().startsWith(QLatin1String("88teujp")) ||
                                                            sensor->modelId().startsWith(QLatin1String("eaxp72v")) ||
                                                           (sensor->manufacturer() == QLatin1String("_TZE200_ckud7u2l")) ) )
                 {
@@ -1852,9 +1864,15 @@ int DeRestPluginPrivate::changeThermostatSchedule(const ApiRequest &req, ApiResp
     
     if ((sensor->modelId() == QLatin1String("kud7u2l")) ||
         (sensor->modelId() == QLatin1String("eaxp72v")) ||
+        (sensor->modelId() == QLatin1String("88teujp")) ||
+        (sensor->modelId() == QLatin1String("fvq6avy")) ||
         (sensor->modelId() == QLatin1String("GbxAXL2")) )
     {
-        ok2 = SendTuyaRequestThermostatSetWeeklySchedule(task, weekdays , transitions );
+        ok2 = SendTuyaRequestThermostatSetWeeklySchedule(task, weekdays , transitions , 0x70 );
+    }
+    else if (sensor->manufacturer() == QLatin1String("_TZE200_aoclfnxz"))
+    {
+        ok2 = SendTuyaRequestThermostatSetWeeklySchedule(task, weekdays , transitions , 0x65 );
     }
     else
     {

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1659,7 +1659,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                     else if (map[pi.key()].type() == QVariant::List)
                     {
                         QVariantList setting = map[pi.key()].toList();
-                        if ((settings.size() == 3) && (setting[0].type() == QVariant::Bool) && (setting[1].type() == QVariant::Double) && (setting[2].type() == QVariant::Double))
+                        if ((setting.size() == 3) && (setting[0].type() == QVariant::Bool) && (setting[1].type() == QVariant::Double) && (setting[2].type() == QVariant::Double))
                         {
                             QByteArray data = QByteArray("\x00",1);
                             if (setting[0].toBool())

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1659,7 +1659,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                     else if (map[pi.key()].type() == QVariant::List)
                     {
                         QVariantList setting = map[pi.key()].toList();
-                        if (setting[0].type() == QVariant::Bool && setting[1].type() == QVariant::Double && setting[2].type() == QVariant::Double)
+                        if ((settings.size() == 3) && (setting[0].type() == QVariant::Bool) && (setting[1].type() == QVariant::Double) && (setting[2].type() == QVariant::Double))
                         {
                             QByteArray data = QByteArray("\x00",1);
                             if (setting[0].toBool())

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -556,11 +556,12 @@ const std::vector<Sensor::ButtonMap> Sensor::buttonMap(const QMap<QString, std::
         }
         // Workaround for Tuya without usable modelid
         if ((manufacturer == QLatin1String("_TZ3000_bi6lpsew")) ||  // can't use model id but manufacture name is device specific
-                 (manufacturer == QLatin1String("_TZ3400_keyjhapk")) ||
-                 (manufacturer == QLatin1String("_TYZB02_key8kk7r")) ||
-                 (manufacturer == QLatin1String("_TZ3400_keyjqthh")) ||
-                 (manufacturer == QLatin1String("_TZ3400_key8kk7r")) ||
-                 (manufacturer == QLatin1String("_TYZB02_keyjqthh")))
+            (manufacturer == QLatin1String("_TZ3400_keyjhapk")) ||
+            (manufacturer == QLatin1String("_TYZB02_key8kk7r")) ||
+            (manufacturer == QLatin1String("_TZ3400_keyjqthh")) ||
+            (manufacturer == QLatin1String("_TZ3400_key8kk7r")) ||
+            (manufacturer == QLatin1String("_TZ3000_vp6clf9d")) ||
+            (manufacturer == QLatin1String("_TYZB02_keyjqthh")))
         {
             m_buttonMap = buttonMapData.value("Tuya3gangMap");
         }

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -555,7 +555,12 @@ const std::vector<Sensor::ButtonMap> Sensor::buttonMap(const QMap<QString, std::
             }
         }
         // Workaround for Tuya without usable modelid
-        if (manufacturer == QLatin1String("_TZ3000_bi6lpsew")) // can't use model id but manufacture name is device specific
+        if ((manufacturer == QLatin1String("_TZ3000_bi6lpsew")) ||  // can't use model id but manufacture name is device specific
+                 (manufacturer == QLatin1String("_TZ3400_keyjhapk")) ||
+                 (manufacturer == QLatin1String("_TYZB02_key8kk7r")) ||
+                 (manufacturer == QLatin1String("_TZ3400_keyjqthh")) ||
+                 (manufacturer == QLatin1String("_TZ3400_key8kk7r")) ||
+                 (manufacturer == QLatin1String("_TYZB02_keyjqthh")))
         {
             m_buttonMap = buttonMapData.value("Tuya3gangMap");
         }

--- a/tuya.cpp
+++ b/tuya.cpp
@@ -135,6 +135,11 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
         QDataStream stream(zclFrame.payload());
         stream.setByteOrder(QDataStream::LittleEndian);
 
+        // "dp" field describes the action/message of a command frame and was composed by a type and an identifier
+        // "transid" is just a "counter", a response will have the same transif than the command.
+        // "Status" and "fn" are always 0
+        // More explanations at top of file
+        
         quint8 status;
         quint8 transid;
         quint16 dp;
@@ -188,7 +193,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
             // Sunday = W001
             // All days = W127
             
-            QString transitions = QString("");
+            QString transitions;
             
             length = length / 3;
             

--- a/tuya.cpp
+++ b/tuya.cpp
@@ -439,6 +439,11 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                     quint8 bat = (qint8)(data & 0xFF);
                     if (bat > 100) { bat = 100; }
                     ResourceItem *item = sensorNode->item(RConfigBattery);
+                    
+                    if (!item && bat > 0) // valid value: create resource item
+                    {
+                        item = sensorNode->addItem(DataTypeUInt8, RConfigBattery);
+                    }
 
                     if (item && item->toNumber() != bat)
                     {

--- a/tuya.cpp
+++ b/tuya.cpp
@@ -236,12 +236,13 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                         .arg(hour, 2, 10, QChar('0'))
                         .arg(minut, 2, 10, QChar('0'))
                         .arg(heatSetpoint);
+                        
+                    if (part > 0 && listday.size() >= static_cast<int>(part))
+                    {
+                        updateThermostatSchedule(sensorNode, listday.at(part - 1), transitions);
+                    }
+                        
                 }
-            }
-            
-            if (part > 0 && listday.size() >= static_cast<int>(part))
-            {
-                updateThermostatSchedule(sensorNode, listday.at(part - 1), transitions);
             }
             
             return;
@@ -394,7 +395,6 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                     else if (data == 1) { mode = QLatin1String("heat"); }
                     else
                     {
-                        DBG_Assert(data <= 0); // unsupported
                         return;
                     }
                     
@@ -468,7 +468,6 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                     else if (data == 1) { mode = QLatin1String("manu"); }
                     else
                     {
-                        DBG_Assert(data <= 0); // unsupported
                         return;
                     }
                     
@@ -509,7 +508,6 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                     else if (data == 1) { mode = QLatin1String("auto"); } // back to "auto"
                     else
                     {
-                        DBG_Assert(data <= 0); // unsupported
                         return;
                     }
                     
@@ -673,9 +671,6 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                             enqueueEvent(e);
                         }
                     }
-                    else
-                    {
-                    }
                 }
                 case 0x026A : // Siren Humidity
                 {
@@ -720,7 +715,6 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                     else if (dp == 0x0403) { preset = QLatin1String("program"); }
                     else
                     {
-                        DBG_Assert(data <= 0); // unsupported
                         return;
                     }
                     
@@ -745,7 +739,6 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                     else if (data == 6) { preset = QLatin1String("complex"); }
                     else
                     {
-                        DBG_Assert(data <= 0); // unsupported
                         return;
                     }
                     
@@ -766,7 +759,6 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                     else if (data == 2) { mode = QLatin1String("off"); }
                     else
                     {
-                        DBG_Assert(data <= 0); // unsupported
                         return;
                     }
                     

--- a/tuya.cpp
+++ b/tuya.cpp
@@ -419,8 +419,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                     }
                 }
                 break;
-                case 0x0203: // Thermostat temperature
-                case 0x0269: // siren temperature
+                case 0x0203: // Thermostat current temperature
                 {
                     qint16 temp = ((qint16)(data & 0xFFFF)) * 10;
                     ResourceItem *item = sensorNode->item(RStateTemperature);
@@ -502,15 +501,34 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                     }
                 }
                 break;
+                case 0x0269: // siren temperature, Boost time
+                {
+                    if (sensorNode->modelId() == QLatin1String("0yu2xgi")) //siren
+                    {
+                        qint16 temp = ((qint16)(data & 0xFFFF)) * 10;
+                        ResourceItem *item = sensorNode->item(RStateTemperature);
+
+                        if (item && item->toNumber() != temp)
+                        {
+                            item->setValue(temp);
+                            Event e(RSensors, RStateTemperature, sensorNode->id(), item);
+                            enqueueEvent(e);
+
+                        }
+                    }
+                    else
+                    {
+                    }
+                }
                 case 0x026A : // Siren Humidity
                 {
-                    qint16 RStateHumidity = ((qint16)(data & 0xFFFF)) * 10;
-                    ResourceItem *item = sensorNode->item(RStateTemperature);
+                    qint16 Hum = ((qint16)(data & 0xFFFF)) * 10;
+                    ResourceItem *item = sensorNode->item(RStateHumidity);
 
-                    if (item && item->toNumber() != RStateHumidity)
+                    if (item && item->toNumber() != Hum)
                     {
-                        item->setValue(RStateHumidity);
-                        Event e(RSensors, RStateTemperature, sensorNode->id(), item);
+                        item->setValue(Hum);
+                        Event e(RSensors, RStateHumidity, sensorNode->id(), item);
                         enqueueEvent(e);
                     }
                 }


### PR DESCRIPTION
- Remove my try to filter VENDOR_EMBER device, solve https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3424
- Correction for Moes HY368 and Tuya TS0601 thermostat (30 degree bug), solve https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3440
- Add Tuya Essentials Premium thermostat https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3381
- Add Tuya BTH-002 thermostat https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3304
- Add Saswell SEA801-Zigbee TRV https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3109
- Add Revolt NX-4911-675 thermostat https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3588
- Re adding Tuya / Zemismart switches TS0041, TS0042, TS0043, TS0043, TS0044 removed by error from another PR https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3524
- Correction for Tuya / Zemismart Zigbee Smart Curtain switch ZW-EC-01 that not support `lift` https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3438
- Added calibation command for Tuya Smart Life ZigBee 3.0 Curtain Blind Switch https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3134
- Removing "Heiman" for manufacture name with VENDOR_EMBER code.
- Starting to add schedule feature for Tuya device.


Not tuya stuff
- Kwikset 914 ZigBee smart lock https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3152
