### PR TITLE
Set ConfigPending flag for Heiman Watersensor

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6047,6 +6047,12 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
              node->nodeDescriptor().manufacturerCode() == VENDOR_HEIMAN)
     {
         sensorNode.setManufacturer("Heiman");
+
+        if (fingerPrint.hasInCluster(IAS_ZONE_CLUSTER_ID)) // POLL_CONTROL_CLUSTER_ID
+        {
+            item = sensorNode.addItem(DataTypeUInt8, RConfigPending);
+            item->setValue(item->toNumber() | R_PENDING_WRITE_POLL_CHECKIN_INTERVAL | R_PENDING_SET_LONG_POLL_INTERVAL);
+        }
     }
     else if (modelId.startsWith(QLatin1String("45127")))
     {


### PR DESCRIPTION
This fix the problem that Heiman water sensor could not be paired.
It will still join as "unreachable" until it is activated once.
TODO: remove the unreachable state after pairing