### PR TITLE
Resource and ResourceItem ctor and assignment improvements

### DIFF
--- a/resource.h
+++ b/resource.h
@@ -233,12 +233,16 @@ public:
     qint64 validMax;
 };
 
+extern const ResourceItemDescriptor rInvalidItemDescriptor;
+
 class ResourceItem
 {
 public:
     ResourceItem(const ResourceItem &other);
+    ResourceItem(ResourceItem &&other);
     ResourceItem(const ResourceItemDescriptor &rid);
     ResourceItem &operator=(const ResourceItem &other);
+    ResourceItem &operator=(ResourceItem &&other);
     ~ResourceItem();
     const QString &toString() const;
     qint64 toNumber() const;
@@ -264,7 +268,7 @@ private:
     qint64 m_num = 0;
     qint64 m_numPrev = 0;
     QString *m_str = nullptr;
-    ResourceItemDescriptor m_rid;
+    const ResourceItemDescriptor *m_rid = &rInvalidItemDescriptor;
     QDateTime m_lastSet;
     QDateTime m_lastChanged;
     std::vector<int> m_rulesInvolved; // the rules a resource item is trigger
@@ -274,9 +278,11 @@ class Resource
 {
 public:
     Resource(const char *prefix);
-    ~Resource();
+    ~Resource() = default;
     Resource(const Resource &other);
+    Resource(Resource &&other);
     Resource &operator=(const Resource &other);
+    Resource &operator=(Resource &&other);
     const char *prefix() const;
     ResourceItem *addItem(ApiDataType type, const char *suffix);
     void removeItem(const char *suffix);
@@ -294,7 +300,7 @@ public:
 
 private:
     Resource() = delete;
-    const char *m_prefix;
+    const char *m_prefix = nullptr;
     std::vector<ResourceItem> m_rItems;
 };
 


### PR DESCRIPTION
* Fix memory leak in ResourceItem copy assignment, previous string wasn't deleted;
* Add move constructor and move assignment operators for performance;
* Replace ResourceItemDescriptor for each item by const pointer to original;
* Add asserts to enforce valid state;
* Move invalid string out of string vector, since only one item was used anyway.