### PR TITLE
Fix updating heatpoint for newer Eurotronic Spirit Zigbee thermostats

### DIFF
--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1083,7 +1083,15 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                         hostFlags &= ~0x04; // clear `boost` flag
                         hostFlags |=  0x10; // set `disable off` flag
 
-                        if (addTaskThermostatReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, VENDOR_JENNIC, 0x4003, deCONZ::Zcl16BitInt, heatsetpoint))
+                        // Older models of the Eurotroninc Spirit updated the heat set point via the manufacturer custom attribute 0x4003. 
+                        // For newer models it is not possible to write to this attribute.
+                        // Newer models must use the standard Occupied Heating Setpoint value (0x0012) using a default (or none) manufacturer.
+                        // See GitHub issue #1098
+                        bool success = sensor->swVersion().toInt() < 22190930 ? 
+                            addTaskThermostatReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, VENDOR_JENNIC, 0x4003, deCONZ::Zcl16BitInt, heatsetpoint) :
+                            addTaskThermostatReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, VENDOR_NONE, 0x0012, deCONZ::Zcl16BitInt, heatsetpoint);
+                
+                        if (success)
                         {
                             updated = true;
                         }


### PR DESCRIPTION
This pull request fixes issue # 1098. 
In short: some newer versions of the Eurotronic Spirit Zigbee thermostats do not accept updating the manufacturer specific attribute 0x4003 when changing the current heating setpoint. These models only accept the standard 0x0012 attribute, Occupied Heating Setpoint. 
For backward compatibility sake a check is added to compare the current software version. If this is lesser than 22190903 the old attribute (0x4003) is written to, otherwise the value is written to 0x0012 (without a specific vendor code).