### PR TITLE
Merry Christmas!

### DIFF
--- a/de_web.pro
+++ b/de_web.pro
@@ -180,7 +180,8 @@ SOURCES  = air_quality.cpp \
            rest_userparameter.cpp \
            zcl_tasks.cpp \
            window_covering.cpp \
-           websocket_server.cpp
+           websocket_server.cpp \
+           xmas.cpp
 
 win32 {
 

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2627,7 +2627,7 @@ void DeRestPluginPrivate::setLightNodeStaticCapabilities(LightNode *lightNode)
         item = lightNode->item(RStateY);
         if (item) { item->setIsPublic(false); }
     }
-    else if (isXmasManufacturerName(lightNode->manufacturer()))
+    else if (isXmasLightStrip(lightNode))
     {
         lightNode->removeItem(RStateAlert);
         lightNode->removeItem(RStateX);
@@ -2914,7 +2914,7 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
 
             if (ic->id() == COLOR_CLUSTER_ID && (event.clusterId() == COLOR_CLUSTER_ID))
             {
-                if (isXmasManufacturerName(lightNode->manufacturer()))
+                if (isXmasLightStrip(lightNode))
                 {
                     continue;
                 }
@@ -3059,7 +3059,7 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
             }
             else if (ic->id() == LEVEL_CLUSTER_ID && (event.clusterId() == LEVEL_CLUSTER_ID))
             {
-                if (isXmasManufacturerName(lightNode->manufacturer()))
+                if (isXmasLightStrip(lightNode))
                 {
                     continue;
                 }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2075,7 +2075,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
                 openDb();
                 manufacturer = loadDataForLightNodeFromDb(generateUniqueId(node->address().ext(),0,0));
                 closeDb();
-                
+
                 if (manufacturer.isEmpty())
                 {
                     // extract from sensor if possible
@@ -2627,6 +2627,12 @@ void DeRestPluginPrivate::setLightNodeStaticCapabilities(LightNode *lightNode)
         item = lightNode->item(RStateY);
         if (item) { item->setIsPublic(false); }
     }
+    else if (isXmasManufacturerName(lightNode->manufacturer()))
+    {
+        lightNode->removeItem(RStateAlert);
+        lightNode->removeItem(RStateX);
+        lightNode->removeItem(RStateY);
+    }
 }
 
 /*! Force polling if the node has updated simple descriptors in setup phase.
@@ -2908,6 +2914,10 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
 
             if (ic->id() == COLOR_CLUSTER_ID && (event.clusterId() == COLOR_CLUSTER_ID))
             {
+                if (isXmasManufacturerName(lightNode->manufacturer()))
+                {
+                    continue;
+                }
                 std::vector<deCONZ::ZclAttribute>::const_iterator ia = ic->attributes().begin();
                 std::vector<deCONZ::ZclAttribute>::const_iterator enda = ic->attributes().end();
                 for (;ia != enda; ++ia)
@@ -3018,7 +3028,7 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
                     {
                         if (lightNode->toNumber(RStateEffect) <= 1)
                         {
-                            lightNode->setValue(RStateEffect, ia->numericValue().u8);
+                            lightNode->setValue(RStateEffect, RStateEffectValues[ia->numericValue().u8]);
                         }
                     }
                     else if (ia->id() == 0x4004) // color loop time
@@ -3049,6 +3059,10 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
             }
             else if (ic->id() == LEVEL_CLUSTER_ID && (event.clusterId() == LEVEL_CLUSTER_ID))
             {
+                if (isXmasManufacturerName(lightNode->manufacturer()))
+                {
+                    continue;
+                }
                 std::vector<deCONZ::ZclAttribute>::const_iterator ia = ic->attributes().begin();
                 std::vector<deCONZ::ZclAttribute>::const_iterator enda = ic->attributes().end();
                 for (;ia != enda; ++ia)
@@ -3257,7 +3271,7 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
                         quint8 scene = ia->numericValue().u8;
                         if (scene >= 1 && scene <= 6)
                         {
-                            lightNode->setValue(RStateEffect, scene + 1);
+                            lightNode->setValue(RStateEffect, RStateEffectValuesMueller[scene + 1]);
                         }
                     }
                 }
@@ -6265,18 +6279,18 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                 sensorNode.modelId() == QLatin1String("eaxp72v") || // Tuya
                 sensorNode.modelId() == QLatin1String("88teujp") || // Tuya
                 sensorNode.modelId() == QLatin1String("fvq6avy") || // Tuya
-               (sensorNode.manufacturer() == QLatin1String("_TZE200_aoclfnxz")) || 
+               (sensorNode.manufacturer() == QLatin1String("_TZE200_aoclfnxz")) ||
                (sensorNode.manufacturer() == QLatin1String("_TZE200_ckud7u2l")) )   // Tuya
             {
                 sensorNode.addItem(DataTypeString, RConfigPreset);
                 sensorNode.addItem(DataTypeBool, RConfigLocked);
                 sensorNode.addItem(DataTypeBool, RConfigSetValve);
             }
-            
+
             if (sensorNode.modelId() == QLatin1String("kud7u2l") || // Tuya
                 sensorNode.modelId() == QLatin1String("88teujp") || // Tuya
                 sensorNode.modelId() == QLatin1String("fvq6avy") || // Tuya
-               (sensorNode.manufacturer() == QLatin1String("_TZE200_aoclfnxz")) || 
+               (sensorNode.manufacturer() == QLatin1String("_TZE200_aoclfnxz")) ||
                (sensorNode.manufacturer() == QLatin1String("_TZE200_ckud7u2l")) )   // Tuya
             {
                 sensorNode.addItem(DataTypeString, RConfigSchedule);

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -787,7 +787,35 @@ enum TaskType
     TaskDoorLock = 38,
     TaskDoorUnlock = 39,
     TaskSyncTime = 40,
-    TaskTuyaRequest = 41
+    TaskTuyaRequest = 41,
+    TaskXmas = 42
+};
+
+enum XmasMode
+{
+    ModeWhite = 0,
+    ModeColour = 1,
+    ModeEffect = 2
+};
+
+enum XmasEffect
+{
+    EffectSteady = 0x00,
+    EffectSnow = 0x01,
+    EffectRainbow = 0x02,
+    EffectSnake = 0x03,
+    EffectTinkle = 0x04,
+    EffectFireworks = 0x05,
+    EffectFlag = 0x06,
+    EffectWaves = 0x07,
+    EffectUpdown = 0x08,
+    EffectVintage = 0x09,
+    EffectFading = 0x0a,
+    EffectCollide = 0x0b,
+    EffectStrobe = 0x0c,
+    EffectSparkles = 0x0d,
+    EffectCarnaval = 0x0e,
+    EffectGlow = 0x0f
 };
 
 struct TaskItem
@@ -1454,6 +1482,15 @@ public:
     bool addTaskSyncTime(Sensor *sensor);
     bool addTaskThermostatUiConfigurationReadWriteAttribute(TaskItem &task, uint8_t readOrWriteCmd, uint16_t attrId, uint8_t attrType, uint32_t attrValue, uint16_t mfrCode=0);
     bool addTaskFanControlReadWriteAttribute(TaskItem &task, uint8_t readOrWriteCmd, uint16_t attrId, uint8_t attrType, uint32_t attrValue, uint16_t mfrCode=0);
+
+    // Merry Christmas!
+    bool isXmasManufacturerName(QString manufacturerName);
+    bool addTaskXmasOn(TaskItem &task, bool on);
+    bool addTaskXmasMode(TaskItem &task, XmasMode mode);
+    bool addTaskXmasWhite(TaskItem &task, quint8 bri);
+    bool addTaskXmasColour(TaskItem &task, quint16 hue, quint8 sat, quint8 bri);
+    bool addTaskXmasEffect(TaskItem &task, XmasEffect effect, quint8 speed, QList<QList<quint8>> &colours);
+    int setXmasState(const ApiRequest &req, ApiResponse &rsp, TaskItem &taskRef, QVariantMap &map);
 
     void handleGroupClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleSceneClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -788,17 +788,17 @@ enum TaskType
     TaskDoorUnlock = 39,
     TaskSyncTime = 40,
     TaskTuyaRequest = 41,
-    TaskXmas = 42
+    TaskXmasLightStrip = 42
 };
 
-enum XmasMode
+enum XmasLightStripMode
 {
     ModeWhite = 0,
     ModeColour = 1,
     ModeEffect = 2
 };
 
-enum XmasEffect
+enum XmasLightStripEffect
 {
     EffectSteady = 0x00,
     EffectSnow = 0x01,
@@ -1484,13 +1484,13 @@ public:
     bool addTaskFanControlReadWriteAttribute(TaskItem &task, uint8_t readOrWriteCmd, uint16_t attrId, uint8_t attrType, uint32_t attrValue, uint16_t mfrCode=0);
 
     // Merry Christmas!
-    bool isXmasManufacturerName(QString manufacturerName);
-    bool addTaskXmasOn(TaskItem &task, bool on);
-    bool addTaskXmasMode(TaskItem &task, XmasMode mode);
-    bool addTaskXmasWhite(TaskItem &task, quint8 bri);
-    bool addTaskXmasColour(TaskItem &task, quint16 hue, quint8 sat, quint8 bri);
-    bool addTaskXmasEffect(TaskItem &task, XmasEffect effect, quint8 speed, QList<QList<quint8>> &colours);
-    int setXmasState(const ApiRequest &req, ApiResponse &rsp, TaskItem &taskRef, QVariantMap &map);
+    bool isXmasLightStrip(LightNode *lightNode);
+    bool addTaskXmasLightStripOn(TaskItem &task, bool on);
+    bool addTaskXmasLightStripMode(TaskItem &task, XmasLightStripMode mode);
+    bool addTaskXmasLightStripWhite(TaskItem &task, quint8 bri);
+    bool addTaskXmasLightStripColour(TaskItem &task, quint16 hue, quint8 sat, quint8 bri);
+    bool addTaskXmasLightStripEffect(TaskItem &task, XmasLightStripEffect effect, quint8 speed, QList<QList<quint8>> &colours);
+    int setXmasLightStripState(const ApiRequest &req, ApiResponse &rsp, TaskItem &taskRef, QVariantMap &map);
 
     void handleGroupClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleSceneClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);

--- a/light_node.cpp
+++ b/light_node.cpp
@@ -474,7 +474,7 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
                         {
                             addItem(DataTypeUInt16, RStateX);
                             addItem(DataTypeUInt16, RStateY);
-                            addItem(DataTypeUInt8, RStateEffect);
+                            addItem(DataTypeString, RStateEffect);
                             addItem(DataTypeUInt16, RStateHue);
                             addItem(DataTypeUInt8, RStateSat);
                         }

--- a/resource.cpp
+++ b/resource.cpp
@@ -221,7 +221,7 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RStateCt));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, RStateDark));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, RStateDaylight));
-    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, RStateEffect));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RStateEffect));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RStateErrorCode));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RStateEventDuration));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, RStateFire));
@@ -531,10 +531,6 @@ const QString &ResourceItem::toString() const
             *m_str = dt.toString(format);
             return *m_str;
         }
-    }
-    else if (m_rid->suffix == RStateEffect)
-    {
-        return RStateEffectValuesMueller[m_num];
     }
 
     return rInvalidString;

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -565,9 +565,9 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
     {
         return setWarningDeviceState(req, rsp, taskRef, map);
     }
-    else if (isXmasManufacturerName(taskRef.lightNode->manufacturer()))
+    else if (isXmasLightStrip(taskRef.lightNode))
     {
-        return setXmasState(req, rsp, taskRef, map);
+        return setXmasLightStripState(req, rsp, taskRef, map);
     }
     else if (UseTuyaCluster(taskRef.lightNode->manufacturer()))
     {

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -565,6 +565,10 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
     {
         return setWarningDeviceState(req, rsp, taskRef, map);
     }
+    else if (isXmasManufacturerName(taskRef.lightNode->manufacturer()))
+    {
+        return setXmasState(req, rsp, taskRef, map);
+    }
     else if (UseTuyaCluster(taskRef.lightNode->manufacturer()))
     {
         //window covering
@@ -967,7 +971,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
             rspItemState[QString("/lights/%1/state/on").arg(id)] = true;
             rspItem["success"] = rspItemState;
             rsp.list.append(rspItem);
-            
+
             if (!isDoorLockDevice) // Avoid reporting the new state before the lock report its state as locking/unlocking operations takes time and can also gets stuck.
             {
                 taskRef.lightNode->setValue(RStateOn, targetOn);
@@ -1074,7 +1078,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
             rspItem["success"] = rspItemState;
             rsp.list.append(rspItem);
 
-            taskRef.lightNode->setValue(RStateEffect, effect);
+            taskRef.lightNode->setValue(RStateEffect, RStateEffectValues[effect]);
         }
         else
         {
@@ -1314,7 +1318,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
             rspItem["success"] = rspItemState;
             rsp.list.append(rspItem);
 
-            taskRef.lightNode->setValue(RStateEffect, effect);
+            taskRef.lightNode->setValue(RStateEffect, RStateEffectValues[effect]);
         }
         else
         {
@@ -1339,7 +1343,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
             rspItem["success"] = rspItemState;
             rsp.list.append(rspItem);
 
-            taskRef.lightNode->setValue(RStateEffect, effect);
+            taskRef.lightNode->setValue(RStateEffect, RStateEffectValuesMueller[effect]);
         }
         else
         {
@@ -1517,7 +1521,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
             rspItemState[QString("/lights/%1/state/on").arg(id)] = targetOn;
             rspItem["success"] = rspItemState;
             rsp.list.append(rspItem);
-	
+
             if (!isDoorLockDevice) // Avoid reporting the new state before the lock report its state as locking/unlocking operations takes time and can also gets stuck.
             {
                 taskRef.lightNode->setValue(RStateOn, targetOn);
@@ -1867,8 +1871,8 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
             rspItemState[QString("/lights/%1/state/lift").arg(id)] = targetLift;
             rspItem["success"] = rspItemState;
             rsp.list.append(rspItem);
-            
-            
+
+
             // I m using this code only for Legrand ATM but can be used for other device.
             // Because the attribute reporting take realy long time to be done, can be 2 minutes
             // Or it can be changed only after this time, so using an read attribute don't give usable value
@@ -1917,7 +1921,7 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
             rspItemState[QString("/lights/%1/state/open").arg(id)] = targetOpen;
             rspItem["success"] = rspItemState;
             rsp.list.append(rspItem);
-            
+
             // I m using this code only for Legrand ATM but can be used for other device.
             // Because the attribute reporting take realy long time to be done, can be 2 minutes
             // Or it can be changed only after this time, so using an read attribute don't give usable value
@@ -2441,7 +2445,7 @@ int DeRestPluginPrivate::setLightAttributes(const ApiRequest &req, ApiResponse &
         {
             value = 0x01;
         }
-        
+
         deCONZ::ZclAttribute attr(0xf001, deCONZ::Zcl8BitEnum, "calibration", deCONZ::ZclReadWrite, true);
         attr.setValue(value);
 
@@ -2950,14 +2954,7 @@ void DeRestPluginPrivate::handleLightEvent(const Event &e)
                     }
                     else if (item->lastSet().isValid() && (gwWebSocketNotifyAll || (item->lastChanged().isValid() && item->lastChanged() >= lightNode->lastStatePush)))
                     {
-                        if (rid.suffix == RStateEffect)
-                        {
-                            state[key] = RStateEffectValuesMueller[item->toNumber()];
-                        }
-                        else
-                        {
-                            state[key] = item->toVariant();
-                        }
+                        state[key] = item->toVariant();
                     }
                 }
             }

--- a/tuya.cpp
+++ b/tuya.cpp
@@ -121,9 +121,9 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
     {
         // 0x00 : Used to send command, so not used here
     }
-    else if (lightNode != nullptr && isXmasManufacturerName(lightNode->manufacturer()) &&
-            zclFrame.commandId() == 0x01 &&
-            !(zclFrame.frameControl() & deCONZ::ZclFCDisableDefaultResponse))
+    else if (isXmasLightStrip(lightNode) &&
+             zclFrame.commandId() == 0x01 &&
+             !(zclFrame.frameControl() & deCONZ::ZclFCDisableDefaultResponse))
     {
         sendZclDefaultResponse(ind, zclFrame, deCONZ::ZclSuccessStatus);
     }

--- a/tuya.cpp
+++ b/tuya.cpp
@@ -13,7 +13,7 @@
 //***********************************************************************************
 
 // Value for dp_type
-// ------------------    
+// ------------------
 // 0x00 	DP_TYPE_RAW 	?
 // 0x01 	DP_TYPE_BOOL 	?
 // 0x02 	DP_TYPE_VALUE 	4 byte unsigned integer
@@ -57,7 +57,7 @@
 // -------------------------
 // 0x03     Presence detection (with 0x04)
 // 0x65     Water leak (with 0x01)
-        
+
 //******************************************************************************************
 
 
@@ -82,7 +82,7 @@ bool UseTuyaCluster(QString manufacturer)
     //_TYZB01 don't use tuya cluster
     //_TYZB02 don't use tuya cluster
     //_TZ3400 don't use tuya cluster
-    
+
     if (manufacturer.startsWith(QLatin1String("_TZE200_")) || // Tuya clutster visible
         manufacturer.startsWith(QLatin1String("Tuya_C_")) ||  // Used by fake device
         manufacturer.startsWith(QLatin1String("_TYST11_")) )  // Tuya cluster invisible
@@ -96,17 +96,17 @@ bool UseTuyaCluster(QString manufacturer)
 /*! Handle packets related to Tuya 0xEF00 cluster.
     \param ind the APS level data indication containing the ZCL packet
     \param zclFrame the actual ZCL frame which holds the scene cluster reponse
-    
+
     Taken from https://medium.com/@dzegarra/zigbee2mqtt-how-to-add-support-for-a-new-tuya-based-device-part-2-5492707e882d
  */
- 
+
 void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame)
