### PR TITLE
Initial support BOSCH Air quality sensor

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -3195,6 +3195,19 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             item = sensor.addItem(DataTypeInt16, RConfigOffset);
             item->setValue(0);
         }
+        else if (sensor.type().endsWith(QLatin1String("AirQuality")))
+        {
+            if (sensor.fingerPrint().hasInCluster(BOSCH_AIR_QUALITY_CLUSTER_ID))
+            {
+                clusterId = clusterId ? clusterId : BOSCH_AIR_QUALITY_CLUSTER_ID;
+            }
+            else if (sensor.fingerPrint().hasInCluster(0xFC03))  // Develco air quality sensor
+            {
+                clusterId = clusterId ? clusterId : 0xFC03;
+            }
+            item = sensor.addItem(DataTypeString, RStateAirQuality);
+            item = sensor.addItem(DataTypeUInt16, RStateAirQualityPpb);
+        }
         else if (sensor.type().endsWith(QLatin1String("Spectral")))
         {
             if (sensor.fingerPrint().hasInCluster(VENDOR_CLUSTER_ID))

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -211,6 +211,7 @@
 #define SAMJIN_CLUSTER_ID                     0xFC02
 #define LEGRAND_CONTROL_CLUSTER_ID            0xFC40
 #define XAL_CLUSTER_ID                        0xFCCE
+#define BOSCH_AIR_QUALITY_CLUSTER_ID          quint16(0xFDEF)
 
 #define IAS_ZONE_CLUSTER_ATTR_ZONE_STATUS_ID  0x0002
 
@@ -317,6 +318,7 @@
 #define VENDOR_WAXMAN               0x113B
 #define VENDOR_OWON                 0x113C
 #define VENDOR_LUTRON               0x1144
+#define VENDOR_BOSCH2               0x1155
 #define VENDOR_ZEN                  0x1158
 #define VENDOR_KEEN_HOME            0x115B
 #define VENDOR_XIAOMI               0x115F

--- a/general.xml
+++ b/general.xml
@@ -3701,6 +3701,71 @@ Contactor > On/off=0003 - HP/HC=0004</description>
 			</client>
 		</cluster>
 
+		<cluster id="0xfdee" name="AIR Measurement Config" mfcode="0x1155">
+			<description>BOSCH Thermotechnik indoor air quality configuration</description>
+			<server>
+			<attribute id="0x4001" name="Unknown" type="enum8" required="m" access="r" default="0">
+				<description></description>
+			</attribute>
+			<attribute id="0x4002" name="Unknown" type="lcstring" access="r" required="m">
+				<description></description>
+			</attribute>
+			<attribute id="0x4003" name="Unkown" type="ostring" required="m" access="r">
+				<description></description>
+			</attribute>
+			<attribute id="0x4004" name="Unknown" type="u8" required="m" access="r" default="0">
+				<description></description>
+			</attribute>
+			<attribute id="0x4005" name="Unknown" type="u8" required="m" access="r" default="0">
+				<description></description>
+			</attribute>
+			<attribute id="0x4006" name="Unknown" type="u32" required="m" access="r" default="0">
+				<description></description>
+			</attribute>
+		  </server>
+		  <client>
+		  </client>
+		</cluster>
+
+		<cluster id="0xfdef" name="AIR Measurement" mfcode="0x1155">
+			<description>BOSCH Thermotechnik indoor air quality</description>
+			<server>
+			<attribute id="0x4001" name="Air pressure" type="u16" required="m" access="r" default="0">
+				<description>Air pressure (mBar)</description>
+			</attribute>
+			<attribute id="0x4002" name="Temperature" type="s16" access="r" required="m">
+				<description>Temperature (°C)</description>
+			</attribute>
+			<attribute id="0x4003" name="Humidity" type="u8" required="m" access="r" default="0">
+				<description>Relative humidity (%)</description>
+			</attribute>
+			<attribute id="0x4004" name="Air quality" type="u16" required="m" access="r" default="0">
+				<description>Air quality VOC (ppm) </description>
+			</attribute>
+			<attribute id="0x4005" name="Brightness" type="u16" required="m" access="r" default="0">
+				<description>Ambient light brightness (lux)</description>
+			</attribute>
+			<attribute id="0x4006" name="Loudness" type="u8" required="m" access="r" default="0">
+				<description>Noise level (dB)</description>
+			</attribute>
+			<attribute id="0x4008" name="timestamp" type="u32" required="m" access="r" default="0">
+				<description>Relative timestamp since start(seconds)</description>
+			</attribute>
+			<attribute id="0x4009" name="Trigger" type="enum8" required="m" access="r" default="0">
+				<value name="by timer" value="0x00"></value>
+				<value name="by double tap" value="0x01"></value>
+				<description>Trigger of this measurement</description>
+			</attribute>
+			<attribute id="0x400B" name="ModeOfOperation" type="enum8" required="m" access="r" default="0">
+				<value name="normal, day mode" value="0x00"></value>
+				<value name="night, up side down" value="0x01"></value>
+				<description>Device orientation</description>
+			</attribute>
+		  </server>
+		  <client>
+		  </client>
+		</cluster>
+
 		<!-- DEVELCO -->
 		<cluster id="0xfc03" name="VOC Measurement" mfcode="0x1015">
 			<description>Develco specific attributes.</description>

--- a/resource.cpp
+++ b/resource.cpp
@@ -39,6 +39,7 @@ const char *RAttrLastSeen = "attr/lastseen";
 const char *RActionScene = "action/scene";
 
 const char *RStateAirQuality = "state/airquality";
+const char *RStateAirQualityPpb = "state/airqualityppb";
 const char *RStateAlarm = "state/alarm";
 const char *RStateAlert = "state/alert";
 const char *RStateAllOn = "state/all_on";
@@ -204,6 +205,7 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeTime, RAttrLastSeen));
 
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RStateAirQuality));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RStateAirQualityPpb));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, RStateAlarm));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RStateAlert));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, RStateAllOn));

--- a/resource.h
+++ b/resource.h
@@ -54,6 +54,7 @@ extern const char *RAttrLastSeen;
 extern const char *RActionScene;
 
 extern const char *RStateAirQuality;
+extern const char *RStateAirQualityPpb;
 extern const char *RStateAlarm;
 extern const char *RStateAlert;
 extern const char *RStateAllOn;


### PR DESCRIPTION
Issue: https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3538

This also adds the numeric air quality value in (ppb) to Develco air quality sensor.

Loudness sensor not yet included, will be added later.
The battery state doesn't seem to carry a valid value not does the cluster support reporting.

```
{
        "config": {
            "on": true,
            "reachable": true
        },
        "ep": 2,
        "etag": "2e340ae4cd2a88ef53c1cb38cc9f224f",
        "lastseen": "2020-11-15T19:23Z",
        "manufacturername": "BOSCH",
        "modelid": "AIR",
        "name": "Air quality sensor",
        "state": {
            "airquality": "moderate",
            "airqualityppb": 484,
            "lastupdated": "2020-11-15T19:23:03.296"
        },
        "swversion": "20200402",
        "type": "ZHAAirQuality",
        "uniqueid": "00:12:4b:00:14:4d:eb:87-02-fdef"
}
```

Other standard sensor resources which are exposed are: ZHATemperature, ZHALightLevel, ZHAHumidity and ZHAPressure.
