### PR TITLE
Support checking for software updates.

### DIFF
--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1641,6 +1641,7 @@ public:
     bool gwLANBridgeId;
     QString gwBridgeId;
     QString gwUuid;
+    bool gwUpdateCheck;
     QString gwUpdateVersion;
     QString gwUpdateDate;
     QString gwSwUpdateState;

--- a/discovery.cpp
+++ b/discovery.cpp
@@ -182,6 +182,7 @@ void DeRestPluginPrivate::internetDiscoveryTimerFired()
     {
         return;
     }
+    gwUpdateCheck = true;
 
     int i = 0;
     const deCONZ::Node *node;
@@ -266,6 +267,7 @@ void DeRestPluginPrivate::internetDiscoveryFinishedRequest(QNetworkReply *reply)
     }
 
     reply->deleteLater();
+    gwUpdateCheck = false;
 }
 
 /*! Extracts the update channels version info about the deCONZ/WebApp.

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -78,6 +78,7 @@ void DeRestPluginPrivate::initConfig()
     gwZigbeeChannel = 0;
     gwGroup0 = 0;
     gwName = GW_DEFAULT_NAME;
+    gwUpdateCheck = false;
     gwUpdateVersion = GW_SW_VERSION; // will be replaced by discovery handler
     {
         const QDateTime d = QDateTime::fromMSecsSinceEpoch(GW_SW_DATE * 1000LLU);
@@ -999,12 +1000,12 @@ void DeRestPluginPrivate::configToMap(const ApiRequest &req, QVariantMap &map)
         devicetypes["sensors"] = QVariantList();
         swupdate["devicetypes"] = devicetypes;
         swupdate["updatestate"] = static_cast<double>(0);
-        swupdate["checkforupdate"] = false;
+        swupdate["checkforupdate"] = gwUpdateCheck;
         swupdate["url"] = "";
         swupdate["text"] = "";
         swupdate["notify"] = false;
-        map["portalconnection"] = QLatin1String("disconnected");
-        portalstate["signedon"] = false;
+        map["portalconnection"] = QLatin1String("connected");
+        portalstate["signedon"] = true;
         portalstate["incoming"] = false;
         portalstate["outgoing"] = false;
         portalstate["communication"] = QLatin1String("disconnected");
@@ -1020,10 +1021,10 @@ void DeRestPluginPrivate::configToMap(const ApiRequest &req, QVariantMap &map)
     bridge["state"] = gwSwUpdateState;
     bridge["lastinstall"] = gwUpdateDate;
     swupdate2["bridge"] = bridge;
-    swupdate2["checkforupdate"] = false;
+    swupdate2["checkforupdate"] = gwUpdateCheck;
     swupdate2["state"] = gwSwUpdateState;
     swupdate2["install"] = false;
-    autoinstall["updatetime"] = "";
+    autoinstall["updatetime"] = "T14:00:00";
     autoinstall["on"] = false;
     swupdate2["autoinstall"] = autoinstall;
     swupdate2["lastchange"] = "";
@@ -2172,6 +2173,21 @@ int DeRestPluginPrivate::modifyConfig(const ApiRequest &req, ApiResponse &rsp)
         rspItemState["/config/disablePermitJoinAutoOff"] = v;
         rspItem["success"] = rspItemState;
         rsp.list.append(rspItem);
+    }
+
+    if (map.contains("swupdate2")) // optional
+    {
+        QVariantMap swupdate2 = map["swupdate2"].toMap();
+        if (swupdate2.contains("checkforupdate") && swupdate2["checkforupdate"].toBool())
+        {
+            internetDiscoveryTimerFired();
+
+            QVariantMap rspItem;
+            QVariantMap rspItemState;
+            rspItemState["/config/swupdate2/checkforupdate"] = swupdate2["checkforupdate"];
+            rspItem["success"] = rspItemState;
+            rsp.list.append(rspItem);
+        }
     }
 
     if (changed)


### PR DESCRIPTION
When update state indicates 'noupdates', this allows checking for updates by a PUT of 'checkforupdate: true' to swupdate2 (as the hue app does).