### PR TITLE
Tuya covering direction correction for models "Tuya Zigbee Curtain module QS-Zigbee-C01" and _TZ3000_xzqbrqk1  (covering switch)

### DIFF
--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1732,6 +1732,7 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
         if (taskRef.lightNode->modelId().startsWith(QLatin1String("lumi.curtain")) ||
            (taskRef.lightNode->manufacturer() == QLatin1String("_TZ3000_egq7y6pr")) ||
            (taskRef.lightNode->manufacturer() == QLatin1String("_TZ3000_vd43bbfq")) ||
+           (taskRef.lightNode->manufacturer() == QLatin1String("_TZ3000_xzqbrqk1")) ||
            (taskRef.lightNode->modelId() == QLatin1String("Motor Controller")))
         {
             targetLiftZigBee = 100 - targetLift;

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1731,6 +1731,7 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
     {
         if (taskRef.lightNode->modelId().startsWith(QLatin1String("lumi.curtain")) ||
            (taskRef.lightNode->manufacturer() == QLatin1String("_TZ3000_egq7y6pr")) ||
+           (taskRef.lightNode->manufacturer() == QLatin1String("_TZ3000_vd43bbfq")) ||
            (taskRef.lightNode->modelId() == QLatin1String("Motor Controller")))
         {
             targetLiftZigBee = 100 - targetLift;

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1731,8 +1731,8 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
     {
         if (taskRef.lightNode->modelId().startsWith(QLatin1String("lumi.curtain")) ||
            (taskRef.lightNode->manufacturer() == QLatin1String("_TZ3000_egq7y6pr")) ||
-           (taskRef.lightNode->manufacturer() == QLatin1String("_TZ3000_vd43bbfq")) ||
-           (taskRef.lightNode->manufacturer() == QLatin1String("_TZ3000_xzqbrqk1")) ||
+           (taskRef.lightNode->manufacturer() == QLatin1String("_TZ3000_vd43bbfq")) || // TS130F Tuya Zigbee Curtain module QS-Zigbee-C01
+           (taskRef.lightNode->manufacturer() == QLatin1String("_TZ3000_xzqbrqk1")) || // Tuya covering switch
            (taskRef.lightNode->modelId() == QLatin1String("Motor Controller")))
         {
             targetLiftZigBee = 100 - targetLift;

--- a/tuya.cpp
+++ b/tuya.cpp
@@ -314,6 +314,11 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                         lightNode->setValue(RStateOn, on);
                     }
                     break;
+                    case 0x0405: // rotation direction
+                    {
+                        DBG_Printf(DBG_INFO, "Tuya debug 3 : Covering motor direction %ld\n", data);
+                    }
+                    break;
 
                     //other
                     default:

--- a/window_covering.cpp
+++ b/window_covering.cpp
@@ -181,7 +181,8 @@ void DeRestPluginPrivate::handleWindowCoveringClusterIndication(const deCONZ::Ap
                     }
                 }
                 // Reverse for some tuya covering
-                if (lightNode->manufacturer() == QLatin1String("_TZ3000_egq7y6pr"))
+                if ((lightNode->manufacturer() == QLatin1String("_TZ3000_egq7y6pr")) ||
+                    (lightNode->manufacturer() == QLatin1String("_TZ3000_vd43bbfq")) )
                 {
                     lift = 100 - lift;
                 }

--- a/window_covering.cpp
+++ b/window_covering.cpp
@@ -182,6 +182,7 @@ void DeRestPluginPrivate::handleWindowCoveringClusterIndication(const deCONZ::Ap
                 }
                 // Reverse for some tuya covering
                 if ((lightNode->manufacturer() == QLatin1String("_TZ3000_egq7y6pr")) ||
+                    (lightNode->manufacturer() == QLatin1String("_TZ3000_xzqbrqk1")) ||
                     (lightNode->manufacturer() == QLatin1String("_TZ3000_vd43bbfq")) )
                 {
                     lift = 100 - lift;

--- a/window_covering.cpp
+++ b/window_covering.cpp
@@ -182,8 +182,8 @@ void DeRestPluginPrivate::handleWindowCoveringClusterIndication(const deCONZ::Ap
                 }
                 // Reverse for some tuya covering
                 if ((lightNode->manufacturer() == QLatin1String("_TZ3000_egq7y6pr")) ||
-                    (lightNode->manufacturer() == QLatin1String("_TZ3000_xzqbrqk1")) ||
-                    (lightNode->manufacturer() == QLatin1String("_TZ3000_vd43bbfq")) )
+                    (lightNode->manufacturer() == QLatin1String("_TZ3000_xzqbrqk1")) || //Tuya covering switch
+                    (lightNode->manufacturer() == QLatin1String("_TZ3000_vd43bbfq")) ) // TS130F Tuya Zigbee Curtain module QS-Zigbee-C01
                 {
                     lift = 100 - lift;
                 }


### PR DESCRIPTION
Direction problem https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3757#issuecomment-751828899
This PR reverse the motor direction compared to native one. Thery are using classic covering cluster (not the tuya one)

Model TS130F Tuya Zigbee Curtain module QS-Zigbee-C01 : _TZ3000_vd43bbfq
Tuya covering switch : _TZ3000_xzqbrqk1

Edit:
Tested, working mode ok.