### PR TITLE
Added support for (Revolt NX-4911-675) _TZE200_kfvq6avy

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6340,6 +6340,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                 sensorNode.modelId() == QLatin1String("eaxp72v") || // Tuya
                 sensorNode.modelId() == QLatin1String("88teujp") || // Tuya
                 sensorNode.modelId() == QLatin1String("fvq6avy") || // Tuya
+               (sensorNode.manufacturer() == QLatin1String("_TZE200_kfvq6avy")) ||
                (sensorNode.manufacturer() == QLatin1String("_TZE200_c88teujp")) ||
                (sensorNode.manufacturer() == QLatin1String("_TZE200_aoclfnxz")) ||
                (sensorNode.manufacturer() == QLatin1String("_TZE200_ckud7u2l")) )   // Tuya
@@ -6352,6 +6353,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             if (sensorNode.modelId() == QLatin1String("kud7u2l") || // Tuya
                 sensorNode.modelId() == QLatin1String("88teujp") || // Tuya
                 sensorNode.modelId() == QLatin1String("fvq6avy") || // Tuya
+               (sensorNode.manufacturer() == QLatin1String("_TZE200_kfvq6avy")) ||
                (sensorNode.manufacturer() == QLatin1String("_TZE200_c88teujp")) ||
                (sensorNode.manufacturer() == QLatin1String("_TZE200_aoclfnxz")) ||
                (sensorNode.manufacturer() == QLatin1String("_TZE200_ckud7u2l")) )   // Tuya
@@ -6363,6 +6365,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                 sensorNode.modelId() == QLatin1String("eaxp72v") || // Tuya
                 sensorNode.modelId() == QLatin1String("88teujp") || // Tuya
                 sensorNode.modelId() == QLatin1String("fvq6avy") || // Tuya
