### PR TITLE
Improve HTTP accept header parsing of API versions; Reintroduce colorcapabilities in API version v1.1

### DIFF
--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -876,8 +876,10 @@ public:
 
 enum ApiVersion
 {
-    ApiVersion_1,      //!< common version 1.0
-    ApiVersion_1_DDEL  //!< version 1.0, "Accept: application/vnd.ddel.v1"
+    ApiVersion_1,        //!< common version 1.0
+    ApiVersion_1_DDEL,   //!< version 1.0, "Accept: application/vnd.ddel.v1"
+    ApiVersion_1_1_DDEL, //!< version 1.1, "Accept: application/vnd.ddel.v1.1"
+    ApiVersion_2_DDEL,   //!< version 2.0, "Accept: application/vnd.ddel.v2"
 };
 
 enum ApiAuthorisation

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -918,7 +918,7 @@ void DeRestPluginPrivate::configToMap(const ApiRequest &req, QVariantMap &map)
         }
     }
 
-    if (req.apiVersion() == ApiVersion_1_DDEL)
+    if (req.apiVersion() >= ApiVersion_1_DDEL)
     {
         map["permitjoin"] = static_cast<double>(gwPermitJoinDuration);
         map["permitjoinfull"] = static_cast<double>(gwPermitJoinResend);

--- a/rest_groups.cpp
+++ b/rest_groups.cpp
@@ -1887,7 +1887,7 @@ bool DeRestPluginPrivate::groupToMap(const ApiRequest &req, const Group *group, 
     map["state"] = state;
 
     // following attributes are only shown for Phoscon App
-    if (req.apiVersion() == ApiVersion_1_DDEL)
+    if (req.apiVersion() >= ApiVersion_1_DDEL)
     {
         QStringList multis;
         auto m = group->m_multiDeviceIds.begin();

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -252,8 +252,8 @@ bool DeRestPluginPrivate::lightToMap(const ApiRequest &req, const LightNode *lig
         else if (item->descriptor().suffix == RStateReachable) { state["reachable"] = item->toBool(); }
         else if (item->descriptor().suffix == RConfigCtMin) { map["ctmin"] = item->toNumber(); }
         else if (item->descriptor().suffix == RConfigCtMax) { map["ctmax"] = item->toNumber(); }
-        else if (item->descriptor().suffix == RConfigColorCapabilities) { map["colorcapabilities"] = item->toNumber(); }
-//        else if (item->descriptor().suffix == RConfigColorCapabilities) { icc = item; } // TODO enable again in beta v2.6.x
+        else if (req.apiVersion() <= ApiVersion_1_DDEL && item->descriptor().suffix == RConfigColorCapabilities) { map["colorcapabilities"] = item->toNumber(); }
+        else if (req.apiVersion() >= ApiVersion_1_1_DDEL && item->descriptor().suffix == RConfigColorCapabilities) { icc = item; }
         else if (item->descriptor().suffix == RConfigPowerup) { map["powerup"] = item->toNumber(); }
         else if (item->descriptor().suffix == RConfigPowerOnLevel) { map["poweronlevel"] = item->toNumber(); }
         else if (item->descriptor().suffix == RConfigPowerOnCt) { map["poweronct"] = item->toNumber(); }
@@ -331,6 +331,15 @@ bool DeRestPluginPrivate::lightToMap(const ApiRequest &req, const LightNode *lig
         QString etag = lightNode->etag;
         etag.remove('"'); // no quotes allowed in string
         map["etag"] = etag;
+
+        if (req.apiVersion() >= ApiVersion_2_DDEL)
+        {
+            QVariantMap links;
+            QVariantMap self;
+            self["href"] = QString("%1/%2").arg(req.hdr.url().path()).arg(lightNode->uniqueId());
+            links["self"] = self;
+            map["_links"] = links;
+        }
     }
 
     map["state"] = state;


### PR DESCRIPTION
### Improve HTTP accept header parsing of API versions

- Always pick the largest supported version;
- Support headers with multiple versions;
- To add more versions simply extend the array.

The `getAcceptHeaderApiVersion()` is a pure function for easier testing later on.

### Reintroduce colorcapabilities in API version v1.1

For clients which support `vnd.ddel.v1` or don't provide an API version this won't be a breaking change and `colorcapabilities` still returns a number. Clients which support `vnd.ddel.v1.1` need to support `colorcapabilities` as array.

Related PR https://github.com/dresden-elektronik/deconz-rest-plugin/pull/3642