### PR TITLE
Refactor of IAS zone cluster handling to improve robustness

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -3086,6 +3086,11 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
             {
                 ret = queueBindingTask(bindingTask);
             }
+            
+            if (*i == IAS_ZONE_CLUSTER_ID)
+            {
+                checkIasEnrollmentStatus(sensor);
+            }
         }
             break;
 

--- a/database.cpp
+++ b/database.cpp
@@ -3821,6 +3821,8 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             }
             item = sensor.addItem(DataTypeUInt8, RConfigPending);
             item->setValue(0);
+            item = sensor.addItem(DataTypeBool, RConfigEnrolled);
+            item->setValue(false);
         }
 
         if (sensor.fingerPrint().hasInCluster(POWER_CONFIGURATION_CLUSTER_ID))

--- a/database.cpp
+++ b/database.cpp
@@ -3821,8 +3821,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             }
             item = sensor.addItem(DataTypeUInt8, RConfigPending);
             item->setValue(0);
-            item = sensor.addItem(DataTypeBool, RConfigEnrolled);
-            item->setValue(false);
+            sensor.addItem(DataTypeBool, RConfigEnrolled)->setValue(false);
         }
 
         if (sensor.fingerPrint().hasInCluster(POWER_CONFIGURATION_CLUSTER_ID))

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -7270,7 +7270,6 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
             case ELECTRICAL_MEASUREMENT_CLUSTER_ID:
             case DOOR_LOCK_CLUSTER_ID:
             case SAMJIN_CLUSTER_ID:
-            case IAS_ZONE_CLUSTER_ID:
             case TIME_CLUSTER_ID:
                 break;
 
@@ -9153,35 +9152,6 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                             i->setNeedSaveDatabase(true);
                             enqueueEvent(Event(RSensors, RStateLastUpdated, i->id()));
                             updateSensorEtag(&*i);
-                        }
-                    }
-                    else if (event.clusterId() == IAS_ZONE_CLUSTER_ID)
-                    {
-                        for (;ia != enda; ++ia)
-                        {
-                            if (ia->id() == 0x0000) // IAS zone status
-                            {
-                                if (updateType != NodeValue::UpdateInvalid)
-                                {
-                                    i->setZclValue(updateType, event.endpoint(), event.clusterId(), 0x0000, ia->numericValue());
-                                    pushZclValueDb(event.node()->address().ext(), event.endpoint(), event.clusterId(), ia->id(), ia->numericValue().u8);
-                                }
-
-                                ResourceItem *item = i->item(RConfigPending);
-                                if (item && ia->numericValue().u8 == 1)
-                                {
-                                    DBG_Printf(DBG_INFO_L2, "[IAS] Sensor already enrolled\n");
-                                    item->setValue(item->toNumber() & ~R_PENDING_WRITE_CIE_ADDRESS);
-                                    item->setValue(item->toNumber() & ~R_PENDING_ENROLL_RESPONSE);
-                                }
-                                else
-                                {
-                                    DBG_Printf(DBG_INFO_L2, "[IAS] Sensor NOT enrolled\n");
-                                    writeIasCieAddress(&*i);
-                                }
-
-                                updateSensorEtag(&*i);
-                            }
                         }
                     }
                     else if (event.clusterId() == TIME_CLUSTER_ID)

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6815,7 +6815,8 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
         }
         item = sensorNode.addItem(DataTypeUInt8, RConfigPending);
         item->setValue(item->toNumber() | R_PENDING_WRITE_CIE_ADDRESS | R_PENDING_ENROLL_RESPONSE);
-        writeIasCieAddress(&sensorNode);
+        item = sensorNode.addItem(DataTypeBool, RConfigEnrolled);
+        item->setValue(false);
     }
 
     QString uid = generateUniqueId(sensorNode.address().ext(), sensorNode.fingerPrint().endpoint, clusterId);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6815,8 +6815,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
         }
         item = sensorNode.addItem(DataTypeUInt8, RConfigPending);
         item->setValue(item->toNumber() | R_PENDING_WRITE_CIE_ADDRESS | R_PENDING_ENROLL_RESPONSE);
