### PR TITLE
Improve setup of Aqara Opple switches

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -3770,6 +3770,13 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 //item = sensor.addItem(DataTypeInt16, RConfigOffset);
                 //item->setValue(0);
             }
+
+            if (sensor.modelId().endsWith(QLatin1String("86opcn01")))
+            {
+                // Aqara Opple switches need to be configured to send proper button events
+                item = sensor.addItem(DataTypeUInt8, RConfigPending);
+                item->setValue(item->toNumber() | R_PENDING_MODE);
+            }
         }
         else if (sensor.modelId().startsWith(QLatin1String("tagv4"))) // SmartThings Arrival sensor
         {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6538,6 +6538,14 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             //sensorNode.addItem(DataTypeInt16, RConfigOffset);
         }
 
+        if (sensorNode.modelId().endsWith(QLatin1String("86opcn01")))
+        {
+            // Aqara Opple switches need to be configured to send proper button events
+            // write basic cluster attribute 0x0009 value 1
+            item = sensorNode.addItem(DataTypeUInt8, RConfigPending);
+            item->setValue(item->toNumber() | R_PENDING_MODE);
+        }
+
         if (sensorNode.modelId().startsWith(QLatin1String("lumi.vibration")))
         {
             ResourceItem *item = nullptr;
@@ -11722,6 +11730,7 @@ void DeRestPluginPrivate::handleZclAttributeReportIndicationXiaomiSpecial(const 
     }
 
     RestNodeBase *restNodePending = nullptr;
+    QString modelId;
 
     for (LightNode &lightNode: nodes)
     {
@@ -11840,6 +11849,11 @@ void DeRestPluginPrivate::handleZclAttributeReportIndicationXiaomiSpecial(const 
         else
         {
             continue;
+        }
+
+        if (modelId.isEmpty())
+        {
+            modelId = sensor.modelId();
         }
 
         sensor.rx();
@@ -12075,6 +12089,21 @@ void DeRestPluginPrivate::handleZclAttributeReportIndicationXiaomiSpecial(const 
     if (!r)
     {
         return;
+    }
+
+    if (modelId.endsWith(QLatin1String("86opcn01")))
+    {
+        auto *item = r->item(RConfigPending);
+        if (item && (item->toNumber() & R_PENDING_MODE))
+        {
+            // Aqara Opple switches need to be configured to send proper button events
+            // send the magic word
+            DBG_Printf(DBG_INFO, "Write Aqara Opple switch 0x%016llX mode attribute 0x0009 = 1\n", ind.srcAddress().ext());
+            deCONZ::ZclAttribute attr(0x0009, deCONZ::Zcl8BitUint, QLatin1String("mode"), deCONZ::ZclReadWrite, false);
+            attr.setValue(static_cast<quint64>(1));
+            writeAttribute(restNodePending, 0x01, 0xFCC0, attr, VENDOR_XIAOMI);
+            item->setValue(item->toNumber() & ~R_PENDING_MODE);
+        }
     }
 
     if (dateCode.isEmpty() && restNodePending)
@@ -16313,10 +16342,16 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
         }
         else if (sensor->modelId().endsWith(QLatin1String("86opcn01")))  // Aqara Opple
         {
-             // send the magic word to the Aqara Opple switch
-             deCONZ::ZclAttribute attr(0x0009, deCONZ::Zcl8BitUint, "mode", deCONZ::ZclReadWrite, false);
-             attr.setValue((quint64) 1);
-             writeAttribute(sensor, sensor->fingerPrint().endpoint, 0xFCC0, attr, VENDOR_XIAOMI);
+            auto *item = sensor->item(RConfigPending);
+            if (item && item->toNumber() & R_PENDING_MODE)
+            {
+                DBG_Printf(DBG_INFO, "Write Aqara Opple switch 0x%016llX mode attribute 0x0009 = 1\n", sensor->address().ext());
+                // send the magic word to the Aqara Opple switch
+                deCONZ::ZclAttribute attr(0x0009, deCONZ::Zcl8BitUint, "mode", deCONZ::ZclReadWrite, false);
+                attr.setValue(static_cast<quint64>(1));
+                writeAttribute(sensor, sensor->fingerPrint().endpoint, 0xFCC0, attr, VENDOR_XIAOMI);
+                item->setValue(item->toNumber() & ~R_PENDING_MODE);
+            }
         }
 
         for (auto &s : sensors)

--- a/resource.h
+++ b/resource.h
@@ -209,6 +209,7 @@ extern const QStringList RConfigLastChangeSourceValues;
 #define R_PENDING_USERTEST          (1 << 3)
 #define R_PENDING_WRITE_CIE_ADDRESS (1 << 4)
 #define R_PENDING_ENROLL_RESPONSE   (1 << 5)
+#define R_PENDING_MODE              (1 << 6)
 #define R_PENDING_WRITE_POLL_CHECKIN_INTERVAL  (1 << 6)
 #define R_PENDING_SET_LONG_POLL_INTERVAL       (1 << 7)
 

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -2498,6 +2498,10 @@ bool DeRestPluginPrivate::sensorToMap(const Sensor *sensor, QVariantMap &map, co
                 {
                     pending.append("usertest");
                 }
+                if (value & R_PENDING_MODE)
+                {
+                    pending.append(QLatin1String("mode"));
+                }
                 config[key] = pending;
             }
             else if (rid.suffix == RConfigLastChangeSource)


### PR DESCRIPTION
This PR ensures the magic attribute to enable button events is written in the hourly report, and at least once per deCONZ start.
After startup writing the attribute can be enforced by pressing the 'C' button on the back of the switch.
There was also another issue when the switch is paired a simple descriptor request loop could happen, this is fixed in deCONZ core now.

 Issue https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3670