### PR TITLE
Various fixes

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -3624,8 +3624,6 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     sensor.addItem(DataTypeBool, RConfigDisplayFlipped);
                     sensor.addItem(DataTypeBool, RConfigLocked);
                     sensor.addItem(DataTypeBool, RConfigMountingMode);
-                    sensor.addItem(DataTypeString, RConfigSchedule);
-                    sensor.addItem(DataTypeBool, RConfigScheduleOn);
                 }
                 else if (sensor.modelId() == QLatin1String("AC201")) // OWON AC201 Thermostat
                 {

--- a/database.cpp
+++ b/database.cpp
@@ -3520,18 +3520,8 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     sensor.modelId() == QLatin1String("kud7u2l") ||         // Tuya
                     sensor.modelId() == QLatin1String("902010/32") ||       // Bitron
                    (sensor.manufacturer() == QLatin1String("_TZE200_ckud7u2l")) ||          // Tuya
-                   (sensor.manufacturer() == QLatin1String("_TZE200_aoclfnxz")) ||          // Tuya
-                    sensor.modelId() == QLatin1String("Zen-01") )           // Zen
+                   (sensor.manufacturer() == QLatin1String("_TZE200_aoclfnxz")))            // Tuya
                 {
-                    sensor.addItem(DataTypeString, RConfigMode);
-                }
-                
-                if (sensor.modelId() == QLatin1String("Super TR"))   // ELKO
-                {
-                    sensor.addItem(DataTypeString, RConfigTemperatureMeasurement);
-                    sensor.addItem(DataTypeInt16, RStateFloorTemperature);
-                    sensor.addItem(DataTypeBool, RStateHeating);
-                    sensor.addItem(DataTypeBool, RConfigLocked);
                     sensor.addItem(DataTypeString, RConfigMode);
                 }
 
@@ -3582,6 +3572,14 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     sensor.addItem(DataTypeUInt8, RStateValve);
                     sensor.addItem(DataTypeUInt32, RConfigHostFlags); // hidden
                     sensor.addItem(DataTypeBool, RConfigDisplayFlipped);
+                    sensor.addItem(DataTypeBool, RConfigLocked);
+                    sensor.addItem(DataTypeString, RConfigMode);
+                }
+                else if (sensor.modelId() == QLatin1String("Super TR"))   // ELKO
+                {
+                    sensor.addItem(DataTypeString, RConfigTemperatureMeasurement);
+                    sensor.addItem(DataTypeInt16, RStateFloorTemperature);
+                    sensor.addItem(DataTypeBool, RStateHeating);
                     sensor.addItem(DataTypeBool, RConfigLocked);
                     sensor.addItem(DataTypeString, RConfigMode);
                 }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6304,15 +6304,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                 sensorNode.addItem(DataTypeString, RConfigMode);
             }
 
-            if (sensorNode.modelId() == QLatin1String("Super TR"))   // ELKO
-            {
-                sensorNode.addItem(DataTypeString, RConfigTemperatureMeasurement);
-                sensorNode.addItem(DataTypeInt16, RStateFloorTemperature);
-                sensorNode.addItem(DataTypeBool, RStateHeating);
-                sensorNode.addItem(DataTypeBool, RConfigLocked);
-                sensorNode.addItem(DataTypeString, RConfigMode);
-            }
-
             if (sensorNode.modelId() == QLatin1String("kud7u2l") || // Tuya
                 sensorNode.modelId() == QLatin1String("GbxAXL2") || // Tuya
                 (sensorNode.manufacturer() == QLatin1String("_TZE200_ckud7u2l")) )   // Tuya
@@ -6360,6 +6351,14 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                 sensorNode.addItem(DataTypeUInt8, RStateValve);
                 sensorNode.addItem(DataTypeUInt32, RConfigHostFlags); // hidden
                 sensorNode.addItem(DataTypeBool, RConfigDisplayFlipped);
