### PR TITLE
Handle case when view scene returns no entry status

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -13645,6 +13645,28 @@ void DeRestPluginPrivate::handleSceneClusterIndication(TaskItem &task, const deC
                         onOff, bri, x, y, transitionTime);
             }
         }
+        else if (status == 0x8b && zclFrame.payload().size() >= 4) // scene not found
+        {
+            uint16_t groupId;
+            uint8_t sceneId;
+
+            stream >> groupId;
+            stream >> sceneId;
+
+            Group *group = getGroupForId(groupId);
+            Scene *scene = group->getScene(sceneId);
+
+            if (!group || !scene)
+            {
+                return;
+            }
+
+            auto *ls = scene->getLightState(lightNode->id());
+            if (ls)
+            {
+                ls->setNeedRead(false); // move to add scene
+            }
+        }
     }
     else if (zclFrame.commandId() == 0x05 && !(zclFrame.frameControl() & deCONZ::ZclFCDirectionServerToClient)) // Recall scene command
     {


### PR DESCRIPTION
In some cases a Add Scene command was never sent, causing a scene not to be created after 3 times trying to read the scene.

Story behind this: My 4x IKEA GU10 color temperature lights corrupted 4 scenes after an OTA update. The scenes were still there but the colorY field was no longer part of the scene, only on, bri and colorX.

To fix the scenes:
1) Execute Remove All Scenes for the group
2) Executed Get Scene Membership for the group

After that the plugin started to recreate the scenes via Add Scene command, but on two lights only 3 out of 4 scenes were created. This commit fixed the remaining ones and all scenes work again.