### PR TITLE
Fix ZGP proxy pairing

### DIFF
--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1979,6 +1979,7 @@ public:
     QString lastLightsScan;
 
     SearchSensorsState searchSensorsState;
+    size_t searchSensorGppPairCounter = 0;
     deCONZ::Address fastProbeAddr;
     std::vector<deCONZ::ApsDataIndication> fastProbeIndications;
     QVariantMap searchSensorsResult;

--- a/green_power.cpp
+++ b/green_power.cpp
@@ -124,12 +124,12 @@ bool GP_SendProxyCommissioningMode(deCONZ::ApsController *apsCtrl, quint8 zclSeq
 
 /*! Send Pair command to GP proxy device.
  */
-bool GP_SendPairing(quint32 gpdSrcId, quint16 sinkGroupId, quint8 deviceId, quint32 frameCounter, const GpKey_t &key, deCONZ::ApsController *apsCtrl, quint8 zclSeqNo)
+bool GP_SendPairing(quint32 gpdSrcId, quint16 sinkGroupId, quint8 deviceId, quint32 frameCounter, const GpKey_t &key, deCONZ::ApsController *apsCtrl, quint8 zclSeqNo, quint16 gppShortAddress)
 {
     deCONZ::ApsDataRequest req;
 
     req.setDstAddressMode(deCONZ::ApsNwkAddress);
-    req.dstAddress().setNwk(deCONZ::BroadcastRouters);
+    req.dstAddress().setNwk(gppShortAddress);
     req.setProfileId(GP_PROFILE_ID);
     req.setClusterId(GREEN_POWER_CLUSTER_ID);
     req.setDstEndpoint(GREEN_POWER_ENDPOINT);
@@ -198,10 +198,10 @@ bool GP_SendPairing(quint32 gpdSrcId, quint16 sinkGroupId, quint8 deviceId, quin
     // broadcast
     if (apsCtrl->apsdeDataRequest(req) == deCONZ::Success)
     {
-        DBG_Printf(DBG_INFO, "send GP pairing\n");
+        DBG_Printf(DBG_INFO, "send GP pairing to 0x%04X\n", gppShortAddress);
         return true;
     }
 
-    DBG_Printf(DBG_INFO, "send GP pairing\n");
+    DBG_Printf(DBG_INFO, "send GP pairing to 0x%04X failed\n", gppShortAddress);
     return false;
 }

--- a/green_power.h
+++ b/green_power.h
@@ -18,11 +18,17 @@
 #define GREEN_POWER_CLUSTER_ID  0x0021
 #define GREEN_POWER_ENDPOINT    0xf2
 #define GP_SECURITY_KEY_SIZE 16
+#define GP_MAX_PROXY_PAIRINGS 3
+#define GP_DEFAULT_PROXY_GROUP 0xdd09
+
+#if DECONZ_LIB_VERSION < 0x011000
+  #define DBG_ZGP DBG_INFO  // DBG_ZGP didn't exist before version v2.8.x
+#endif
 
 using GpKey_t = std::array<unsigned char, GP_SECURITY_KEY_SIZE>;
 
 GpKey_t GP_DecryptSecurityKey(quint32 sourceID, const GpKey_t &securityKey);
 bool GP_SendProxyCommissioningMode(deCONZ::ApsController *apsCtrl, quint8 zclSeqNo);
-bool GP_SendPairing(quint32 gpdSrcId, quint16 sinkGroupId, quint8 deviceId, quint32 frameCounter, const GpKey_t &key, deCONZ::ApsController *apsCtrl, quint8 zclSeqNo);
+bool GP_SendPairing(quint32 gpdSrcId, quint16 sinkGroupId, quint8 deviceId, quint32 frameCounter, const GpKey_t &key, deCONZ::ApsController *apsCtrl, quint8 zclSeqNo, quint16 gppShortAddress);
 
 #endif // GREEN_POWER_H

--- a/permitJoin.cpp
+++ b/permitJoin.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2016-2020 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -164,7 +164,7 @@ void DeRestPluginPrivate::permitJoinTimerFired()
 
             if (gwPermitJoinDuration > 0)
             {
-                // sendGPProxyCommissioningMode(); TODO enable when GP security is implemented
+                GP_SendProxyCommissioningMode(apsCtrl, zclSeq++);
             }
         }
         else
@@ -172,7 +172,6 @@ void DeRestPluginPrivate::permitJoinTimerFired()
             DBG_Printf(DBG_INFO, "send permit join failed\n");
         }
 
-        GP_SendProxyCommissioningMode(apsCtrl, zclSeq++);
     }
 }
 

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -3055,6 +3055,7 @@ void DeRestPluginPrivate::startSearchSensors()
         searchSensorsResult.clear();
         lastSensorsScan = QDateTime::currentDateTimeUtc().toString(QLatin1String("yyyy-MM-ddTHH:mm:ss"));
         QTimer::singleShot(1000, this, SLOT(searchSensorsTimerFired()));
+        searchSensorGppPairCounter = 0;
         searchSensorsState = SearchSensorsActive;
     }
     else


### PR DESCRIPTION
- Send GP Pair command to at most 3 proxies, which report at least moderate LQI for the GPD;
- Send GP Proxy Commissioning Mode only while Permit Join is set;
- Add logging for LQI/RSSI of received proxy notifications.

Issue: https://github.com/dresden-elektronik/deconz-rest-plugin/issues/436