### PR TITLE
Fix too broad mac check that prevents from pairing

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -126,13 +126,13 @@ bool DeRestPluginPrivate::readBindingTable(RestNodeBase *node, quint8 startIndex
     if (node->mgmtBindSupported())
     {
     }
-    else if (checkMacVendor(node->address(), VENDOR_DDEL))
+    else if (existDevicesWithVendorCodeForMacPrefix(node->address(), VENDOR_DDEL))
     {
     }
-    else if (checkMacVendor(node->address(), VENDOR_UBISYS))
+    else if (existDevicesWithVendorCodeForMacPrefix(node->address(), VENDOR_UBISYS))
     {
     }
-    else if (checkMacVendor(node->address(), VENDOR_DEVELCO))
+    else if (existDevicesWithVendorCodeForMacPrefix(node->address(), VENDOR_DEVELCO))
     {
     }
     else if (r && r->item(RAttrModelId)->toString().startsWith(QLatin1String("FLS-")))
@@ -1492,12 +1492,12 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq.dataType = deCONZ::ZclBoolean;
         rq.attributeId = 0x0000; // on/off
 
-        if (checkMacVendor(bt.restNode->address(), VENDOR_DDEL))
+        if (existDevicesWithVendorCodeForMacPrefix(bt.restNode->address(), VENDOR_DDEL))
         {
             rq.minInterval = 5;
             rq.maxInterval = 180;
         }
-        else if (checkMacVendor(bt.restNode->address(), VENDOR_XAL) ||
+        else if (existDevicesWithVendorCodeForMacPrefix(bt.restNode->address(), VENDOR_XAL) ||
                  bt.restNode->node()->nodeDescriptor().manufacturerCode() == VENDOR_XAL)
         {
             rq.minInterval = 5;
@@ -1650,7 +1650,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq.dataType = deCONZ::Zcl8BitUint;
         rq.attributeId = 0x0000; // current level
 
-        if (checkMacVendor(bt.restNode->address(), VENDOR_DDEL))
+        if (existDevicesWithVendorCodeForMacPrefix(bt.restNode->address(), VENDOR_DDEL))
         {
             rq.minInterval = 5;
             rq.maxInterval = 180;
@@ -1796,7 +1796,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             return sendConfigureReportingRequest(bt, {rq, rq1, rq2, rq3});
         }
     }
-    else if (bt.binding.clusterId == BASIC_CLUSTER_ID && checkMacVendor(bt.restNode->address(), VENDOR_PHILIPS))
+    else if (bt.binding.clusterId == BASIC_CLUSTER_ID && existDevicesWithVendorCodeForMacPrefix(bt.restNode->address(), VENDOR_PHILIPS))
     {
         Sensor *sensor = dynamic_cast<Sensor*>(bt.restNode);
         if (!sensor)
@@ -2153,7 +2153,7 @@ void DeRestPluginPrivate::checkLightBindingsForAttributeReporting(LightNode *lig
             }
 
             BindingTask bt;
-            if (checkMacVendor(lightNode->address(), VENDOR_DDEL))
+            if (existDevicesWithVendorCodeForMacPrefix(lightNode->address(), VENDOR_DDEL))
             {
                 bt.state = BindingTask::StateCheck;
             }
@@ -2198,7 +2198,7 @@ void DeRestPluginPrivate::checkLightBindingsForAttributeReporting(LightNode *lig
         return;
     }
 
-    if (checkMacVendor(lightNode->address(), VENDOR_DDEL) || lightNode->manufacturerCode() == VENDOR_XAL)
+    if (existDevicesWithVendorCodeForMacPrefix(lightNode->address(), VENDOR_DDEL) || lightNode->manufacturerCode() == VENDOR_XAL)
     {
         lightNode->enableRead(READ_BINDING_TABLE);
         lightNode->setNextReadTime(READ_BINDING_TABLE, queryTime);
@@ -3966,7 +3966,7 @@ void DeRestPluginPrivate::bindingToRuleTimerFired()
 
             for (const deCONZ::ZclCluster &cl : sd.outClusters())
             {
-                if (cl.id() == ILLUMINANCE_MEASUREMENT_CLUSTER_ID && checkMacVendor(node->address(), VENDOR_DDEL))
+                if (cl.id() == ILLUMINANCE_MEASUREMENT_CLUSTER_ID && existDevicesWithVendorCodeForMacPrefix(node->address(), VENDOR_DDEL))
                 {
                     continue; // ignore, binding only allowed for server cluster
                 }
@@ -4046,7 +4046,7 @@ void DeRestPluginPrivate::bindingToRuleTimerFired()
             continue;
         }
 
-        if (checkMacVendor(bnd.srcAddress, VENDOR_UBISYS))
+        if (existDevicesWithVendorCodeForMacPrefix(bnd.srcAddress, VENDOR_UBISYS))
         {
             processUbisysBinding(&*i, bnd);
             return;

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2093,11 +2093,11 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
                     {
                         if (hasServerOnOff)
                         {
-                            if (checkMacVendor(node->address(), VENDOR_JENNIC) &&
+                            if (checkMacAndVendor(node, VENDOR_JENNIC) &&
                                 // prevent false positives like Immax IM-Z3.0-DIM which has only two endpoints (0x01)
                                 // lumi.ctrl_neutral1 and lumi.ctrl_neutral2 have more 5 endpoints
                                 node->simpleDescriptors().size() > 5  &&
-                                node->nodeDescriptor().manufacturerCode() == VENDOR_JENNIC && i->endpoint() != 0x02 && i->endpoint() != 0x03)
+                                i->endpoint() != 0x02 && i->endpoint() != 0x03)
                             {
                                 // TODO better filter for lumi. devices (i->deviceId(), modelid?)
                                 // blacklist switch endpoints for lumi.ctrl_neutral1 and lumi.ctrl_neutral2
@@ -2244,7 +2244,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
         QString uid = generateUniqueId(lightNode.address().ext(), lightNode.haEndpoint().endpoint(), 0);
         lightNode.setUniqueId(uid);
 
-        if (checkMacVendor(node->address(), VENDOR_DDEL) && i->deviceId() != DEV_ID_CONFIGURATION_TOOL)
+        if (existDevicesWithVendorCodeForMacPrefix(node->address(), VENDOR_DDEL) && i->deviceId() != DEV_ID_CONFIGURATION_TOOL)
         {
             ResourceItem *item = lightNode.addItem(DataTypeUInt32, RConfigPowerup);
             DBG_Assert(item != 0);
@@ -2299,8 +2299,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
             lightNode.setNeedSaveDatabase(true);
         }
 
-        if (checkMacVendor(node->address(), VENDOR_OSRAM) &&
-            (node->nodeDescriptor().manufacturerCode() == VENDOR_OSRAM || node->nodeDescriptor().manufacturerCode() == VENDOR_OSRAM_STACK))
+        if (checkMacAndVendor(node, VENDOR_OSRAM) || checkMacAndVendor(node, VENDOR_OSRAM_STACK))
         {
             if (lightNode.manufacturer() != QLatin1String("OSRAM"))
             {
@@ -2309,7 +2308,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
             }
         }
 
-        if (checkMacVendor(node->address(), VENDOR_PHILIPS))
+        if (existDevicesWithVendorCodeForMacPrefix(node->address(), VENDOR_PHILIPS))
         {
             if (lightNode.manufacturer() != QLatin1String("Philips"))
             { // correct vendor name, was atmel, de sometimes
@@ -2339,7 +2338,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
         }
 
         //Add missing values for Profalux device
-        if (checkMacVendor(node->address(), VENDOR_PROFALUX))
+        if (existDevicesWithVendorCodeForMacPrefix(node->address(), VENDOR_PROFALUX))
         {
             //Shutter ?
             if (i->deviceId() == DEV_ID_ZLL_COLOR_LIGHT)
@@ -6887,12 +6886,12 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
             case VENDOR_CLUSTER_ID:
             {
                 // ubisys device management (UBISYS_DEVICE_SETUP_CLUSTER_ID)
-                if (event.endpoint() == 0xE8 && checkMacVendor(event.node()->address(), VENDOR_UBISYS))
+                if (event.endpoint() == 0xE8 && existDevicesWithVendorCodeForMacPrefix(event.node()->address(), VENDOR_UBISYS))
                 {
                     break;
                 }
                 // dresden elektronik spectral sensor
-                else if (i->modelId() == QLatin1String("de_spect") && checkMacVendor(event.node()->address(), VENDOR_DDEL))
+                else if (i->modelId() == QLatin1String("de_spect") && existDevicesWithVendorCodeForMacPrefix(event.node()->address(), VENDOR_DDEL))
                 {
                     break;
                 }
@@ -6914,7 +6913,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
             // filter endpoint
             if (event.endpoint() != i->fingerPrint().endpoint)
             {
-                if (checkMacVendor(event.node()->address(), VENDOR_JENNIC))
+                if (existDevicesWithVendorCodeForMacPrefix(event.node()->address(), VENDOR_JENNIC))
                 {
                     if (i->modelId().startsWith(QLatin1String("lumi.sensor_86sw")) ||
                         i->modelId().startsWith(QLatin1String("lumi.ctrl_neutral")) ||
@@ -8576,7 +8575,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                         }
                     }
                     else if (event.clusterId() == UBISYS_DEVICE_SETUP_CLUSTER_ID && event.endpoint() == 0xE8 &&
-                            checkMacVendor(event.node()->address(), VENDOR_UBISYS)) // ubisys device management
+                            existDevicesWithVendorCodeForMacPrefix(event.node()->address(), VENDOR_UBISYS)) // ubisys device management
                     {
 //                        bool updated = false;
                         for (;ia != enda; ++ia)
@@ -8794,7 +8793,7 @@ bool DeRestPluginPrivate::isDeviceSupported(const deCONZ::Node *node, const QStr
     while (s->modelId)
     {
         if ((!node->nodeDescriptor().isNull() && node->nodeDescriptor().manufacturerCode() == s->vendorId) ||
-            ((node->address().ext() & macPrefixMask) == s->mac) || checkMacVendor(node->address(), s->vendorId))
+            ((node->address().ext() & macPrefixMask) == s->mac) || existDevicesWithVendorCodeForMacPrefix(node->address(), s->vendorId))
         {
             if (modelId.startsWith(QLatin1String(s->modelId)))
             {
@@ -10895,7 +10894,7 @@ void DeRestPluginPrivate::handleXalClusterIndication(const deCONZ::ApsDataIndica
         return;
     }
 
-    if (!checkMacVendor(lightNode->address(), VENDOR_XAL))
+    if (!existDevicesWithVendorCodeForMacPrefix(lightNode->address(), VENDOR_XAL))
     {
         return;
     }
@@ -11076,14 +11075,14 @@ void DeRestPluginPrivate::handleZclAttributeReportIndication(const deCONZ::ApsDa
         checkReporting = true;
         sendZclDefaultResponse(ind, zclFrame, deCONZ::ZclSuccessStatus);
     }
-    else if (checkMacVendor(ind.srcAddress(), VENDOR_PHILIPS) ||
+    else if (existDevicesWithVendorCodeForMacPrefix(ind.srcAddress(), VENDOR_PHILIPS) ||
             macPrefix == tiMacPrefix ||
-            checkMacVendor(ind.srcAddress(), VENDOR_DDEL) ||
-            checkMacVendor(ind.srcAddress(), VENDOR_IKEA) ||
-            checkMacVendor(ind.srcAddress(), VENDOR_OSRAM_STACK) ||
-            checkMacVendor(ind.srcAddress(), VENDOR_JENNIC) ||
-            checkMacVendor(ind.srcAddress(), VENDOR_SI_LABS) ||
-            checkMacVendor(ind.srcAddress(), VENDOR_CENTRALITE))
+            existDevicesWithVendorCodeForMacPrefix(ind.srcAddress(), VENDOR_DDEL) ||
+            existDevicesWithVendorCodeForMacPrefix(ind.srcAddress(), VENDOR_IKEA) ||
+            existDevicesWithVendorCodeForMacPrefix(ind.srcAddress(), VENDOR_OSRAM_STACK) ||
+            existDevicesWithVendorCodeForMacPrefix(ind.srcAddress(), VENDOR_JENNIC) ||
+            existDevicesWithVendorCodeForMacPrefix(ind.srcAddress(), VENDOR_SI_LABS) ||
+            existDevicesWithVendorCodeForMacPrefix(ind.srcAddress(), VENDOR_CENTRALITE))
     {
         // these sensors tend to mac data poll after report
         checkReporting = true;
@@ -11122,7 +11121,7 @@ void DeRestPluginPrivate::handleZclAttributeReportIndication(const deCONZ::ApsDa
         }
     }
 
-    if (zclFrame.isProfileWideCommand() && checkMacVendor(ind.srcAddress().ext(), VENDOR_XIAOMI) && (ind.clusterId() == BASIC_CLUSTER_ID || ind.clusterId() == 0xfcc0))
+    if (zclFrame.isProfileWideCommand() && existDevicesWithVendorCodeForMacPrefix(ind.srcAddress().ext(), VENDOR_XIAOMI) && (ind.clusterId() == BASIC_CLUSTER_ID || ind.clusterId() == 0xfcc0))
     {
         handleZclAttributeReportIndicationXiaomiSpecial(ind, zclFrame);
     }
@@ -15642,21 +15641,20 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
 
             bool skip = false;
 
-            if (thermostatClusterEndpoint == 0) // e.g. Eurotronic SPZB0001 thermostat
+            if (thermostatClusterEndpoint > 0) // e.g. Eurotronic SPZB0001 thermostat
             {  }
             else if (iasZoneType > 0) // IAS motion and contact sensors
-            {  }
-            else if (node->nodeDescriptor().manufacturerCode() == VENDOR_IKEA)
-            {  }
-            else if (node->nodeDescriptor().manufacturerCode() == VENDOR_DANFOSS)
             {  }
             else if (modelId.startsWith(QLatin1String("lumi.")))
             {
                 skip = true; // Xiaomi Mija devices won't respond to ZCL read
+                DBG_Printf(DBG_INFO, "[4] Skipping additional attribute read - Model starts with 'lumi.'\n");
             }
-            else if (checkMacVendor(sc->address, VENDOR_JENNIC))
+            else if (checkMacAndVendor(node, VENDOR_JENNIC) ||
+                     checkMacAndVendor(node, VENDOR_ADUROLIGHT))
             {
                 skip = true; // e.g. Trust remote (ZYCT-202)
+                DBG_Printf(DBG_INFO, "[4] Skipping additional attribute read -  Assumed Trust remote (ZYCT-202)\n");
             }
 
             if (skip)
@@ -15664,22 +15662,32 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
                 // don't read these (Xiaomi, Trust, ...)
                 // response is empty or no response at all
             }
-            else if (manufacturer.isEmpty()) { attributes.push_back(0x0004); }// manufacturer
-            else if (modelId.isEmpty()) { attributes.push_back(0x0005); } // model id
+            else if (manufacturer.isEmpty())
+            {
+                DBG_Printf(DBG_INFO, "[4.1] Get manufacturer code\n");
+                attributes.push_back(0x0004); // manufacturer
+            }
+            else if (modelId.isEmpty())
+            { 
+                DBG_Printf(DBG_INFO, "[4.1] Get model ID\n");
+                attributes.push_back(0x0005); // model id
+            } 
             else if (swBuildId.isEmpty() && dateCode.isEmpty())
             {
                 if ((sc->address.ext() & macPrefixMask) == tiMacPrefix ||
-                    checkMacVendor(sc->address, VENDOR_UBISYS) ||
+                    existDevicesWithVendorCodeForMacPrefix(sc->address, VENDOR_UBISYS) ||
                     modelId == QLatin1String("Motion Sensor-A") || // OSRAM motion sensor
                     manufacturer.startsWith(QLatin1String("Climax")) ||
                     modelId.startsWith(QLatin1String("lumi")) ||
                     node->nodeDescriptor().manufacturerCode() == VENDOR_CENTRALITE ||
                     !swBuildIdAvailable)
                 {
+                    DBG_Printf(DBG_INFO, "[4.1] Get date code\n");
                     attributes.push_back(0x0006); // date code
                 }
                 else
                 {
+                    DBG_Printf(DBG_INFO, "[4.1] Get sw build id\n");
                     attributes.push_back(0x4000); // sw build id
                 }
             }
@@ -15705,7 +15713,7 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
                 for (quint16 attrId : attributes)
                 {
                     stream << attrId;
-                    DBG_Printf(DBG_INFO, "[4] get basic cluster attr 0x%04X for 0x%016llx\n", attrId, sc->address.ext());
+                    DBG_Printf(DBG_INFO, "[4.2] get basic cluster attr 0x%04X for 0x%016llx\n", attrId, sc->address.ext());
                 }
 
                 { // ZCL frame

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -15650,7 +15650,8 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
             {
                 skip = true; // Xiaomi Mija devices won't respond to ZCL read
             }
-            else if (node->nodeDescriptor().manufacturerCode() == VENDOR_JENNIC)
+            else if (node->nodeDescriptor().manufacturerCode() == VENDOR_JENNIC &&
+                checkMacVendor(sc->address, VENDOR_JENNIC))
             {
                 skip = true; // e.g. Trust remote (ZYCT-202)
             }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -15646,12 +15646,15 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
             {  }
             else if (iasZoneType > 0) // IAS motion and contact sensors
             {  }
+            else if (node->nodeDescriptor().manufacturerCode() == VENDOR_IKEA)
+            {  }
+            else if (node->nodeDescriptor().manufacturerCode() == VENDOR_DANFOSS)
+            {  }
             else if (modelId.startsWith(QLatin1String("lumi.")))
             {
                 skip = true; // Xiaomi Mija devices won't respond to ZCL read
             }
-            else if (node->nodeDescriptor().manufacturerCode() == VENDOR_JENNIC &&
-                checkMacVendor(sc->address, VENDOR_JENNIC))
+            else if (checkMacVendor(sc->address, VENDOR_JENNIC))
             {
                 skip = true; // e.g. Trust remote (ZYCT-202)
             }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -15650,7 +15650,7 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
             {
                 skip = true; // Xiaomi Mija devices won't respond to ZCL read
             }
-            else if (checkMacVendor(sc->address, VENDOR_JENNIC))
+            else if (node->nodeDescriptor().manufacturerCode() == VENDOR_JENNIC)
             {
                 skip = true; // e.g. Trust remote (ZYCT-202)
             }

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -277,75 +277,76 @@
 
 // manufacturer codes
 // https://github.com/wireshark/wireshark/blob/master/epan/dissectors/packet-zbee.h
-#define VENDOR_NONE         0x0000
-#define VENDOR_EMBER        0x1002
-#define VENDOR_PHILIPS      0x100B // Also used by iCasa routers
-#define VENDOR_VISONIC      0x1011
-#define VENDOR_ATMEL        0x1014
-#define VENDOR_DEVELCO      0x1015
-#define VENDOR_MAXSTREAM    0x101E // Used by Digi
-#define VENDOR_VANTAGE      0x1021
-#define VENDOR_LEGRAND      0x1021 // wrong name?
-#define VENDOR_LGE          0x102E
-#define VENDOR_JENNIC       0x1037 // Used by Xiaomi, Trust, Eurotronic
-#define VENDOR_ALERTME      0x1039
-#define VENDOR_CLS          0x104E
-#define VENDOR_CENTRALITE   0x104E // wrong name?
-#define VENDOR_SI_LABS      0x1049
-#define VENDOR_4_NOKS       0x1071
-#define VENDOR_BITRON       0x1071 // branded
-#define VENDOR_COMPUTIME    0x1078
-#define VENDOR_AXIS         0x1262 // Axis
-#define VENDOR_MMB          0x109a
-#define VENDOR_NETVOX       0x109F
-#define VENDOR_NYCE         0x10B9
-#define VENDOR_UNIVERSAL2   0x10EF
-#define VENDOR_UBISYS       0x10F2
-#define VENDOR_DANALOCK     0x115C
-#define VENDOR_SCHLAGE      0x1236 // Used by Schlage Locks
-#define VENDOR_BEGA         0x1105
-#define VENDOR_PHYSICAL     0x110A // Used by SmartThings
-#define VENDOR_OSRAM        0x110C
-#define VENDOR_PROFALUX     0x1110
-#define VENDOR_EMBERTEC     0x1112
-#define VENDOR_JASCO        0x1124 // Used by GE
-#define VENDOR_BUSCH_JAEGER 0x112E
-#define VENDOR_SERCOMM      0x1131
-#define VENDOR_BOSCH        0x1133
-#define VENDOR_DDEL         0x1135
-#define VENDOR_WAXMAN       0x113B
-#define VENDOR_LUTRON       0x1144
-#define VENDOR_ZEN          0x1158
-#define VENDOR_KEEN_HOME    0x115B
-#define VENDOR_XIAOMI       0x115F
-#define VENDOR_SENGLED_OPTOELEC 0x1160
-#define VENDOR_INNR         0x1166
-#define VENDOR_LDS          0x1168 // Used by Samsung SmartPlug 2019
-#define VENDOR_PLUGWISE_BV  0x1172
-#define VENDOR_INSTA        0x117A
-#define VENDOR_IKEA         0x117C
-#define VENDOR_3A_SMART_HOME  0x117E
-#define VENDOR_STELPRO      0x1185
-#define VENDOR_LEDVANCE     0x1189
-#define VENDOR_SINOPE       0x119C
-#define VENDOR_JIUZHOU      0x119D
-#define VENDOR_PAULMANN     0x119D // branded
-#define VENDOR_HEIMAN       0x120B
-#define VENDOR_MUELLER      0x121B // Used by Mueller Licht
-#define VENDOR_AURORA       0x121C // Used by Aurora Aone
-#define VENDOR_SUNRICHER    0x1224 // white label used by iCasa, Illuminize, Namron ...
-#define VENDOR_XAL          0x122A
-#define VENDOR_THIRD_REALITY 0x1233
-#define VENDOR_DSR          0x1234
-#define VENDOR_HANGZHOU_IMAGIC 0x123B
-#define VENDOR_SAMJIN       0x1241
-#define VENDOR_DANFOSS      0x1246
-#define VENDOR_NIKO_NV      0x125F
-#define VENDOR_KONKE        0x1268
-#define VENDOR_SHYUGJ_TECHNOLOGY 0x126A
-#define VENDOR_OSRAM_STACK  0xBBAA
-#define VENDOR_C2DF         0xC2DF
-#define VENDOR_PHILIO       0xFFA0
+#define VENDOR_NONE                 0x0000
+#define VENDOR_EMBER                0x1002
+#define VENDOR_PHILIPS              0x100B // Also used by iCasa routers
+#define VENDOR_VISONIC              0x1011
+#define VENDOR_ATMEL                0x1014
+#define VENDOR_DEVELCO              0x1015
+#define VENDOR_MAXSTREAM            0x101E // Used by Digi
+#define VENDOR_VANTAGE              0x1021
+#define VENDOR_LEGRAND              0x1021 // wrong name?
+#define VENDOR_LGE                  0x102E
+#define VENDOR_JENNIC               0x1037 // Used by Xiaomi, Trust, Eurotronic
+#define VENDOR_ALERTME              0x1039
+#define VENDOR_CLS                  0x104E
+#define VENDOR_CENTRALITE           0x104E // wrong name?
+#define VENDOR_SI_LABS              0x1049
+#define VENDOR_4_NOKS               0x1071
+#define VENDOR_BITRON               0x1071 // branded
+#define VENDOR_COMPUTIME            0x1078
+#define VENDOR_AXIS                 0x1262 // Axis
+#define VENDOR_MMB                  0x109a
+#define VENDOR_NETVOX               0x109F
+#define VENDOR_NYCE                 0x10B9
+#define VENDOR_UNIVERSAL2           0x10EF
+#define VENDOR_UBISYS               0x10F2
+#define VENDOR_DANALOCK             0x115C
+#define VENDOR_SCHLAGE              0x1236 // Used by Schlage Locks
+#define VENDOR_BEGA                 0x1105
+#define VENDOR_PHYSICAL             0x110A // Used by SmartThings
+#define VENDOR_OSRAM                0x110C
+#define VENDOR_PROFALUX             0x1110
+#define VENDOR_EMBERTEC             0x1112
+#define VENDOR_JASCO                0x1124 // Used by GE
+#define VENDOR_BUSCH_JAEGER         0x112E
+#define VENDOR_SERCOMM              0x1131
+#define VENDOR_BOSCH                0x1133
+#define VENDOR_DDEL                 0x1135
+#define VENDOR_WAXMAN               0x113B
+#define VENDOR_LUTRON               0x1144
+#define VENDOR_ZEN                  0x1158
+#define VENDOR_KEEN_HOME            0x115B
+#define VENDOR_XIAOMI               0x115F
+#define VENDOR_SENGLED_OPTOELEC     0x1160
+#define VENDOR_INNR                 0x1166
+#define VENDOR_LDS                  0x1168 // Used by Samsung SmartPlug 2019
+#define VENDOR_PLUGWISE_BV          0x1172
+#define VENDOR_INSTA                0x117A
+#define VENDOR_IKEA                 0x117C
+#define VENDOR_3A_SMART_HOME        0x117E
+#define VENDOR_STELPRO              0x1185
+#define VENDOR_LEDVANCE             0x1189
+#define VENDOR_SINOPE               0x119C
+#define VENDOR_JIUZHOU              0x119D
+#define VENDOR_PAULMANN             0x119D // branded
+#define VENDOR_HEIMAN               0x120B
+#define VENDOR_MUELLER              0x121B // Used by Mueller Licht
+#define VENDOR_AURORA               0x121C // Used by Aurora Aone
+#define VENDOR_SUNRICHER            0x1224 // white label used by iCasa, Illuminize, Namron ...
+#define VENDOR_XAL                  0x122A
+#define VENDOR_THIRD_REALITY        0x1233
+#define VENDOR_DSR                  0x1234
+#define VENDOR_HANGZHOU_IMAGIC      0x123B
+#define VENDOR_SAMJIN               0x1241
+#define VENDOR_DANFOSS              0x1246
+#define VENDOR_NIKO_NV              0x125F
+#define VENDOR_KONKE                0x1268
+#define VENDOR_SHYUGJ_TECHNOLOGY    0x126A
+#define VENDOR_OSRAM_STACK          0xBBAA
+#define VENDOR_C2DF                 0xC2DF
+#define VENDOR_PHILIO               0xFFA0
+#define VENDOR_ADUROLIGHT           0x122D
 
 #define ANNOUNCE_INTERVAL 45 // minutes default announce interval
 
@@ -474,7 +475,7 @@ extern const quint64 schlageMacPrefix;
 
 extern const QDateTime epoch;
 
-inline bool checkMacVendor(quint64 addr, quint16 vendor)
+inline bool existDevicesWithVendorCodeForMacPrefix(quint64 addr, quint16 vendor)
 {
     const quint64 prefix = addr & macPrefixMask;
     switch (vendor) {
@@ -535,8 +536,7 @@ inline bool checkMacVendor(quint64 addr, quint16 vendor)
         case VENDOR_INSTA:
             return prefix == instaMacPrefix;
         case VENDOR_JENNIC:
-            return prefix == jennicMacPrefix ||
-                   prefix == silabs2MacPrefix;
+            return prefix == jennicMacPrefix;
         case VENDOR_KEEN_HOME:
             return prefix == keenhomeMacPrefix;
         case VENDOR_LGE:
@@ -597,15 +597,22 @@ inline bool checkMacVendor(quint64 addr, quint16 vendor)
             return prefix == zenMacPrefix;
         case VENDOR_SCHLAGE:
             return prefix == schlageMacPrefix;
+        case VENDOR_ADUROLIGHT:
+	        return prefix == jennicMacPrefix;
         default:
             return false;
     }
 }
 
-inline bool checkMacVendor(const deCONZ::Address &addr, quint16 vendor)
+inline bool existDevicesWithVendorCodeForMacPrefix(const deCONZ::Address &addr, quint16 vendor)
 {
-    return checkMacVendor(addr.ext(), vendor);
+    return existDevicesWithVendorCodeForMacPrefix(addr.ext(), vendor);
 }
+
+inline bool checkMacAndVendor(const deCONZ::Node *node, quint16 vendor)
+{
+    return node->nodeDescriptor().manufacturerCode() == vendor && existDevicesWithVendorCodeForMacPrefix(node->address(), vendor);
+};
 
 // HTTP status codes
 extern const char *HttpStatusOk;

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -612,7 +612,7 @@ inline bool existDevicesWithVendorCodeForMacPrefix(const deCONZ::Address &addr, 
 inline bool checkMacAndVendor(const deCONZ::Node *node, quint16 vendor)
 {
     return node->nodeDescriptor().manufacturerCode() == vendor && existDevicesWithVendorCodeForMacPrefix(node->address(), vendor);
-};
+}
 
 // HTTP status codes
 extern const char *HttpStatusOk;

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -2930,7 +2930,7 @@ void DeRestPluginPrivate::checkSensorStateTimerFired()
  */
 void DeRestPluginPrivate::checkInstaModelId(Sensor *sensor)
 {
-    if (sensor && checkMacVendor(sensor->address(), VENDOR_INSTA))
+    if (sensor && existDevicesWithVendorCodeForMacPrefix(sensor->address(), VENDOR_INSTA))
     {
         if (!sensor->modelId().endsWith(QLatin1String("_1")))
         {   // extract model identifier from mac address 6th byte
@@ -2986,24 +2986,24 @@ void DeRestPluginPrivate::handleIndicationSearchSensors(const deCONZ::ApsDataInd
         // filter supported devices
 
         // Busch-Jaeger
-        if (checkMacVendor(ext, VENDOR_BUSCH_JAEGER))
+        if (existDevicesWithVendorCodeForMacPrefix(ext, VENDOR_BUSCH_JAEGER))
         {
         }
-        else if (checkMacVendor(ext, VENDOR_UBISYS))
+        else if (existDevicesWithVendorCodeForMacPrefix(ext, VENDOR_UBISYS))
         {
         }
-        else if (checkMacVendor(ext, VENDOR_BOSCH))
+        else if (existDevicesWithVendorCodeForMacPrefix(ext, VENDOR_BOSCH))
         { // macCapabilities == 0
         }
-        else if (checkMacVendor(ext, VENDOR_DEVELCO))
+        else if (existDevicesWithVendorCodeForMacPrefix(ext, VENDOR_DEVELCO))
         { // macCapabilities == 0
         }
         else if (macCapabilities & deCONZ::MacDeviceIsFFD)
         {
-            if (checkMacVendor(ext, VENDOR_LDS))
+            if (existDevicesWithVendorCodeForMacPrefix(ext, VENDOR_LDS))
             { //  Fix to allow Samsung SmartThings plug sensors to be created (7A-PL-Z-J3, modelId ZB-ONOFFPlug-D0005)
             }
-            else if (checkMacVendor(ext, VENDOR_JASCO))
+            else if (existDevicesWithVendorCodeForMacPrefix(ext, VENDOR_JASCO))
             { //  Fix to support GE mains powered switches
             }
             else
@@ -3261,7 +3261,7 @@ void DeRestPluginPrivate::handleIndicationSearchSensors(const deCONZ::ApsDataInd
     }
 
     // check for dresden elektronik devices
-    if (checkMacVendor(sc->address, VENDOR_DDEL))
+    if (existDevicesWithVendorCodeForMacPrefix(sc->address, VENDOR_DDEL))
     {
         if (sc->macCapabilities & deCONZ::MacDeviceIsFFD) // end-devices only
             return;
@@ -3561,7 +3561,7 @@ void DeRestPluginPrivate::handleIndicationSearchSensors(const deCONZ::ApsDataInd
             }
         }
     }
-    else if (checkMacVendor(sc->address, VENDOR_IKEA))
+    else if (existDevicesWithVendorCodeForMacPrefix(sc->address, VENDOR_IKEA))
     {
         if (sc->macCapabilities & deCONZ::MacDeviceIsFFD) // end-devices only
             return;


### PR DESCRIPTION
```checkMacVendor(sc->address, VENDOR_X)``` is not exclusive, and while it evaluates as true for VENDOR_X, it might evaluate as true for VENDOR_Y as well.

This creates a problem in ```void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *event)``` when deciding whether to skip getting additional attributes (such as modelId and manufacturer).

Since getting additional attributes is skipped, adding a node fails later on, and it is not exposed to the API. Note that this only happens when adding a new node, but not if a node is already paired.

I suspect this might also be relevant for issue #3482 and maybe other issues related to pairing new devices.

Finally, I'm not sure whether ```checkMacVendor``` in general is expected to evaluate as true for multiple vendors for the same mac address. If it is not, then there are probably other bugs in the source code due to this.