-{    
+{
     if (zclFrame.isDefaultResponse())
     {
         return;
     }
-    
+
     bool update = false;
 
     LightNode *lightNode = getLightNodeForAddress(ind.srcAddress(), ind.srcEndpoint());
@@ -116,10 +116,16 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
     {
         return;
     }
-        
+
     if (zclFrame.commandId() == 0x00)
     {
         // 0x00 : Used to send command, so not used here
+    }
+    else if (lightNode != nullptr && isXmasManufacturerName(lightNode->manufacturer()) &&
+            zclFrame.commandId() == 0x01 &&
+            !(zclFrame.frameControl() & deCONZ::ZclFCDisableDefaultResponse))
+    {
+        sendZclDefaultResponse(ind, zclFrame, deCONZ::ZclSuccessStatus);
     }
     else if ( (zclFrame.commandId() == 0x01) || (zclFrame.commandId() == 0x02) )
     {
@@ -131,7 +137,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
             DBG_Printf(DBG_INFO, "Tuya : Payload too short");
             return;
         }
-        
+
         QDataStream stream(zclFrame.payload());
         stream.setByteOrder(QDataStream::LittleEndian);
 
@@ -139,18 +145,18 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
         // "transid" is just a "counter", a response will have the same transif than the command.
         // "Status" and "fn" are always 0
         // More explanations at top of file
-        
+
         quint8 status;
         quint8 transid;
         quint16 dp;
         quint8 fn;
         quint8 length = 0;
         qint32 data = 0;
-        
+
         quint8 dp_type;
         quint8 dp_identifier;
         quint8 dummy;
-        
+
         stream >> status;
         stream >> transid;
         stream >> dp;
@@ -158,7 +164,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
 
         //Convertion octet string to decimal value
         stream >> length;
-        
+
         //security, it seem 4 is the maximum
         if (length > 4)
         {
@@ -173,17 +179,17 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                 data = data + dummy;
             }
         }
-        
+
         //To be more precise
         dp_identifier = (quint8) (dp & 0xFF);
         dp_type = (quint8) ((dp >> 8) & 0xFF);
 
         DBG_Printf(DBG_INFO, "Tuya debug 4 : Address 0x%016llX Payload %s\n" , ind.srcAddress().ext(), qPrintable(zclFrame.payload().toHex()));
         DBG_Printf(DBG_INFO, "Tuya debug 5 : Status: %d Transid: %d Dp: %d (0x%02X,0x%02X) Fn: %d Data %ld\n", status , transid , dp , dp_type, dp_identifier, fn , data);
-        
+
         if (length > 4) //schedule command
         {
-            
+
             // Monday = 64, Tuesday = 32, Wednesday = 16, Thursday = 8, Friday = 4, Saturday = 2, Sunday = 1
             // If you want your schedule to run only on workdays, the value would be W124. (64+32+16+8+4 = 124)
             // The API specifies 3 numbers, so a schedule that runs on Monday would be W064.
@@ -192,24 +198,24 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
             // Saturday = W002
             // Sunday = W001
             // All days = W127
-            
+
             QString transitions;
-            
+
             length = length / 3;
-            
+
             if (zclFrame.payload().size() < (( length * 3) + 6) )
             {
                 DBG_Printf(DBG_INFO, "Tuya : Schedule data error\n");
                 return;
             }
-            
+
             quint8 hour;
             quint8 minut;
             quint8 heatSetpoint;
-            
+
             quint8 part = 1;
             QList<int> listday;
-            
+
             if (dp == 0x0070) //work days (6)
             {
                 listday << 124;
@@ -223,7 +229,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                 part = length / 3;
                 listday << 124 << 2 << 1;
             }
-            
+
             for (; part > 0; part--)
             {
                 for (; length > 0; length--)
@@ -236,18 +242,18 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                         .arg(hour, 2, 10, QChar('0'))
                         .arg(minut, 2, 10, QChar('0'))
                         .arg(heatSetpoint);
-                        
+
                     if (part > 0 && listday.size() >= static_cast<int>(part))
                     {
                         updateThermostatSchedule(sensorNode, listday.at(part - 1), transitions);
                     }
-                        
+
                 }
             }
-            
+
             return;
         }