+               (sensorNode.manufacturer() == QLatin1String("_TZE200_kfvq6avy")) ||
                (sensorNode.manufacturer() == QLatin1String("_TZE200_c88teujp")) ||
                (sensorNode.manufacturer() == QLatin1String("_TZE200_ckud7u2l")) )   // Tuya
             {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2139,9 +2139,11 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
             // _TYST11_ckud7u2l is valve with 2 cluster
             // _TYST11_jeaxp72v same
             // _TYST11_kfvq6avy same
+            // _TZE200_kfvq6avy same
             // _TYST11_c88teujp same
             if ((lightNode.manufacturer() == QLatin1String("_TYST11_ckud7u2l")) ||
                 (lightNode.manufacturer() == QLatin1String("_TYST11_kfvq6avy")) ||
+                (lightNode.manufacturer() == QLatin1String("_TZE200_kfvq6avy")) ||
                 (lightNode.manufacturer() == QLatin1String("_TYST11_c88teujp")) ||
                 (lightNode.manufacturer() == QLatin1String("_TYST11_jeaxp72v")) )
             {
@@ -5278,6 +5280,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                         (modelId == QLatin1String("GbxAXL2")) ||
                         (manufacturer == QLatin1String("_TYST11_jeaxp72v")) ||
                         (manufacturer == QLatin1String("_TYST11_kfvq6avy")) ||
+                        (manufacturer == QLatin1String("_TZE200_kfvq6avy")) ||
                         (manufacturer == QLatin1String("_TYST11_c88teujp")) ||
                         (manufacturer == QLatin1String("_TZE200_aoclfnxz")) ||
                         (manufacturer == QLatin1String("_TZE200_c88teujp")) ||

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4832,6 +4832,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                         // For some device the Tuya cluster is sometime Invisible, so force device detection
                         if ((modelId == QLatin1String("kud7u2l")) ||
                             (modelId == QLatin1String("eaxp72v")) ||
+                            (modelId == QLatin1String("TS0601")) ||
                             (modelId == QLatin1String("88teujp")) ||
                             (modelId == QLatin1String("fvq6avy")) ||
                             (modelId == QLatin1String("GbxAXL2")) )

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6340,7 +6340,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                 sensorNode.modelId() == QLatin1String("eaxp72v") || // Tuya
                 sensorNode.modelId() == QLatin1String("88teujp") || // Tuya
                 sensorNode.modelId() == QLatin1String("fvq6avy") || // Tuya
-               (sensorNode.manufacturer() == QLatin1String("_TZE200_kfvq6avy")) ||
+                sensorNode.modelId() == QLatin1String("TS0601") || // Tuya
                (sensorNode.manufacturer() == QLatin1String("_TZE200_c88teujp")) ||
                (sensorNode.manufacturer() == QLatin1String("_TZE200_aoclfnxz")) ||
                (sensorNode.manufacturer() == QLatin1String("_TZE200_ckud7u2l")) )   // Tuya
@@ -6353,7 +6353,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             if (sensorNode.modelId() == QLatin1String("kud7u2l") || // Tuya
                 sensorNode.modelId() == QLatin1String("88teujp") || // Tuya
                 sensorNode.modelId() == QLatin1String("fvq6avy") || // Tuya
-               (sensorNode.manufacturer() == QLatin1String("_TZE200_kfvq6avy")) ||
+                sensorNode.modelId() == QLatin1String("TS0601") || // Tuya
                (sensorNode.manufacturer() == QLatin1String("_TZE200_c88teujp")) ||
                (sensorNode.manufacturer() == QLatin1String("_TZE200_aoclfnxz")) ||
                (sensorNode.manufacturer() == QLatin1String("_TZE200_ckud7u2l")) )   // Tuya
@@ -6365,7 +6365,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                 sensorNode.modelId() == QLatin1String("eaxp72v") || // Tuya
                 sensorNode.modelId() == QLatin1String("88teujp") || // Tuya
                 sensorNode.modelId() == QLatin1String("fvq6avy") || // Tuya
-               (sensorNode.manufacturer() == QLatin1String("_TZE200_kfvq6avy")) ||
+                sensorNode.modelId() == QLatin1String("TS0601") || // Tuya
                (sensorNode.manufacturer() == QLatin1String("_TZE200_c88teujp")) ||
                (sensorNode.manufacturer() == QLatin1String("_TZE200_ckud7u2l")) )   // Tuya
             {

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1004,7 +1004,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                                sensor->modelId().startsWith(QLatin1String("GbxAXL2")) ||
                                sensor->modelId().startsWith(QLatin1String("88teujp")) ||
                                sensor->modelId().startsWith(QLatin1String("eaxp72v")) ||
-                               sensor->modelId().startsWith(QLatin1String("fvq6avy")) ||
+                              (sensor->manufacturer().endsWith(QLatin1String("fvq6avy"))) ||
                               (sensor->manufacturer() == QLatin1String("_TZE200_c88teujp")) ||
                               (sensor->manufacturer() == QLatin1String("_TZE200_ckud7u2l")) ) ) // Tuya Smart TRV HY369 Thermostatic Radiator Valve
                     {
@@ -1128,7 +1128,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                              sensor->modelId().startsWith(QLatin1String("GbxAXL2")) ||
                              sensor->modelId().startsWith(QLatin1String("88teujp")) ||
                              sensor->modelId().startsWith(QLatin1String("eaxp72v")) ||
-                             sensor->modelId().startsWith(QLatin1String("fvq6avy")) ||
+                            (sensor->manufacturer().endsWith(QLatin1String("fvq6avy"))) ||
                             (sensor->manufacturer() == QLatin1String("_TZE200_aoclfnxz")) ||
                             (sensor->manufacturer() == QLatin1String("_TZE200_c88teujp")) ||
                             (sensor->manufacturer() == QLatin1String("_TZE200_ckud7u2l")) )// Tuya Smart TRV HY369 Thermostatic Radiator Valve