-        item = sensorNode.addItem(DataTypeBool, RConfigEnrolled);
-        item->setValue(false);
+        sensorNode.addItem(DataTypeBool, RConfigEnrolled)->setValue(false);
     }
 
     QString uid = generateUniqueId(sensorNode.address().ext(), sensorNode.fingerPrint().endpoint, clusterId);

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1437,6 +1437,7 @@ public:
     void patchNodeDescriptor(const deCONZ::ApsDataIndication &ind);
     void writeIasCieAddress(Sensor*);
     void checkIasEnrollmentStatus(Sensor*);
+    void processIasZoneStatus(Sensor *sensor, quint16 zoneStatus, NodeValue::UpdateType updateType);
 
     void pushClientForClose(QTcpSocket *sock, int closeTimeout, const QHttpRequestHeader &hdr);
 

--- a/ias_zone.cpp
+++ b/ias_zone.cpp
@@ -470,13 +470,12 @@ void DeRestPluginPrivate::checkIasEnrollmentStatus(Sensor *sensor)
         DBG_Printf(DBG_INFO_L2, "[IAS ZONE] - 0x%016llX Sensor ID: %s\n", sensor->address().ext(), qPrintable(sensor->type()));
 
         NodeValue val = sensor->getZclValue(IAS_ZONE_CLUSTER_ID, IAS_ZONE_STATE);
-        deCONZ::NumericUnion iasZoneStatus = val.value;
+        deCONZ::NumericUnion iasZoneState = val.value;
         DBG_Printf(DBG_INFO_L2, "[IAS ZONE] - 0x%016llX Sensor zone state timestamp: %s\n", sensor->address().ext(), qPrintable(val.timestamp.toString()));
-        DBG_Printf(DBG_INFO_L2, "[IAS ZONE] - 0x%016llX Sensor zone state value: %d\n", sensor->address().ext(), iasZoneStatus.u8);
+        DBG_Printf(DBG_INFO_L2, "[IAS ZONE] - 0x%016llX Sensor zone state value: %d\n", sensor->address().ext(), iasZoneState.u8);
 
         NodeValue val1 = sensor->getZclValue(IAS_ZONE_CLUSTER_ID, IAS_CIE_ADDRESS);
         deCONZ::NumericUnion iasCieAddress = val1.value;
-
         DBG_Printf(DBG_INFO_L2, "[IAS ZONE] - 0x%016llX Sensor IAS CIE address timestamp: %s\n", sensor->address().ext(), qPrintable(val1.timestamp.toString()));
         DBG_Printf(DBG_INFO_L2, "[IAS ZONE] - 0x%016llX Sensor IAS CIE address: 0x%016llX\n", sensor->address().ext(), iasCieAddress.u64);
 
@@ -488,7 +487,7 @@ void DeRestPluginPrivate::checkIasEnrollmentStatus(Sensor *sensor)
             DBG_Printf(DBG_INFO_L2, "[IAS ZONE] - 0x%016llX Sensor config pending value: %d\n", sensor->address().ext(), item->toNumber());
         }
 
-        if (item && iasZoneStatus.u8 == 1 && iasCieAddress.u64 != 0 && iasCieAddress.u64 != 0xFFFFFFFFFFFFFFFF)
+        if (item && iasZoneState.u8 == 1 && iasCieAddress.u64 != 0 && iasCieAddress.u64 != 0xFFFFFFFFFFFFFFFF)
         {
             DBG_Printf(DBG_INFO, "[IAS ZONE] - 0x%016llX Sensor enrolled. Removing all pending flags.\n", sensor->address().ext());
             R_ClearFlags(item, R_PENDING_WRITE_CIE_ADDRESS | R_PENDING_ENROLL_RESPONSE);
@@ -504,7 +503,7 @@ void DeRestPluginPrivate::checkIasEnrollmentStatus(Sensor *sensor)
             return;
         }
 
-        if (item && item->toNumber() == 0 && iasZoneStatus.u8 == 0)
+        if (item && item->toNumber() == 0 && iasZoneState.u8 == 0)
         {
             DBG_Printf(DBG_INFO, "[IAS ZONE] - 0x%016llX Sensor NOT enrolled (check).\n", sensor->address().ext());
 
@@ -519,7 +518,7 @@ void DeRestPluginPrivate::checkIasEnrollmentStatus(Sensor *sensor)
                 R_SetFlags(item, R_PENDING_ENROLL_RESPONSE);
             }
 