-        
+
         // Sensor and light use same cluster, so need to make a choice for device that have both
         // Some device have sensornode AND lightnode, so need to use the good one.
         if (sensorNode && lightNode)
@@ -256,7 +262,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
             {
                 lightNode = nullptr;
             }
-        
+
             if (sensorNode->type() == QLatin1String("ZHAThermostat"))
             {
                 lightNode = nullptr;
@@ -271,7 +277,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                 (lightNode->manufacturer() == QLatin1String("_TZE200_wmcdj3aq")) ||
                 (lightNode->manufacturer() == QLatin1String("_TYST11_xu1rkty3")) )
             {
-                
+
                 switch (dp)
                 {
                     // 0x0407 > starting moving
@@ -293,25 +299,25 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                         }
                     }
                     break;
-                    case 0x0202: // going to position 
+                    case 0x0202: // going to position
                     case 0x0203: // position reached (more usefull I think)
                     {
                         quint8 lift = (quint8) data;
                         bool open = lift < 100;
                         lightNode->setValue(RStateLift, lift);
                         lightNode->setValue(RStateOpen, open);
-                        
+
                         quint8 level = lift * 254 / 100;
                         bool on = level > 0;
                         lightNode->setValue(RStateBri, level);
                         lightNode->setValue(RStateOn, on);
                     }
                     break;