@@ -1225,7 +1225,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                     else if ((sensor->modelId().startsWith(QLatin1String("kud7u2l"))) ||
                              (sensor->modelId().startsWith(QLatin1String("eaxp72v"))) ||
                              (sensor->modelId().startsWith(QLatin1String("88teujp"))) ||
-                             (sensor->modelId().startsWith(QLatin1String("fvq6avy"))) ||
+                             (sensor->manufacturer().endsWith(QLatin1String("fvq6avy"))) ||
                              (sensor->manufacturer() == QLatin1String("_TZE200_c88teujp")) ||
                              (sensor->manufacturer() == QLatin1String("_TZE200_ckud7u2l")) ) // Tuya Smart TRV HY369 Thermostatic Radiator Valve
                     {
@@ -1423,8 +1423,8 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                 else if ((rid.suffix == RConfigPreset) && (sensor->modelId().startsWith(QLatin1String("kud7u2l")) ||
                                                            sensor->modelId().startsWith(QLatin1String("GbxAXL2")) ||
                                                            sensor->modelId().startsWith(QLatin1String("88teujp")) ||
-                                                           sensor->modelId().startsWith(QLatin1String("fvq6avy")) ||
                                                            sensor->modelId().startsWith(QLatin1String("eaxp72v")) ||
+                                                          (sensor->manufacturer().endsWith(QLatin1String("fvq6avy"))) ||
                                                           (sensor->manufacturer() == QLatin1String("_TZE200_c88teujp")) ||
                                                           (sensor->manufacturer() == QLatin1String("_TZE200_ckud7u2l")) ))
                 {
@@ -1473,9 +1473,9 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                     {
                         if (sensor->modelId().startsWith(QLatin1String("kud7u2l")) ||
                             sensor->modelId().startsWith(QLatin1String("GbxAXL2")) ||
-                            sensor->modelId().startsWith(QLatin1String("fvq6avy")) ||
                             sensor->modelId().startsWith(QLatin1String("eaxp72v")) ||
                             sensor->modelId().startsWith(QLatin1String("88teujp")) ||
+                           (sensor->manufacturer().endsWith(QLatin1String("fvq6avy"))) ||
                            (sensor->manufacturer() == QLatin1String("_TZE200_c88teujp")) ||
                            (sensor->manufacturer() == QLatin1String("_TZE200_aoclfnxz")) ||
                            (sensor->manufacturer() == QLatin1String("_TZE200_ckud7u2l")) )
@@ -1673,9 +1673,9 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                 }
                 else if ((rid.suffix == RConfigWindowOpen) && (sensor->modelId().startsWith(QLatin1String("kud7u2l")) ||
                                                            sensor->modelId().startsWith(QLatin1String("GbxAXL2")) ||
-                                                           sensor->modelId().startsWith(QLatin1String("fvq6avy")) ||
                                                            sensor->modelId().startsWith(QLatin1String("88teujp")) ||
                                                            sensor->modelId().startsWith(QLatin1String("eaxp72v")) ||
+                                                          (sensor->manufacturer().endsWith(QLatin1String("fvq6avy"))) ||
                                                           (sensor->manufacturer() == QLatin1String("_TZE200_c88teujp")) ||
                                                           (sensor->manufacturer() == QLatin1String("_TZE200_ckud7u2l")) ) )
                 {
@@ -2039,7 +2039,7 @@ int DeRestPluginPrivate::changeThermostatSchedule(const ApiRequest &req, ApiResp
     if ((sensor->modelId() == QLatin1String("kud7u2l")) ||
         (sensor->modelId() == QLatin1String("eaxp72v")) ||
         (sensor->modelId() == QLatin1String("88teujp")) ||
-        (sensor->modelId() == QLatin1String("fvq6avy")) ||
+        (sensor->manufacturer().endsWith(QLatin1String("fvq6avy"))) ||
         (sensor->manufacturer() == QLatin1String("_TZE200_c88teujp")) ||
         (sensor->modelId() == QLatin1String("GbxAXL2")) )
     {


### PR DESCRIPTION
It seems that Revolt released a new revision (or something) of their Zigbee TRV (old: _TYST11_kfvq6avy).
This just adds the necessary strings to make it detectable in deconz. The old TRV is already supported with #3381