### PR TITLE
Improve support for Centralite pearl thermostat (3157100)

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1216,6 +1216,44 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
 
             return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4});
         }
+        else if (sensor && sensor->modelId().startsWith(QLatin1String("3157100"))) // Centralite Pearl
+        {
+            rq.dataType = deCONZ::Zcl16BitInt;
+            rq.attributeId = 0x0000;        // Local Temperature
+            rq.minInterval = 1;
+            rq.maxInterval = 600;
+            rq.reportableChange16bit = 20;
+
+            ConfigureReportingRequest rq2;
+            rq2.dataType = deCONZ::Zcl16BitInt;
+            rq2.attributeId = 0x0011;        // Occupied cooling setpoint
+            rq2.minInterval = 1;
+            rq2.maxInterval = 600;
+            rq2.reportableChange16bit = 50;
+
+            ConfigureReportingRequest rq3;
+            rq3.dataType = deCONZ::Zcl16BitInt;
+            rq3.attributeId = 0x0012;        // Occupied heating setpoint
+            rq3.minInterval = 1;
+            rq3.maxInterval = 600;
+            rq3.reportableChange16bit = 50;
+
+            ConfigureReportingRequest rq4;
+            rq4.dataType = deCONZ::Zcl16BitBitMap;
+            rq4.attributeId = 0x0029;        // Thermostat running state
+            rq4.minInterval = 1;
+            rq4.maxInterval = 600;
+            rq4.reportableChange16bit = 0xffff;
+
+            ConfigureReportingRequest rq5;
+            rq5.dataType = deCONZ::Zcl8BitEnum;
+            rq5.attributeId = 0x001C;        // Thermostat mode
+            rq5.minInterval = 1;
+            rq5.maxInterval = 600;
+            rq5.reportableChange8bit = 0xff;
+
+            return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4, rq5});
+        }
         else if (sensor && sensor->modelId() == QLatin1String("AC201")) // OWON AC201 Thermostat
         {
             rq.dataType = deCONZ::Zcl16BitInt;
@@ -1386,7 +1424,8 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             return sendConfigureReportingRequest(bt, {rq}) || // Use OR because of manuf. specific attributes
                    sendConfigureReportingRequest(bt, {rq2});
         }