-                    
+
                     //other
                     default:
                     break;
-                    
+
                 }
             }
             else
@@ -325,12 +331,12 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                     {
 
                         bool onoff = (data == 0) ? false : true;
-                        
+
                         {
                             uint ep = 0x01;
                             if (dp == 0x0102) { ep = 0x02; }
                             if (dp == 0x0103) { ep = 0x03; }
-                        
+
                             LightNode *lightNode2 = lightNode;
                             lightNode = getLightNodeForAddress(ind.srcAddress(), ep);
 
@@ -338,7 +344,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                             {
                                 return;
                             }
-                            
+
                             //Find model id if missing ( modelId().isEmpty ?) and complete it
                             if (lightNode->modelId().isNull() || (lightNode->modelId() == QLatin1String("Unknown")) || (lightNode->manufacturer() == QLatin1String("Unknown")))
                             {
@@ -352,7 +358,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                                     lightNode->setManufacturerName(lightNode2->manufacturer());
                                 }
                             }
-                            
+
                             ResourceItem *item = lightNode->item(RStateOn);
                             if (item && item->toBool() != onoff)
                             {
@@ -366,11 +372,11 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                         }
                     }
                     break;
-                    
+
                     //other
                     default:
                     break;
-                    
+
                 }
             }
         }
@@ -383,9 +389,9 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                     quint8 valve = (quint8) (dp & 0xFF);
                     quint8 temperature = (quint8) ((dp >> 8) & 0xFF);
                     quint8 minute = (quint8) ((dp >> 16) & 0xFF);
-                    
+
                     DBG_Printf(DBG_INFO, "Tuya debug 9 : windows open info: %d %d %d" ,valve , temperature, minute );
-                    
+
                 }
                 break;
                 case 0x0101: // off / running for Moe
@@ -397,7 +403,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                     {
                         return;
                     }
-                    
+
                     ResourceItem *item = sensorNode->item(RConfigMode);
 
                     if (item && item->toString() != mode)
@@ -433,11 +439,11 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                     }
                 }
                 break;
-                case 0x0114: // Valve state on / off 
+                case 0x0114: // Valve state on / off
                 {
                     bool onoff = false;
                     if (data == 1) { onoff = true; }
-                    
+
                     ResourceItem *item = sensorNode->item(RConfigSetValve);
 
                     if (item && item->toBool() != onoff)
@@ -470,7 +476,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                     {
                         return;
                     }
-                    
+
                     ResourceItem *item = sensorNode->item(RConfigMode);
 
                     if ((item && item->toString() != mode) && (data == 0) ) // Only change if off
@@ -484,7 +490,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                 {
                     bool alarm = false;
                     if (data == 1) { alarm = true; }
-                    
+
                     ResourceItem *item = sensorNode->item(RStateAlarm);
 
                     if (item && item->toBool() != alarm)
@@ -510,7 +516,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                     {
                         return;
                     }
-                    
+
                     ResourceItem *item = sensorNode->item(RConfigMode);
 
                     if (item && item->toString() != mode)
@@ -524,7 +530,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                 {
                     bool bat = false;
                     if (data == 1) { bat = true; }
-                    
+
                     ResourceItem *item = sensorNode->item(RStateLowBattery);
 
                     if (item && item->toBool() != bat)
@@ -545,7 +551,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                         item->setValue(temp);
                         Event e(RSensors, RConfigHeatSetpoint, sensorNode->id(), item);
                         enqueueEvent(e);
-                        
+
                     }
                 }
                 break;
@@ -581,7 +587,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                     quint8 bat = (static_cast<qint8>(data & 0xFF));
                     if (bat > 100) { bat = 100; }
                     ResourceItem *item = sensorNode->item(RConfigBattery);
-                    
+
                     if (!item && bat > 0) // valid value: create resource item
                     {
                         item = sensorNode->addItem(DataTypeUInt8, RConfigBattery);
@@ -634,7 +640,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                             item->setValue(temp);
                             Event e(RSensors, RStateTemperature, sensorNode->id(), item);
                             enqueueEvent(e);
-                            
+
                         }
                     }
                 }
@@ -652,7 +658,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                             item->setValue(temp);
                             Event e(RSensors, RConfigHeatSetpoint, sensorNode->id(), item);
                             enqueueEvent(e);
-                            
+
                         }
                     }
                 }
