### PR TITLE
Various small bug fixes and enhancements

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2481,6 +2481,7 @@ void DeRestPluginPrivate::setLightNodeStaticCapabilities(LightNode *lightNode)
              lightNode->modelId() == QLatin1String("Classic A60 TW") ||
              lightNode->modelId() == QLatin1String("Classic A60 TW") ||
              lightNode->modelId() == QLatin1String("Zigbee CCT Downlight") ||
+             lightNode->modelId() == QLatin1String("Halo_RL5601") ||
              (lightNode->manufacturerCode() == VENDOR_LEDVANCE && lightNode->modelId() == QLatin1String("Down Light TW")) ||
              (lightNode->manufacturerCode() == VENDOR_LEDVANCE && lightNode->modelId() == QLatin1String("BR30 TW")) ||
              (lightNode->manufacturerCode() == VENDOR_LEDVANCE && lightNode->modelId() == QLatin1String("MR16 TW")) ||

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -227,6 +227,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_XIAOMI, "lumi.plug", xiaomiMacPrefix }, // Xiaomi smart plugs (router)
     { VENDOR_XIAOMI, "lumi.switch.b1naus01", xiaomiMacPrefix }, // Xiaomi Aqara ZB3.0 Smart Wall Switch Single Rocker WS-USC03
     // { VENDOR_XIAOMI, "lumi.curtain", jennicMacPrefix}, // Xiaomi curtain controller (router) - exposed only as light
+    { VENDOR_XIAOMI, "lumi.curtain.hagl04", xiaomiMacPrefix}, // Xiaomi B1 curtain controller
     { VENDOR_UBISYS, "C4", ubisysMacPrefix },
     { VENDOR_UBISYS, "D1", ubisysMacPrefix },
     { VENDOR_UBISYS, "J1", ubisysMacPrefix },
@@ -4658,6 +4659,11 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     fpAlarmSensor.inClusters.push_back(ci->id());
                     if (node->nodeDescriptor().manufacturerCode() == VENDOR_IKEA &&
                         (modelId.startsWith(QLatin1String("FYRTUR")) || modelId.startsWith(QLatin1String("KADRILJ"))))
+                    {
+                        fpBatterySensor.inClusters.push_back(ci->id());
+                    }
+                    if (node->nodeDescriptor().manufacturerCode() == VENDOR_XIAOMI &&
+                        modelId.startsWith(QLatin1String("lumi.curtain.hagl04")))
                     {
                         fpBatterySensor.inClusters.push_back(ci->id());
                     }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2479,6 +2479,8 @@ void DeRestPluginPrivate::setLightNodeStaticCapabilities(LightNode *lightNode)
              lightNode->modelId() == QLatin1String("A19 TW 10 year") ||
              lightNode->modelId() == QLatin1String("Classic B40 TW - LIGHTIFY") ||
              lightNode->modelId() == QLatin1String("Classic A60 TW") ||
+             lightNode->modelId() == QLatin1String("Classic A60 TW") ||
+             lightNode->modelId() == QLatin1String("Zigbee CCT Downlight") ||
              (lightNode->manufacturerCode() == VENDOR_LEDVANCE && lightNode->modelId() == QLatin1String("Down Light TW")) ||
              (lightNode->manufacturerCode() == VENDOR_LEDVANCE && lightNode->modelId() == QLatin1String("BR30 TW")) ||
              (lightNode->manufacturerCode() == VENDOR_LEDVANCE && lightNode->modelId() == QLatin1String("MR16 TW")) ||

--- a/general.xml
+++ b/general.xml
@@ -567,7 +567,7 @@
 							</attribute>
 						</attribute-set>
             <attribute-set id="0x8000" description="Xiaomi" mfcode="0x1037">
-              <attribute id="0x8000" name="Button Event" type="u8" access="r" required="o"/>
+              <attribute id="0x8000" name="Button Press" type="u8" access="r" required="o"/>
             </attribute-set>
 			<command id="00" dir="recv" name="Off" required="m">
 				<description>On receipt of this command, a device shall enter its 'Off' state. This state is device dependent, but it is recommended that it is used for power off or similar functions.</description>

--- a/general.xml
+++ b/general.xml
@@ -566,7 +566,9 @@
                 <value name="Previous" value="0xff"></value>
 							</attribute>
 						</attribute-set>
