### PR TITLE
Small enhancements

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1085,13 +1085,6 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq2.maxInterval = 600;
             rq2.reportableChange16bit = 50;
 
-            ConfigureReportingRequest rq3;
-            rq3.dataType = deCONZ::Zcl8BitEnum;
-            rq3.attributeId = 0x001C;        // Thermostat mode
-            rq3.minInterval = 1;
-            rq3.maxInterval = 600;
-            rq3.reportableChange8bit = 0xff;
-
             ConfigureReportingRequest rq4;
             rq4.dataType = deCONZ::ZclBoolean;
             rq4.attributeId = 0x0406;        // Device on
@@ -1117,7 +1110,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq7.minInterval = 1;
             rq7.maxInterval = 600;
 
-            return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4, rq5, rq6, rq7});
+            return sendConfigureReportingRequest(bt, {rq, rq2, rq4, rq5, rq6, rq7});
         }
         else if (sensor && sensor->modelId() == QLatin1String("Zen-01")) // Zen
         {

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -3295,6 +3295,7 @@ void DeRestPluginPrivate::checkSensorGroup(Sensor *sensor)
         sensor->modelId().startsWith(QLatin1String("TRADFRI wireless dimmer")) ||
         // sensor->modelId().startsWith(QLatin1String("SYMFONISK")) ||
         sensor->modelId().startsWith(QLatin1String("902010/23")) || // bitron remote
+        sensor->modelId().startsWith(QLatin1String("WB01")) || // Sonoff SNZB-01
         sensor->modelId().startsWith(QLatin1String("Bell")) || // Sage doorbell sensor
         sensor->modelId().startsWith(QLatin1String("ZBT-CCTSwitch-D0001")) || //LDS Remote
         sensor->modelId().startsWith(QLatin1String("ZBT-DIMSwitch")) || // Linkind 1 key Remote Control / ZS23000178

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1418,6 +1418,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
                             sensor->modelId() == QLatin1String("motionv4") ||
                             sensor->modelId() == QLatin1String("multiv4") ||
                             sensor->modelId() == QLatin1String("RFDL-ZB-MS") ||
+                            sensor->modelId() == QLatin1String("SZ-DWS04") ||
                             sensor->modelId() == QLatin1String("Zen-01") ||
                             sensor->modelId() == QLatin1String("Bell") ||
                             sensor->modelId() == QLatin1String("ISW-ZPR1-WP13") ||

--- a/database.cpp
+++ b/database.cpp
@@ -3518,6 +3518,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     sensor.addItem(DataTypeInt16, RStateFloorTemperature);
                     sensor.addItem(DataTypeBool, RStateHeating);
                     sensor.addItem(DataTypeBool, RConfigLocked);
+                    sensor.addItem(DataTypeString, RConfigMode);
                 }
 
                 if (sensor.modelId() == QLatin1String("kud7u2l") || // Tuya

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1793,7 +1793,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
     }
 
     //Make 2 fakes device for tuya stuff
