### PR TITLE
Fix possible segfault by wrong printf argument type

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4641,7 +4641,7 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
 
                             if (dt > 0 && dt < 500)
                             {
-                                DBG_Printf(DBG_INFO, "[INFO] - Button %u %s, discard too fast event (dt = %d) %s\n", buttonMap.button, qPrintable(cmd), (int)dt, qPrintable(sensor->modelId()));
+                                DBG_Printf(DBG_INFO, "[INFO] - Button %u %s, discard too fast event (dt = %d) %s\n", buttonMap.button, qPrintable(cmd), static_cast<int>(dt), qPrintable(sensor->modelId()));
                                 break;
                             }
                         }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4641,7 +4641,7 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
 
                             if (dt > 0 && dt < 500)
                             {
-                                DBG_Printf(DBG_INFO, "[INFO] - Button %u %s, discard too fast event (dt = %d) %s\n", buttonMap.button, qPrintable(cmd), dt, qPrintable(sensor->modelId()));
+                                DBG_Printf(DBG_INFO, "[INFO] - Button %u %s, discard too fast event (dt = %d) %s\n", buttonMap.button, qPrintable(cmd), (int)dt, qPrintable(sensor->modelId()));
                                 break;
                             }
                         }

--- a/ias_zone.cpp
+++ b/ias_zone.cpp
@@ -688,7 +688,7 @@ void DeRestPluginPrivate::checkIasEnrollmentStatus(Sensor *sensor)
 
             if (dt > 5)
             {
-                DBG_Printf(DBG_IAS, "[IAS ZONE] - 0x%016llX initiate unsoliticed enroll response after %d seconds delay.\n", sensor->address().ext(), (int)dt);
+                DBG_Printf(DBG_IAS, "[IAS ZONE] - 0x%016llX initiate unsoliticed enroll response after %d seconds delay.\n", sensor->address().ext(), static_cast<int>(dt));
                 iasState = IAS_SetState(sensor, itemIasState, IAS_STATE_ENROLL);
             }
         }
@@ -752,12 +752,12 @@ void DeRestPluginPrivate::checkIasEnrollmentStatus(Sensor *sensor)
 
             if (dt > 8) // Wait up to 8 seconds, because next mac poll might take 7.x seconds until max transactions expires.
             {
-                DBG_Printf(DBG_IAS, "[IAS ZONE] - 0x%016llX timeout after %d seconds, state: %d, retry...\n", sensor->address().ext(), (int)dt, iasState);
+                DBG_Printf(DBG_IAS, "[IAS ZONE] - 0x%016llX timeout after %d seconds, state: %d, retry...\n", sensor->address().ext(), static_cast<int>(dt), iasState);
                 IAS_SetState(sensor, itemIasState, IAS_STATE_INIT);
             }
             else
             {
-                DBG_Printf(DBG_IAS, "[IAS ZONE] - 0x%016llX Sensor enrollment pending... since %d seconds.\n", sensor->address().ext(), (int)dt);
+                DBG_Printf(DBG_IAS, "[IAS ZONE] - 0x%016llX Sensor enrollment pending... since %d seconds.\n", sensor->address().ext(), static_cast<int>(dt));
             }
         }
     }

--- a/ias_zone.cpp
+++ b/ias_zone.cpp
@@ -688,7 +688,7 @@ void DeRestPluginPrivate::checkIasEnrollmentStatus(Sensor *sensor)
 
             if (dt > 5)
             {
-                DBG_Printf(DBG_IAS, "[IAS ZONE] - 0x%016llX initiate unsoliticed enroll response after %d seconds delay.\n", sensor->address().ext(), dt);
+                DBG_Printf(DBG_IAS, "[IAS ZONE] - 0x%016llX initiate unsoliticed enroll response after %d seconds delay.\n", sensor->address().ext(), (int)dt);
                 iasState = IAS_SetState(sensor, itemIasState, IAS_STATE_ENROLL);
             }
         }
@@ -752,12 +752,12 @@ void DeRestPluginPrivate::checkIasEnrollmentStatus(Sensor *sensor)
 
             if (dt > 8) // Wait up to 8 seconds, because next mac poll might take 7.x seconds until max transactions expires.
             {
-                DBG_Printf(DBG_IAS, "[IAS ZONE] - 0x%016llX timeout after %d seconds, state: %d, retry...\n", sensor->address().ext(), dt, iasState);
+                DBG_Printf(DBG_IAS, "[IAS ZONE] - 0x%016llX timeout after %d seconds, state: %d, retry...\n", sensor->address().ext(), (int)dt, iasState);
                 IAS_SetState(sensor, itemIasState, IAS_STATE_INIT);
             }
             else
             {
-                DBG_Printf(DBG_IAS, "[IAS ZONE] - 0x%016llX Sensor enrollment pending... since %d seconds.\n", sensor->address().ext(), dt);
+                DBG_Printf(DBG_IAS, "[IAS ZONE] - 0x%016llX Sensor enrollment pending... since %d seconds.\n", sensor->address().ext(), (int)dt);
             }
         }
     }


### PR DESCRIPTION
Proposed fix avoid possible segfault by wrong type of argument supplied to DBG_Printf, expected int (got wide-int?),
see https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3611#issuecomment-761917726 for details

I'm pretty sure it is not the single place where it is used in same way, but have no time at the moment to check whole codebase.
FWIW, it is doubtful (at least not advisable) to use printf without check of argument types, let alone the arguments declared as auto-variable supplied without cast, etc.