### PR TITLE
Improve end-device pairing

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -15629,7 +15629,7 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
             apsReq.setProfileId(ZDP_PROFILE_ID);
             apsReq.setRadius(0);
             apsReq.setClusterId(ZDP_ACTIVE_ENDPOINTS_CLID);
-            //apsReq.setTxOptions(deCONZ::ApsTxAcknowledgedTransmission);
+            apsReq.setTxOptions(deCONZ::ApsTxAcknowledgedTransmission);
 
             QDataStream stream(&apsReq.asdu(), QIODevice::WriteOnly);
             stream.setByteOrder(QDataStream::LittleEndian);
@@ -15679,7 +15679,7 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
                     apsReq.setProfileId(ZDP_PROFILE_ID);
                     apsReq.setRadius(0);
                     apsReq.setClusterId(ZDP_SIMPLE_DESCRIPTOR_CLID);
-                    //apsReq.setTxOptions(deCONZ::ApsTxAcknowledgedTransmission);
+                    apsReq.setTxOptions(deCONZ::ApsTxAcknowledgedTransmission);
 
                     QDataStream stream(&apsReq.asdu(), QIODevice::WriteOnly);
                     stream.setByteOrder(QDataStream::LittleEndian);

--- a/event_queue.cpp
+++ b/event_queue.cpp
@@ -48,6 +48,11 @@ void DeRestPluginPrivate::eventQueueTimerFired()
  */
 void DeRestPluginPrivate::enqueueEvent(const Event &event)
 {
+    if (DBG_IsEnabled(DBG_INFO_L2) && event.what() && event.resource())
+    {
+        DBG_Printf(DBG_INFO_L2, "enqueue event %s for %s/%s\n", event.what(), event.resource(), qPrintable(event.id()));
+    }
+
     eventQueue.push_back(event);
 
     if (!eventTimer->isActive())

--- a/reset_device.cpp
+++ b/reset_device.cpp
@@ -32,7 +32,7 @@ void DeRestPluginPrivate::initResetDeviceApi()
  */
 void DeRestPluginPrivate::checkResetState()
 {
-    if (!apsCtrl || !isInNetwork())
+    if (!apsCtrl || !isInNetwork() || searchSensorsState == SearchSensorsActive || searchLightsState == SearchLightsActive)
     {
         resetDeviceTimer->start(CHECK_RESET_DEVICES);
         return;


### PR DESCRIPTION
- Enable APS ACKs for ACtive Endpoints and Simple Descriptor requests;
- When a device was paired previously it could have happen that during pairing it was forced to leave the network;
- Add INFO_L2 debug print to trace emitted events.