### PR TITLE
Improve Legrand Shutter support.

### DIFF
--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1741,7 +1741,7 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
             // Legrand invert bri and don't support other value than 0
             bool bStatus = false;
             uint nHex = taskRef.lightNode->swBuildId().toUInt(&bStatus,16);
-            if (bStatus && (nHex < 33))
+            if (bStatus && (nHex < 28))
             {
                 targetLiftZigBee = targetLift == 0 ? 100 : 0;
             }

--- a/window_covering.cpp
+++ b/window_covering.cpp
@@ -175,7 +175,7 @@ void DeRestPluginPrivate::handleWindowCoveringClusterIndication(const deCONZ::Ap
                 {
                     bool bStatus = false;
                     uint nHex = lightNode->swBuildId().toUInt(&bStatus,16);
-                    if (bStatus && (nHex < 33))
+                    if (bStatus && (nHex < 28))
                     {
                         lift = 100 - lift;
                     }


### PR DESCRIPTION
The support change according to version https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3876

> 0x0B > need reverse (code reverse) WORKING (dpmworld with bticino)
> 0x16 > No need to reverse (code reverse) NOT WOKING (zinoalex with bticion)
> 0x1A > need to reverse (code reverse) WORKING (samsam-rolon with Legrand)
> 0x1C > No need to reverse (code reverse) NOT WOKING (zinoalex with bticion)
> 0x21 > No need to reverse (code don't reverse) WORKING (samsam-rolon with Legrand)