### PR TITLE
Allow throttling of `lastseen` updates

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -1561,6 +1561,15 @@ static int sqliteLoadConfigCallback(void *user, int ncols, char **colval , char 
             d->dbZclValueMaxAge = maxAge;
         }
     }
+    else if (strcmp(colval[0], "lightlastseeninterval") == 0)
+    {
+        int lightLastSeen = val.toUInt(&ok);
+        if (!val.isEmpty() && ok)
+        {
+            d->gwConfig["lightlastseeninterval"] = lightLastSeen;
+            d->gwLightLastSeenInterval = lightLastSeen;
+        }
+    }
 
     return 0;
 }
@@ -4567,6 +4576,7 @@ void DeRestPluginPrivate::saveDb()
         gwConfig["proxyaddress"] = gwProxyAddress;
         gwConfig["proxyport"] = gwProxyPort;
         gwConfig["zclvaluemaxage"] = dbZclValueMaxAge;
+        gwConfig["lightlastseeninterval"] = gwLightLastSeenInterval;
 
         QVariantMap::iterator i = gwConfig.begin();
         QVariantMap::iterator end = gwConfig.end();

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -601,6 +601,7 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
     gwLinkButton = false;
     gwWebSocketNotifyAll = true;
     gwdisablePermitJoinAutoOff = false;
+    gwLightLastSeenInterval = 60;
 
     // preallocate memory to get consistent pointers
     nodes.reserve(300);

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1658,6 +1658,7 @@ public:
     QString gwWifiEth0;
     QString gwWifiWlan0;
     QVariantList gwWifiAvailable;
+    int gwLightLastSeenInterval; // Intervall to throttle lastseen updates
     enum WifiState {
         WifiStateInitMgmt,
         WifiStateIdle

--- a/light_node.cpp
+++ b/light_node.cpp
@@ -338,7 +338,7 @@ void LightNode::rx()
 {
     RestNodeBase *b = static_cast<RestNodeBase *>(this);
     b->rx();
-    if (lastRx() >= item(RAttrLastSeen)->lastChanged().addSecs(60))
+    if (lastRx() >= item(RAttrLastSeen)->lastChanged().addSecs(plugin->gwLightLastSeenInterval))
     {
         setValue(RAttrLastSeen, lastRx().toUTC());
     }

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -2173,6 +2173,29 @@ int DeRestPluginPrivate::modifyConfig(const ApiRequest &req, ApiResponse &rsp)
         rspItem["success"] = rspItemState;
         rsp.list.append(rspItem);
     }
+    if (map.contains("lightlastseeninterval")) // optional
+    {
+        int lightLastSeen = map["lightlastseeninterval"].toInt(&ok);
+        if (!ok || lightLastSeen = 0 || lightLastSeen > 65535)
+        {
+            rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/config/lightlastseeninterval"), QString("invalid value, %1, for parameter, lightlastseeninterval").arg(map["lightlastseeninterval"].toString())));
+            rsp.httpStatus = HttpStatusBadRequest;
+            return REQ_READY_SEND;
+        }
+
+        if (gwLightLastSeenInterval != lightLastSeen)
+        {
+            gwLightLastSeenInterval = lightLastSeen;
+            queSaveDb(DB_CONFIG, DB_SHORT_SAVE_DELAY);
+            changed = true;
+        }
+
+        QVariantMap rspItem;
+        QVariantMap rspItemState;
+        rspItemState["/config/lightlastseeninterval"] = lightLastSeen;
+        rspItem["success"] = rspItemState;
+        rsp.list.append(rspItem);
+    }
 
     if (changed)
     {

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -2176,7 +2176,7 @@ int DeRestPluginPrivate::modifyConfig(const ApiRequest &req, ApiResponse &rsp)
     if (map.contains("lightlastseeninterval")) // optional
     {
         int lightLastSeen = map["lightlastseeninterval"].toInt(&ok);
-        if (!ok || lightLastSeen = 0 || lightLastSeen > 65535)
+        if (!ok || lightLastSeen <= 0 || lightLastSeen > 65535)
         {
             rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/config/lightlastseeninterval"), QString("invalid value, %1, for parameter, lightlastseeninterval").arg(map["lightlastseeninterval"].toString())));
             rsp.httpStatus = HttpStatusBadRequest;


### PR DESCRIPTION
Currently, the period for updating `lastseen` is fixed to 60 secs and if the actual timestamp is older, the value is updated, emitting a websocket event for `/light` resources. By introducing `lightlastseeninterval` for the REST API gateway configuration, this value is now configurable between 1 and 655535 seconds, keeping the default of 60 seconds.