+                sensorNode.addItem(DataTypeBool, RConfigLocked);
+                sensorNode.addItem(DataTypeString, RConfigMode);
+            }
+            else if (sensorNode.modelId() == QLatin1String("Super TR"))   // ELKO
+            {
+                sensorNode.addItem(DataTypeString, RConfigTemperatureMeasurement);
+                sensorNode.addItem(DataTypeInt16, RStateFloorTemperature);
+                sensorNode.addItem(DataTypeBool, RStateHeating);
                 sensorNode.addItem(DataTypeBool, RConfigLocked);
                 sensorNode.addItem(DataTypeString, RConfigMode);
             }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -761,9 +761,9 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
     }
 
     const QStringList buttonMapLocations = {
+        deCONZ::getStorageLocation(deCONZ::ApplicationsDataLocation) + QLatin1String("/devices/button_maps.json")
 #ifdef Q_OS_LINUX
-        QLatin1String("/usr/share/deCONZ/devices/button_maps.json"), deCONZ::getStorageLocation(deCONZ::ApplicationsDataLocation) +
-        QLatin1String("/devices/button_maps.json")
+        , "/usr/share/deCONZ/devices/button_maps.json"
 #endif
 #ifdef Q_OS_WIN
         , qApp->applicationDirPath() + QLatin1String("/../devices/button_maps.json")

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -761,9 +761,9 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
     }
 
     const QStringList buttonMapLocations = {
-        deCONZ::getStorageLocation(deCONZ::ApplicationsDataLocation) + QLatin1String("/devices/button_maps.json")
 #ifdef Q_OS_LINUX
-        , "/usr/share/deCONZ/devices/button_maps.json"
+        QLatin1String("/usr/share/deCONZ/devices/button_maps.json"), deCONZ::getStorageLocation(deCONZ::ApplicationsDataLocation) +
+        QLatin1String("/devices/button_maps.json")
 #endif
 #ifdef Q_OS_WIN
         , qApp->applicationDirPath() + QLatin1String("/../devices/button_maps.json")

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -11706,7 +11706,7 @@ void DeRestPluginPrivate::handleZclAttributeReportIndicationXiaomiSpecial(const 
         }
         else if (tag == 0x0b && dataType == deCONZ::Zcl8BitUint)
         {
-            DBG_Printf(DBG_INFO, "\t0b unknown %d (0x%04X)\n", u8, u8);
+            DBG_Printf(DBG_INFO, "\t0b unknown %d (0x%02X)\n", u8, u8);
         }
         else if ((tag == 0x64 || structIndex == 0x01) && dataType == deCONZ::ZclBoolean) // lumi.ctrl_ln2 endpoint 01
         {
@@ -11720,7 +11720,7 @@ void DeRestPluginPrivate::handleZclAttributeReportIndicationXiaomiSpecial(const 
                 lift = 100 - u8;
             }
             DBG_Printf(DBG_INFO, "\t64 lift %d (%d%%)\n", u8, lift);
-            DBG_Printf(DBG_INFO, "\t64 somke/gas density %d (%d%%)\n", u8);   // lumi.sensor_smoke/lumi.sensor_natgas
+            DBG_Printf(DBG_INFO, "\t64 somke/gas density %d (0x%02X)\n", u8, u8);   // lumi.sensor_smoke/lumi.sensor_natgas
         }
         else if (tag == 0x64 && dataType == deCONZ::Zcl16BitInt)
         {
@@ -11743,6 +11743,14 @@ void DeRestPluginPrivate::handleZclAttributeReportIndicationXiaomiSpecial(const 
         {
             DBG_Printf(DBG_INFO, "\t65 humidity %u\n", u16); // Mi
             humidity = u16;
+        }
+        else if (tag == 0x65 && dataType == deCONZ::Zcl8BitUint)
+        {
+            DBG_Printf(DBG_INFO, "\t65 unknown %d (0x%02X)\n", u8, u8);
+        }
+        else if (tag == 0x66 && dataType == deCONZ::Zcl16BitUint)
+        {
+            DBG_Printf(DBG_INFO, "\t66 unknown %d (0x%04X)\n", u16, u16);
         }
         else if (tag == 0x66 && dataType == deCONZ::Zcl32BitInt) // lumi.weather
         {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -11666,7 +11666,7 @@ void DeRestPluginPrivate::handleZclAttributeReportIndicationXiaomiSpecial(const 
         }
         else if (tag == 0x03 && dataType == deCONZ::Zcl8BitInt)
         {
-            DBG_Printf(DBG_INFO, "\t03 temperature %d °C\n", int(s8)); // Device temperature for lumi.plug.mmeu01
+            DBG_Printf(DBG_INFO, "\t03 Device temperature %d °C\n", int(s8)); // Device temperature for lumi.plug.mmeu01
             temperature = qint16(s8) * 100;
         }
         else if ((tag == 0x04 || structIndex == 0x03) && dataType == deCONZ::Zcl16BitUint)
@@ -11675,7 +11675,7 @@ void DeRestPluginPrivate::handleZclAttributeReportIndicationXiaomiSpecial(const 
         }
         else if (tag == 0x05 && dataType == deCONZ::Zcl16BitUint)
         {
-            DBG_Printf(DBG_INFO, "\t05 RSSI dB (?) %d (0x%04X)\n", u16, u16);
+            DBG_Printf(DBG_INFO, "\t05 RSSI dB (?) %d (0x%04X)\n", u16, u16); // Power outages for lumi.plug.mmeu01
         }
         else if ((tag == 0x06 || structIndex == 0x04) && dataType == deCONZ::Zcl40BitUint)
         {
@@ -11695,7 +11695,7 @@ void DeRestPluginPrivate::handleZclAttributeReportIndicationXiaomiSpecial(const 
         }
         else if (tag == 0x0a && dataType == deCONZ::Zcl16BitUint) // lumi.vibration.aq1
         {
-            DBG_Printf(DBG_INFO, "\t0a unknown %d (0x%04X)\n", u16, u16);
+            DBG_Printf(DBG_INFO, "\t0a Parent NWK %d (0x%04X)\n", u16, u16);
         }
         else if (tag == 0x0b && dataType == deCONZ::Zcl16BitUint)
         {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -786,6 +786,7 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
             btnMapClusterCommands = loadButtonMapCommadsJson(buttonMaps);
             buttonMapForModelId = loadButtonMapModelIdsJson(buttonMaps);
             buttonMapData = loadButtonMapsJson(buttonMaps, btnMapClusters, btnMapClusterCommands);
+            break; // only load once
         }
     }
 }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -7457,7 +7457,9 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     i->modelId() == QLatin1String("Motion Sensor-A") ||  // Osram motion sensor
                                     i->modelId() == QLatin1String("Bell") ||             // Sage doorbell sensor
                                     i->modelId() == QLatin1String("ISW-ZPR1-WP13") ||    // Bosch motion sensor
-                                    i->modelId().endsWith(QLatin1String("86opcn01")) ||  // Aqara Opple
+                                    i->modelId() == QLatin1String("3AFE14010402000D") ||   // Konke motion sensor
+                                    i->modelId() == QLatin1String("3AFE28010402000D") ||   // Konke motion sensor v2
+                                    i->modelId().endsWith(QLatin1String("86opcn01")) ||    // Aqara Opple
                                     i->modelId().startsWith(QLatin1String("AQSZB-1")) ||   // Develco air quality sensor
                                     i->modelId().startsWith(QLatin1String("SMSZB-1")) ||   // Develco smoke sensor
                                     i->modelId().startsWith(QLatin1String("HESZB-1")) ||   // Develco heat sensor

--- a/general.xml
+++ b/general.xml
@@ -3651,8 +3651,13 @@ Contactor > On/off=0003 - HP/HC=0004</description>
 		<!-- LUMI -->
 		<cluster id="0xfcc0" name="Lumi specific" mfcode="0x115f">
 			<description>Lumi specific attributes.
-Note - Aqara Opple switches have 2 modes of operation: Switch all devices (0), event based switching (1).</description>
+Note - Aqara Opple switches have 2 modes of operation (0x0009): Switch all devices (0), event based switching (1).</description>
 			<server>
+				<attribute id="0x0002" name="Power outages" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
+				<attribute id="0x0003" name="Unknown" type="enum8" mfcode="0x115f" access="rw" required="m"> </attribute>
+				<attribute id="0x0006" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"> </attribute>
+				<attribute id="0x0007" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"> </attribute>
+				<attribute id="0x0008" name="Unknown (write only)" type="ostring" mfcode="0x115f" access="w" required="m"> </attribute>
 				<attribute id="0x0009" name="Opple switch mode" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
 				<attribute id="0x00f3" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
 				<attribute id="0x00f5" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"> </attribute>

--- a/general.xml
+++ b/general.xml
@@ -1892,6 +1892,18 @@ Note: It does not clear or delete previous weekly schedule programming configura
 			<attribute id="0x404E" name="Unknown" type="bmp8" access="rw" required="m" mfcode="0x1246"></attribute>
 		</attribute-set>
 
+		<!-- Sinope manufacturer specific -->
+		<attribute-set id="0x0400" description="Sinope specific" mfcode="0x119c">
+			<attribute id="0x0400" name="Occupancy" type="enum8" access="rw" required="m" mfcode="0x119c">
+				<value name="Unoccupied" value="0x00"></value>
+				<value name="Occupied" value="0x01"></value>
+			</attribute>
+			<attribute id="0x0402" name="Backlight" type="enum8" access="rw" required="m" mfcode="0x119c">
+				<value name="On demand" value="0x00"></value>
+				<value name="Sensing" value="0x01"></value>
+			</attribute>
+		</attribute-set>
+
 		<!-- Stelpro manufacturer specific -->
 		<attribute-set id="0x4000" description="Stelpro specific" mfcode="0x1185">
 			<attribute id="0x4001" name="Outdoor temp" type="s16" access="rw" required="m" mfcode="0x1185"></attribute>
@@ -3678,6 +3690,43 @@ Note - Aqara Opple switches have 2 modes of operation (0x0009): Switch all devic
 				<attribute id="0x020b" name="Max. Load Exceeded at (W)" type="float" mfcode="0x115f" access="rw" required="m"> </attribute>
 				<attribute id="0xf000" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
 				<attribute id="0xfffd" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
+			</server>
+			<client>
+			</client>
+		</cluster>
+        
+		<!-- SINOPE -->
+		<cluster id="0xff01" name="Sinope specific" mfcode="0x119c">
+			<description>Sinope specific attributes.
+
+Outdoor Temp to Display Timeout: set 30 for 'off' and 10800 for 'on'</description>
+			<server>
+				<attribute id="0x0010" name="Outdoor Temp on Display" type="s16" mfcode="0x119c" access="rw" required="m"> </attribute>
+				<attribute id="0x0011" name="Outdoor Temp on Display Timeout" type="u16" mfcode="0x119c" access="rw" required="m"> </attribute>
+				<attribute id="0x0020" name="Current Time on Display" type="u32" mfcode="0x119c" access="rw" required="m"> </attribute>
+				<attribute id="0x0105" name="Floor Control Mode" type="enum8" mfcode="0x119c" access="rw" required="m">
+					<value name="Ambient" value="0x01"></value>
+					<value name="Floor" value="0x02"></value>
+				</attribute>
+				<attribute id="0x0108" name="Ambient Max Heat Setpoint Limit" type="s16" mfcode="0x119c" access="rw" required="m"> </attribute>
+				<attribute id="0x0109" name="Floor Min Heat Setpoint Limit" type="s16" mfcode="0x119c" access="rw" required="m"> </attribute>
+				<attribute id="0x0110" name="Floor Max Heat Setpoint Limit" type="s16" mfcode="0x119c" access="rw" required="m"> </attribute>
+				<attribute id="0x0111" name="Temperature Sensor" type="enum8" mfcode="0x119c" access="rw" required="m">
+					<value name="10k" value="0x00"></value>
+					<value name="12k" value="0x01"></value>
+				</attribute>
+				<attribute id="0x0112" name="Floor Limit Status" type="enum8" mfcode="0x119c" access="r" required="m">
+					<value name="Off" value="0x00"></value>
+					<value name="On" value="0x01"></value>
+				</attribute>
+				<attribute id="0x0114" name="Time Format on Display" type="enum8" mfcode="0x119c" access="rw" required="m">
+					<value name="24h" value="0x00"></value>
+					<value name="12h" value="0x01"></value>
+				</attribute>
+				<attribute id="0x0115" name="GFCi Status" type="enum8" mfcode="0x119c" access="r" required="m">
+					<value name="Off" value="0x00"></value>
+					<value name="On" value="0x01"></value>
+				</attribute>
 			</server>
 			<client>
 			</client>

--- a/read_files.cpp
+++ b/read_files.cpp
@@ -161,7 +161,7 @@ QMap<QString, QString> loadButtonMapModelIdsJson(const QJsonDocument &buttonMaps
 
                 if (buttonMapModelIds.size() == 0)
                 {
-                    DBG_Printf(DBG_INFO, "[ERROR] - Button map '%s' in JSON file has no assigned ModelIDs. Skip loading button map...\n", qPrintable(buttonMapName));
+                    DBG_Printf(DBG_INFO, "[WARNING] - Button map '%s' in JSON file has no assigned ModelIDs. Skip loading button map...\n", qPrintable(buttonMapName));
                     continue;   // Skip button map
                 }
 

--- a/read_files.cpp
+++ b/read_files.cpp
@@ -161,7 +161,7 @@ QMap<QString, QString> loadButtonMapModelIdsJson(const QJsonDocument &buttonMaps
 
                 if (buttonMapModelIds.size() == 0)
                 {
-                    DBG_Printf(DBG_INFO, "[WARNING] - Button map '%s' in JSON file has no assigned ModelIDs. Skip loading button map...\n", qPrintable(buttonMapName));
+                    DBG_Printf(DBG_INFO, "[ERROR] - Button map '%s' in JSON file has no assigned ModelIDs. Skip loading button map...\n", qPrintable(buttonMapName));
                     continue;   // Skip button map
                 }
 

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1171,12 +1171,8 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                 }
                 else if (rid.suffix == RConfigCoolSetpoint)
                 {
-                    
-                    // Further Clarification on the type check required. Value should come in as integer by the client and expected as such by the API
-                    // Suspended for now in favor of functionality
-                    
-                    //if (map[pi.key()].type() == QVariant::Double)
-                    //{
+                    if (map[pi.key()].type() == QVariant::Double)
+                    {
                         qint16 coolsetpoint = map[pi.key()].toInt(&ok);
 
                         if (addTaskThermostatReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, 0x0000, 0x0011, deCONZ::Zcl16BitInt, coolsetpoint))
@@ -1190,14 +1186,14 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                             rsp.httpStatus = HttpStatusBadRequest;
                             return REQ_READY_SEND;
                         }
-                    /*}
+                    }
                     else
                     {
                         rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/sensors/%1/config/%2").arg(id).arg(pi.key()).toHtmlEscaped(),
                                                    QString("invalid value, %1, for parameter %2").arg(map[pi.key()].toString()).arg(pi.key()).toHtmlEscaped()));
                         rsp.httpStatus = HttpStatusBadRequest;
                         return REQ_READY_SEND;
-                    }*/
+                    }
                 }
                 else if ((rid.suffix == RConfigMode) && !sensor->modelId().startsWith(QLatin1String("SPZB")))
                 {


### PR DESCRIPTION
- Re-enable typ check for RConfigCoolSetpoint
- Remove unsupported config parameters for Danfoss/Hive thermostats (`RConfigSchedule` and `RConfigScheduleOn` got created while loading the sensor from DB without the device supporting it)
- Some cleanup for thermostat capabilities (re-order the entries, remove `RConfigMode` duplicate for Zen and prevent ELKO Super TR to expose `RConfigSchedule` and `RConfigScheduleOn`)
- Additions for Xiaomi specific cluster
- Update for Xiaomi special reporting output
- Add Sinope specific clusters/attributes to general.xml (#2104)
- Process Konke motion sensor battery reports (#1607)
- Further additions for Xiaomi special reporting output
- Ensure button map is only loaded once