### PR TITLE
Add option to enable hue-mode as a deCONZ argument

### DIFF
--- a/authorisation.cpp
+++ b/authorisation.cpp
@@ -194,8 +194,13 @@ void DeRestPluginPrivate::authorise(ApiRequest &req, ApiResponse &rsp)
             {
                 // supports deCONZ specifics
             }
+            // else if (!(i->useragent.isEmpty()) && i->useragent.startsWith(QLatin1String("Mozilla"))) // Phoscon
+            // {
+            //     req.mode = ApiModeNormal;
+            // }
             else if (i->devicetype.startsWith(QLatin1String("hue_")) ||
-                     i->devicetype.startsWith(QLatin1String("Hue ")))
+                     i->devicetype.startsWith(QLatin1String("Hue ")) ||
+                     gwHueMode)
             {
                 req.mode = ApiModeHue;
             }

--- a/authorisation.cpp
+++ b/authorisation.cpp
@@ -194,10 +194,6 @@ void DeRestPluginPrivate::authorise(ApiRequest &req, ApiResponse &rsp)
             {
                 // supports deCONZ specifics
             }
-            // else if (!(i->useragent.isEmpty()) && i->useragent.startsWith(QLatin1String("Mozilla"))) // Phoscon
-            // {
-            //     req.mode = ApiModeNormal;
-            // }
             else if (i->devicetype.startsWith(QLatin1String("hue_")) ||
                      i->devicetype.startsWith(QLatin1String("Hue ")) ||
                      gwHueMode)

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -17197,8 +17197,9 @@ int DeRestPlugin::handleHttpRequest(const QHttpRequestHeader &hdr, QTcpSocket *s
 
     QStringList path = hdrmod.path().split(QLatin1String("/"), QString::SkipEmptyParts);
     ApiRequest req(hdrmod, path, sock, content);
-    ApiResponse rsp;
+    req.mode = d->gwHueMode ? ApiModeHue : ApiModeNormal;
 
+    ApiResponse rsp;
     rsp.httpStatus = HttpStatusNotFound;
     rsp.contentType = HttpContentHtml;
 

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1000,7 +1000,7 @@ public:
     int putHomebridgeUpdated(const ApiRequest &req, ApiResponse &rsp);
 
     void configToMap(const ApiRequest &req, QVariantMap &map);
-    void basicConfigToMap(QVariantMap &map);
+    void basicConfigToMap(const ApiRequest &req, QVariantMap &map);
 
     // REST API userparameter
     int handleUserparameterApi(const ApiRequest &req, ApiResponse &rsp);
@@ -1638,6 +1638,7 @@ public:
     QString gwHomebridgeUpdateVersion;
     bool gwHomebridgeUpdate;
     QString gwName;
+    bool gwHueMode;
     bool gwLANBridgeId;
     QString gwBridgeId;
     QString gwUuid;

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -1085,14 +1085,12 @@ void DeRestPluginPrivate::basicConfigToMap(const ApiRequest &req, QVariantMap &m
         const QString swversion = QString("%1.%2.%3").arg(versions[0].toInt()).arg(versions[1].toInt()).arg(versions[2].toInt());
         map["swversion"] = swversion;
         map["apiversion"] = QString(GW_API_VERSION);
-        // map["modelid"] = QLatin1String("deCONZ");
         map["datastoreversion"] = QLatin1String("93");
     } 
     else
     {
         map["swversion"] = QLatin1String("1941132070");
         map["apiversion"] = QLatin1String("1.41.0");
-        // map["modelid"] = QLatin1String("BSB002");
         map["datastoreversion"] = QLatin1String("98");
     }
     map["mac"] = gwMAC;

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -1078,9 +1078,9 @@ void DeRestPluginPrivate::configToMap(const ApiRequest &req, QVariantMap &map)
 void DeRestPluginPrivate::basicConfigToMap(const ApiRequest &req, QVariantMap &map)
 {
     map["name"] = gwName;
-    map["modelid"] = QLatin1String("deCONZ");
     if (req.mode == ApiModeNormal)
     {
+        map["modelid"] = QLatin1String("deCONZ");
         const QStringList versions = QString(GW_SW_VERSION).split('.');
         const QString swversion = QString("%1.%2.%3").arg(versions[0].toInt()).arg(versions[1].toInt()).arg(versions[2].toInt());
         map["swversion"] = swversion;
@@ -1089,6 +1089,7 @@ void DeRestPluginPrivate::basicConfigToMap(const ApiRequest &req, QVariantMap &m
     } 
     else
     {
+        map["modelid"] = QLatin1String("BSB002");
         map["swversion"] = QLatin1String("1941132070");
         map["apiversion"] = QLatin1String("1.41.0");
         map["datastoreversion"] = QLatin1String("98");

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -381,7 +381,7 @@ void DeRestPluginPrivate::initNetworkInfo()
                 QString mac = i->hardwareAddress().toLower();
                 gwMAC = mac;
                 if (gwLANBridgeId) {
-                    gwBridgeId = mac.mid(0,2) + mac.mid(3,2) + mac.mid(6,2) + "fffe" + mac.mid(9,2) + mac.mid(12,2) + mac.mid(15,2);
+                    gwBridgeId = (mac.mid(0,2) + mac.mid(3,2) + mac.mid(6,2) + "fffe" + mac.mid(9,2) + mac.mid(12,2) + mac.mid(15,2)).toUpper();
                     if (!gwConfig.contains("bridgeid") || gwConfig["bridgeid"] != gwBridgeId)
                     {
                         DBG_Printf(DBG_INFO, "Set bridgeid to %s\n", qPrintable(gwBridgeId));
@@ -1090,8 +1090,8 @@ void DeRestPluginPrivate::basicConfigToMap(const ApiRequest &req, QVariantMap &m
     else
     {
         map["modelid"] = QLatin1String("BSB002");
-        map["swversion"] = QLatin1String("1941132070");
-        map["apiversion"] = QLatin1String("1.41.0");
+        map["swversion"] = QLatin1String("1942135050");
+        map["apiversion"] = QLatin1String("1.42.0");
         map["datastoreversion"] = QLatin1String("98");
     }
     map["mac"] = gwMAC;


### PR DESCRIPTION
Without this command-line deconz argument option the basic config (without a user/api-key) isn't hue-compatible as the mode is normally based on the api-key. That seems to hinder initial hue-app pairing sometimes.