### PR TITLE
Add ability to recall the most recently recalled scene

### DIFF
--- a/rest_groups.cpp
+++ b/rest_groups.cpp
@@ -2704,6 +2704,7 @@ int DeRestPluginPrivate::storeScene(const ApiRequest &req, ApiResponse &rsp)
 /*! PUT /api/<apikey>/groups/<group_id>/scenes/<scene_id>/recall
     PUT /api/<apikey>/groups/<group_id>/scenes/next/recall
     PUT /api/<apikey>/groups/<group_id>/scenes/prev/recall
+    PUT /api/<apikey>/groups/<group_id>/scenes/recent/recall
     \return REQ_READY_SEND
             REQ_NOT_HANDLED
  */
@@ -2740,7 +2741,7 @@ int DeRestPluginPrivate::recallScene(const ApiRequest &req, ApiResponse &rsp)
     Scene *scene = 0;
     uint8_t sceneId = 0;
     ok = false;
-    if (sid == QLatin1String("next") || sid == QLatin1String("prev"))
+    if (sid == QLatin1String("next") || sid == QLatin1String("prev") || sid == QLatin1String("recent"))
     {
         ResourceItem *item = group->item(RActionScene);
         DBG_Assert(item != 0);
@@ -2778,6 +2779,10 @@ int DeRestPluginPrivate::recallScene(const ApiRequest &req, ApiResponse &rsp)
             if (idx == -1) // not found
             {
                 idx = 0; // use first
+            }
+            else if (sid[0] == 'r') // recent
+            {
+                // no-op, idx already points to recent scene
             }
             else if (sid[0] == 'p') // prev
             {


### PR DESCRIPTION
I had a use case whereby I wanted to recall the previously set scene in a group after the lights had been switched off, and couldn't figure out a way to do it so added a `/groups/<group_id>/scenes/recent/recall` route, similar to `/groups/<group_id>/scenes/next/recall` and `/groups/<group_id>/scenes/prev/recall` to handle this.

So for example I set a scene at night time which has 2/8 lights on, and then go to bed and turn them off. When I press my switch on button in the morning, previously all 8 lights in the group would come back on, whereas I want to restore the scene I set before I switched the lights off - this change allows a rule that can do that.

Hope that makes sense, just thought I would contribute this back in case anyone finds it useful.