### PR TITLE
Fix ambiguous loading of button maps

### DIFF
--- a/button_maps.json
+++ b/button_maps.json
@@ -854,7 +854,7 @@
         "Tuya3gangMap": {
             "vendor": "Tuya",
             "doc": "3-gang remote",
-            "modelids": [""],
+            "modelids": ["_TZ3000_bi6lpsew", "_TZ3400_keyjhapk", "_TYZB02_key8kk7r", "_TZ3400_keyjqthh", "_TZ3400_key8kk7r", "_TZ3000_vp6clf9d", "_TYZB02_keyjqthh"],
             "map": [
                 [1, "0x01", "ONOFF", "0xfd", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "B1 short"],
                 [1, "0x01", "ONOFF", "0xfd", "1", "S_BUTTON_1", "S_BUTTON_ACTION_DOUBLE_PRESS", "B1 double"],

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -8057,6 +8057,9 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     else if (i->modelId() == QLatin1String("lumi.sensor_switch"))
                                     { // handeled by button map
                                     }
+                                    else if (i->modelId() == QLatin1String("lumi.sensor_switch.aq2"))
+                                    { // handeled by button map
+                                    }
                                     else if (i->modelId().startsWith(QLatin1String("lumi.ctrl_neutral")))
                                     {
                                         switch (event.endpoint())

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "sensor.h"
+#include "tuya.h"
 #include "json.h"
 
 /*! Returns a fingerprint as JSON string. */
@@ -544,26 +545,30 @@ const std::vector<Sensor::ButtonMap> Sensor::buttonMap(const QMap<QString, std::
 {
     if (m_buttonMap.empty())
     {
-        const QString &modelid = item(RAttrModelId)->toString();
-        const QString &manufacturer = item(RAttrManufacturerName)->toString();
+        QString modelid;
+
+        if (isTuyaManufacturerName(item(RAttrManufacturerName)->toString()))
+        {
+            // for Tuya devices use manufacturer name as modelid
+            modelid = item(RAttrManufacturerName)->toString();
+        }
+        else
+        {
+            modelid = item(RAttrModelId)->toString();
+        }
 
         for (auto i = buttonMapForModelId.constBegin(); i != buttonMapForModelId.constEnd(); ++i)
         {
-            if (modelid.startsWith(QString(i.key())))
+            if (i.key().isEmpty())
+            {
+                continue;
+            }
+
+            if (modelid == i.key())
             {
                 m_buttonMap = buttonMapData.value(i.value());
+                break;
             }
-        }
-        // Workaround for Tuya without usable modelid
-        if ((manufacturer == QLatin1String("_TZ3000_bi6lpsew")) ||  // can't use model id but manufacture name is device specific
-            (manufacturer == QLatin1String("_TZ3400_keyjhapk")) ||
-            (manufacturer == QLatin1String("_TYZB02_key8kk7r")) ||
-            (manufacturer == QLatin1String("_TZ3400_keyjqthh")) ||
-            (manufacturer == QLatin1String("_TZ3400_key8kk7r")) ||
-            (manufacturer == QLatin1String("_TZ3000_vp6clf9d")) ||
-            (manufacturer == QLatin1String("_TYZB02_keyjqthh")))
-        {
-            m_buttonMap = buttonMapData.value("Tuya3gangMap");
         }
     }
 

--- a/tuya.cpp
+++ b/tuya.cpp
@@ -5,6 +5,7 @@
  *
  */
 
+#include <regex>
 #include "de_web_plugin.h"
 #include "de_web_plugin_private.h"
 #include "tuya.h"
@@ -60,7 +61,21 @@
 
 //******************************************************************************************
 
+/*! Returns true if the \p manufacturer name referes to a Tuya device. */
+bool isTuyaManufacturerName(const QString &manufacturer)
+{
+    return manufacturer.startsWith(QLatin1String("_T")) && // quick check for performance
+           std::regex_match(qPrintable(manufacturer), std::regex("_T[A-Z][A-Z0-9]{4}_[a-z0-9]{8}"));
+}
 
+// Tests for Tuya manufacturer name
+/*
+ Q_ASSERT(isTuyaManufacturerName("_TZ3000_bi6lpsew"));
+ Q_ASSERT(isTuyaManufacturerName("_TYZB02_key8kk7r"));
+ Q_ASSERT(isTuyaManufacturerName("_TYST11_ckud7u2l"));
+ Q_ASSERT(isTuyaManufacturerName("_TYZB02_keyjqthh"));
+ Q_ASSERT(!isTuyaManufacturerName("lumi.sensor_switch.aq2"));
+*/
 
 /*! Helper to generate a new task with new task and req id based on a reference */
 static void copyTaskReq(TaskItem &a, TaskItem &b)
@@ -75,7 +90,7 @@ static void copyTaskReq(TaskItem &a, TaskItem &b)
     b.zclFrame.payload().clear();
 }
 
-bool UseTuyaCluster(QString manufacturer)
+bool UseTuyaCluster(const QString &manufacturer)
 {
     // https://docs.tuya.com/en/iot/device-development/module/zigbee-module/zigbeetyzs11module?id=K989rik5nkhez
     //_TZ3000 don't use tuya cluster

--- a/tuya.h
+++ b/tuya.h
@@ -27,6 +27,7 @@
 #define DP_TYPE_ENUM 0x04
 #define DP_TYPE_FAULT 0x05
 
-bool UseTuyaCluster(QString manufacturer);
+bool isTuyaManufacturerName(const QString &manufacturer);
+bool UseTuyaCluster(const QString &manufacturer);
 
 #endif // TUYA_H


### PR DESCRIPTION
- The missing break, did load all entries which started with a modelid. So lumi.sensor_switch.aq2 was overwritten by lumi.sensor_switch;
- Prevent single press button event to be emitted twice for lumi.sensor_switch.aq2;
- Don't use `QString::startsWith()` always require exact modelId;
- Put manufactuer name of Tuya switch in button map and use it as modelId;
- Add helper `isTuyaManufacturerName()` to detect Tuya devices.

Issue: https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3719