### PR TITLE
Add "mode" command to bitron thermostat

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1247,8 +1247,15 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq2.minInterval = 1;
             rq2.maxInterval = 600;
             rq2.reportableChange8bit = 1;
+            
+            ConfigureReportingRequest rq3;
+            rq3.dataType = deCONZ::Zcl8BitEnum;
+            rq3.attributeId = 0x001C;        // Thermostat mode
+            rq3.minInterval = 1;
+            rq3.maxInterval = 600;
+            rq3.reportableChange8bit = 0xff;
 
-            return sendConfigureReportingRequest(bt, {rq, rq2});
+            return sendConfigureReportingRequest(bt, {rq, rq2, rq3});
         }
         else if (sensor && sensor->modelId().startsWith(QLatin1String("TH112"))) // Sinope Thermostat TH1123ZB & TH1124ZB
         {

--- a/database.cpp
+++ b/database.cpp
@@ -3506,7 +3506,8 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     sensor.modelId() == QLatin1String("GbxAXL2") ||         // Tuya
                     sensor.modelId() == QLatin1String("kud7u2l") ||         // Tuya
                     sensor.modelId() == QLatin1String("TS0601") ||          // Tuya
-                    sensor.modelId() == QLatin1String("eaxp72v") ||          // Tuya
+                    sensor.modelId() == QLatin1String("eaxp72v") ||         // Tuya
+                    sensor.modelId() == QLatin1String("902010/32") ||       // Bitron
                     sensor.modelId() == QLatin1String("Zen-01") )           // Zen
                 {
                     sensor.addItem(DataTypeString, RConfigMode);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -306,6 +306,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_KONKE, "3AFE28010402000D", ikea2MacPrefix }, // Konke Kit Pro-BS Motion Sensor ver.2
     { VENDOR_EMBER, "3AFE140103020000", konkeMacPrefix }, // Konke Kit Pro-FT Temp Humidity Sensor
     { VENDOR_KONKE, "3AFE220103020000", ikea2MacPrefix }, // Konke Kit Pro-BS Temp Humidity Sensor ver.2
+    { VENDOR_KONKE, "3AFE220103020000", konkeMacPrefix }, // Konke Kit Pro-BS Temp Humidity Sensor ver ???
     { VENDOR_EMBER, "3AFE130104020015", konkeMacPrefix }, // Konke Kit Pro-Door Entry Sensor
     { VENDOR_NONE, "RICI01", tiMacPrefix}, // LifeControl smart plug
     { VENDOR_JENNIC, "VOC_Sensor", jennicMacPrefix}, // LifeControl Enviroment sensor

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4497,7 +4497,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
     QList<deCONZ::SimpleDescriptor>::const_iterator end = node->simpleDescriptors().constEnd();
 
     // Trust and iHorn specific
-    if (node->nodeDescriptor().manufacturerCode() == VENDOR_JENNIC && modelId.isEmpty())
+    if (node->nodeDescriptor().manufacturerCode() == VENDOR_JENNIC && modelId.isEmpty() && i != end)
     {
         int inClusterCount = i->inClusters().size();
         int outClusterCount = i->outClusters().size();

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6028,7 +6028,8 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                 sensorNode.modelId() == QLatin1String("kud7u2l") ||         // Tuya
                 sensorNode.modelId() == QLatin1String("GbxAXL2") ||         // Tuya
                 sensorNode.modelId() == QLatin1String("TS0601") ||          // Tuya
-                sensorNode.modelId() == QLatin1String("eaxp72v") ||          // Tuya
+                sensorNode.modelId() == QLatin1String("eaxp72v") ||         // Tuya
+                sensorNode.modelId() == QLatin1String("902010/32") ||       // Bitron
                 sensorNode.modelId() == QLatin1String("Zen-01") )           // Zen
             {
                 sensorNode.addItem(DataTypeString, RConfigMode);

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1226,6 +1226,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                     else if (sensor->modelId().startsWith(QLatin1String("SLR2")) ||   // Hive
                              sensor->modelId() == QLatin1String("SLR1b") ||           // Hive
                              sensor->modelId().startsWith(QLatin1String("TH112")) ||  // Sinope
+                             sensor->modelId().startsWith(QLatin1String("902010/32")) ||  // Bitron
                              sensor->modelId().startsWith(QLatin1String("Zen-01")))   // Zen
                     {
 
@@ -1248,6 +1249,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                         if (mode < 10)
                         {
                             attributeList.insert(0x001C, (quint32)mode);
+
                             //Idk for other device
                             if ( (sensor->modelId().startsWith(QLatin1String("SLR2"))) ||
                                  (sensor->modelId() == QLatin1String("SLR1b")))


### PR DESCRIPTION
- Add "mode" command to bitron thermostat.
- Corrective for a konke temperature sensor.
- Guard against empty simple descriptors.

Nothing special