### PR TITLE
added additional danfoss ally attributes

### DIFF
--- a/general.xml
+++ b/general.xml
@@ -1852,15 +1852,15 @@ Note: It does not clear or delete previous weekly schedule programming configura
 
 		<!-- Danfoss manufacturer specific -->
 		<attribute-set id="0x4000" description="Danfoss specific" mfcode="0x1246">
-			<attribute id="0x4000" name="eTRV Open Window Detection" type="enum8" default="0x00" access="r" required="m" mfcode="0x1246">
+			<attribute id="0x4000" name="eTRV Open Window Detection" type="enum8" default="0x00" access="r" required="o" mfcode="0x1246">
 				<value name="Quarantine" value="0x00"></value>
 				<value name="Closed" value="0x01"></value>
 				<value name="Hold" value="0x02"></value>
 				<value name="Open" value="0x03"></value>
 				<value name="Windows open from external, but detected closed" value="0x04"></value>
 			</attribute>
-			<attribute id="0x4003" name="External Open Window Detected" type="bool" default="0x00" access="rw" required="m" mfcode="0x1246"></attribute>
-			<attribute id="0x4010" name="Exercise day of week" type="enum8" default="0x04" access="rw" required="m" mfcode="0x1246">
+			<attribute id="0x4003" name="External Open Window Detected" type="bool" default="0x00" access="rw" required="o" mfcode="0x1246"></attribute>
+			<attribute id="0x4010" name="Exercise day of week" type="enum8" default="0x04" access="rw" required="o" mfcode="0x1246">
 				<value name="Sunday" value="0x00"></value>
 				<value name="Monday" value="0x01"></value>
 				<value name="Tuesday" value="0x02"></value>
@@ -1870,26 +1870,28 @@ Note: It does not clear or delete previous weekly schedule programming configura
 				<value name="Saturday" value="0x06"></value>
 				<value name="Undefined" value="0x07"></value>
 			</attribute>
-			<attribute id="0x4011" name="Exercise trigger time" type="u16" default="660" access="rw" required="m" mfcode="0x1246"></attribute>
-			<attribute id="0x4012" name="Mounting mode active" type="bool" default="0x01" access="r" required="m" mfcode="0x1246"></attribute>
-			<attribute id="0x4013" name="Mounting mode control" type="bool" access="rw" required="m" mfcode="0x1246"></attribute>
-			<attribute id="0x4014" name="eTRV Orientation" type="bool" default="0x00" access="rw" required="m" mfcode="0x1246"></attribute>
-			<attribute id="0x4015" name="External Measured Room Sensor" type="s16" access="r" required="m" mfcode="0x1246"></attribute>
-			<attribute id="0x4016" name="Unknown" type="bool" access="rw" required="m" mfcode="0x1246"></attribute>
-			<attribute id="0x4020" name="Control algorithm scale factor" type="u8" default="1" access="rw" required="m" mfcode="0x1246"></attribute>
-			<attribute id="0x4030" name="Heat Available" type="bool" default="0x01" access="rw" required="m" mfcode="0x1246"></attribute>
-			<attribute id="0x4031" name="Heat Supply Request " type="bool" access="r" required="m" mfcode="0x1246"></attribute>
-			<attribute id="0x4032" name="Unknown" type="bool" access="rw" required="m" mfcode="0x1246"></attribute>
-			<attribute id="0x4040" name="Unknown" type="s16" access="rw" required="m" mfcode="0x1246"></attribute>
-			<attribute id="0x404A" name="Unknown" type="s16" access="r" required="m" mfcode="0x1246"></attribute>
-			<attribute id="0x404B" name="Unknown" type="s8" access="rw" required="m" mfcode="0x1246"></attribute>
-			<attribute id="0x404C" name="Calibration" type="enum8" default="0x00" access="rw" required="m" mfcode="0x1246">
-				<value name="Idle" value="0x00"></value>
+			<attribute id="0x4011" name="Exercise trigger time" type="u16" default="660" access="rw" required="o" mfcode="0x1246"></attribute>
+			<attribute id="0x4012" name="Mounting mode active" type="bool" default="0x01" access="r" required="o" mfcode="0x1246"></attribute>
+			<attribute id="0x4013" name="Mounting mode control" type="bool" access="rw" required="o" mfcode="0x1246"></attribute>
+			<attribute id="0x4014" name="eTRV Orientation" type="bool" default="0x00" access="rw" required="o" mfcode="0x1246"></attribute>
+			<attribute id="0x4015" name="External Measured Room Sensor" type="s16" access="r" required="o" mfcode="0x1246"></attribute>
+			<attribute id="0x4016" name="Radiator Covered" type="bool" access="rw" required="o" mfcode="0x1246"></attribute>
+			<attribute id="0x4020" name="Control algorithm scale factor" type="u8" default="1" access="rw" required="o" mfcode="0x1246"></attribute>
+			<attribute id="0x4030" name="Heat Available" type="bool" default="0x01" access="rw" required="o" mfcode="0x1246"></attribute>
+			<attribute id="0x4031" name="Heat Supply Request " type="bool" access="r" required="o" mfcode="0x1246"></attribute>
+			<attribute id="0x4032" name="Load Balancing Enable" type="bool" access="rw" required="o" mfcode="0x1246"></attribute>
+			<attribute id="0x4040" name="Load Radiator Room Mean" type="s16" access="rw" required="o" mfcode="0x1246"></attribute>
+			<attribute id="0x404A" name="Load estimate on this radiator" type="s16" access="r" required="o" mfcode="0x1246"></attribute>
+			<attribute id="0x404B" name="Regulation SetPoint Offset" type="s8" access="rw" required="o" mfcode="0x1246"></attribute>
+			<attribute id="0x404C" name="Adaptation run control" type="enum8" default="0x00" access="rw" required="o" mfcode="0x1246">
 				<value name="Start" value="0x01"></value>
 				<value name="Stop" value="0x02"></value>
 			</attribute>
-			<attribute id="0x404D" name="Unknown" type="bmp8" access="rw" required="m" mfcode="0x1246"></attribute>
-			<attribute id="0x404E" name="Unknown" type="bmp8" access="rw" required="m" mfcode="0x1246"></attribute>
+			<attribute id="0x404D" name="Adaptation run status" type="bmp8" access="r" required="o" mfcode="0x1246"></attribute>
+			<attribute id="0x404E" name="Adaptation run settings" type="bmp8" access="rw" required="o" mfcode="0x1246"></attribute>
+			<attribute id="0x404F" name="Preheat Status" type="boolean" access="r" required="o" mfcode="0x1246"></attribute>
+			<attribute id="0x4050" name="Preheat Time" type="u32" access="r" required="o" mfcode="0x1246"></attribute>
+			<attribute id="0x4051" name="Window Open Feature ON/OFF" type="bool" access="rw" required="o" mfcode="0x1246"></attribute>
 		</attribute-set>
 
 		<!-- Sinope manufacturer specific -->


### PR DESCRIPTION
I added some additional attributes for the Danfoss Ally TRV based on
[Danfoss Ally Radiator Thermostat 1.08 Zigbee Cluster Specifications 16122020.pdf](https://raw.githubusercontent.com/SimpleUserHA/DanfosseTRV/main/Danfoss%20Ally%20Radiator%20Thermostat%201.08%20Zigbee%20Cluster%20Specifications%2016122020.pdf) (found [here](https://community.home-assistant.io/t/danfoss-ally-thermostat-firmware-update-ota-v1-08-open-window-external-temp-zha-deconz/261951))