-    if (node->nodeDescriptor().manufacturerCode() == VENDOR_EMBER)
+    if (node->nodeDescriptor().manufacturerCode() == VENDOR_EMBER && !node->simpleDescriptors().isEmpty())
     {
         const deCONZ::SimpleDescriptor *sd = &node->simpleDescriptors()[0];
 

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -8109,7 +8109,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 if (item && buttonevent != -1)
                                 {
                                     item->setValue(buttonevent);
-                                    DBG_Printf(DBG_INFO, "[INFO] - Button %u %s\n", item->toNumber(), qPrintable(sensor->modelId()));
+                                    DBG_Printf(DBG_INFO, "[INFO] - Button %u %s\n", item->toNumber(), qPrintable(i->modelId()));
                                     i->updateStateTimestamp();
                                     i->setNeedSaveDatabase(true);
                                     Event e(RSensors, RStateButtonEvent, i->id(), item);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5142,7 +5142,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                              modelId.startsWith(QLatin1String("ICZB-RM")) || // icasa remote
                              modelId.startsWith(QLatin1String("ZGRC-KEY")) || // Sunricher remote
                              modelId.startsWith(QLatin1String("ED-1001")) || // EcoDim switches
-                             modelId.startsWith(QLatin1String("ED-1001")))   // Namron switches
+                             modelId.startsWith(QLatin1String("45127")))     // Namron switches
                     {
                         if (i->endpoint() == 0x01) // create sensor only for first endpoint
                         {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1309,7 +1309,7 @@ void DeRestPluginPrivate::gpProcessButtonEvent(const deCONZ::GpDataIndication &i
     updateSensorEtag(sensor);
     sensor->updateStateTimestamp();
     item->setValue(btn);
-
+    DBG_Printf(DBG_INFO, "[INFO] - Button %u %s\n", item->toNumber(), qPrintable(sensor->modelId()));
     Event e(RSensors, RStateButtonEvent, sensor->id(), item);
     enqueueEvent(e);
     enqueueEvent(Event(RSensors, RStateLastUpdated, sensor->id()));
@@ -4340,7 +4340,7 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                 if (ok && buttonMap.button != 0)
                 {
                     if (!buttonMap.name.isEmpty()) { cmd = buttonMap.name; }
-                    DBG_Printf(DBG_INFO, "[INFO] - Button %u %s\n", buttonMap.button, qPrintable(cmd));
+                    DBG_Printf(DBG_INFO, "[INFO] - Button %u %s %s\n", buttonMap.button, qPrintable(cmd), qPrintable(sensor->modelId()));
                     ResourceItem *item = sensor->item(RStateButtonEvent);
                     if (item)
                     {
@@ -4351,7 +4351,7 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
 
                             if (dt > 0 && dt < 500)
                             {
-                                DBG_Printf(DBG_INFO, "[INFO] - Button %u %s, discard too fast event (dt = %d)\n", buttonMap.button, qPrintable(cmd), dt);
+                                DBG_Printf(DBG_INFO, "[INFO] - Button %u %s, discard too fast event (dt = %d) %s\n", buttonMap.button, qPrintable(cmd), dt, qPrintable(sensor->modelId()));
                                 break;
                             }
                         }
@@ -8108,6 +8108,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 if (item && buttonevent != -1)
                                 {
                                     item->setValue(buttonevent);
+                                    DBG_Printf(DBG_INFO, "[INFO] - Button %u %s\n", item->toNumber(), qPrintable(sensor->modelId()));
                                     i->updateStateTimestamp();
                                     i->setNeedSaveDatabase(true);
                                     Event e(RSensors, RStateButtonEvent, i->id(), item);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6040,6 +6040,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                 sensorNode.addItem(DataTypeInt16, RStateFloorTemperature);
                 sensorNode.addItem(DataTypeBool, RStateHeating);
                 sensorNode.addItem(DataTypeBool, RConfigLocked);
+                sensorNode.addItem(DataTypeString, RConfigMode);
             }
 
             if (sensorNode.modelId() == QLatin1String("kud7u2l") || // Tuya

--- a/general.xml
+++ b/general.xml
@@ -1789,6 +1789,7 @@ Note: It does not clear or delete previous weekly schedule programming configura
 		<!-- Danfoss manufacturer specific -->
 		<attribute-set id="0x4000" description="Danfoss specific" mfcode="0x1246">
 			<attribute id="0x4000" name="eTRV Open Window Detection" type="enum8" default="0x00" access="r" required="m" mfcode="0x1246">
+				<value name="Quarantine" value="0x00"></value>
 				<value name="Closed" value="0x01"></value>
 				<value name="Hold" value="0x02"></value>
 				<value name="Open" value="0x03"></value>

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1385,7 +1385,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                         {
                             bool data = map[pi.key()].toBool();
 
-                            if (addTaskThermostatReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, 0, 0x0412, deCONZ::ZclBoolean, data))
+                            if (addTaskThermostatReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, 0, 0x0413, deCONZ::ZclBoolean, data))
                             {
                                 updated = true;
                             }

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -2869,7 +2869,7 @@ void DeRestPluginPrivate::checkSensorStateTimerFired()
                     if (item && item->toNumber() == (S_BUTTON_1 + S_BUTTON_ACTION_INITIAL_PRESS))
                     {
                         item->setValue(S_BUTTON_1 + S_BUTTON_ACTION_HOLD);
-                        DBG_Printf(DBG_INFO, "button %d Hold\n", item->toNumber());
+                        DBG_Printf(DBG_INFO, "[INFO] - Button %u Hold %s\n", item->toNumber(), qPrintable(sensor->modelId()));
                         sensor->updateStateTimestamp();
                         Event e(RSensors, RStateButtonEvent, sensor->id(), item);
                         enqueueEvent(e);
@@ -2887,7 +2887,7 @@ void DeRestPluginPrivate::checkSensorStateTimerFired()
                     {
                         btn &= ~0x03;
                         item->setValue(btn + S_BUTTON_ACTION_HOLD);
-                        DBG_Printf(DBG_INFO, "FoH switch button %d Hold\n", item->toNumber());
+                        DBG_Printf(DBG_INFO, "FoH switch button %d Hold %s\n", item->toNumber(), qPrintable(sensor->modelId()));
                         sensor->updateStateTimestamp();
                         Event e(RSensors, RStateButtonEvent, sensor->id(), item);
                         enqueueEvent(e);

--- a/thermostat.cpp
+++ b/thermostat.cpp
@@ -475,8 +475,7 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
                 if (sensor->modelId().startsWith(QLatin1String("SLR2")) ||   // Hive
                     sensor->modelId().startsWith(QLatin1String("SLR1b")) ||  // Hive
                     sensor->modelId().startsWith(QLatin1String("TH112")) ||  // Sinope
-                    sensor->modelId().startsWith(QLatin1String("Zen-01")) || // Zen
-                    sensor->modelId().startsWith(QLatin1String("Super TR"))) // ELKO
+                    sensor->modelId().startsWith(QLatin1String("Zen-01")))   // Zen
                 {
                     qint8 mode = attr.numericValue().s8;
                     QString mode_set;

--- a/thermostat.cpp
+++ b/thermostat.cpp
@@ -638,6 +638,19 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
                         enqueueEvent(Event(RSensors, RStateOn, sensor->id(), item));
                         stateUpdated  = true;
                     }
+                    
+                    // Set config/mode to have an adequate representation based on this attribute
+                    QString mode_set;
+                    if ( bool == false ) { mode_set = QString("off"); }
+                    if ( bool == true ) { mode_set = QString("heat"); }
+                    
+                    item = sensor->item(RConfigMode);
+                    if (item && !item->toString().isEmpty() && item->toString() != mode_set)
+                    {
+                        item->setValue(mode_set);
+                        enqueueEvent(Event(RSensors, RConfigMode, sensor->id(), item));
+                        configUpdated = true;
+                    }
                     sensor->setZclValue(updateType, ind.srcEndpoint(), THERMOSTAT_CLUSTER_ID, attrId, attr.numericValue());
                 }
             }

--- a/thermostat.cpp
+++ b/thermostat.cpp
@@ -476,7 +476,7 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
                     sensor->modelId().startsWith(QLatin1String("SLR1b")) ||  // Hive
                     sensor->modelId().startsWith(QLatin1String("TH112")) ||  // Sinope
                     sensor->modelId().startsWith(QLatin1String("Zen-01")) || // Zen
-                    sensor->modelId().startsWith(QLatin1String("Super TR")))    // ELKO
+                    sensor->modelId().startsWith(QLatin1String("Super TR"))) // ELKO
                 {
                     qint8 mode = attr.numericValue().s8;
                     QString mode_set;
@@ -665,7 +665,7 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
             }
                 break;
 
-            case 0x0412: // Child lock
+            case 0x0413: // Child lock
             {
                 if (sensor->modelId() == QLatin1String("Super TR")) // ELKO
                 {

--- a/thermostat.cpp
+++ b/thermostat.cpp
@@ -599,7 +599,7 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
 
             case 0x0403: // Temperature measurement
             {
-                if (zclFrame.manufacturerCode() == VENDOR_EMBER && sensor->modelId().startsWith(QLatin1String("Super TR"))) // ELKO
+                if (sensor->modelId().startsWith(QLatin1String("Super TR"))) // ELKO
                 {
                     quint8 mode = attr.numericValue().u8;
                     QString mode_set;
@@ -623,7 +623,7 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
 
             case 0x0406: // Device on/off
             {
-                if (zclFrame.manufacturerCode() == VENDOR_EMBER && sensor->modelId() == QLatin1String("Super TR")) // ELKO
+                if (sensor->modelId() == QLatin1String("Super TR")) // ELKO
                 {
                     bool on = attr.numericValue().u8 > 0 ? true : false;
                     item = sensor->item(RStateOn);
@@ -645,7 +645,7 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
 
             case 0x0409: // Floor temperature
             {
-                if (zclFrame.manufacturerCode() == VENDOR_EMBER && sensor->modelId().startsWith(QLatin1String("Super TR"))) // ELKO
+                if (sensor->modelId().startsWith(QLatin1String("Super TR"))) // ELKO
                 {
                     qint16 floortemp = attr.numericValue().s16;
                     item = sensor->item(RStateFloorTemperature);
@@ -667,7 +667,7 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
 
             case 0x0412: // Child lock
             {
-                if (zclFrame.manufacturerCode() == VENDOR_EMBER && sensor->modelId() == QLatin1String("Super TR")) // ELKO
+                if (sensor->modelId() == QLatin1String("Super TR")) // ELKO
                 {
                     bool enabled = attr.numericValue().u8 > 0 ? true : false;
                     item = sensor->item(RConfigLocked);
@@ -684,7 +684,7 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
 
             case 0x0415: // Heating active/inactive
             {
-                if (zclFrame.manufacturerCode() == VENDOR_EMBER && sensor->modelId() == QLatin1String("Super TR")) // ELKO
+                if (sensor->modelId() == QLatin1String("Super TR")) // ELKO
                 {
                     bool on = attr.numericValue().u8 > 0 ? true : false;
                     item = sensor->item(RStateHeating);

--- a/thermostat.cpp
+++ b/thermostat.cpp
@@ -641,8 +641,8 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
                     
                     // Set config/mode to have an adequate representation based on this attribute
                     QString mode_set;
-                    if ( bool == false ) { mode_set = QString("off"); }
-                    if ( bool == true ) { mode_set = QString("heat"); }
+                    if ( on == false ) { mode_set = QString("off"); }
+                    if ( on == true ) { mode_set = QString("heat"); }
                     
                     item = sensor->item(RConfigMode);
                     if (item && !item->toString().isEmpty() && item->toString() != mode_set)


### PR DESCRIPTION
- Enable group creation for Sonoff SNZB-01 (#3490)
- Unify debug output for button presses
- Remove MFC check for Elko Super TR attribute reports (#3123)
- Expose RConfigMode and correct attribute for Elko Super TR (#3123)
- Fix typo to create only 1 switch resource for Namron switches
- Make RConfigMode usable for Elko Super TR to turn device on/off (#3123)
- Remove thermostat mode binding for Elko Super TR (#3123)
- Enable battery attribute reporting for SZ-DWS04 (#3576)
- Added missing "windowopen" value for Danfoss TRV (#3591)
- Guard against empty simple descriptors