### PR TITLE
 Legrand Bticino Living Light L4027C

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2379,6 +2379,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         //Legrand
         sensor->modelId() == QLatin1String("Connected outlet") || //Legrand Plug
         sensor->modelId() == QLatin1String("Shutter switch with neutral") || //Legrand shutter switch
+        sensor->modelId() == QLatin1String("Shutter SW with level control") || //Bticino shutter small size
         sensor->modelId() == QLatin1String("Dimmer switch w/o neutral") || //Legrand dimmer wired
         sensor->modelId() == QLatin1String("Cable outlet") || //Legrand Cable outlet
         sensor->modelId() == QLatin1String("Remote switch") || //Legrand wireless switch

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1699,7 +1699,7 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
         {
             // Legrand invert bri and don't support other value than 0
             bool bStatus = false;
-            uint nHex = taskRef.lightNode->swVersion().toUInt(&bStatus,16);
+            uint nHex = taskRef.lightNode->swBuildId().toUInt(&bStatus,16);
             if (bStatus && (nHex < 26))
             {
                 targetLiftZigBee = targetLift == 0 ? 100 : 0;

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1700,7 +1700,7 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
             // Legrand invert bri and don't support other value than 0
             bool bStatus = false;
             uint nHex = taskRef.lightNode->swBuildId().toUInt(&bStatus,16);
-            if (bStatus && (nHex < 26))
+            if (bStatus && (nHex < 33))
             {
                 targetLiftZigBee = targetLift == 0 ? 100 : 0;
             }

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1836,11 +1836,19 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
             rsp.list.append(rspItem);
             
             
+            // I m using this code only for Legrand ATM but can be used for other device.
+            // Because the attribute reporting take realy long time to be done, can be 2 minutes
+            // Or it can be changed only after this time, so using an read attribute don't give usable value
+            // And can cause issue on some third app
             if ((taskRef.lightNode->modelId() == QLatin1String("Shutter switch with neutral")) ||
                  (taskRef.lightNode->modelId() == QLatin1String("Shutter SW with level control")) )
             {
-                    taskRef.lightNode->setValue(RStateBri, targetLift);
-                    taskRef.lightNode->setValue(RStateLift, targetLift);
+                taskRef.lightNode->setValue(RStateLift, targetLift);
+                taskRef.lightNode->setValue(RStateBri, targetLift * 254 / 100);
+                bool on2 = targetLift > 0;
+                bool open2 = targetLift < 100;
+                taskRef.lightNode->setValue(RStateOpen, open2);
+                taskRef.lightNode->setValue(RStateOn, on2);
             }
 
             // Rely on attribute reporting to update the light state.
@@ -1880,6 +1888,19 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
             rspItemState[QString("/lights/%1/state/open").arg(id)] = targetOpen;
             rspItem["success"] = rspItemState;
             rsp.list.append(rspItem);
+            
+            // I m using this code only for Legrand ATM but can be used for other device.
+            // Because the attribute reporting take realy long time to be done, can be 2 minutes
+            // Or it can be changed only after this time, so using an read attribute don't give usable value
+            // And can cause issue on some third app
+            if ((taskRef.lightNode->modelId() == QLatin1String("Shutter switch with neutral")) ||
+                 (taskRef.lightNode->modelId() == QLatin1String("Shutter SW with level control")) )
+            {
+                    taskRef.lightNode->setValue(RStateOpen, targetOpen);
+                    taskRef.lightNode->setValue(RStateOn, !targetOpen);
+                    taskRef.lightNode->setValue(RStateBri, targetOpen ? 0 : 255);
+                    taskRef.lightNode->setValue(RStateLift, targetOpen ? 0 : 100);
+            }
 
             // Rely on attribute reporting to update the light state.
         }

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1834,6 +1834,14 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
             rspItemState[QString("/lights/%1/state/lift").arg(id)] = targetLift;
             rspItem["success"] = rspItemState;
             rsp.list.append(rspItem);
+            
+            
+            if ((taskRef.lightNode->modelId() == QLatin1String("Shutter switch with neutral")) ||
+                 (taskRef.lightNode->modelId() == QLatin1String("Shutter SW with level control")) )
+            {
+                    taskRef.lightNode->setValue(RStateBri, targetLift);
+                    taskRef.lightNode->setValue(RStateLift, targetLift);
+            }
 
             // Rely on attribute reporting to update the light state.
         }

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1845,12 +1845,6 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
             {
                 taskRef.lightNode->setValue(RStateLift, 50);
                 taskRef.lightNode->setValue(RStateBri, 127);
-                //taskRef.lightNode->setValue(RStateLift, targetLift);
-                //taskRef.lightNode->setValue(RStateBri, targetLift * 254 / 100);
-                //bool on2 = targetLift > 0;
-                //bool open2 = targetLift < 100;
-                //taskRef.lightNode->setValue(RStateOpen, open2);
-                //taskRef.lightNode->setValue(RStateOn, on2);
             }
 
             // Rely on attribute reporting to update the light state.
