### PR TITLE
Improve Zen thermostat support to enable cooling control

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -3587,6 +3587,9 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 }
                 else if (sensor.modelId() == QLatin1String("Zen-01"))
                 {
+                    sensor.addItem(DataTypeInt16, RConfigCoolSetpoint);
+                    sensor.addItem(DataTypeString, RConfigMode);
+                    sensor.addItem(DataTypeString, RConfigFanMode);
                 }
                 else if (sensor.modelId() == QLatin1String("3157100"))
                 {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6174,8 +6174,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                 sensorNode.modelId() == QLatin1String("GbxAXL2") ||         // Tuya
                 sensorNode.modelId() == QLatin1String("902010/32") ||       // Bitron
                (sensorNode.manufacturer() == QLatin1String("_TZE200_ckud7u2l")) ||          // Tuya
-               (sensorNode.manufacturer() == QLatin1String("_TZE200_aoclfnxz")) ||          // Tuya
-                sensorNode.modelId() == QLatin1String("Zen-01") )           // Zen
+               (sensorNode.manufacturer() == QLatin1String("_TZE200_aoclfnxz")))            // Tuya
             {
                 sensorNode.addItem(DataTypeString, RConfigMode);
             }
@@ -6254,6 +6253,9 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             }
             else if (modelId == QLatin1String("Zen-01"))
             {
+                sensorNode.addItem(DataTypeInt16, RConfigCoolSetpoint);
+                sensorNode.addItem(DataTypeString, RConfigMode);
+                sensorNode.addItem(DataTypeString, RConfigFanMode);
             }
             else if (modelId == QLatin1String("3157100"))
             {
@@ -16998,6 +17000,7 @@ void DeRestPlugin::idleTimerFired()
                                 sensorNode->modelId().startsWith(QLatin1String("TRV001")) ||    // Hive TRV
                                 sensorNode->modelId().startsWith(QLatin1String("TH112")) ||     // Sinope devices
                                 sensorNode->modelId().startsWith(QLatin1String("eTRV0100")) ||  // Danfoss Ally
+                                sensorNode->modelId().startsWith(QLatin1String("Zen-01")) ||    // Zen
                                 sensorNode->modelId().startsWith(QLatin1String("Super TR")) ||  // Elko
                                 sensorNode->modelId().startsWith(QLatin1String("AC201")) ||     // Owon
                                 sensorNode->modelId().startsWith(QLatin1String("SORB")) ||      // Stelpro Orleans

--- a/fan_control.cpp
+++ b/fan_control.cpp
@@ -74,7 +74,8 @@ void DeRestPluginPrivate::handleFanControlClusterIndication(const deCONZ::ApsDat
             case 0x0000: // Fan mode
             {
                 if (sensor->modelId() == QLatin1String("AC201") ||     // Owon
-                    sensor->modelId() == QLatin1String("3157100"))     // Centralite pearl
+                    sensor->modelId() == QLatin1String("3157100") ||   // Centralite pearl
+                    sensor->modelId() == QLatin1String("Zen-01"))      // Zen
                 {
                     qint8 mode = attr.numericValue().u8;
                     QString modeSet;

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1715,7 +1715,8 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                 {
                     if (map[pi.key()].type() == QVariant::String && map[pi.key()].toString().size() <= 6)
                     {
-                        if (sensor->modelId() == QLatin1String("AC201") || sensor->modelId() == QLatin1String("3157100"))
+                        if (sensor->modelId() == QLatin1String("AC201") || sensor->modelId() == QLatin1String("3157100") ||
+                            sensor->modelId() == QLatin1String("Zen-01"))
                         {
                             QString modeSet = map[pi.key()].toString();
                             quint8 mode = 0;


### PR DESCRIPTION
Improve Zen thermostat support to enable cooling control (#3382)

- Rely on attribute reporting
- Expose `RConfigCoolSetpoint`, `RConfigMode` and `RConfigFanMode` via API