### PR TITLE
Improve Samjin multi sensor and Samjin battery reporting

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1944,7 +1944,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq.attributeId = 0x0010; // active
             rq.minInterval = manufacturerCode == VENDOR_SAMJIN ? 0 : 10;
             rq.maxInterval = 3600;
-            rq.reportableChange8bit = 1;
+            rq.reportableChange8bit = 0xFF;
             rq.manufacturerCode = manufacturerCode;
 
             ConfigureReportingRequest rq1;

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2846,7 +2846,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
                 continue; // process only once
             }
 
-            if (sensor->manufacturer() == QLatin1String("Samjin") && sensor->modelId() == QLatin1String("multi") && sensor->type() != QLatin1String("ZHAPresence"))
+            if (sensor->manufacturer() == QLatin1String("Samjin") && sensor->modelId() == QLatin1String("multi") && sensor->type() != QLatin1String("ZHAOpenClose"))
             {
                 continue; // process only once
             }

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2838,6 +2838,12 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
             {
                 continue; // process only once
             }
+
+            if (sensor->manufacturer() == QLatin1String("Samjin") && sensor->modelId() == QLatin1String("multi") && sensor->type() != QLatin1String("ZHAPresence"))
+            {
+                continue; // process only once
+            }
+
             if (sensor->modelId() == QLatin1String("Remote switch") ||
                 sensor->modelId() == QLatin1String("Shutters central remote switch") ||
                 sensor->modelId() == QLatin1String("Double gangs remote switch") ||

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1951,7 +1951,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq1.dataType = deCONZ::Zcl16BitInt;
             rq1.attributeId = 0x0012; // acceleration x
             rq1.minInterval = minInterval;
-            rq1.maxInterval = 300;
+            rq1.maxInterval = 3600;
             rq1.reportableChange16bit = 1;
             rq1.manufacturerCode = manufacturerCode;
 
@@ -1959,7 +1959,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq2.dataType = deCONZ::Zcl16BitInt;
             rq2.attributeId = 0x0013; // acceleration y
             rq2.minInterval = minInterval;
-            rq2.maxInterval = 300;
+            rq2.maxInterval = 3600;
             rq2.reportableChange16bit = 1;
             rq2.manufacturerCode = manufacturerCode;
 
@@ -1967,7 +1967,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq3.dataType = deCONZ::Zcl16BitInt;
             rq3.attributeId = 0x0014; // acceleration z
             rq3.minInterval = minInterval;
-            rq3.maxInterval = 300;
+            rq3.maxInterval = 3600;
             rq3.reportableChange16bit = 1;
             rq3.manufacturerCode = manufacturerCode;
 

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -937,12 +937,12 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         {
             // Only configure periodic reports, as events are already sent though zone status change notification commands
             rq.minInterval = 300;
-            rq.maxInterval = 300;
+            rq.maxInterval = 3600;
         }
         else
         {
-            rq.minInterval = 1;
-            rq.maxInterval = 300;
+            rq.minInterval = 300;
+            rq.maxInterval = 3600;
 
             const ResourceItem *item = sensor ? sensor->item(RConfigDuration) : nullptr;
 

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1617,6 +1617,13 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq.maxInterval = 43200;    // according to technical manual
             rq.reportableChange8bit = 0;
         }
+        else if (sensor && sensor->manufacturer() == QLatin1String("Samjin"))
+        {
+            // https://github.com/SmartThingsCommunity/SmartThingsPublic/blob/master/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
+            rq.minInterval = 30;
+            rq.maxInterval = 21600;
+            rq.reportableChange8bit = 10;
+        }
         else
         {
             rq.minInterval = 300;

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -12451,6 +12451,13 @@ void DeRestPluginPrivate::sendZclDefaultResponse(const deCONZ::ApsDataIndication
                              deCONZ::ZclFCDirectionClientToServer |
                              deCONZ::ZclFCDisableDefaultResponse);
 
+
+    if (zclFrame.manufacturerCode_t() != 0x0000_mfcode)
+    {
+        outZclFrame.setFrameControl(outZclFrame.frameControl() | deCONZ::ZclFCManufacturerSpecific);
+        outZclFrame.setManufacturerCode(zclFrame.manufacturerCode_t());
+    }
+
     { // ZCL payload
         QDataStream stream(&outZclFrame.payload(), QIODevice::WriteOnly);
         stream.setByteOrder(QDataStream::LittleEndian);

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -40,6 +40,9 @@
 #include "websocket_server.h"
 #include "tuya.h"
 
+// enable domain specific string literals
+using namespace deCONZ::literals;
+
 #if defined(Q_OS_LINUX) && !defined(Q_PROCESSOR_X86)
   // Workaround to detect ARM and AARCH64 in older Qt versions.
   #define ARCH_ARM


### PR DESCRIPTION
Align with original SmartThings configuration
* Report battery state every 6 hours instead 5 minutes;
* Samjin muli sensor open/close reporting set to 1 hour instead 5 minutes;
* Samjin muli sensor orientation reporting set to 1 hour instead 5 minutes;
* Further, align with ZCL spec and use manufacturer code in ZCL Default Response when the request was manufacturer specific.

Issue: https://github.com/dresden-elektronik/deconz-rest-plugin/issues/4131

The main battery safer comes via Poll Control configuration PR: https://github.com/dresden-elektronik/deconz-rest-plugin/pull/4163 formerly SmartThings devices did MAC Data Polling in very short intervals, sometimes every 5–10 seconds. With the PR this interval is raised to 15 minutes.