-            DBG_Printf(DBG_INFO_L2, "[IAS ZONE] - 0x%016llX Querying IAS zone state and CIE address (EP %d)...\n", sensor->address().ext(), sensor->fingerPrint().endpoint);
+            DBG_Printf(DBG_INFO_L2, "[IAS ZONE] - 0x%016llX Querying IAS zone state and CIE address...\n", sensor->address().ext());
             std::vector<uint16_t> attributes;
             attributes.push_back(IAS_ZONE_STATE); // IAS zone state
             attributes.push_back(IAS_CIE_ADDRESS); // IAS CIE address
@@ -536,7 +535,7 @@ void DeRestPluginPrivate::checkIasEnrollmentStatus(Sensor *sensor)
             }
             sensor->setNeedSaveDatabase(true);
         }
-        else if (item && iasZoneStatus.u8 == 0 && ((item->toNumber() & R_PENDING_ENROLL_RESPONSE) || (item->toNumber() & R_PENDING_WRITE_CIE_ADDRESS)))
+        else if (item && iasZoneState.u8 == 0 && ((item->toNumber() & R_PENDING_ENROLL_RESPONSE) || (item->toNumber() & R_PENDING_WRITE_CIE_ADDRESS)))
         {
             DBG_Printf(DBG_INFO, "[IAS ZONE] - 0x%016llX Sensor enrollment pending...\n", sensor->address().ext());
         }

--- a/ias_zone.cpp
+++ b/ias_zone.cpp
@@ -71,7 +71,7 @@ void DeRestPluginPrivate::handleIasZoneClusterIndication(const deCONZ::ApsDataIn
     for (auto &s : sensors)
     {
         if (!(s.address().ext() == ind.srcAddress().ext() && s.fingerPrint().endpoint == ind.srcEndpoint() &&
-             (s.fingerPrint().hasInCluster(IAS_ZONE_CLUSTER_ID) || s.deletedState() == Sensor::StateNormal))
+             s.fingerPrint().hasInCluster(IAS_ZONE_CLUSTER_ID) && s.deletedState() == Sensor::StateNormal))
         {
             continue;
         }

--- a/ias_zone.cpp
+++ b/ias_zone.cpp
@@ -494,6 +494,14 @@ void DeRestPluginPrivate::checkIasEnrollmentStatus(Sensor *sensor)
             DBG_Printf(DBG_INFO, "[IAS ZONE] - 0x%016llX Sensor enrolled. Removing all pending flags.\n", sensor->address().ext());
             item->setValue(item->toNumber() & ~R_PENDING_WRITE_CIE_ADDRESS);
             item->setValue(item->toNumber() & ~R_PENDING_ENROLL_RESPONSE);
+            
+            ResourceItem *item2 = nullptr;
+            item2 = sensor->item(RConfigEnrolled);
+            if (item2 && item->toBool() != true)
+            {
+                item2->setValue(true);
+            }
+            
             sensor->setNeedSaveDatabase(true);
             return;
         }