@@ -690,7 +696,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                 {
                     quint8 valve = (static_cast<qint8>(data & 0xFF));
                     bool on = valve > 3;
-                    
+
                     ResourceItem *item = sensorNode->item(RStateOn);
                     if (item)
                     {
@@ -718,7 +724,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                     {
                         return;
                     }
-                    
+
                     ResourceItem *item = sensorNode->item(RConfigPreset);
 
                     if (item && item->toString() != preset)
@@ -742,7 +748,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                     {
                         return;
                     }
-                    
+
                     ResourceItem *item = sensorNode->item(RConfigPreset);
 
                     if (item && item->toString() != preset)
@@ -762,7 +768,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                     {
                         return;
                     }
-                    
+
                     ResourceItem *item = sensorNode->item(RConfigMode);
 
                     if (item && item->toString() != mode)
@@ -776,7 +782,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                 {
                     bool bat = false;
                     if (data == 1) { bat = true; }
-                    
+
                     ResourceItem *item = sensorNode->item(RStateLowBattery);
 
                     if (item && item->toBool() != bat)
@@ -787,7 +793,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                     }
                 }
                 break;
-                
+
                 default:
                 break;
             }
@@ -796,13 +802,13 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
         {
             DBG_Printf(DBG_INFO, "Tuya debug 6 : No device found");
         }
-    
+
     }
     else
     {
         return;
     }
