### PR TITLE
new REST API endpoint for network map using DOT (graphviz)

### DIFF
--- a/de_web.pro
+++ b/de_web.pro
@@ -166,6 +166,7 @@ SOURCES  = air_quality.cpp \
            rest_scenes.cpp \
            rest_info.cpp \
            rest_capabilities.cpp \
+           rest_map.cpp \
            rule.cpp \
            thermostat_ui_configuration.cpp \
            upnp.cpp \

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -18033,6 +18033,10 @@ int DeRestPlugin::handleHttpRequest(const QHttpRequestHeader &hdr, QTcpSocket *s
             {
                 ret = d->handleGatewaysApi(req, rsp);
             }
+            else if (path[2] == QLatin1String("map"))
+            {
+                ret = d->handleMapApi(req, rsp);
+            }
             else
             {
                 resourceExist = false;

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1173,6 +1173,10 @@ public:
     int handleCapabilitiesApi(const ApiRequest &req, ApiResponse &rsp);
     int getCapabilities(const ApiRequest &req, ApiResponse &rsp);
 
+    // REST API map
+    int handleMapApi(const ApiRequest &req, ApiResponse &rsp);
+    int getMap(const ApiRequest &req, ApiResponse &rsp);
+
     // REST API common
     QVariantMap errorToMap(int id, const QString &ressource, const QString &description);
 

--- a/rest_map.cpp
+++ b/rest_map.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2013-2019 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ */
+
+#include <QString>
+#include <QUrlQuery>
+#include "de_web_plugin.h"
+#include "de_web_plugin_private.h"
+
+/*! Map REST API broker.
+    \param req - request data
+    \param rsp - response data
+    \return REQ_READY_SEND
+            REQ_NOT_HANDLED
+ */
+int DeRestPluginPrivate::handleMapApi(const ApiRequest &req, ApiResponse &rsp)
+{
+    if (req.path[2] != QLatin1String("map"))
+    {
+        return REQ_NOT_HANDLED;
+    }
+
+    // GET /api/<apikey>/map
+    if ((req.path.size() == 3) && (req.hdr.method() == "GET"))
+    {
+        return getMap(req, rsp);
+    }
+
+    return REQ_NOT_HANDLED;
+}
+
+/*! GET /api/<apikey>/lights
+    \return REQ_READY_SEND
+            REQ_NOT_HANDLED
+ */
+int DeRestPluginPrivate::getMap(const ApiRequest &req, ApiResponse &rsp)
+{
+    QUrlQuery query(req.hdr.url());
+
+    QString colorCoordinator = query.queryItemValue(QLatin1String("colorCoordinator")).replace(QRegExp("^$"), "green");
+    QString colorEndDevice   = query.queryItemValue(QLatin1String("colorEndDevice")).replace(QRegExp("^$"), "blue");
+    QString colorRouter      = query.queryItemValue(QLatin1String("colorRouter")).replace(QRegExp("^$"), "black");
+    QString colorZombie      = query.queryItemValue(QLatin1String("colorZombie"));
+    QString colorBadLink     = query.queryItemValue(QLatin1String("colorBadLink")).replace(QRegExp("^$"), "red");
+
+    // -- links under this threshold are colored differently (using colorBadLink) --
+    bool ok;
+    int thresBadLink = query.queryItemValue(QLatin1String("thresBadLink")).toInt(&ok);
+    if(!ok)
+    {
+        thresBadLink = 10;
+    }
+
+    rsp.httpStatus = HttpStatusOk;
+
+    rsp.str = "digraph G {\n";
+
+    uint n = 0;
+    const deCONZ::Node *node = 0;
+    while (apsCtrl->getNode(n, &node) == 0)
+    {
+        QString address = node->address().toStringExt();
+        QString name = node->userDescriptor();
+
+        // -- convert address to format 01:23:45:67:89:AB:CD:EF for printing --
+        QString addressMAC = "";
+        uint64_t a = node->address().ext();
+        for (int i = 0; i < 8; i++, a >>= 8)
+        {
+            addressMAC.push_front(i>0?":":"");
+            addressMAC.push_front(QString::number(a & 0xFF, 16).rightJustified(2, '0').toUpper());
+        }
+
+        // -- create vertice --
+        QString color = "black";
+        QString style = "solid";
+        if (node->isCoordinator())
+        {
+            color = colorCoordinator;
+        }
+        else if (node->isEndDevice())
+        {
+            color = colorEndDevice;
+        }
+        else if (node->isRouter())
+        {
+            color = colorRouter;
+        }
+        if (node->isZombie() && !colorZombie.isEmpty())
+        {
+            color = colorZombie;
+            style = "dashed";
+        }
+
+        QString label = "\"{"+name+"|"+addressMAC+"}\"";
+        rsp.str += "\"" + address + "\" [shape=Mrecord label="  +label + ", color=" + color + ", style=" + style + "]\n";
+
+        // -- create edge --
+        std::vector<deCONZ::NodeNeighbor>::const_iterator nb = node->neighbors().begin();
+        std::vector<deCONZ::NodeNeighbor>::const_iterator nbEnd = node->neighbors().end();
+        for (; nb != nbEnd; ++nb)
+        {
+            quint8 link = nb->lqi();
+            QString linkColor = "black";
+            if(link < thresBadLink)
+            {
+                linkColor = colorBadLink;
+            }
+            rsp.str += "\"" + node->address().toStringExt() +
+                    "\" -> \"" + nb->address().toStringExt() +
+                    "\" [label=\"" + QString::number(link) + "\", color=" + linkColor + "]\n";
+        }
+
+        n++;
+    }
+
+    rsp.str += "}";
+
+    return REQ_READY_SEND;
+}


### PR DESCRIPTION
Hi,
I created a new endpoint for the REST API that delivers the current network map (using Node::neighbors()) in the DOT language (similar to what Zigbee2MQTT can do). This graph representation can be easily converted to an image using [graphviz](https://graphviz.org/), for example by passing it directly to dot, circo, etc.
I also added some GET-parameters, that allow the user to change some colors.

Example:
$ curl http://192.168.178.49:8080/api/<API_KEY>/map | circo -Gratio=0.56 -Tsvg -o map.svg
leads for my zigbee network to
![map](https://user-images.githubusercontent.com/35545661/104060599-6c427a00-51f7-11eb-8be7-7d285cb7fa39.png)