-        else if (sensor && sensor->modelId() == QLatin1String("SORB"))    // Stelpro Orleans Fan
+        else if (sensor && (sensor->modelId() == QLatin1String("SORB") ||               // Stelpro Orleans Fan
+                            sensor->modelId().startsWith(QLatin1String("3157100"))))    // Centralite pearl
         {
             rq.dataType = deCONZ::Zcl8BitEnum;
             rq.attributeId = 0x0001;       // Keypad Lockout
@@ -1417,7 +1456,8 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
     {
         Sensor *sensor = dynamic_cast<Sensor *>(bt.restNode);
 
-        if (sensor && sensor->modelId() == QLatin1String("AC201"))    // OWON AC201 Thermostat
+        if (sensor && (sensor->modelId() == QLatin1String("AC201") ||               // OWON AC201 Thermostat
+                       sensor->modelId().startsWith(QLatin1String("3157100"))))     // Centralite pearl
         {
             rq.dataType = deCONZ::Zcl8BitEnum;
             rq.attributeId = 0x0000;        // Fan mode
@@ -1529,6 +1569,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
                             sensor->modelId() == QLatin1String("3AFE28010402000D") || // Konke presence sensor
                             sensor->modelId().startsWith(QLatin1String("3300")) ||          // Centralite contatc sensor
                             sensor->modelId().startsWith(QLatin1String("3315")) ||
+                            sensor->modelId().startsWith(QLatin1String("3157100")) ||
                             sensor->modelId().startsWith(QLatin1String("4655BC0"))))
         {
             rq.attributeId = 0x0020;   // battery voltage
@@ -2392,6 +2433,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId().startsWith(QLatin1String("3320-L")) ||
         sensor->modelId().startsWith(QLatin1String("3323")) ||
         sensor->modelId().startsWith(QLatin1String("3326-L")) ||
+        sensor->modelId().startsWith(QLatin1String("3157100")) ||
         // dresden elektronik
         (sensor->manufacturer() == QLatin1String("dresden elektronik") && sensor->modelId() == QLatin1String("de_spect")) ||
         // GE
@@ -2763,6 +2805,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
                      sensor->modelId().startsWith(QLatin1String("3323")) ||
                      sensor->modelId().startsWith(QLatin1String("3326-L")) ||
                      sensor->modelId().startsWith(QLatin1String("3305-S")) ||
+                     sensor->modelId().startsWith(QLatin1String("3157100")) ||
                      sensor->modelId().startsWith(QLatin1String("4655BC0")) ||
                      sensor->modelId() == QLatin1String("113D"))
             {

--- a/database.cpp
+++ b/database.cpp
@@ -3567,6 +3567,13 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 else if (sensor.modelId() == QLatin1String("Zen-01"))
                 {
                 }
+                else if (sensor.modelId() == QLatin1String("3157100"))
+                {
+                    sensor.addItem(DataTypeInt16, RConfigCoolSetpoint);
+                    sensor.addItem(DataTypeBool, RConfigLocked);
+                    sensor.addItem(DataTypeString, RConfigMode);
+                    sensor.addItem(DataTypeString, RConfigFanMode);
+                }
                 else if ((sensor.modelId() == QLatin1String("eTRV0100")) || // Danfoss Ally
                          (sensor.modelId() == QLatin1String("TRV001")) )    // Hive TRV
                 {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6112,6 +6112,13 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             else if (modelId == QLatin1String("Zen-01"))
             {
             }
+            else if (modelId == QLatin1String("3157100"))
+            {
+                sensorNode.addItem(DataTypeInt16, RConfigCoolSetpoint);
+                sensorNode.addItem(DataTypeBool, RConfigLocked);
+                sensorNode.addItem(DataTypeString, RConfigMode);
+                sensorNode.addItem(DataTypeString, RConfigFanMode);
+            }
             else if ((modelId == QLatin1String("eTRV0100")) || // Danfoss Ally
                      (modelId == QLatin1String("TRV001")) )    // Hive TRV
             {
@@ -7152,6 +7159,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     i->modelId().startsWith(QLatin1String("3320-L")) ||    // Centralite contact sensor
                                     i->modelId().startsWith(QLatin1String("3323")) ||      // Centralite contact sensor
                                     i->modelId().startsWith(QLatin1String("3315")) ||      // Centralite water sensor
+                                    i->modelId().startsWith(QLatin1String("3157100")) ||      // Centralite pearl thermostat
                                     i->modelId().startsWith(QLatin1String("4655BC0")) ||      // Ecolink contact sensor
                                     i->modelId().startsWith(QLatin1String("lumi.sen_ill")) || // Xiaomi ZB3.0 light sensor
                                     i->modelId().startsWith(QLatin1String("SZ-DWS04"))   || // Sercomm open/close sensor

--- a/fan_control.cpp
+++ b/fan_control.cpp
@@ -73,7 +73,8 @@ void DeRestPluginPrivate::handleFanControlClusterIndication(const deCONZ::ApsDat
             {
             case 0x0000: // Fan mode
             {
-                if (sensor->modelId() == QLatin1String("AC201"))    // Owon
+                if (sensor->modelId() == QLatin1String("AC201") ||     // Owon
+                    sensor->modelId() == QLatin1String("3157100"))     // Centralite pearl
                 {
                     qint8 mode = attr.numericValue().u8;
                     QString modeSet;

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1262,6 +1262,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                              sensor->modelId().startsWith(QLatin1String("TH112")) ||  // Sinope
                              sensor->modelId().startsWith(QLatin1String("902010/32")) ||  // Bitron
                              sensor->modelId().startsWith(QLatin1String("Zen-01")) || // Zen
+                             sensor->modelId().startsWith(QLatin1String("3157100")) ||// Centralite Pearl
                              sensor->modelId().startsWith(QLatin1String("SORB")) ||   // Stelpro Orleans Fan
                              sensor->modelId().startsWith(QLatin1String("AC201")) ||  // OWON
                              sensor->modelId().startsWith(QLatin1String("Super TR"))) // ELKO
@@ -1434,7 +1435,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                             }
                         }
                         else if (sensor->modelId() == QLatin1String("eTRV0100") || sensor->modelId() == QLatin1String("TRV001") ||
-                                 sensor->modelId() == QLatin1String("SORB"))
+                                 sensor->modelId() == QLatin1String("SORB") || sensor->modelId() == QLatin1String("3157100"))
                         {
                             quint32 data = map[pi.key()].toUInt(&ok);
 
@@ -1622,7 +1623,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                 {
                     if (map[pi.key()].type() == QVariant::String && map[pi.key()].toString().size() <= 6)
                     {
-                        if (sensor->modelId() == QLatin1String("AC201"))
+                        if (sensor->modelId() == QLatin1String("AC201") || sensor->modelId() == QLatin1String("3157100"))
                         {
                             QString modeSet = map[pi.key()].toString();
                             quint8 mode = 0;


### PR DESCRIPTION
Improve support for Centralite pearl thermostat (3157100) (#3240)

- Enable and add attribute reporting
- Expose `RConfigCoolSetpoint`, `RConfigLocked`, `RConfigMode` and `RConfigFanMode`