### PR TITLE
Swap button maps for Sunricher switches ZGRC-KEY-007 and ZGRC-KEY-009

### DIFF
--- a/button_maps.json
+++ b/button_maps.json
@@ -816,8 +816,8 @@
                 [1, "0x01", "ONOFF", "TOGGLE", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "short"]
             ]
         },
-        "ZGRC-KEY-007": {
-            "modelids": ["ZGRC-KEY-007"],
+        "ZGRC-KEY-009": {
+            "modelids": ["ZGRC-KEY-009"],
             "map": [
                 [1, "0x01", "ONOFF", "ON", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],
                 [1, "0x01", "ONOFF", "OFF", "0", "S_BUTTON_2", "S_BUTTON_ACTION_SHORT_RELEASED", "Off"],
@@ -837,8 +837,8 @@
                 [1, "0x01", "SCENES", "RECALL_SCENE", "0", "S_BUTTON_8", "S_BUTTON_ACTION_SHORT_RELEASED", "Recall scene 2"]
             ]
         },
-        "ZGRC-KEY-009": {
-            "modelids": ["ZGRC-KEY-009"],
+        "ZGRC-KEY-007": {
+            "modelids": ["ZGRC-KEY-007"],
             "map": [
                 [1, "0x01", "ONOFF", "ON", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],
                 [1, "0x01", "ONOFF", "OFF", "0", "S_BUTTON_2", "S_BUTTON_ACTION_SHORT_RELEASED", "Off"],


### PR DESCRIPTION
- Swap button maps for Sunricher switches ZGRC-KEY-007 and ZGRC-KEY-009 (#3397)