-
+            <attribute-set id="0x8000" description="Xiaomi" mfcode="0x1037">
+              <attribute id="0x8000" name="Button Event" type="u8" access="r" required="o"/>
+            </attribute-set>
 			<command id="00" dir="recv" name="Off" required="m">
 				<description>On receipt of this command, a device shall enter its 'Off' state. This state is device dependent, but it is recommended that it is used for power off or similar functions.</description>
 			</command>
@@ -1731,13 +1733,13 @@ Note: It does not clear or delete previous weekly schedule programming configura
           <attribute id="0x0031" name="Setpoint Change Amount" type="s16" access="r" required="o" default="0x8000"/>
           <attribute id="0x0032" name="Setpoint Change Timestamp" type="utc" access="r" required="o" default="0"/>
         </attribute-set>
-        
+
         <attribute-set id="0x0080" description="eCozy" mfcode="0x1014">
           <attribute id="0x0080" name="Unknown" type="s16" access="r" required="o"/>
           <attribute id="0x0081" name="Unknown" type="s16" access="r" required="o"/>
           <attribute id="0x0082" name="Unknown (Heat Setpoint?)" type="s16" access="r" required="o"/>
         </attribute-set>
-        
+
 		<!-- ELKO specific -->
 		<attribute-set id="0x0400" description="ELKO specific" mfcode="0x1002">
 			<attribute id="0x0401" name="Unknown" type="u16" access="rw" required="m"></attribute>

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -223,6 +223,7 @@ bool DeRestPluginPrivate::lightToMap(const ApiRequest &req, const LightNode *lig
     QVariantMap state;
     const ResourceItem *ix = nullptr;
     const ResourceItem *iy = nullptr;
+    const ResourceItem *icc = nullptr;
 
     for (int i = 0; i < lightNode->itemCount(); i++)
     {
@@ -251,7 +252,7 @@ bool DeRestPluginPrivate::lightToMap(const ApiRequest &req, const LightNode *lig
         else if (item->descriptor().suffix == RStateReachable) { state["reachable"] = item->toBool(); }
         else if (item->descriptor().suffix == RConfigCtMin) { map["ctmin"] = item->toNumber(); }
         else if (item->descriptor().suffix == RConfigCtMax) { map["ctmax"] = item->toNumber(); }
-        else if (item->descriptor().suffix == RConfigColorCapabilities) { map["colorcapabilities"] = item->toNumber(); }
+        else if (item->descriptor().suffix == RConfigColorCapabilities) { icc = item; }
         else if (item->descriptor().suffix == RConfigPowerup) { map["powerup"] = item->toNumber(); }
         else if (item->descriptor().suffix == RConfigPowerOnLevel) { map["poweronlevel"] = item->toNumber(); }
         else if (item->descriptor().suffix == RConfigPowerOnCt) { map["poweronct"] = item->toNumber(); }
@@ -282,6 +283,20 @@ bool DeRestPluginPrivate::lightToMap(const ApiRequest &req, const LightNode *lig
         xy.append(x);
         xy.append(y);
         state["xy"] = xy;
+    }
+    if (icc)
+    {
+        const int cc = icc->toNumber();
+        const bool hs = cc & 0x01 || cc & 0x02;
+        const bool effect = cc & 0x04;
+        const bool xy = cc & 0x08;
+        const bool ct = cc & 0x10;
+        QVariantMap colorCapabilities;
+        colorCapabilities["hs"] = hs;
+        colorCapabilities["effect"] = effect;
+        colorCapabilities["xy"] = xy;
+        colorCapabilities["ct"] = ct;
+        map["colorcapabilities"] = colorCapabilities;
     }
 
     map["uniqueid"] = lightNode->uniqueId();
@@ -851,10 +866,10 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
     {
         rsp.list.append(errorToMap(ERR_MISSING_PARAMETER, QString("/lights/%1/state").arg(id), QString("missing parameter to set light state")));
     }
-    
+
     // Check whether light is on.
     isOn = taskRef.lightNode->toBool(RStateOn);
-    
+
     // Special part for Profalux device
     // This device is a shutter but is used as a dimmable light, so need some hack
     if (taskRef.lightNode->modelId() == QLatin1String("PFLX Shutter"))
@@ -864,24 +879,24 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         {
             targetBri = targetOn ? 0xFE : 0x00;
         }
-        
+
         // The constructor ask to use setvel instead of on/off
         hasBri = true;
         hasOn = false;
         isOn = true; // to force bri even state = off
-        
+
         //Check limit
         if (targetBri > 0xFE) { targetBri = 0xFE; }
         if (targetBri < 1 ) { targetBri = 0x01; }
-        
+
         //Check for stop
         if (hasBriInc)
         {
             hasStop = true;
         }
-        
+
     }
-    
+
     // Stop command, I think it's useless, but the command exist, and need it for profalux
     if (hasStop)
     {
@@ -889,10 +904,10 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         hasBriInc = false;
         hasBri = false;
         isOn = false;
-        
+
         TaskItem task;
         copyTaskReq(taskRef, task);
-        
+
         if (addTaskStopBrightness(task))
         {
             QVariantMap rspItem;
@@ -1518,7 +1533,7 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
     {
         cluster = ANALOG_OUTPUT_CLUSTER_ID;
     }
-    
+
     if ((taskRef.lightNode->manufacturer() == QLatin1String("_TYST11_wmcdj3aq")) ||
         (taskRef.lightNode->manufacturer() == QLatin1String("_TYST11_xu1rkty3")) )
     {
@@ -1729,7 +1744,7 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
         bool ok;
         TaskItem task;
         copyTaskReq(taskRef, task);
-        
+
         if (cluster == TUYA_CLUSTER_ID)
         {
             ok = SendTuyaRequest(task, TaskTuyaRequest , DP_TYPE_ENUM, 0x01 , QByteArray("\x01", 1) );
@@ -1759,8 +1774,8 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
         bool ok;
         TaskItem task;
         copyTaskReq(taskRef, task);
-        
-        
+
+
         if (cluster == TUYA_CLUSTER_ID)
         {
             QByteArray lev = QByteArray("\x00\x00\x00", 3);
@@ -1837,7 +1852,7 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
         bool ok;
         TaskItem task;
         copyTaskReq(taskRef, task);
-        
+
         if (cluster == TUYA_CLUSTER_ID)
         {
             if (targetOpen)
@@ -1848,7 +1863,7 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
             {
                 ok = SendTuyaRequest(task, TaskTuyaRequest , DP_TYPE_ENUM, 0x01 , QByteArray("\x00", 1) );
             }
-            
+
         }
         else
         {
@@ -1913,19 +1928,19 @@ int DeRestPluginPrivate::setTuyaDeviceState(const ApiRequest &req, ApiResponse &
             bool ok = false;
             qint8 button = 0x01;
             QByteArray data;
-            
+
             targetOn = map["on"].toBool();
-            
+
             //Retreive Fake endpoint, and change button value
             uint8_t ep = taskRef.lightNode->haEndpoint().endpoint();
             if (ep == 0x02) { button = 0x02; }
             if (ep == 0x03) { button = 0x03; }
-            
+
             //Use only the first endpoint for command
             taskRef.req.setDstEndpoint(0x01);
-            
+
             DBG_Printf(DBG_INFO, "Tuya debug 10: EP: %d ID : %s\n",  ep , qPrintable(id));
-            
+
             if (targetOn)
             {
                 data = QByteArray("\x01",1);
@@ -1934,7 +1949,7 @@ int DeRestPluginPrivate::setTuyaDeviceState(const ApiRequest &req, ApiResponse &
             {
                 data = QByteArray("\x00",1);
             }
-            
+
             ok = SendTuyaRequest(taskRef, TaskTuyaRequest , DP_TYPE_BOOL, button , data );
 
             if (ok)
@@ -1944,7 +1959,7 @@ int DeRestPluginPrivate::setTuyaDeviceState(const ApiRequest &req, ApiResponse &
                 rspItemState[QString("/lights/%1/state/on").arg(id)] = targetOn;
                 rspItem["success"] = rspItemState;
                 rsp.list.append(rspItem);
-                
+
                 //Not needed ?
                 //taskRef.lightNode->setValue(RStateOn, targetOn);
             }
@@ -2062,7 +2077,7 @@ int DeRestPluginPrivate::setWarningDeviceState(const ApiRequest &req, ApiRespons
         {
             task.options = 0x00; // Warning mode 0 (no warning), No strobe, Low sound
             task.duration = 0;
-            
+
             // Quickfix for clearing the alarm bit of Develco smoke, heat and water leak sensor
             if (taskRef.lightNode->modelId() == QLatin1String("SMSZB-120") ||
                 taskRef.lightNode->modelId() == QLatin1String("HESZB-120") ||

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -287,15 +287,12 @@ bool DeRestPluginPrivate::lightToMap(const ApiRequest &req, const LightNode *lig
     if (icc)
     {
         const int cc = icc->toNumber();
-        const bool hs = cc & 0x01 || cc & 0x02;
-        const bool effect = cc & 0x04;
-        const bool xy = cc & 0x08;
-        const bool ct = cc & 0x10;
-        QVariantMap colorCapabilities;
-        colorCapabilities["hs"] = hs;
-        colorCapabilities["effect"] = effect;
-        colorCapabilities["xy"] = xy;
-        colorCapabilities["ct"] = ct;
+        QStringList colorCapabilities;
+        // Keep sorted by string value
+        if (cc & 0x10) colorCapabilities.push_back(QLatin1String("ct"));
+        if (cc & 0x04) colorCapabilities.push_back(QLatin1String("effect"));
+        if (cc & 0x01 || cc & 0x02) colorCapabilities.push_back(QLatin1String("hs"));
+        if (cc & 0x08) colorCapabilities.push_back(QLatin1String("xy"));
         map["colorcapabilities"] = colorCapabilities;
     }
 

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1590,7 +1590,7 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
         {
             paramOk = true;
             hasCmd = true;
-            if (map[param].type() == QVariant::String && map[param].toString() == "stop" && cluster != ANALOG_OUTPUT_CLUSTER_ID)
+            if (map[param].type() == QVariant::String && map[param].toString() == "stop")
             {
                 valueOk = true;
                 hasStop = true;
@@ -1610,7 +1610,7 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
         {
             paramOk = true;
             hasCmd = true;
-            if (map[param].type() == QVariant::String && map[param].toString() == "stop" && cluster != ANALOG_OUTPUT_CLUSTER_ID)
+            if (map[param].type() == QVariant::String && map[param].toString() == "stop")
             {
                 valueOk = true;
                 hasStop = true;
@@ -1626,7 +1626,7 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
                 }
             }
         }
-        else if (param == "bri_inc" && taskRef.lightNode->item(RStateBri) && cluster != ANALOG_OUTPUT_CLUSTER_ID)
+        else if (param == "bri_inc" && taskRef.lightNode->item(RStateBri))
         {
             paramOk = true;
             hasCmd = true;


### PR DESCRIPTION
- Add 0x8000 attribute to _On/Off_ cluster for `lumi.sensor_switch.aq2`, see #3480;
- Whitelist `Zigbee CCT Downlight` _Color Dimmable Light_ by ETI to expose `ct`, see #3493;
- Whitelist `Halo_RL5601` _Color Dimmable Light_ by Eaton to expose `ct`, see #3509.
- Expose `colorcapabilities` as an array, instead of raw bitmap value, see Discord #technical-talk channel.
  ```json
  {
    "colorcapabilities": [
      "ct",
      "effect",
      "hs",
      "xy"
    ],
    "ctmax": 500,
    "ctmin": 153,
    "etag": "7d7845fe999a26bf7a034b110a424393",
    "hascolor": true,
    "lastannounced": null,
    "lastseen": "2020-10-25T19:36Z",
    "manufacturername": "Philips",
    "modelid": "LCT015",
    "name": "Hue",
    "state": {
      "alert": "none",
      "bri": 254,
      "colormode": "hs",
      "ct": 447,
      "effect": "none",
      "hue": 0,
      "on": false,
      "reachable": true,
      "sat": 100,
      "xy": [
        0.5029,
        0.3498
      ]
    },
    "swversion": "1.50.2_r30933",
    "type": "Extended color light",
    "uniqueid": "00:17:88:01:04:34:2c:ff-0b"
  }
  ```
- Support `"bri_inc": 0` and similar deprecated calls for Xiaomi Aqara B1 curtain controller, see #3508;
- Expose ZHABattery `/sensors` resource for for Xiaomi Aqara B1 curtain controller, see #3508.  Untested; not sure if `state.battery` is actually updated.