### PR TITLE
Lidl motion sensor (TY0202) don't reset presence

### DIFF
--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -3126,6 +3126,12 @@ void DeRestPluginPrivate::checkSensorStateTimerFired()
         if (sensor->durationDue.isValid())
         {
             QDateTime now = QDateTime::currentDateTime();
+
+            if (sensor->modelId() == QLatin1String("TY0202")) // Lidl/SILVERCREST motion sensor
+            {
+                continue; // will be only reset via IAS Zone status
+            }
+
             if (sensor->durationDue <= now)
             {
                 // automatically set presence to false, if not triggered in config.duration


### PR DESCRIPTION
Wait for IAS Zone status, the sensor doesn't update presence if in activated state.
In future we should configure reporting for Zone status.