--- a/ias_zone.cpp
+++ b/ias_zone.cpp
@@ -71,20 +71,7 @@ void DeRestPluginPrivate::handleIasZoneClusterIndication(const deCONZ::ApsDataIn
     for (auto &s : sensors)
     {
         if (!(s.address().ext() == ind.srcAddress().ext() && s.fingerPrint().endpoint == ind.srcEndpoint() &&
-             (s.fingerPrint().hasInCluster(IAS_ZONE_CLUSTER_ID) || s.fingerPrint().hasInCluster(IAS_ZONE_CLUSTER_ID)) &&
-              s.deletedState() == Sensor::StateNormal))
-        {
-            continue;
-        }
-
-        // Do we require this???
-        if (s.type() != QLatin1String("ZHAAlarm") &&
-            s.type() != QLatin1String("ZHACarbonMonoxide") &&
-            s.type() != QLatin1String("ZHAFire") &&
-            s.type() != QLatin1String("ZHAOpenClose") &&
-            s.type() != QLatin1String("ZHAPresence") &&
-            s.type() != QLatin1String("ZHAVibration") &&
-            s.type() != QLatin1String("ZHAWater"))
+             (s.fingerPrint().hasInCluster(IAS_ZONE_CLUSTER_ID) || s.deletedState() == Sensor::StateNormal))
         {
             continue;
         }
@@ -94,7 +81,7 @@ void DeRestPluginPrivate::handleIasZoneClusterIndication(const deCONZ::ApsDataIn
 
     if (!sensor)
     {
-        DBG_Printf(DBG_INFO, "No IAS sensor found for 0x%016llX, endpoint: 0x%08X\n", ind.srcAddress().ext(), ind.srcEndpoint());
+        DBG_Printf(DBG_INFO, "[IAS ZONE] - 0x%016llX No IAS sensor found for endpoint: 0x%02X\n", ind.srcAddress().ext(), ind.srcEndpoint());
         return;
     }
 
@@ -117,7 +104,6 @@ void DeRestPluginPrivate::handleIasZoneClusterIndication(const deCONZ::ApsDataIn
     if ((zclFrame.frameControl() & 0x09) == (deCONZ::ZclFCDirectionServerToClient | deCONZ::ZclFCClusterCommand))
     {
         isClusterCmd = true;
-        DBG_Printf(DBG_INFO, "IAS cluster specific command.\n");
     }
 
     // Read ZCL reporting and ZCL Read Attributes Response
@@ -174,11 +160,13 @@ void DeRestPluginPrivate::handleIasZoneClusterIndication(const deCONZ::ApsDataIn
                     //sensor->setNeedSaveDatabase(true);
                 }
                     break;
+
                 case IAS_ZONE_TYPE: // IAS zone type
                 {
                     sensor->setZclValue(updateType, ind.srcEndpoint(), IAS_ZONE_CLUSTER_ID, attrId, attr.numericValue());
                 }
                     break;
+
                 case IAS_ZONE_STATUS: // IAS zone status
                 {
                     quint16 zoneStatus = attr.numericValue().u16;   // might be reported or received via CMD_STATUS_CHANGE_NOTIFICATION
@@ -187,6 +175,7 @@ void DeRestPluginPrivate::handleIasZoneClusterIndication(const deCONZ::ApsDataIn
                     stateUpdated = true;
                 }
                     break;
+
                 case IAS_CIE_ADDRESS: // IAS CIE address
                 {
                     quint64 iasCieAddress = attr.numericValue().u64;

--- a/ias_zone.cpp
+++ b/ias_zone.cpp
@@ -260,6 +260,8 @@ void DeRestPluginPrivate::handleIasZoneClusterIndication(const deCONZ::ApsDataIn
         updateEtag(gwConfigEtag);
         sensor->setNeedSaveDatabase(true);
         queSaveDb(DB_SENSORS, DB_SHORT_SAVE_DELAY);
+        
+        checkIasEnrollmentStatus(sensor);
     }
     else if (isClusterCmd && zclFrame.commandId() == CMD_ZONE_ENROLL_REQUEST)
     {

--- a/resource.cpp
+++ b/resource.cpp
@@ -123,6 +123,7 @@ const char *RConfigCoolSetpoint = "config/coolsetpoint";
 const char *RConfigDelay = "config/delay";
 const char *RConfigDisplayFlipped = "config/displayflipped";
 const char *RConfigDuration = "config/duration";
+const char *RConfigEnrolled = "config/enrolled";
 const char *RConfigFanMode = "config/fanmode";
 const char *RConfigGroup = "config/group";
 const char *RConfigHeatSetpoint = "config/heatsetpoint";
@@ -284,6 +285,7 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigDelay));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, RConfigDisplayFlipped));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigDuration));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, RConfigEnrolled));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RConfigFanMode));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RConfigGroup));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeInt16, RConfigHeatSetpoint, 500, 3200));

--- a/resource.h
+++ b/resource.h
@@ -131,6 +131,7 @@ extern const char *RConfigCoolSetpoint;
 extern const char *RConfigDelay;
 extern const char *RConfigDisplayFlipped;
 extern const char *RConfigDuration;
+extern const char *RConfigEnrolled;
 extern const char *RConfigFanMode;
 extern const char *RConfigGroup;
 extern const char *RConfigHeatSetpoint;


### PR DESCRIPTION
Short description (for now):

- Streamline coding with other clusters
- Ensure to always pick the right sensor containing IAS cluster
- Significantly increase verbosity
- Catch attribute read requests which were silently discarded and retry until success
- Catch failed IAS CIE address write requests and retry until success
- Based on the 2 aforementioned enhancements, drastically improve IAS enrollment
- IAS enrollment is checked and initialized (if required) upon full attribute read
- Expose `config.enrolled` to provide IAS enrollment transparency via REST API
- Check enrollment status upon reception of IAS zone status notifications and set `config.enrolled` to "true" if enrollment is confirmed to be successful