### PR TITLE
Introduce getSensorNodeForAddressEndpointAndCluster()

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -9466,6 +9466,31 @@ Sensor *DeRestPluginPrivate::getSensorNodeForAddress(const deCONZ::Address &addr
     return 0;
 }
 
+/*! Returns the Sensor for its given \p Address and \p Endpoint and \p cluster or 0 if not found.
+ */
+Sensor *DeRestPluginPrivate::getSensorNodeForAddressEndpointAndCluster(const deCONZ::Address &addr, quint8 ep, quint16 cluster)
+{
+    for (Sensor &sensor: sensors)
+    {
+        if (sensor.deletedState() != Sensor::StateNormal || !sensor.node() ||
+            sensor.fingerPrint().endpoint != ep || !sensor.fingerPrint().hasInCluster(cluster))
+        {
+            continue;
+        }
+        if (sensor.address().hasExt() && addr.hasExt() &&
+            sensor.address().ext() == addr.ext())
+        {
+            return &sensor;
+        }
+        if (sensor.address().hasNwk() && addr.hasNwk() &&
+            sensor.address().nwk() == addr.nwk())
+        {
+            return &sensor;
+        }
+    }
+    return nullptr;
+}
+
 /*! Returns the first Sensor for its given \p Address and \p Endpoint and \p Type or 0 if not found.
  */
 Sensor *DeRestPluginPrivate::getSensorNodeForAddressAndEndpoint(const deCONZ::Address &addr, quint8 ep, const QString &type)

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -9473,7 +9473,7 @@ Sensor *DeRestPluginPrivate::getSensorNodeForAddressEndpointAndCluster(const deC
     for (Sensor &sensor: sensors)
     {
         if (sensor.deletedState() != Sensor::StateNormal || !sensor.node() ||
-            sensor.fingerPrint().endpoint != ep || !sensor.fingerPrint().hasInCluster(cluster))
+            sensor.fingerPrint().endpoint != ep || !sensor.fingerPrint().hasInCluster(cluster) || !sensor.fingerPrint().hasOutCluster(cluster))
         {
             continue;
         }

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1392,6 +1392,7 @@ public:
     void updateSensorNode(const deCONZ::NodeEvent &event);
     void updateSensorLightLevel(Sensor &sensor, quint16 measuredValue);
     bool isDeviceSupported(const deCONZ::Node *node, const QString &modelId);
+    Sensor *getSensorNodeForAddressEndpointAndCluster(const deCONZ::Address &addr, quint8 ep, quint16 cluster);
     Sensor *getSensorNodeForAddressAndEndpoint(const deCONZ::Address &addr, quint8 ep, const QString &type);
     Sensor *getSensorNodeForAddressAndEndpoint(const deCONZ::Address &addr, quint8 ep);
     Sensor *getSensorNodeForAddress(quint64 extAddr);


### PR DESCRIPTION
This function provides the ability to chose a sensor more precisely than both functions `getSensorNodeForAddressAndEndpoint()`. The first implementation (which doesn't use the sensor type as argument) returns the first sensor found, which is problematic if more than one "sensor-worthy" cluster is available on one endpoint. The second implementation (which usea the sensor type as argument) is more accurate, but can only handle one sensor type (there's multiple sensor types based on IAS zone cluster).

The proposed function would eliminate both weaknesses, however, it relies on the correctness of a sensor's fingerprint. In this regard, some minor updates on the corresponding code are required.

As small caveat remains: As of now, basic cluster and power configuration clusters are not exclusively added to the sensor fingerprints. In those cases, the function will just return the first sensor found.