@@ -1898,10 +1892,6 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
             if ((taskRef.lightNode->modelId() == QLatin1String("Shutter switch with neutral")) ||
                  (taskRef.lightNode->modelId() == QLatin1String("Shutter SW with level control")) )
             {
-                //taskRef.lightNode->setValue(RStateOpen, targetOpen);
-                //taskRef.lightNode->setValue(RStateOn, !targetOpen);
-                //taskRef.lightNode->setValue(RStateBri, targetOpen ? 0 : 255);
-                //taskRef.lightNode->setValue(RStateLift, targetOpen ? 0 : 100);
                 taskRef.lightNode->setValue(RStateLift, 50);
                 taskRef.lightNode->setValue(RStateBri, 127);
             }

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1843,12 +1843,14 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
             if ((taskRef.lightNode->modelId() == QLatin1String("Shutter switch with neutral")) ||
                  (taskRef.lightNode->modelId() == QLatin1String("Shutter SW with level control")) )
             {
-                taskRef.lightNode->setValue(RStateLift, targetLift);
-                taskRef.lightNode->setValue(RStateBri, targetLift * 254 / 100);
-                bool on2 = targetLift > 0;
-                bool open2 = targetLift < 100;
-                taskRef.lightNode->setValue(RStateOpen, open2);
-                taskRef.lightNode->setValue(RStateOn, on2);
+                taskRef.lightNode->setValue(RStateLift, 50);
+                taskRef.lightNode->setValue(RStateBri, 127);
+                //taskRef.lightNode->setValue(RStateLift, targetLift);
+                //taskRef.lightNode->setValue(RStateBri, targetLift * 254 / 100);
+                //bool on2 = targetLift > 0;
+                //bool open2 = targetLift < 100;
+                //taskRef.lightNode->setValue(RStateOpen, open2);
+                //taskRef.lightNode->setValue(RStateOn, on2);
             }
 
             // Rely on attribute reporting to update the light state.
@@ -1896,10 +1898,12 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
             if ((taskRef.lightNode->modelId() == QLatin1String("Shutter switch with neutral")) ||
                  (taskRef.lightNode->modelId() == QLatin1String("Shutter SW with level control")) )
             {
-                    taskRef.lightNode->setValue(RStateOpen, targetOpen);
-                    taskRef.lightNode->setValue(RStateOn, !targetOpen);
-                    taskRef.lightNode->setValue(RStateBri, targetOpen ? 0 : 255);
-                    taskRef.lightNode->setValue(RStateLift, targetOpen ? 0 : 100);
+                //taskRef.lightNode->setValue(RStateOpen, targetOpen);
+                //taskRef.lightNode->setValue(RStateOn, !targetOpen);
+                //taskRef.lightNode->setValue(RStateBri, targetOpen ? 0 : 255);
+                //taskRef.lightNode->setValue(RStateLift, targetOpen ? 0 : 100);
+                taskRef.lightNode->setValue(RStateLift, 50);
+                taskRef.lightNode->setValue(RStateBri, 127);
             }
 
             // Rely on attribute reporting to update the light state.

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1694,7 +1694,8 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
         {
             targetLiftZigBee = 100 - targetLift;
         }