-    
+
     if (update)
     {
         if (lightNode)
@@ -828,13 +834,13 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
 bool DeRestPluginPrivate::SendTuyaRequestThermostatSetWeeklySchedule(TaskItem &taskRef, quint8 weekdays , QString transitions , qint8 Dp_identifier )
 {
     QByteArray data;
-    
+
     QStringList list = transitions.split("T", QString::SkipEmptyParts);
 
     quint8 hh;
     quint8 mm;
     quint8 heatSetpoint;
-    
+
     if (Dp_identifier == 0x65)
     {
         //To finish
@@ -850,7 +856,7 @@ bool DeRestPluginPrivate::SendTuyaRequestThermostatSetWeeklySchedule(TaskItem &t
             DBG_Printf(DBG_INFO, "Tuya : Schedule command error, need to have 6 values\n");
         }
     }
-    
+
     for (const QString &entry : list)
     {
         QStringList attributes = entry.split("|");
@@ -861,13 +867,13 @@ bool DeRestPluginPrivate::SendTuyaRequestThermostatSetWeeklySchedule(TaskItem &t
         hh = attributes.at(0).mid(0, 2).toUInt();
         mm = attributes.at(0).mid(3, 2).toUInt();
         heatSetpoint = attributes.at(1).toInt();
-        
+
         data.append(QByteArray::number(hh,16));
         data.append(QByteArray::number(mm,16));
         data.append(QByteArray::number(heatSetpoint,16));
 
     }
-    
+
     return SendTuyaRequest(taskRef, TaskThermostat , DP_TYPE_RAW , Dp_identifier , data );
 }
 
@@ -876,12 +882,12 @@ bool DeRestPluginPrivate::SendTuyaRequestThermostatSetWeeklySchedule(TaskItem &t
 //
 bool DeRestPluginPrivate::SendTuyaRequest(TaskItem &taskRef, TaskType taskType , qint8 Dp_type, qint8 Dp_identifier , QByteArray data )
 {
-    
+
     DBG_Printf(DBG_INFO, "Send Tuya Request: Dp_type: 0x%02X Dp_ identifier 0x%02X Data: %s\n", Dp_type, Dp_identifier , qPrintable(data.toHex()));
 
     TaskItem task;
     copyTaskReq(taskRef, task);
-    
+
     //Tuya task
     task.taskType = taskType;
 
@@ -896,7 +902,7 @@ bool DeRestPluginPrivate::SendTuyaRequest(TaskItem &taskRef, TaskType taskType ,
     // payload
     QDataStream stream(&task.zclFrame.payload(), QIODevice::WriteOnly);
     stream.setByteOrder(QDataStream::LittleEndian);
-    
+
     //Status always 0x00
     stream << (qint8) 0x00;
     //TransID , use 0

--- a/xmas.cpp
+++ b/xmas.cpp
@@ -1,0 +1,652 @@
+/* Merry Christmas!
+ *
+ * Handle LIDL Melinera Smart LED lightstrip (for Xmas tree).
+ */
+
+#include "de_web_plugin_private.h"
+#include <QBuffer>
+
+#define TUYA_COMMAND_SET 0x00
+
+enum XmasAttribute
+{
+    AttrOn = 1,
+    AttrMode = 2,
+    AttrBri = 3,
+    AttrColour = 5,
+    AttrEffect = 6
+};
+
+enum XmasDataType
+{
+    TypeBool = 1,
+    TypeNumber = 2,
+    TypeString = 3,
+    TypeEnum = 4
+};
+
+const QStringList RStateEffectValuesXmas({
+    "none",
+    "steady", "snow", "rainbow", "snake",
+    "tinkle", "fireworks", "flag", "waves",
+    "updown", "vintage", "fading", "collide",
+    "strobe", "sparkles", "carnival", "glow"
+});
+
+static void initTask(TaskItem &task, quint8 seq)
+{
+    task.taskType = TaskXmas;
+
+    task.req.setClusterId(TUYA_CLUSTER_ID);
+    task.req.setProfileId(HA_PROFILE_ID);
+
+    task.zclFrame.payload().clear();
+    task.zclFrame.setSequenceNumber(seq);
+    task.zclFrame.setCommandId(TUYA_COMMAND_SET); // Set
+    task.zclFrame.setFrameControl(deCONZ::ZclFCClusterCommand |
+                                  deCONZ::ZclFCDirectionClientToServer);
+}
+
+static void tlvOn(QDataStream &stream, bool on)
+{
+    stream << (quint8) AttrOn;
+    stream << (quint8) TypeBool;
+    stream << (quint16) 1;
+    stream << (quint8) (on ? 1 : 0);
+}
+
+static void tlvMode(QDataStream &stream, XmasMode mode)
+{
+    stream << (quint8) AttrMode;
+    stream << (quint8) TypeEnum;
+    stream << (quint16) 1;
+    stream << (quint8) mode;
+}
+
+static void tlvBrightness(QDataStream &stream, quint8 bri)
+{
+    stream << (quint8) AttrBri;
+    stream << (quint8) TypeNumber;
+    stream << (quint16) 4;
+    stream << (quint32) bri * 10;
+}
+
+static void tlvColour(QDataStream &stream, quint16 hue, quint8 sat, quint8 bri)
+{
+    char s[13];
+    sprintf(s, "%04x%04x%04x", hue, sat * 10, bri * 10);
+
+    stream << (quint8) AttrColour;
+    stream << (quint8) TypeString;
+    stream << (quint16) strlen(s);
+    stream.writeRawData(s, strlen(s));
+}
+
+static void tlvEffect(QDataStream &stream, quint8 effect, quint8 speed, QList<QList<quint8>> &colours)
+{
+    char s[41];
+    sprintf(s, "%02x%02x", effect, speed);
+    int i = 4;
+    for (const QList<quint8> colour: colours)
+    {
+        sprintf(s + i, "%02x%02x%02x", colour[0], colour[1], colour[2]);
+        i += 6;
+    }
+
+    stream << (quint8) AttrEffect;
+    stream << (quint8) TypeString;
+    stream << (quint16) strlen(s);
+    stream.writeRawData(s, strlen(s));
+}
+
+/*! Check whether the manufacturerName is for the Smart LED lightstrip.
+    \param ind - the indication primitive
+ */
+bool DeRestPluginPrivate::isXmasManufacturerName(QString manufacturerName)
+{
+    return manufacturerName == QLatin1String("_TZE200_s8gkrkxk");
+}
+
+QString XmasEffectName(quint8 effect)
+{
+    return RStateEffectValuesXmas[effect];
+}
+
+/*! Switch the lightstrip on or off.
+    \param task - the task item
+    \param on - on (true) or off (false)
+    \return true - on success
+            false - on error
+ */
+bool DeRestPluginPrivate::addTaskXmasOn(TaskItem &task, bool on)
+{
+    const quint8 seq = zclSeq++;
+    initTask(task, seq);
+
+    // payload
+    QDataStream stream(&task.zclFrame.payload(), QIODevice::WriteOnly);
+    stream.setByteOrder(QDataStream::BigEndian); // !
+    stream << (quint8) 0; // Status
+    stream << (quint8) seq; // Transaction ID
+
+    tlvOn(stream, on);
+
+    { // ZCL frame
+        task.req.asdu().clear(); // cleanup old request data if there is any
+        QDataStream stream(&task.req.asdu(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+        task.zclFrame.writeToStream(stream);
+    }
+
+    return addTask(task);
+}
+
+/*! Switch the lightstrip on or off.
+    \param task - the task item
+    \param on - on (true) or off (false)
+    \return true - on success
+            false - on error
+ */
+bool DeRestPluginPrivate::addTaskXmasMode(TaskItem &task, XmasMode mode)
+{
+    const quint8 seq = zclSeq++;
+    initTask(task, seq);
+
+    // payload
+    QDataStream stream(&task.zclFrame.payload(), QIODevice::WriteOnly);
+    stream.setByteOrder(QDataStream::BigEndian); // !
+    stream << (quint8) 0; // Status
+    stream << (quint8) seq; // Transaction ID
+
+    tlvMode(stream, mode);
+
+    { // ZCL frame
+        task.req.asdu().clear(); // cleanup old request data if there is any
+        QDataStream stream(&task.req.asdu(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+        task.zclFrame.writeToStream(stream);
+    }
+
+    return addTask(task);
+}
+
+/*! Switch the lightstrip on, set it to white mode, and set the brightness.
+    \param task - the task item
+    \param bri - the brightness, between 0 and 100
+    \return true - on success
+            false - on error
+ */
+bool DeRestPluginPrivate::addTaskXmasWhite(TaskItem &task, quint8 bri)
+{
+    const quint8 seq = zclSeq++;
+    initTask(task, seq);
+
+    // payload
+    QDataStream stream(&task.zclFrame.payload(), QIODevice::WriteOnly);
+    stream.setByteOrder(QDataStream::BigEndian); // !
+    stream << (quint8) 0; // Status
+    stream << (quint8) seq; // Transaction ID
+
+    // tlvOn(stream, true);
+    // tlvMode(stream, ModeWhite);
+    tlvBrightness(stream, bri);
+
+    { // ZCL frame
+        task.req.asdu().clear(); // cleanup old request data if there is any
+        QDataStream stream(&task.req.asdu(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+        task.zclFrame.writeToStream(stream);
+    }
+
+    return addTask(task);
+}
+
+/*! Switch the lightstrip on, set it to colour mode, and set the colour.
+    \param task - the task item
+    \param hue - the hue, between 0 and 360
+    \param sat - the saturation, between 0 and 100
+    \param bri - the level, between 0 and 100
+    \note The lightstrip uses HSL values to set the colour and brightness.
+ */
+bool DeRestPluginPrivate::addTaskXmasColour(TaskItem &task, quint16 hue, quint8 sat, quint8 bri)
+{
+    const quint8 seq = zclSeq++;
+    initTask(task, seq);
+
+    // payload
+    QDataStream stream(&task.zclFrame.payload(), QIODevice::WriteOnly);
+    stream.setByteOrder(QDataStream::BigEndian); // !
+    stream << (quint8) 0; // Status
+    stream << (quint8) seq; // Transaction ID
+
+    // tlvOn(stream, true);
+    // tlvMode(stream, ModeColour);
+    tlvColour(stream, hue, sat, bri);
+
+    { // ZCL frame
+        task.req.asdu().clear(); // cleanup old request data if there is any
+        QDataStream stream(&task.req.asdu(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+        task.zclFrame.writeToStream(stream);
+    }
+
+    return addTask(task);
+}
+
+/*! Switch the lightstrip on, set it to effect mode, and set the effect.
+    \param task - the task item
+    \param effect - the effect, between 0 and 15
+    \param speed - the effect speed, between 0 and 100
+    \param colours - a list of 0 to 6 RGB colours.  Each colour is a list of 3 quint8 values.
+    \note The lightstrip uses RGB values to set the effect colours.
+ */
+bool DeRestPluginPrivate::addTaskXmasEffect(TaskItem &task, XmasEffect effect, quint8 speed, QList<QList<quint8>> &colours)
+{
+    const quint8 seq = zclSeq++;
+    initTask(task, seq);
+
+    // payload
+    QDataStream stream(&task.zclFrame.payload(), QIODevice::WriteOnly);
+    stream.setByteOrder(QDataStream::BigEndian); // !
+    stream << (quint8) 0; // Status
+    stream << (quint8) seq; // Transaction ID
+
+    tlvOn(stream, true);
+    tlvMode(stream, ModeEffect);
+    tlvEffect(stream, effect, speed, colours);
+
+    { // ZCL frame
+        task.req.asdu().clear(); // cleanup old request data if there is any
+        QDataStream stream(&task.req.asdu(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+        task.zclFrame.writeToStream(stream);
+    }
+
+    return addTask(task);
+}
+
+/*! Helper to generate a new task with new task and req id based on a reference */
+static void copyTaskReq(TaskItem &a, TaskItem &b)
+{
+    b.req.dstAddress() = a.req.dstAddress();
+    b.req.setDstAddressMode(a.req.dstAddressMode());
+    b.req.setSrcEndpoint(a.req.srcEndpoint());
+    b.req.setDstEndpoint(a.req.dstEndpoint());
+    b.req.setRadius(a.req.radius());
+    b.req.setTxOptions(a.req.txOptions());
+    b.req.setSendDelay(a.req.sendDelay());
+    b.transitionTime = a.transitionTime;
+    b.onTime = a.onTime;
+    b.lightNode = a.lightNode;
+}
+
+/*! PUT, PATCH /api/<apikey>/lights/<id>/state for Xmas lights.
+    \return REQ_READY_SEND
+            REQ_NOT_HANDLED
+ */
+int DeRestPluginPrivate::setXmasState(const ApiRequest &req, ApiResponse &rsp, TaskItem &taskRef, QVariantMap &map)
+{
+    bool ok;
+    QString id = req.path[3];
+
+    bool hasCmd = false;
+    bool isOn = false;
+    bool hasOn = false;
+    bool targetOn = false;
+    bool hasBri = false;
+    quint8 targetBri = 0;
+    bool hasHue = false;
+    quint16 targetHue = 0;
+    bool hasSat = false;
+    quint8 targetSat = 0;
+    int effect = -1;
+    bool hasEffectSpeed = false;
+    quint16 effectSpeed = 50;
+    QList<QList<quint8>> effectColours;
+
+    // Check parameters.
+    for (QVariantMap::const_iterator p = map.begin(); p != map.end(); p++)
+    {
+        bool paramOk = false;
+        bool valueOk = false;
+        QString param = p.key();
+        if (param == "on" && taskRef.lightNode->item(RStateOn))
+        {
+            paramOk = true;
+            hasCmd = true;
+            if (map[param].type() == QVariant::Bool)
+            {
+                valueOk = true;
+                hasOn = true;
+                targetOn = map[param].toBool();
+            }
+        }
+        else if (param == "bri" && taskRef.lightNode->item(RStateBri))
+        {
+            paramOk = true;
+            hasCmd = true;
+            if (map[param].type() == QVariant::Double)
+            {
+                const uint bri = map[param].toUInt(&ok);
+                if (ok && bri <= 0xFF)
+                {
+                    valueOk = true;
+                    hasBri = true;
+                    targetBri = bri > 0xFE ? 0xFE : bri;
+                }
+            }
+        }
+        else if (param == "hue" && taskRef.lightNode->item(RStateHue) && taskRef.lightNode->item(RStateSat))
+        {
+            paramOk = true;
+            hasCmd = true;
+            const uint hue = map[param].toUInt(&ok);
+            if (ok && hue <= 0xFFFF)
+            {
+                valueOk = true;
+                hasHue = true;
+                targetHue = hue; // Funny: max CurrentHue is 0xFE, max EnhancedCurrentHue is 0xFFFF
+            }
+        }
+        else if (param == "sat" && taskRef.lightNode->item(RStateHue) && taskRef.lightNode->item(RStateSat))
+        {
+            paramOk = true;
+            hasCmd = true;
+            const uint sat = map[param].toUInt(&ok);
+            if (ok && sat <= 0xFF)
+            {
+                valueOk = true;
+                hasSat = true;
+                targetSat = sat > 0xFE ? 0xFE : sat;
+            }
+        }
+        else if (param == "effect" && taskRef.lightNode->item(RStateEffect))
+        {
+            paramOk = true;
+            hasCmd = true;
+            if (map[param].type() == QVariant::String)
+            {
+                effect = RStateEffectValuesXmas.indexOf(map[param].toString());
+                valueOk = effect >= 0;
+            }
+        }
+        else if (param == "effectSpeed" && taskRef.lightNode->item(RStateEffect))
+        {
+            paramOk = true;
+            const uint speed = map[param].toUInt(&ok);
+            if (ok && speed <= 100)
+            {
+                valueOk = true;
+                effectSpeed = speed < 1 ? 1 : speed;
+            }
+        }
+        else if (param == "effectColours" && taskRef.lightNode->item(RStateEffect))
+        {
+            paramOk = true;
+            ok = true;
+            if (map[param].type() == QVariant::List)
+            {
+                QVariantList colours = map["effectColours"].toList();
+                if (colours.length() <= 6) {
+                    for (const QVariant colour: colours)
+                    {
+                        if (colour.type() == QVariant::List)
+                        {
+                            QVariantList rgb = colour.toList();
+                            if (rgb.length() != 3) {
+                                ok = false;
+                                break;
+                            }
+                            const uint r = rgb[0].toUInt(&ok);
+                            if (!ok)
+                            {
+                                break;
+                            }
+                            const uint g = rgb[1].toUInt(&ok);
+                            if (!ok)
+                            {
+                                break;
+                            }
+                            const uint b = rgb[2].toUInt(&ok);
+                            if (!ok)
+                            {
+                                break;
+                            }
+                            if (r > 0xFF || g > 0xFF || b > 0xFF)
+                            {
+                                ok = false;
+                                break;
+                            }
+                            effectColours.push_back({(quint8) r, (quint8) g, (quint8) b});
+                        }
+                    }
+                    if (ok)
+                    {
+                        valueOk = true;
+                    }
+                    else
+                    {
+                        effectColours = {};
+                    }
+                }
+            }
+        }
+        else if (param == "ontime")
+        {
+            paramOk = true;
+            if (map[param].type() == QVariant::Double)
+            {
+                const uint ot = map[param].toUInt(&ok);
+                if (ok && ot <= 0xFFFF)
+                {
+                    valueOk = true;
+                    taskRef.onTime = ot;
+                }
+            }
+        }
+        if (!paramOk)
+        {
+            rsp.list.append(errorToMap(ERR_PARAMETER_NOT_AVAILABLE, QString("/lights/%1/state").arg(id), QString("parameter, %1, not available").arg(param)));
+        }
+        else if (!valueOk)
+        {
+            rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/lights/%1/state").arg(id), QString("invalid value, %1, for parameter, %2").arg(map[param].toString()).arg(param)));
+        }
+    }
+    if (taskRef.onTime > 0 && !hasOn)
+    {
+        rsp.list.append(errorToMap(ERR_MISSING_PARAMETER, QString("/lights/%1/state").arg(id), QString("missing parameter, on, for parameter, ontime")));
+    }
+    if (hasEffectSpeed && effect < 1)
+    {
+        rsp.list.append(errorToMap(ERR_MISSING_PARAMETER, QString("/lights/%1/state").arg(id), QString("missing parameter, effect, for parameter, effectSpeed")));
+    }
+    if (effectColours.length() > 0 && effect < 1)
+    {
+        rsp.list.append(errorToMap(ERR_MISSING_PARAMETER, QString("/lights/%1/state").arg(id), QString("missing parameter, effect, for parameter, effectSpeed")));
+    }
+    if (!hasCmd)
+    {
+        rsp.list.append(errorToMap(ERR_MISSING_PARAMETER, QString("/lights/%1/state").arg(id), QString("missing parameter to set light state")));
+    }
+
+    // Check whether light is on.
+    isOn = taskRef.lightNode->toBool(RStateOn);
+
+    // state.on: true
+    if (hasOn && targetOn)
+    {
+        TaskItem task;
+        copyTaskReq(taskRef, task);
+
+        const quint8 cmd = taskRef.onTime > 0
+                ? ONOFF_COMMAND_ON_WITH_TIMED_OFF
+                : ONOFF_COMMAND_ON;
+        ok = addTaskSetOnOff(task, cmd, taskRef.onTime, 0);
+
+        if (ok)
+        {
+            isOn = true;
+            QVariantMap rspItem;
+            QVariantMap rspItemState;
+            rspItemState[QString("/lights/%1/state/on").arg(id)] = true;
+            rspItem["success"] = rspItemState;
+            rsp.list.append(rspItem);
+            taskRef.lightNode->setValue(RStateOn, targetOn);
+        }
+        else
+        {
+            rsp.list.append(errorToMap(ERR_INTERNAL_ERROR, QString("/lights/%1/state/on").arg(id), QString("Internal error, %1").arg(ERR_BRIDGE_BUSY)));
+        }
+    }
+
+    if (effect >= 0)
+    {
+        TaskItem task;
+        copyTaskReq(taskRef, task);
+
+        if (effect == R_EFFECT_NONE)
+        {
+            targetSat = taskRef.lightNode->toNumber(RStateSat);
+            ok = addTaskXmasMode(task, targetSat > 0 ? ModeColour : ModeWhite);
+        }
+        else
+        {
+            ok = addTaskXmasEffect(task, XmasEffect(effect - 1), effectSpeed, effectColours);
+        }
+        if (ok)
+        {
+            QVariantMap rspItem;
+            QVariantMap rspItemState;
+            rspItemState[QString("/lights/%1/state/effect").arg(id)] = RStateEffectValuesXmas[effect];
+            rspItem["success"] = rspItemState;
+            rsp.list.append(rspItem);
+
+            taskRef.lightNode->setValue(RStateEffect, RStateEffectValuesXmas[effect]);
+        }
+        else
+        {
+            rsp.list.append(errorToMap(ERR_INTERNAL_ERROR, QString("/lights/%1/state/effect").arg(id), QString("Internal error, %1").arg(ERR_BRIDGE_BUSY)));
+        }
+    }
+    else if (hasBri || hasHue || hasSat)
+    {
+        TaskItem task;
+        copyTaskReq(taskRef, task);
+
+        if (!isOn)
+        {
+            if (hasHue)
+            {
+                rsp.list.append(errorToMap(ERR_DEVICE_OFF, QString("/lights/%1/state").arg(id), QString("parameter, hue, is not modifiable. Device is set to off.")));
+            }
+            if (hasSat)
+            {
+                rsp.list.append(errorToMap(ERR_DEVICE_OFF, QString("/lights/%1/state").arg(id), QString("parameter, sat, is not modifiable. Device is set to off.")));
+            }
+            if (hasBri)
+            {
+                rsp.list.append(errorToMap(ERR_DEVICE_OFF, QString("/lights/%1/state").arg(id), QString("parameter, bri, is not modifiable. Device is set to off.")));
+            }
+        }
+        if (!hasHue) // only state.sat
+        {
+            targetHue = taskRef.lightNode->toNumber(RStateHue);
+        }
+        if (!hasSat) // only state.hue
+        {
+            targetSat = taskRef.lightNode->toNumber(RStateSat);
+        }
+        if (!hasBri)
+        {
+            targetBri = taskRef.lightNode->toNumber(RStateBri);
+        }
+
+        if (targetSat == 0)
+        {
+            quint8 bri = round(targetBri * 100.0 / 0xFF);
+            ok = addTaskXmasWhite(task, bri);
+        }
+        else
+        {
+            quint16 h = round(targetHue * 360.0 / 0xFFFF);
+            quint8 s = round(targetSat * 100.0 / 0xFF);
+            quint8 l = round(targetBri * 100.0 / 0xFF);
+            ok = addTaskXmasColour(task, h, s, l);
+        }
+        if (ok)
+        {
+            if (hasBri)
+            {
+                QVariantMap rspItem;
+                QVariantMap rspItemState;
+                rspItemState[QString("/lights/%1/state/bri").arg(id)] = targetBri;
+                rspItem["success"] = rspItemState;
+                rsp.list.append(rspItem);
+
+                taskRef.lightNode->setValue(RStateBri, targetBri);
+            }
+            if (hasHue)
+            {
+                QVariantMap rspItem;
+                QVariantMap rspItemState;
+                rspItemState[QString("/lights/%1/state/hue").arg(id)] = targetHue;
+                rspItem["success"] = rspItemState;
+                rsp.list.append(rspItem);
+
+                taskRef.lightNode->setValue(RStateHue, targetHue);
+            }
+            if (hasSat)
+            {
+                QVariantMap rspItem;
+                QVariantMap rspItemState;
+                rspItemState[QString("/lights/%1/state/sat").arg(id)] = targetSat;
+                rspItem["success"] = rspItemState;
+                rsp.list.append(rspItem);
+
+                taskRef.lightNode->setValue(RStateSat, targetSat);
+            }
+            taskRef.lightNode->setValue(RStateEffect, RStateEffectValuesXmas[R_EFFECT_NONE]);
+        }
+        else
+        {
+            if (hasBri)
+            {
+                rsp.list.append(errorToMap(ERR_INTERNAL_ERROR, QString("/lights/%1/state/bri").arg(id), QString("Internal error, %1").arg(ERR_BRIDGE_BUSY)));
+            }
+            if (hasHue)
+            {
+                rsp.list.append(errorToMap(ERR_INTERNAL_ERROR, QString("/lights/%1/state/hue").arg(id), QString("Internal error, %1").arg(ERR_BRIDGE_BUSY)));
+            }
+            if (hasSat)
+            {
+                rsp.list.append(errorToMap(ERR_INTERNAL_ERROR, QString("/lights/%1/state/sat").arg(id), QString("Internal error, %1").arg(ERR_BRIDGE_BUSY)));
+            }
+        }
+    }
+
+    // state.on: false
+    if (hasOn && !targetOn)
+    {
+        TaskItem task;
+        copyTaskReq(taskRef, task);
+
+        if (addTaskSetOnOff(task, ONOFF_COMMAND_OFF, 0, 0))
+        {
+            QVariantMap rspItem;
+            QVariantMap rspItemState;
+            rspItemState[QString("/lights/%1/state/on").arg(id)] = targetOn;
+            rspItem["success"] = rspItemState;
+            rsp.list.append(rspItem);
+            taskRef.lightNode->setValue(RStateOn, targetOn);
+        }
+        else
+        {
+            rsp.list.append(errorToMap(ERR_INTERNAL_ERROR, QString("/lights/%1/state/on").arg(id), QString("Internal error, %1").arg(ERR_BRIDGE_BUSY)));
+        }
+    }
+
+    rsp.etag = taskRef.lightNode->etag;
+    processTasks();
+    return REQ_READY_SEND;
+}


### PR DESCRIPTION
This PR adds REST API support for the LIDL Melinera Smart LED strip, a.k.a. the Xmas light strip, see #3716.

I've implemented the following changes:
- Created `xmas.cpp` with exposes the following public methods:
  - `DeRestPluginPrivate::isXmasLightStrip()` to check whether a `LightNode` is, in fact the Xmas light strip;
  - `DeRestPluginPrivate::setXmasLightStripState()` to handle a PUT to the state of the Xmas light strip;
  - `DeRestPluginPrivate::addTaskXmasLightStrip...()` to queue tasks for _Tuya_ cluster of the Xmas light strip;
- Created the following public enums:
  - `XmasLightStripMode`;
  - `XmasLightStripEffect`;
- Changed `RStateEffect` back to `DataTypeString`;
- Added a hook in `DeRestPluginPrivate::setLightNodeCapabilities()` to delete unsupported `state` attributes, which are probably created before the _Manufacturer Name_ has been read'
- Added hooks in `DeRestPluginPrivate::updateLightNode()` to ignore _Level Control_ and _Color Control_ attributes, as the Xmas light strip doesn't update these when updating the state through the _Tuya_ cluster;
- Added hook in `DeRestPluginPrivate::handleTuyaClusterIndication()` to send a _ZCL Default Response_ on receiving command 0x01.