### PR TITLE
Lidl plugs fill manufacturername, modelid and swversion for all endpoints

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -2569,19 +2569,19 @@ static int sqliteLoadLightNodeCallback(void *user, int ncols, char **colval , ch
  */
 QString DeRestPluginPrivate::loadDataForLightNodeFromDb(QString extAddress)
 {
-
+    QString result;
     DBG_Assert(db != nullptr);
 
     if (!db || extAddress.isEmpty())
     {
-        return NULL;
+        return result;
     }
 
     QString sql = QString("SELECT manufacturername FROM nodes WHERE mac LIKE '%1%' COLLATE NOCASE").arg(extAddress);
     DBG_Printf(DBG_INFO_L2, "sql exec %s\n", qPrintable(sql));
 
     const char * val = nullptr;
-    sqlite3_stmt *res = NULL;
+    sqlite3_stmt *res = nullptr;
     int rc;
 
     rc = sqlite3_prepare_v2(db, qPrintable(sql), -1, &res, nullptr);
@@ -2593,7 +2593,11 @@ QString DeRestPluginPrivate::loadDataForLightNodeFromDb(QString extAddress)
     if (rc == SQLITE_ROW)
     {
         val = reinterpret_cast<const char*>(sqlite3_column_text(res, 0));
-        DBG_Printf(DBG_INFO, "DB %s: %s\n", qPrintable(sql), val);
+        if (val)
+        {
+            result = val;
+            DBG_Printf(DBG_INFO, "DB %s: %s\n", qPrintable(sql), qPrintable(val));
+        }
     }
 
     if (res)
@@ -2601,7 +2605,7 @@ QString DeRestPluginPrivate::loadDataForLightNodeFromDb(QString extAddress)
         rc = sqlite3_finalize(res);
     }
 
-    return QString(val);
+    return result;
 }
 
 /*! Loads data (if available) for a LightNode from the database.

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2084,9 +2084,10 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
         lightNode.address() = node->address();
         lightNode.setManufacturerCode(node->nodeDescriptor().manufacturerCode());
 
-
         // For Tuya, we realy need manufacture Name, but can't use it to compare because of fonction setManufacturerCode() that put "Heiman",
-        if (((!node->nodeDescriptor().isNull() && node->nodeDescriptor().manufacturerCode() == VENDOR_NONE) || (node->nodeDescriptor().manufacturerCode() == VENDOR_EMBER)) /*&& (node->simpleDescriptors().size() == 1)*/)
+        if (node->nodeDescriptor().isNull() || node->simpleDescriptors().empty())
+        { }
+        else if (node->nodeDescriptor().manufacturerCode() == VENDOR_NONE || (node->nodeDescriptor().manufacturerCode() == VENDOR_EMBER))
         {
             if (manufacturer.isEmpty())
             {
@@ -2111,12 +2112,11 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
 				{
 					DBG_Printf(DBG_INFO, "Tuya debug 7 : Missing manufacture name, till missing in DB.\n");
 				}
-
-
             }
             if (!manufacturer.isEmpty())
             {
                 lightNode.setManufacturerName(manufacturer);
+                lightNode.setNeedSaveDatabase(true);
             }
         }
 

--- a/poll_manager.cpp
+++ b/poll_manager.cpp
@@ -445,8 +445,15 @@ void PollManager::pollTimerFired()
         if (item && (item->toString().isEmpty() ||
              (item->lastSet().secsTo(now) > READ_SWBUILD_ID_INTERVAL))) // dynamic
         {
-
-            if (lightNode->manufacturerCode() == VENDOR_UBISYS ||
+            if (lightNode->manufacturerCode() == VENDOR_EMBER && lightNode->modelId() == QLatin1String("TS011F")) // LIDL plugs
+            {
+                if (item->toString().isEmpty())
+                {
+                    attributes.push_back(0x0001);  // application version
+                    clusterId = BASIC_CLUSTER_ID;
+                }
+            }
+            else if (lightNode->manufacturerCode() == VENDOR_UBISYS ||
                 lightNode->manufacturerCode() == VENDOR_EMBER ||
                 lightNode->manufacturerCode() == VENDOR_HEIMAN ||
                 lightNode->manufacturerCode() == VENDOR_XIAOMI ||
@@ -503,6 +510,11 @@ void PollManager::pollTimerFired()
                             // discard attributes which are not be available
                             if (attrId == attr.id() && attr.isAvailable())
                             {
+                                if (attr.dataType_t() == deCONZ::ZclCharacterString && attr.toString().isEmpty() && attr.lastRead() != static_cast<time_t>(-1))
+                                {
+                                    continue; // skip empty string attributes which are available, read only once
+                                }
+
                                 check.push_back(attr.id());     // Only use available attributes
 
                                 if (cl.id() == BASIC_CLUSTER_ID)


### PR DESCRIPTION
- Fill the data from endpoint 0x01, which is the only valid Basic Cluster, into endpoints 0x02 and 0x03;
- Use Basic Cluster application version attribute for `swversion`;
- Don't endlessly read empty string attributes in poll manager.