-        else if (taskRef.lightNode->modelId() == QLatin1String("Shutter switch with neutral"))
+        else if ((taskRef.lightNode->modelId() == QLatin1String("Shutter switch with neutral")) ||
+                 (taskRef.lightNode->modelId() == QLatin1String("Shutter SW with level control")) )
         {
             // Legrand invert bri and don't support other value than 0
             targetLiftZigBee = targetLift == 0 ? 100 : 0;

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1706,7 +1706,7 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
             }
             else
             {
-                targetLiftZigBee = targetLift == 0 ? 0 : 100;
+                targetLiftZigBee = targetLift == 100 ? 100 : 0;
             }
         }
         else

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1698,7 +1698,16 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
                  (taskRef.lightNode->modelId() == QLatin1String("Shutter SW with level control")) )
         {
             // Legrand invert bri and don't support other value than 0
-            targetLiftZigBee = targetLift == 0 ? 100 : 0;
+            bool bStatus = false;
+            uint nHex = taskRef.lightNode->swVersion().toUInt(&bStatus,16);
+            if (bStatus && (nHex < 26))
+            {
+                targetLiftZigBee = targetLift == 0 ? 100 : 0;
+            }
+            else
+            {
+                targetLiftZigBee = targetLift == 0 ? 0 : 100;
+            }
         }
         else
         {

--- a/window_covering.cpp
+++ b/window_covering.cpp
@@ -163,13 +163,22 @@ void DeRestPluginPrivate::handleWindowCoveringClusterIndication(const deCONZ::Ap
                 lightNode->setZclValue(updateType, ind.srcEndpoint(), WINDOW_COVERING_CLUSTER_ID, attrid, numericValue);
 
                 quint8 lift = attrValue;
-                // Reverse value for Xiaomi curtain and Legrand switch
+                // Reverse value for Xiaomi curtain 
                 if (lightNode->modelId().startsWith(QLatin1String("lumi.curtain")) || 
-                    (lightNode->modelId() == QLatin1String("Motor Controller")) ||
-                    (lightNode->modelId() == QLatin1String("Shutter SW with level control")) ||
-                    (lightNode->modelId() == QLatin1String("Shutter switch with neutral")))
+                   (lightNode->modelId() == QLatin1String("Motor Controller")) )
                 {
                     lift = 100 - lift;
+                }
+                // Reverse value for Legrand but only for old value
+                if ((lightNode->modelId() == QLatin1String("Shutter SW with level control")) ||
+                    (lightNode->modelId() == QLatin1String("Shutter switch with neutral")) )
+                {
+                    bool bStatus = false;
+                    uint nHex = lightNode->swVersion().toUInt(&bStatus,16);
+                    if (bStatus && (nHex < 26))
+                    {
+                        lift = 100 - lift;
+                    }
                 }
                 bool open = lift < 100;
 

--- a/window_covering.cpp
+++ b/window_covering.cpp
@@ -174,7 +174,7 @@ void DeRestPluginPrivate::handleWindowCoveringClusterIndication(const deCONZ::Ap
                     (lightNode->modelId() == QLatin1String("Shutter switch with neutral")) )
                 {
                     bool bStatus = false;
-                    uint nHex = lightNode->swVersion().toUInt(&bStatus,16);
+                    uint nHex = lightNode->swBuildId().toUInt(&bStatus,16);
                     if (bStatus && (nHex < 26))
                     {
                         lift = 100 - lift;

--- a/window_covering.cpp
+++ b/window_covering.cpp
@@ -166,6 +166,7 @@ void DeRestPluginPrivate::handleWindowCoveringClusterIndication(const deCONZ::Ap
                 // Reverse value for Xiaomi curtain and Legrand switch
                 if (lightNode->modelId().startsWith(QLatin1String("lumi.curtain")) || 
                     (lightNode->modelId() == QLatin1String("Motor Controller")) ||
+                    (lightNode->modelId() == QLatin1String("Shutter SW with level control")) ||
                     (lightNode->modelId() == QLatin1String("Shutter switch with neutral")))
                 {
                     lift = 100 - lift;

--- a/window_covering.cpp
+++ b/window_covering.cpp
@@ -175,7 +175,7 @@ void DeRestPluginPrivate::handleWindowCoveringClusterIndication(const deCONZ::Ap
                 {
                     bool bStatus = false;
                     uint nHex = lightNode->swBuildId().toUInt(&bStatus,16);
-                    if (bStatus && (nHex < 26))
+                    if (bStatus && (nHex < 33))
                     {
                         lift = 100 - lift;
                     }


### PR DESCRIPTION
- Improve support of Legrand Bticino Living Light L4027C (Shutter SW with level control)
  Handle inverted lift values.

- Improve Legrand covering support  https://github.com/dresden-elektronik/deconz-rest-plugin/issues/2812
Some device have different firmware support.