### PR TITLE
Enhacements and improvements

### DIFF
--- a/air_quality.cpp
+++ b/air_quality.cpp
@@ -91,7 +91,7 @@ void DeRestPluginPrivate::handleAirQualityClusterIndication(const deCONZ::ApsDat
             {
                 QString airquality = QLatin1String("none");
 
-                if (levelPpb > 0 && levelPpb <= 65)      { airquality = QLatin1String("excellent"); }
+                if (levelPpb >= 0 && levelPpb <= 65)     { airquality = QLatin1String("excellent"); }
                 if (levelPpb > 65 && levelPpb <= 220)    { airquality = QLatin1String("good"); }
                 if (levelPpb > 220 && levelPpb <= 660)   { airquality = QLatin1String("moderate"); }
                 if (levelPpb > 660 && levelPpb <= 2200)  { airquality = QLatin1String("poor"); }

--- a/air_quality.cpp
+++ b/air_quality.cpp
@@ -91,7 +91,7 @@ void DeRestPluginPrivate::handleAirQualityClusterIndication(const deCONZ::ApsDat
             {
                 QString airquality = QLatin1String("none");
 
-                if (levelPpb >= 0 && levelPpb <= 65)     { airquality = QLatin1String("excellent"); }
+                if (levelPpb <= 65)                      { airquality = QLatin1String("excellent"); }
                 if (levelPpb > 65 && levelPpb <= 220)    { airquality = QLatin1String("good"); }
                 if (levelPpb > 220 && levelPpb <= 660)   { airquality = QLatin1String("moderate"); }
                 if (levelPpb > 660 && levelPpb <= 2200)  { airquality = QLatin1String("poor"); }

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -605,8 +605,8 @@ bool DeRestPluginPrivate::sendBindRequest(BindingTask &bt)
             // Whitelist sensors which don't seem to have a valid node descriptor.
             // This is a workaround currently only required for Develco smoke sensor
             // and potentially Bosch motion sensor
-            if (s.modelId().startsWith(QLatin1String("SMSZB-120")) ||    // Develco smoke sensor
-                s.modelId().startsWith(QLatin1String("EMIZB-132")) ||    // Develco EMI Norwegian HAN
+            if (s.modelId().startsWith(QLatin1String("SMSZB-1")) ||      // Develco smoke sensor
+                s.modelId().startsWith(QLatin1String("EMIZB-1")) ||      // Develco EMI Norwegian HAN
                 s.modelId().startsWith(QLatin1String("ISW-ZPR1-WP13")))  // Bosch motion sensor
             {
             }
@@ -965,7 +965,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq.dataType = deCONZ::Zcl16BitUint;
         rq.attributeId = 0x0000;         // measured value
 
-        if (sensor && (sensor->modelId().startsWith(QLatin1String("MOSZB-130")) ||          // Develco motion sensor
+        if (sensor && (sensor->modelId().startsWith(QLatin1String("MOSZB-1")) ||            // Develco motion sensor
                        sensor->modelId().startsWith(QLatin1String("MotionSensor51AU"))))    // Aurora (Develco) motion sensor
         {
             rq.minInterval = 0;
@@ -987,12 +987,12 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq.dataType = deCONZ::Zcl16BitInt;
         rq.attributeId = 0x0000;       // measured value
 
-        if (sensor && (sensor->modelId().startsWith(QLatin1String("AQSZB-110")) ||       // Develco air quality sensor
-                       sensor->modelId().startsWith(QLatin1String("SMSZB-120")) ||       // Develco smoke sensor
-                       sensor->modelId().startsWith(QLatin1String("HESZB-120")) ||       // Develco heat sensor
-                       sensor->modelId().startsWith(QLatin1String("MOSZB-130")) ||       // Develco motion sensor
-                       sensor->modelId().startsWith(QLatin1String("WISZB-120")) ||       // Develco window sensor
-                       sensor->modelId().startsWith(QLatin1String("FLSZB-110")) ||       // Develco water leak sensor
+        if (sensor && (sensor->modelId().startsWith(QLatin1String("AQSZB-1")) ||         // Develco air quality sensor
+                       sensor->modelId().startsWith(QLatin1String("SMSZB-1")) ||         // Develco smoke sensor
+                       sensor->modelId().startsWith(QLatin1String("HESZB-1")) ||         // Develco heat sensor
+                       sensor->modelId().startsWith(QLatin1String("MOSZB-1")) ||         // Develco motion sensor
+                       sensor->modelId().startsWith(QLatin1String("WISZB-1")) ||         // Develco window sensor
+                       sensor->modelId().startsWith(QLatin1String("FLSZB-1")) ||         // Develco water leak sensor
                        sensor->modelId().startsWith(QLatin1String("ZHMS101")) ||         // Wattle (Develco) magnetic sensor
                        sensor->modelId().startsWith(QLatin1String("MotionSensor51AU")))) // Aurora (Develco) motion sensor
         {
@@ -1593,13 +1593,13 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq.maxInterval = 21600;
             rq.reportableChange8bit = 0;
         }
-        else if (sensor && (sensor->modelId().startsWith(QLatin1String("AQSZB-110")) ||       // Develco air quality sensor
-                            sensor->modelId().startsWith(QLatin1String("SMSZB-120")) ||       // Develco smoke sensor
-                            sensor->modelId().startsWith(QLatin1String("HESZB-120")) ||       // Develco heat sensor
-                            sensor->modelId().startsWith(QLatin1String("MOSZB-130")) ||       // Develco motion sensor
-                            sensor->modelId().startsWith(QLatin1String("WISZB-120")) ||       // Develco window sensor
-                            sensor->modelId().startsWith(QLatin1String("FLSZB-110")) ||       // Develco water leak sensor
-                            sensor->modelId().startsWith(QLatin1String("SIRZB-110")) ||       // Develco siren
+        else if (sensor && (sensor->modelId().startsWith(QLatin1String("AQSZB-1")) ||         // Develco air quality sensor
+                            sensor->modelId().startsWith(QLatin1String("SMSZB-1")) ||         // Develco smoke sensor
+                            sensor->modelId().startsWith(QLatin1String("HESZB-1")) ||         // Develco heat sensor
+                            sensor->modelId().startsWith(QLatin1String("MOSZB-1")) ||         // Develco motion sensor
+                            sensor->modelId().startsWith(QLatin1String("WISZB-1")) ||         // Develco window sensor
+                            sensor->modelId().startsWith(QLatin1String("FLSZB-1")) ||         // Develco water leak sensor
+                            sensor->modelId().startsWith(QLatin1String("SIRZB-1")) ||         // Develco siren
                             sensor->modelId().startsWith(QLatin1String("ZHMS101")) ||         // Wattle (Develco) magnetic sensor
                             sensor->modelId().startsWith(QLatin1String("MotionSensor51AU")))) // Aurora (Develco) motion sensor
         {
@@ -1746,7 +1746,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq2.maxInterval = 300;
         if (sensor && (sensor->modelId() == QLatin1String("SmartPlug") ||       // Heiman
                        sensor->modelId() == QLatin1String("SKHMP30-I1") ||      // GS smart plug
-                       sensor->modelId() == QLatin1String("SPLZB-131")))        // Develco smart plug
+                       sensor->modelId().startsWith(QLatin1String("SPLZB-1")))) // Develco smart plug
         {
             rq2.reportableChange16bit = 100; // 1 V
         }
@@ -1773,17 +1773,17 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq3.maxInterval = 300;
         if (sensor && (sensor->modelId() == QLatin1String("SP 120") ||           // innr
                        sensor->modelId() == QLatin1String("DoubleSocket50AU") || // Aurora
-                       sensor->modelId() == QLatin1String("SPLZB-131") ||        // Develco smart plug
+                       sensor->modelId().startsWith(QLatin1String("SPLZB-1"))    // Develco smart plug
                        sensor->modelId() == QLatin1String("SZ-ESW01-AU") ||      // Sercomm / Telstra smart plug
                        sensor->modelId() == QLatin1String("Connected socket outlet") || // Niko smart socket
                        sensor->modelId() == QLatin1String("TS0121")))            // Tuya / Blitzwolf
         {
             rq3.reportableChange16bit = 100; // 0.1 A
         }
-        else if (sensor && (sensor->modelId() == QLatin1String("SmartPlug") ||  // Heiman
-                            sensor->modelId() == QLatin1String("EMIZB-132") ||  // Develco
-                            sensor->modelId() == QLatin1String("SKHMP30-I1") || // GS smart plug
-                            sensor->modelId().startsWith(QLatin1String("SPW35Z")))) // RT-RK OBLO SPW35ZD0 smart plug
+        else if (sensor && (sensor->modelId() == QLatin1String("SmartPlug") ||        // Heiman
+                            sensor->modelId().startsWith(QLatin1String("EMIZB-1"))    // Develco EMI
+                            sensor->modelId() == QLatin1String("SKHMP30-I1") ||       // GS smart plug
+                            sensor->modelId().startsWith(QLatin1String("SPW35Z"))))   // RT-RK OBLO SPW35ZD0 smart plug
         {
             rq3.reportableChange16bit = 10; // 0.1 A
         }
@@ -2421,8 +2421,8 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         // Whitelist sensors which don't seem to have a valid node descriptor.
         // This is a workaround currently only required for Develco smoke sensor
         // and potentially Bosch motion sensor
-        if (sensor->modelId().startsWith(QLatin1String("SMSZB-120")) ||   // Develco smoke sensor
-            sensor->modelId().startsWith(QLatin1String("EMIZB-132")) ||   // Develco EMI Norwegian HAN
+        if (sensor->modelId().startsWith(QLatin1String("SMSZB-1")) ||     // Develco smoke sensor
+            sensor->modelId().startsWith(QLatin1String("EMIZB-1")) ||     // Develco EMI Norwegian HAN
             sensor->modelId().startsWith(QLatin1String("ISW-ZPR1-WP13"))) // Bosch motion sensor
         {
         }
@@ -2545,17 +2545,17 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         // Bitron
         sensor->modelId().startsWith(QLatin1String("902010")) ||
         // Develco
-        sensor->modelId().startsWith(QLatin1String("AQSZB-110")) || // air quality sensor
-        sensor->modelId().startsWith(QLatin1String("SMSZB-120")) || // smoke sensor
-        sensor->modelId().startsWith(QLatin1String("HESZB-120")) || // heat sensor
-        sensor->modelId().startsWith(QLatin1String("WISZB-120")) || // window sensor
-        sensor->modelId().startsWith(QLatin1String("FLSZB-110")) || // water leak sensor
-        sensor->modelId().startsWith(QLatin1String("MOSZB-130")) || // motion sensor
+        sensor->modelId().startsWith(QLatin1String("AQSZB-1")) ||   // air quality sensor
+        sensor->modelId().startsWith(QLatin1String("SMSZB-1")) ||   // smoke sensor
+        sensor->modelId().startsWith(QLatin1String("HESZB-1")) ||   // heat sensor
+        sensor->modelId().startsWith(QLatin1String("WISZB-1")) ||   // window sensor
+        sensor->modelId().startsWith(QLatin1String("FLSZB-1")) ||   // water leak sensor
+        sensor->modelId().startsWith(QLatin1String("MOSZB-1")) ||   // motion sensor
         sensor->modelId().startsWith(QLatin1String("ZHMS101")) ||   // Wattle (Develco) magnetic sensor
-        sensor->modelId().startsWith(QLatin1String("EMIZB-132")) || // EMI Norwegian HAN
-        sensor->modelId().startsWith(QLatin1String("SMRZB-33")) ||  // Smart Relay DIN
-        sensor->modelId().startsWith(QLatin1String("SIRZB-110")) || // siren
-        sensor->modelId() == QLatin1String("SPLZB-131") ||          // smart plug
+        sensor->modelId().startsWith(QLatin1String("EMIZB-1")) ||   // EMI Norwegian HAN
+        sensor->modelId().startsWith(QLatin1String("SMRZB-3")) ||   // Smart Relay DIN
+        sensor->modelId().startsWith(QLatin1String("SIRZB-1")) ||   // siren
+        sensor->modelId().startsWith(QLatin1String("SPLZB-1")) ||   // smart plug
         sensor->modelId() == QLatin1String("MotionSensor51AU") ||   // Aurora (Develco) motion sensor
         // LG
         sensor->modelId() == QLatin1String("LG IP65 HMS") ||

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1744,8 +1744,9 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq2.attributeId = 0x0505; // RMS Voltage
         rq2.minInterval = 1;
         rq2.maxInterval = 300;
-        if (sensor && (sensor->modelId() == QLatin1String("SmartPlug") || // Heiman
-                       sensor->modelId() == QLatin1String("SKHMP30-I1"))) // GS smart plug
+        if (sensor && (sensor->modelId() == QLatin1String("SmartPlug") ||       // Heiman
+                       sensor->modelId() == QLatin1String("SKHMP30-I1") ||      // GS smart plug
+                       sensor->modelId() == QLatin1String("SPLZB-131")))        // Develco smart plug
         {
             rq2.reportableChange16bit = 100; // 1 V
         }
@@ -1772,6 +1773,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq3.maxInterval = 300;
         if (sensor && (sensor->modelId() == QLatin1String("SP 120") ||           // innr
                        sensor->modelId() == QLatin1String("DoubleSocket50AU") || // Aurora
+                       sensor->modelId() == QLatin1String("SPLZB-131") ||        // Develco smart plug
                        sensor->modelId() == QLatin1String("SZ-ESW01-AU") ||      // Sercomm / Telstra smart plug
                        sensor->modelId() == QLatin1String("Connected socket outlet") || // Niko smart socket
                        sensor->modelId() == QLatin1String("TS0121")))            // Tuya / Blitzwolf

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2824,12 +2824,12 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
                 val = sensor->getZclValue(*i, 0x0035); // battery alarm mask
             }
             else if (sensor->modelId() == QLatin1String("Motion Sensor-A") ||
-                     sensor->modelId() == QLatin1String("AQSZB-110") ||
-                     sensor->modelId() == QLatin1String("SMSZB-120") ||
-                     sensor->modelId() == QLatin1String("HESZB-120") ||
-                     sensor->modelId() == QLatin1String("WISZB-120") ||
-                     sensor->modelId() == QLatin1String("MOSZB-130") ||
-                     sensor->modelId() == QLatin1String("FLSZB-110") ||
+                     sensor->modelId().startsWith(QLatin1String("AQSZB-1")) ||
+                     sensor->modelId().startsWith(QLatin1String("SMSZB-1")) ||
+                     sensor->modelId().startsWith(QLatin1String("HESZB-1")) ||
+                     sensor->modelId().startsWith(QLatin1String("WISZB-1")) ||
+                     sensor->modelId().startsWith(QLatin1String("MOSZB-1")) ||
+                     sensor->modelId().startsWith(QLatin1String("FLSZB-1")) ||
                      sensor->modelId() == QLatin1String("MotionSensor51AU") ||
                      sensor->modelId() == QLatin1String("Zen-01") ||
                      sensor->modelId() == QLatin1String("ISW-ZPR1-WP13") ||

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1773,7 +1773,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq3.maxInterval = 300;
         if (sensor && (sensor->modelId() == QLatin1String("SP 120") ||           // innr
                        sensor->modelId() == QLatin1String("DoubleSocket50AU") || // Aurora
-                       sensor->modelId().startsWith(QLatin1String("SPLZB-1"))    // Develco smart plug
+                       sensor->modelId().startsWith(QLatin1String("SPLZB-1")) || // Develco smart plug
                        sensor->modelId() == QLatin1String("SZ-ESW01-AU") ||      // Sercomm / Telstra smart plug
                        sensor->modelId() == QLatin1String("Connected socket outlet") || // Niko smart socket
                        sensor->modelId() == QLatin1String("TS0121")))            // Tuya / Blitzwolf
@@ -1781,7 +1781,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq3.reportableChange16bit = 100; // 0.1 A
         }
         else if (sensor && (sensor->modelId() == QLatin1String("SmartPlug") ||        // Heiman
-                            sensor->modelId().startsWith(QLatin1String("EMIZB-1"))    // Develco EMI
+                            sensor->modelId().startsWith(QLatin1String("EMIZB-1")) || // Develco EMI
                             sensor->modelId() == QLatin1String("SKHMP30-I1") ||       // GS smart plug
                             sensor->modelId().startsWith(QLatin1String("SPW35Z"))))   // RT-RK OBLO SPW35ZD0 smart plug
         {

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2685,6 +2685,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId() == QLatin1String("MS01") ||
         sensor->modelId() == QLatin1String("MSO1") ||
         sensor->modelId() == QLatin1String("ms01") ||
+        sensor->modelId() == QLatin1String("66666") ||
         sensor->modelId() == QLatin1String("TH01") ||
         sensor->modelId() == QLatin1String("DS01") ||
         // Danfoss

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -302,16 +302,16 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_STELPRO, "ST218", xalMacPrefix }, // Stelpro Thermostat
     { VENDOR_STELPRO, "STZB402", xalMacPrefix }, // Stelpro baseboard thermostat
     { VENDOR_STELPRO, "SORB", xalMacPrefix }, // Stelpro Orleans Fan
-    { VENDOR_DEVELCO, "AQSZB-110", develcoMacPrefix }, // Develco air quality sensor
-    { VENDOR_DEVELCO, "SMSZB-120", develcoMacPrefix }, // Develco smoke sensor
-    { VENDOR_DEVELCO, "HESZB-120", develcoMacPrefix }, // Develco heat sensor
-    { VENDOR_DEVELCO, "SPLZB-131", develcoMacPrefix }, // Develco smart plug
-    { VENDOR_DEVELCO, "WISZB-120", develcoMacPrefix }, // Develco window sensor
-    { VENDOR_DEVELCO, "MOSZB-130", develcoMacPrefix }, // Develco motion sensor
-    { VENDOR_DEVELCO, "FLSZB-110", develcoMacPrefix }, // Develco water leak sensor
-    { VENDOR_DEVELCO, "EMIZB-132", develcoMacPrefix }, // Develco EMI Norwegian HAN
-    { VENDOR_DEVELCO, "SMRZB-33", develcoMacPrefix }, // Develco Smart Relay DIN
-    { VENDOR_DEVELCO, "SIRZB-110", develcoMacPrefix }, // Develco siren
+    { VENDOR_DEVELCO, "AQSZB-1", develcoMacPrefix }, // Develco air quality sensor
+    { VENDOR_DEVELCO, "SMSZB-1", develcoMacPrefix }, // Develco smoke sensor
+    { VENDOR_DEVELCO, "HESZB-1", develcoMacPrefix }, // Develco heat sensor
+    { VENDOR_DEVELCO, "SPLZB-1", develcoMacPrefix }, // Develco smart plug
+    { VENDOR_DEVELCO, "WISZB-1", develcoMacPrefix }, // Develco window sensor
+    { VENDOR_DEVELCO, "MOSZB-1", develcoMacPrefix }, // Develco motion sensor
+    { VENDOR_DEVELCO, "FLSZB-1", develcoMacPrefix }, // Develco water leak sensor
+    { VENDOR_DEVELCO, "EMIZB-1", develcoMacPrefix }, // Develco EMI Norwegian HAN
+    { VENDOR_DEVELCO, "SMRZB-3", develcoMacPrefix }, // Develco Smart Relay DIN
+    { VENDOR_DEVELCO, "SIRZB-1", develcoMacPrefix }, // Develco siren
     { VENDOR_DEVELCO, "ZHMS101", develcoMacPrefix }, // Wattle (Develco) magnetic sensor
     { VENDOR_DEVELCO, "MotionSensor51AU", develcoMacPrefix }, // Aurora (Develco) motion sensor
     { VENDOR_EMBER, "3AFE14010402000D", konkeMacPrefix }, // Konke Kit Pro-BS Motion Sensor
@@ -4861,7 +4861,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                              modelId.startsWith(QLatin1String("Door")) ||             // Heiman door/window sensor (newer model)
                              modelId == QLatin1String("3AFE130104020015") ||          // Konke door/window sensor
                              modelId.startsWith(QLatin1String("902010/21")) ||        // Bitron door/window sensor
-                             modelId.startsWith(QLatin1String("WISZB-120")) ||        // Develco door/window sensor
+                             modelId.startsWith(QLatin1String("WISZB-1")) ||          // Develco door/window sensor
                              modelId.startsWith(QLatin1String("ZHMS101")) ||          // Wattle (Develco) door/window sensor
                              modelId.startsWith(QLatin1String("4655BC0")) ||          // Ecolink contact sensor
                              modelId.startsWith(QLatin1String("3300")) ||             // Centralite contact sensor
@@ -4879,7 +4879,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                              modelId == QLatin1String("ZB-MotionSensor-D0003") ||     // Linkind motion sensor
                              modelId.startsWith(QLatin1String("902010/22")) ||        // Bitron motion sensor
                              modelId.startsWith(QLatin1String("SN10ZW")) ||           // ORVIBO motion sensor
-                             modelId.startsWith(QLatin1String("MOSZB-130")) ||        // Develco motion sensor
+                             modelId.startsWith(QLatin1String("MOSZB-1")) ||          // Develco motion sensor
                              modelId.startsWith(QLatin1String("MotionSensor51AU")) || // Aurora (Develco) motion sensor
                              modelId.startsWith(QLatin1String("MOT003")) ||           // Hive motion sensor
                              modelId == QLatin1String("4in1-Sensor-ZB3.0") ||         // Immax NEO ZB3.0 4 in 1 sensor E13-A21
@@ -4896,8 +4896,8 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                              modelId.startsWith(QLatin1String("SMOK_")) ||            // Heiman fire sensor
                              modelId.startsWith(QLatin1String("Smoke")) ||            // Heiman fire sensor (newer model)
                              modelId.startsWith(QLatin1String("902010/24")) ||        // Bitron smoke detector
-                             modelId.startsWith(QLatin1String("SMSZB-120")) ||        // Develco smoke detector
-                             modelId.startsWith(QLatin1String("HESZB-120")) ||        // Develco heat detector
+                             modelId.startsWith(QLatin1String("SMSZB-1")) ||          // Develco smoke detector
+                             modelId.startsWith(QLatin1String("HESZB-1")) ||          // Develco heat detector
                              modelId.startsWith(QLatin1String("SF2")) ||              // ORVIBO (Heiman) smoke sensor
                              modelId.startsWith(QLatin1String("LH05121")) ||          // iHorn smoke detector
                              modelId.startsWith(QLatin1String("lumi.sensor_smoke")) || // Xiaomi Mi smoke sensor
@@ -4914,14 +4914,14 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                              modelId.startsWith(QLatin1String("lumi.sensor_wleak")) || // Xiaomi Aqara flood sensor
                              modelId.startsWith(QLatin1String("WL4200")) ||           // Sinope Water Leak detector
                              modelId.startsWith(QLatin1String("3315")) ||             // Centralite water sensor
-                             modelId.startsWith(QLatin1String("FLSZB-110")) ||        // Develco Water Leak detector
+                             modelId.startsWith(QLatin1String("FLSZB-1")) ||          // Develco Water Leak detector
                              modelId.startsWith(QLatin1String("TS0207")))             // Tuya water leak sensor
                     {
                         fpWaterSensor.inClusters.push_back(ci->id());
                     }
                     else if (modelId == QLatin1String("WarningDevice") ||               // Heiman siren
                              modelId == QLatin1String("SZ-SRN12N") ||                   // Sercomm siren
-                             modelId == QLatin1String("SIRZB-110") ||                   // Develco siren
+                             modelId == QLatin1String("SIRZB-1") ||                     // Develco siren
                              modelId == QLatin1String("902010/29"))                     // Bitron outdoor siren
                     {
                         fpAlarmSensor.inClusters.push_back(ci->id());
@@ -7345,13 +7345,13 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     i->modelId() == QLatin1String("Bell") ||             // Sage doorbell sensor
                                     i->modelId() == QLatin1String("ISW-ZPR1-WP13") ||    // Bosch motion sensor
                                     i->modelId().endsWith(QLatin1String("86opcn01")) ||  // Aqara Opple
-                                    i->modelId().startsWith(QLatin1String("AQSZB-110")) || // Develco air quality sensor
-                                    i->modelId().startsWith(QLatin1String("SMSZB-120")) || // Develco smoke sensor
-                                    i->modelId().startsWith(QLatin1String("HESZB-120")) || // Develco heat sensor
-                                    i->modelId().startsWith(QLatin1String("MOSZB-130")) || // Develco motion sensor
-                                    i->modelId().startsWith(QLatin1String("WISZB-120")) || // Develco window sensor
-                                    i->modelId().startsWith(QLatin1String("FLSZB-110")) || // Develco water leak sensor
-                                    i->modelId().startsWith(QLatin1String("SIRZB-110")) || // Develco siren
+                                    i->modelId().startsWith(QLatin1String("AQSZB-1")) ||   // Develco air quality sensor
+                                    i->modelId().startsWith(QLatin1String("SMSZB-1")) ||   // Develco smoke sensor
+                                    i->modelId().startsWith(QLatin1String("HESZB-1")) ||   // Develco heat sensor
+                                    i->modelId().startsWith(QLatin1String("MOSZB-1")) ||   // Develco motion sensor
+                                    i->modelId().startsWith(QLatin1String("WISZB-1")) ||   // Develco window sensor
+                                    i->modelId().startsWith(QLatin1String("FLSZB-1")) ||   // Develco water leak sensor
+                                    i->modelId().startsWith(QLatin1String("SIRZB-1")) ||   // Develco siren
                                     i->modelId().startsWith(QLatin1String("ZHMS101")) ||   // Wattle (Develco) magnetic sensor
                                     i->modelId().startsWith(QLatin1String("MotionSensor51AU")) || // Aurora (Develco) motion sensor
                                     i->modelId().startsWith(QLatin1String("RFDL-ZB-MS")) ||// Bosch motion sensor
@@ -8684,8 +8684,8 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 if (item && voltage != 65535)
                                 {
                                     if (i->modelId() == QLatin1String("SmartPlug") ||         // Heiman
-                                        i->modelId() == QLatin1String("SPLZB-131") ||         // Develco smart plug
-                                        i->modelId().startsWith(QLatin1String("SMRZB-33")) || // Develco smart relay
+                                        i->modelId().startsWith(QLatin1String("SPLZB-1")) ||  // Develco smart plug
+                                        i->modelId().startsWith(QLatin1String("SMRZB-3")) ||  // Develco smart relay
                                         i->modelId().startsWith(QLatin1String("SKHMP30")))    // GS smart plug
                                     {
                                         //voltage += 50; voltage /= 100; // 0.01V -> V
@@ -8693,7 +8693,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     }
                                     else if (i->modelId() == QLatin1String("RICI01") ||           // LifeControl Smart Plug
                                              i->modelId().startsWith(QLatin1String("outlet")) ||  // Samsung SmartThings IM6001-OTP/IM6001-OTP01
-                                             i->modelId() == QLatin1String("EMIZB-13") ||         // Develco EMI
+                                             i->modelId().startsWith(QLatin1String("EMIZB-1")) || // Develco EMI
                                              i->modelId().startsWith(QLatin1String("ROB_200")) || // ROBB Smarrt micro dimmer
                                              i->modelId().startsWith(QLatin1String("Micro Smart Dimmer")) || // Sunricher Micro Smart Dimmer
                                              i->modelId() == QLatin1String("Connected socket outlet") || // Niko smart socket
@@ -8728,7 +8728,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     if (i->modelId() == QLatin1String("SP 120") ||            // innr
                                         i->modelId().startsWith(QLatin1String("outlet")) ||   // Samsung SmartThings IM6001-OTP/IM6001-OTP01
                                         i->modelId() == QLatin1String("DoubleSocket50AU") ||  // Aurora
-                                        i->modelId() == QLatin1String("SPLZB-131") ||         // Develco smart plug
+                                        i->modelId().startsWith(QLatin1String("SPLZB-1")) ||  // Develco smart plug
                                         i->modelId() == QLatin1String("RICI01") ||            // LifeControl Smart Plug
                                         i->modelId().startsWith(QLatin1String("SZ-ESW01")) || // Sercomm / Telstra smart plug
                                         i->modelId() == QLatin1String("TS0121") ||            // Tuya smart plug
@@ -8743,7 +8743,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                         // already in mA
                                     }
                                     else if (i->modelId() == QLatin1String("SmartPlug") ||      // Heiman
-                                             i->modelId() == QLatin1String("EMIZB-132") ||      // Develco EMI Norwegian HAN
+                                             i->modelId().startsWith(QLatin1String("EMIZB-1")) || // Develco EMI
                                              i->modelId().startsWith(QLatin1String("SKHMP30")) || // GS smart plug
                                              i->modelId().startsWith(QLatin1String("3200-S")) ||  // Samsung smart outlet
                                              i->modelId().startsWith(QLatin1String("SPW35Z")))    // RT-RK OBLO SPW35ZD0 smart plug

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -17141,8 +17141,7 @@ void DeRestPlugin::idleTimerFired()
                                 sensorNode->modelId().startsWith(QLatin1String("Super TR")) ||  // Elko
                                 sensorNode->modelId().startsWith(QLatin1String("AC201")) ||     // Owon
                                 sensorNode->modelId().startsWith(QLatin1String("SORB")) ||      // Stelpro Orleans
-                                sensorNode->modelId().startsWith(QLatin1String("3157100")) ||   // Centralite pearl
-                                sensorNode->modelId().startsWith(QLatin1String("902010/32")))   // Bitron
+                                sensorNode->modelId().startsWith(QLatin1String("3157100")))     // Centralite pearl
                             {
                                 // supports reporting, no need to read attributes
                             }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -8728,6 +8728,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     if (i->modelId() == QLatin1String("SP 120") ||            // innr
                                         i->modelId().startsWith(QLatin1String("outlet")) ||   // Samsung SmartThings IM6001-OTP/IM6001-OTP01
                                         i->modelId() == QLatin1String("DoubleSocket50AU") ||  // Aurora
+                                        i->modelId() == QLatin1String("SPLZB-131") ||         // Develco smart plug
                                         i->modelId() == QLatin1String("RICI01") ||            // LifeControl Smart Plug
                                         i->modelId().startsWith(QLatin1String("SZ-ESW01")) || // Sercomm / Telstra smart plug
                                         i->modelId() == QLatin1String("TS0121") ||            // Tuya smart plug

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -411,6 +411,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_NONE, "MS01", tiMacPrefix }, // Sonoff SNZB-03
     { VENDOR_NONE, "MSO1", tiMacPrefix }, // Sonoff SNZB-03
     { VENDOR_NONE, "ms01", tiMacPrefix }, // Sonoff SNZB-03
+    { VENDOR_NONE, "66666", tiMacPrefix }, // Sonoff SNZB-03
     { VENDOR_NONE, "TH01", tiMacPrefix }, // Sonoff SNZB-02
     { VENDOR_NONE, "DS01", tiMacPrefix }, // Sonoff SNZB-04
     { VENDOR_DANFOSS, "eTRV0100", silabs2MacPrefix }, // Danfoss Ally thermostat
@@ -4884,6 +4885,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                              modelId == QLatin1String("4in1-Sensor-ZB3.0") ||         // Immax NEO ZB3.0 4 in 1 sensor E13-A21
                              modelId == QLatin1String("E13-A21") ||                   // Sengled E13-A21 PAR38 bulp with motion sensor
                              modelId == QLatin1String("TS0202") ||                    // Tuya generic motion sensor
+                             modelId == QLatin1String("66666") ||                     // Sonoff SNZB-03
                              modelId == QLatin1String("MS01") ||                      // Sonoff SNZB-03
                              modelId == QLatin1String("MSO1") ||                      // Sonoff SNZB-03
                              modelId == QLatin1String("ms01"))                        // Sonoff SNZB-03

--- a/general.xml
+++ b/general.xml
@@ -3650,8 +3650,10 @@ Contactor > On/off=0003 - HP/HC=0004</description>
 
 		<!-- LUMI -->
 		<cluster id="0xfcc0" name="Lumi specific" mfcode="0x115f">
-			<description>Lumi specific attributes.</description>
+			<description>Lumi specific attributes.
+Note - Aqara Opple switches have 2 modes of operation: Switch all devices (0), event based switching (1).</description>
 			<server>
+				<attribute id="0x0009" name="Opple switch mode" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
 				<attribute id="0x00f3" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
 				<attribute id="0x00f5" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"> </attribute>
 				<attribute id="0x00f6" name="Reporting Interval" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>

--- a/ias_zone.cpp
+++ b/ias_zone.cpp
@@ -83,12 +83,6 @@ void DeRestPluginPrivate::handleIasZoneClusterIndication(const deCONZ::ApsDataIn
             return; // sanity
         }
     }
-    
-    // Allow clearing the alarm bit for Develco devices
-    if (!(zclFrame.frameControl() & deCONZ::ZclFCDisableDefaultResponse))
-    {
-        sendZclDefaultResponse(ind, zclFrame, deCONZ::ZclSuccessStatus);
-    }
 
     if ((zclFrame.commandId() == CMD_STATUS_CHANGE_NOTIFICATION && zclFrame.isClusterCommand()) || attrId == IAS_ZONE_CLUSTER_ATTR_ZONE_STATUS_ID)
     {
@@ -254,6 +248,13 @@ void DeRestPluginPrivate::handleIasZoneClusterIndication(const deCONZ::ApsDataIn
         {
             item->setValue(item->toNumber() & ~R_PENDING_ENROLL_RESPONSE);
         }
+        return;
+    }
+    
+    // Allow clearing the alarm bit for Develco devices
+    if (!(zclFrame.frameControl() & deCONZ::ZclFCDisableDefaultResponse))
+    {
+        sendZclDefaultResponse(ind, zclFrame, deCONZ::ZclSuccessStatus);
     }
 }
 

--- a/ias_zone.cpp
+++ b/ias_zone.cpp
@@ -83,6 +83,12 @@ void DeRestPluginPrivate::handleIasZoneClusterIndication(const deCONZ::ApsDataIn
             return; // sanity
         }
     }
+    
+    // Allow clearing the alarm bit for Develco devices
+    if (!(zclFrame.frameControl() & deCONZ::ZclFCDisableDefaultResponse))
+    {
+        sendZclDefaultResponse(ind, zclFrame, deCONZ::ZclSuccessStatus);
+    }
 
     if ((zclFrame.commandId() == CMD_STATUS_CHANGE_NOTIFICATION && zclFrame.isClusterCommand()) || attrId == IAS_ZONE_CLUSTER_ATTR_ZONE_STATUS_ID)
     {

--- a/light_node.cpp
+++ b/light_node.cpp
@@ -544,10 +544,10 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
                 else if (i->id() == IAS_WD_CLUSTER_ID)
                 {
                     if (modelId().startsWith(QLatin1String("902010/24")) ||   // Bitron Smoke Detector with siren
-                        modelId() == QLatin1String("SMSZB-120") ||            // Develco Smoke Alarm with siren
-                        modelId() == QLatin1String("HESZB-120") ||            // Develco heat sensor with siren
-                        modelId() == QLatin1String("FLSZB-110") ||            // Develco water leak sensor with siren
-                        modelId() == QLatin1String("SIRZB-110") ||            // Develco siren
+                        modelId().startsWith(QLatin1String("SMSZB-1")) ||     // Develco Smoke Alarm with siren
+                        modelId().startsWith(QLatin1String("HESZB-1")) ||     // Develco heat sensor with siren
+                        modelId().startsWith(QLatin1String("FLSZB-1")) ||     // Develco water leak sensor with siren
+                        modelId().startsWith(QLatin1String("SIRZB-1")) ||     // Develco siren
                         modelId() == QLatin1String("902010/29"))              // Bitron outdoor siren
                     {
                         removeItem(RStateOn);

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -2113,52 +2113,6 @@ int DeRestPluginPrivate::setWarningDeviceState(const ApiRequest &req, ApiRespons
         {
             task.options = 0x00; // Warning mode 0 (no warning), No strobe, Low sound
             task.duration = 0;
-
-            // Quickfix for clearing the alarm bit of Develco smoke, heat and water leak sensor
-            if (taskRef.lightNode->modelId() == QLatin1String("SMSZB-120") ||
-                taskRef.lightNode->modelId() == QLatin1String("HESZB-120") ||
-                taskRef.lightNode->modelId() == QLatin1String("FLSZB-110"))
-            {
-                deCONZ::ApsDataRequest apsReq;
-
-                // ZDP Header
-                apsReq.dstAddress() = taskRef.lightNode->node()->address();
-                apsReq.setDstAddressMode(deCONZ::ApsNwkAddress);
-                apsReq.setDstEndpoint(0x23);
-                apsReq.setSrcEndpoint(0x01);
-                apsReq.setProfileId(HA_PROFILE_ID);
-                apsReq.setRadius(0);
-                apsReq.setClusterId(IAS_ZONE_CLUSTER_ID);
-
-                deCONZ::ZclFrame outZclFrame;
-                outZclFrame.setSequenceNumber(zclSeq++);
-                outZclFrame.setCommandId(deCONZ::ZclDefaultResponseId);
-                outZclFrame.setFrameControl(deCONZ::ZclFCProfileCommand |
-                                         deCONZ::ZclFCDirectionClientToServer |
-                                         deCONZ::ZclFCDisableDefaultResponse);
-
-                { // ZCL payload
-                    QDataStream stream(&outZclFrame.payload(), QIODevice::WriteOnly);
-                    stream.setByteOrder(QDataStream::LittleEndian);
-
-                    quint8 cmd = 0x00;      // Zone Status Change notification
-                    quint8 status = 0x00;   // Success
-
-                    stream << cmd;
-                    stream << status;
-                }
-
-                { // ZCL frame
-                    QDataStream stream(&apsReq.asdu(), QIODevice::WriteOnly);
-                    stream.setByteOrder(QDataStream::LittleEndian);
-                    outZclFrame.writeToStream(stream);
-                }
-
-                if (apsCtrl && apsCtrl->apsdeDataRequest(apsReq) == deCONZ::Success)
-                {
-                    queryTime = queryTime.addSecs(1);
-                }
-            }
         }
         else if (alert == "select")
         {

--- a/rest_rules.cpp
+++ b/rest_rules.cpp
@@ -439,6 +439,13 @@ int DeRestPluginPrivate::createRule(const ApiRequest &req, ApiResponse &rsp)
 
         if ((map["name"].type() == QVariant::String) && !name.isEmpty())
         {
+            if (name.size() > MAX_RULE_NAME_LENGTH)
+            {
+                rsp.list.append(errorToMap(ERR_MISSING_PARAMETER, QString("/rules/name"), QString("invalid/missing parameters in body")));
+                rsp.httpStatus = HttpStatusBadRequest;
+                return REQ_READY_SEND;
+            }
+            
             QVariantMap rspItem;
             QVariantMap rspItemState;
 

--- a/rest_rules.cpp
+++ b/rest_rules.cpp
@@ -441,7 +441,7 @@ int DeRestPluginPrivate::createRule(const ApiRequest &req, ApiResponse &rsp)
         {
             if (name.size() > MAX_RULE_NAME_LENGTH)
             {
-                rsp.list.append(errorToMap(ERR_MISSING_PARAMETER, QString("/rules/name"), QString("invalid/missing parameters in body")));
+                rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/rules/name"), QString("invalid/missing parameters in body")));
                 rsp.httpStatus = HttpStatusBadRequest;
                 return REQ_READY_SEND;
             }

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1167,8 +1167,8 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                 }
                 else if (rid.suffix == RConfigCoolSetpoint)
                 {
-                    if (map[pi.key()].type() == QVariant::Double)
-                    {
+                    //if (map[pi.key()].type() == QVariant::Double)
+                    //{
                         qint16 coolsetpoint = map[pi.key()].toInt(&ok);
 
                         if (addTaskThermostatReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, 0x0000, 0x0011, deCONZ::Zcl16BitInt, coolsetpoint))
@@ -1182,14 +1182,14 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                             rsp.httpStatus = HttpStatusBadRequest;
                             return REQ_READY_SEND;
                         }
-                    }
+                    /*}
                     else
                     {
                         rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/sensors/%1/config/%2").arg(id).arg(pi.key()).toHtmlEscaped(),
                                                    QString("invalid value, %1, for parameter %2").arg(map[pi.key()].toString()).arg(pi.key()).toHtmlEscaped()));
                         rsp.httpStatus = HttpStatusBadRequest;
                         return REQ_READY_SEND;
-                    }
+                    }*/
                 }
                 else if ((rid.suffix == RConfigMode) && !sensor->modelId().startsWith(QLatin1String("SPZB")))
                 {

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1167,6 +1167,10 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                 }
                 else if (rid.suffix == RConfigCoolSetpoint)
                 {
+                    
+                    // Further Clarification on the type check required. Value should come in as integer by the client and expected as such by the API
+                    // Suspended for now in favor of functionality
+                    
                     //if (map[pi.key()].type() == QVariant::Double)
                     //{
                         qint16 coolsetpoint = map[pi.key()].toInt(&ok);


### PR DESCRIPTION
- Whitelist yet another Sonoff SNZB-02/SNZB-03 modelID (#3713)
- Restrict rule name length during rule creation (#3727)
- Reenable polling for Bitron 902010/32 thermostat
- Correction in air quality scale
- Update for Develco SPLZB-131 power values
- Allow clearing the alarm bit for Develco devices (#3272)
- Ease Develco modelID checks to include newer models
- Add Opple switch mode attribute to LUMI cluster (#3670)
- Suspend RConfigCoolSetpoint type check (#3382)