### PR TITLE
Avoid fake device creation for TUYA light 

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1830,6 +1830,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
     if (node->nodeDescriptor().manufacturerCode() == VENDOR_EMBER && !node->simpleDescriptors().isEmpty())
     {
         const deCONZ::SimpleDescriptor *sd = &node->simpleDescriptors()[0];
+        bool hasColorCluster = false;
 
         if (sd && (sd->deviceId() == DEV_ID_SMART_PLUG) && (node->simpleDescriptors().size() < 2) &&
         (((node->address().ext() & 0xffffff0000000000ULL ) == silabs3MacPrefix) ||
@@ -1840,9 +1841,10 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
             for (int c = 0; c < sd->inClusters().size(); c++)
             {
                 if (sd->inClusters()[c].id() == TUYA_CLUSTER_ID) { hasTuyaCluster = true; }
+                if (sd->inClusters()[c].id() == COLOR_CLUSTER_ID) { hasColorCluster = true; }
             }
 
-            if (hasTuyaCluster)
+            if  (hasTuyaCluster && !hasColorCluster)
             {
                 DBG_Printf(DBG_INFO, "Tuya : Creating 2 Fake Endpoints\n");
 

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -566,6 +566,10 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         {
             return setWindowCoveringState(req, rsp, taskRef, map);
         }
+        // light, don't use tuya stuff (for the moment)
+        else if (taskRef.lightNode->item(RStateColorMode))
+        {
+        }
         //switch
         else
         {

--- a/tuya.cpp
+++ b/tuya.cpp
@@ -136,6 +136,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
         stream.setByteOrder(QDataStream::LittleEndian);
 
         // "dp" field describes the action/message of a command frame and was composed by a type and an identifier
+        // Composed by a type (dp_type) and an identifier (dp_identifier), the identifier is device dependant.
         // "transid" is just a "counter", a response will have the same transif than the command.
         // "Status" and "fn" are always 0
         // More explanations at top of file


### PR DESCRIPTION
This code is used to make fake device for wired switches.
Need to be skipped for light device.