### PR TITLE
No updates if current version is newer than announced version.

### DIFF
--- a/discovery.cpp
+++ b/discovery.cpp
@@ -361,9 +361,10 @@ void DeRestPluginPrivate::internetDiscoveryExtractVersionInfo(QNetworkReply *rep
             {
                 QStringList gwUpdateVersionList = gwUpdateVersion.split('.');
                 QStringList versionList = version.split('.');
-                if (((gwUpdateVersionList[0].toInt() <  versionList[0].toInt())) ||
-                    ((gwUpdateVersionList[0].toInt() == versionList[0].toInt()) && (gwUpdateVersionList[1].toInt() <  versionList[1].toInt())) ||
-                    ((gwUpdateVersionList[0].toInt() == versionList[0].toInt()) && (gwUpdateVersionList[1].toInt() == versionList[1].toInt()) && (gwUpdateVersionList[2].toInt() < versionList[2].toInt())))
+                if (gwUpdateVersionList.size() >= 3 && versionList.size() >= 3 &&
+                    (((gwUpdateVersionList[0].toInt() <  versionList[0].toInt())) ||
+                     ((gwUpdateVersionList[0].toInt() == versionList[0].toInt()) && (gwUpdateVersionList[1].toInt() <  versionList[1].toInt())) ||
+                     ((gwUpdateVersionList[0].toInt() == versionList[0].toInt()) && (gwUpdateVersionList[1].toInt() == versionList[1].toInt()) && (gwUpdateVersionList[2].toInt() < versionList[2].toInt()))))
                 {
                     DBG_Printf(DBG_INFO, "discovery found version %s for update channel %s\n", qPrintable(version), qPrintable(gwUpdateChannel));
                     gwUpdateVersion = version;

--- a/discovery.cpp
+++ b/discovery.cpp
@@ -359,13 +359,21 @@ void DeRestPluginPrivate::internetDiscoveryExtractVersionInfo(QNetworkReply *rep
 
             if (!version.isEmpty())
             {
-                if (gwUpdateVersion != version)
+                QStringList gwUpdateVersionList = gwUpdateVersion.split('.');
+                QStringList versionList = version.split('.');
+                if (((gwUpdateVersionList[0].toInt() <  versionList[0].toInt())) ||
+                    ((gwUpdateVersionList[0].toInt() == versionList[0].toInt()) && (gwUpdateVersionList[1].toInt() <  versionList[1].toInt())) ||
+                    ((gwUpdateVersionList[0].toInt() == versionList[0].toInt()) && (gwUpdateVersionList[1].toInt() == versionList[1].toInt()) && (gwUpdateVersionList[2].toInt() < versionList[2].toInt())))
                 {
                     DBG_Printf(DBG_INFO, "discovery found version %s for update channel %s\n", qPrintable(version), qPrintable(gwUpdateChannel));
                     gwUpdateVersion = version;
                     gwSwUpdateState = swUpdateState.readyToInstall;
-                    updateEtag(gwConfigEtag);
                 }
+                else
+                {
+                    gwSwUpdateState = swUpdateState.noUpdate;
+                }
+                updateEtag(gwConfigEtag);
             }
             else
             {


### PR DESCRIPTION
Current versions of deCONZ are much newer than the announced version and since it was a simple compare not equal it always showed an update was available.
Changed it so only if a newer version is announced an update is shown.