### PR TITLE
Fix iCasa Pulse 2, Pulse 4S and Pulse 8S button maps

### DIFF
--- a/button_maps.json
+++ b/button_maps.json
@@ -719,10 +719,60 @@
                 [1, "0x08", "LEVEL_CONTROL", "STOP", "1", "S_BUTTON_27", "S_BUTTON_ACTION_LONG_RELEASED", "DimDown 6"]
             ]
         },
-        "icasaKeypadMap": {
+        "icasaKPD12Map": {
             "vendor": "iCasa",
-            "doc": "ICZB-KPD1 remote",
-            "modelids": ["ICZB-KPD1"],
+            "doc": "ICZB-KPD12 remote",
+            "modelids": ["ICZB-KPD12"],
+            "buttons": [
+                {"S_BUTTON_1": "Off button"},
+                {"S_BUTTON_2": "On button"}
+            ],
+            "map": [
+                [1, "0x01", "ONOFF", "OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "Off"],
+                [1, "0x01", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "1", "S_BUTTON_1", "S_BUTTON_ACTION_HOLD", "Move down (with on/off)"],
+                [1, "0x01", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "1", "S_BUTTON_1", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ (with on/off)"],
+                [1, "0x01", "ONOFF", "ON", "0", "S_BUTTON_2", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],
+                [1, "0x01", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "0", "S_BUTTON_2", "S_BUTTON_ACTION_HOLD", "Move up (with on/off)"],
+                [1, "0x01", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "0", "S_BUTTON_2", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ (with on/off)"]
+            ]
+        },
+        "icasaKPD14SMap": {
+            "vendor": "iCasa",
+            "doc": "ICZB-KPD14S remote",
+            "modelids": ["ICZB-KPD14S"],
+            "buttons": [
+                {"S_BUTTON_1": "Off button"},
+                {"S_BUTTON_2": "On button"},
+                {"S_BUTTON_3": "S1 button"},
+                {"S_BUTTON_4": "S2 button"}
+            ],
+            "map": [
+                [1, "0x01", "ONOFF", "OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "Off"],
+                [1, "0x01", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "1", "S_BUTTON_1", "S_BUTTON_ACTION_HOLD", "Move down (with on/off)"],
+                [1, "0x01", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "1", "S_BUTTON_1", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ (with on/off)"],
+                [1, "0x01", "ONOFF", "ON", "0", "S_BUTTON_2", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],
+                [1, "0x01", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "0", "S_BUTTON_2", "S_BUTTON_ACTION_HOLD", "Move up (with on/off)"],
+                [1, "0x01", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "0", "S_BUTTON_2", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ (with on/off)"],
+                [1, "0x01", "SCENES", "RECALL_SCENE", "1", "S_BUTTON_3", "S_BUTTON_ACTION_SHORT_RELEASED", "Recall scene 1"],
+                [1, "0x01", "SCENES", "STORE_SCENE", "1", "S_BUTTON_3", "S_BUTTON_ACTION_LONG_RELEASED", "Store scene 1"],
+                [1, "0x01", "SCENES", "RECALL_SCENE", "2", "S_BUTTON_4", "S_BUTTON_ACTION_SHORT_RELEASED", "Recall scene 2"],
+                [1, "0x01", "SCENES", "STORE_SCENE", "2", "S_BUTTON_4", "S_BUTTON_ACTION_LONG_RELEASED", "Store scene 2"]
+            ]
+        },
+        "icasaKPD18SMap": {
+            "vendor": "iCasa",
+            "doc": "ICZB-KPD18S remote",
+            "modelids": ["ICZB-KPD18S"],
+            "buttons": [
+                {"S_BUTTON_1": "Off button"},
+                {"S_BUTTON_2": "On button"},
+                {"S_BUTTON_3": "S1 button"},
+                {"S_BUTTON_4": "S2 button"},
+                {"S_BUTTON_5": "S3 button"},
+                {"S_BUTTON_6": "S4 button"},
+                {"S_BUTTON_7": "S5 button"},
+                {"S_BUTTON_8": "S6 button"}
+            ],
             "map": [
                 [1, "0x01", "ONOFF", "OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "Off"],
                 [1, "0x01", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "1", "S_BUTTON_1", "S_BUTTON_ACTION_HOLD", "Move down (with on/off)"],

--- a/button_maps.schema.json
+++ b/button_maps.schema.json
@@ -88,7 +88,7 @@
       "enum": [ "ADD_SCENE", "VIEW_SCENE", "REMOVE_SCENE", "STORE_SCENE", "RECALL_SCENE", "IKEA_STEP_CT", "IKEA_MOVE_CT", "IKEA_STOP_CT" ]
     },
     "onoff-commands": {
-      "enum": [ "ATTRIBUTE_REPORT", "OFF", "ON", "TOGGLE", "OFF_WITH_EFFECT", "ON_WITH_TIMED_OFF" ]
+      "enum": [ "ATTRIBUTE_REPORT", "OFF", "ON", "TOGGLE", "OFF_WITH_EFFECT", "ON_WITH_TIMED_OFF", "LIDL" ]
     },
     "level-commands": {
       "enum": [ "MOVE_TO_LEVEL", "MOVE", "STEP", "STOP", "MOVE_TO_LEVEL_WITH_ON_OFF", "MOVE_WITH_ON_OFF", "STEP_WITH_ON_OFF", "STOP_WITH_ON_OFF" ]


### PR DESCRIPTION
- Explicitly state model identifiers;
- Split into one map per switch to improve documentation and clearly state what a certain switch supports.