### PR TITLE
Add initial support for MoesHouse / Livolo Roller Blinds

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2221,7 +2221,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
             }
             //Battery covering
             if ((lightNode.manufacturer() == QLatin1String("_TZE200_wmcdj3aq")) ||
-                (lightNode.manufacturer() == QLatin1String("_TZE200_zah67ekd")) )
+                (lightNode.manufacturer() == QLatin1String("_TZE200_zah67ekd")) ) // MoesHouse / Livolo Roller Blinds
             {
                 hasServerOnOff = true;
             }
@@ -2552,7 +2552,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
         if ((lightNode.manufacturer() == QString("_TYST11_xu1rkty3")) ||
             (lightNode.manufacturer() == QString("_TZE200_xuzcvlku")) ||
             (lightNode.manufacturer() == QString("_TZE200_wmcdj3aq")) ||
-            (lightNode.manufacturer() == QString("_TZE200_zah67ekd")) ||
+            (lightNode.manufacturer() == QString("_TZE200_zah67ekd")) || // MoesHouse / Livolo Roller Blinds
             (lightNode.manufacturer() == QString("_TYST11_wmcdj3aq")) )
         {
             lightNode.addItem(DataTypeBool, RStateOpen);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2219,8 +2219,9 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
             {
                 hasServerOnOff = false;
             }
-            //to test
-            if (lightNode.manufacturer() == QLatin1String("_TZE200_wmcdj3aq"))
+            //Battery covering
+            if ((lightNode.manufacturer() == QLatin1String("_TZE200_wmcdj3aq")) ||
+                (lightNode.manufacturer() == QLatin1String("_TZE200_zah67ekd")) )
             {
                 hasServerOnOff = true;
             }
@@ -2551,6 +2552,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
         if ((lightNode.manufacturer() == QString("_TYST11_xu1rkty3")) ||
             (lightNode.manufacturer() == QString("_TZE200_xuzcvlku")) ||
             (lightNode.manufacturer() == QString("_TZE200_wmcdj3aq")) ||
+            (lightNode.manufacturer() == QString("_TZE200_zah67ekd")) ||
             (lightNode.manufacturer() == QString("_TYST11_wmcdj3aq")) )
         {
             lightNode.addItem(DataTypeBool, RStateOpen);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2237,7 +2237,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
             }
             //Battery covering
             if ((lightNode.manufacturer() == QLatin1String("_TZE200_wmcdj3aq")) ||
-                (lightNode.manufacturer() == QLatin1String("_TZE200_zah67ekd")) ) // MoesHouse / Livolo Roller Blinds
+                (lightNode.manufacturer() == QLatin1String("_TZE200_zah67ekd"))) // MoesHouse / Livolo Roller Blinds
             {
                 hasServerOnOff = true;
             }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2552,6 +2552,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
         if ((lightNode.manufacturer() == QString("_TYST11_xu1rkty3")) ||
             (lightNode.manufacturer() == QString("_TZE200_xuzcvlku")) ||
             (lightNode.manufacturer() == QString("_TZE200_wmcdj3aq")) ||
+            (lightNode.manufacturer() == QString("_TZE200_nogaemzt")) ||
             (lightNode.manufacturer() == QString("_TZE200_zah67ekd")) || // MoesHouse / Livolo Roller Blinds
             (lightNode.manufacturer() == QString("_TYST11_wmcdj3aq")) )
         {

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -575,6 +575,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         if ((taskRef.lightNode->manufacturer() == QLatin1String("_TYST11_wmcdj3aq")) ||
             (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_xuzcvlku")) ||
             (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_wmcdj3aq")) ||
+            (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_zah67ekd")) ||
             (taskRef.lightNode->manufacturer() == QLatin1String("_TYST11_xu1rkty3")) )
         {
             return setWindowCoveringState(req, rsp, taskRef, map);
@@ -1560,6 +1561,7 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
     if ((taskRef.lightNode->manufacturer() == QLatin1String("_TYST11_wmcdj3aq")) ||
         (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_xuzcvlku")) ||
         (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_wmcdj3aq")) ||
+        (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_zah67ekd")) ||
         (taskRef.lightNode->manufacturer() == QLatin1String("_TYST11_xu1rkty3")) )
     {
         cluster = TUYA_CLUSTER_ID;

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -575,6 +575,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         if ((taskRef.lightNode->manufacturer() == QLatin1String("_TYST11_wmcdj3aq")) ||
             (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_xuzcvlku")) ||
             (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_wmcdj3aq")) ||
+            (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_nogaemzt")) ||
             (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_zah67ekd")) || // MoesHouse / Livolo Roller Blinds
             (taskRef.lightNode->manufacturer() == QLatin1String("_TYST11_xu1rkty3")) )
         {
@@ -1561,6 +1562,7 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
     if ((taskRef.lightNode->manufacturer() == QLatin1String("_TYST11_wmcdj3aq")) ||
         (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_xuzcvlku")) ||
         (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_wmcdj3aq")) ||
+        (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_nogaemzt")) ||
         (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_zah67ekd")) || // MoesHouse / Livolo Roller Blinds
         (taskRef.lightNode->manufacturer() == QLatin1String("_TYST11_xu1rkty3")) )
     {

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -575,7 +575,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         if ((taskRef.lightNode->manufacturer() == QLatin1String("_TYST11_wmcdj3aq")) ||
             (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_xuzcvlku")) ||
             (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_wmcdj3aq")) ||
-            (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_zah67ekd")) ||
+            (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_zah67ekd")) || // MoesHouse / Livolo Roller Blinds
             (taskRef.lightNode->manufacturer() == QLatin1String("_TYST11_xu1rkty3")) )
         {
             return setWindowCoveringState(req, rsp, taskRef, map);
@@ -1561,7 +1561,7 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
     if ((taskRef.lightNode->manufacturer() == QLatin1String("_TYST11_wmcdj3aq")) ||
         (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_xuzcvlku")) ||
         (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_wmcdj3aq")) ||
-        (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_zah67ekd")) ||
+        (taskRef.lightNode->manufacturer() == QLatin1String("_TZE200_zah67ekd")) || // MoesHouse / Livolo Roller Blinds
         (taskRef.lightNode->manufacturer() == QLatin1String("_TYST11_xu1rkty3")) )
     {
         cluster = TUYA_CLUSTER_ID;

--- a/tuya.cpp
+++ b/tuya.cpp
@@ -291,7 +291,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
             if ((lightNode->manufacturer() == QLatin1String("_TYST11_wmcdj3aq")) ||
                 (lightNode->manufacturer() == QLatin1String("_TZE200_xuzcvlku")) ||
                 (lightNode->manufacturer() == QLatin1String("_TZE200_wmcdj3aq")) ||
-                (lightNode->manufacturer() == QLatin1String("_TZE200_zah67ekd")) ||
+                (lightNode->manufacturer() == QLatin1String("_TZE200_zah67ekd")) || // MoesHouse / Livolo Roller Blinds
                 (lightNode->manufacturer() == QLatin1String("_TYST11_xu1rkty3")) )
             {
 

--- a/tuya.cpp
+++ b/tuya.cpp
@@ -291,6 +291,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
             if ((lightNode->manufacturer() == QLatin1String("_TYST11_wmcdj3aq")) ||
                 (lightNode->manufacturer() == QLatin1String("_TZE200_xuzcvlku")) ||
                 (lightNode->manufacturer() == QLatin1String("_TZE200_wmcdj3aq")) ||
+                (lightNode->manufacturer() == QLatin1String("_TZE200_nogaemzt")) ||
                 (lightNode->manufacturer() == QLatin1String("_TZE200_zah67ekd")) || // MoesHouse / Livolo Roller Blinds
                 (lightNode->manufacturer() == QLatin1String("_TYST11_xu1rkty3")) )
             {

--- a/tuya.cpp
+++ b/tuya.cpp
@@ -291,6 +291,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
             if ((lightNode->manufacturer() == QLatin1String("_TYST11_wmcdj3aq")) ||
                 (lightNode->manufacturer() == QLatin1String("_TZE200_xuzcvlku")) ||
                 (lightNode->manufacturer() == QLatin1String("_TZE200_wmcdj3aq")) ||
+                (lightNode->manufacturer() == QLatin1String("_TZE200_zah67ekd")) ||
                 (lightNode->manufacturer() == QLatin1String("_TYST11_xu1rkty3")) )
             {
 


### PR DESCRIPTION
Ok no not sure for model name but probably "Zemismart Chain Roller Shades Driver (Model M515EGB)".
Battery powered device, using tuya cluster for covering, see > https://github.com/dresden-elektronik/deconz-rest-plugin/issues/4071

Have added too a new generic tuya covering too (_TZE200_nogaemzt), no more information https://github.com/dresden-elektronik/deconz-rest-plugin/issues/4288 (Not tested)