### PR TITLE
Tobular Motor Zemismart ZM25TQ

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2551,6 +2551,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
         if ((lightNode.manufacturer() == QString("_TYST11_xu1rkty3")) ||
             (lightNode.manufacturer() == QString("_TZE200_xuzcvlku")) ||
             (lightNode.manufacturer() == QString("_TZE200_wmcdj3aq")) ||
+            (lightNode.manufacturer() == QString("_TZE200_fzo2pocs")) ||
             (lightNode.manufacturer() == QString("_TYST11_wmcdj3aq")) )
         {
             lightNode.addItem(DataTypeBool, RStateOpen);

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -575,6 +575,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         if ((taskRef.lightNode->manufacturer() == QLatin1String("_TYST11_wmcdj3aq")) ||
             (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_xuzcvlku")) ||
             (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_wmcdj3aq")) ||
+            (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_fzo2pocs")) ||
             (taskRef.lightNode->manufacturer() == QLatin1String("_TYST11_xu1rkty3")) )
         {
             return setWindowCoveringState(req, rsp, taskRef, map);
@@ -1560,6 +1561,7 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
     if ((taskRef.lightNode->manufacturer() == QLatin1String("_TYST11_wmcdj3aq")) ||
         (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_xuzcvlku")) ||
         (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_wmcdj3aq")) ||
+        (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_fzo2pocs")) ||
         (taskRef.lightNode->manufacturer() == QLatin1String("_TYST11_xu1rkty3")) )
     {
         cluster = TUYA_CLUSTER_ID;

--- a/tuya.cpp
+++ b/tuya.cpp
@@ -291,6 +291,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
             if ((lightNode->manufacturer() == QLatin1String("_TYST11_wmcdj3aq")) ||
                 (lightNode->manufacturer() == QLatin1String("_TZE200_xuzcvlku")) ||
                 (lightNode->manufacturer() == QLatin1String("_TZE200_wmcdj3aq")) ||
+                (lightNode->manufacturer() == QLatin1String("_TZE200_fzo2pocs")) ||
                 (lightNode->manufacturer() == QLatin1String("_TYST11_xu1rkty3")) )
             {
 


### PR DESCRIPTION
Add new device > https://github.com/dresden-elektronik/deconz-rest-plugin/issues/4132

Working but for the moment the api create 2 fake device for it, (this code part is used for switches and no way to differentiate them).
