### PR TITLE
Fixes

### DIFF
--- a/read_files.cpp
+++ b/read_files.cpp
@@ -74,7 +74,7 @@ QMap<QString, quint16> loadButtonMapClustersJson(const QJsonDocument &buttonMaps
             DBG_Printf(DBG_INFO, "[ERROR] - Key #%d for object 'clusters' is no string or too long. Skipping entry...\n", counter);
             continue;
         }
-        else if (!i.value().isDouble() || i.value().toDouble() > 2000)
+        else if (!i.value().isDouble() || i.value().toDouble() > 65535)
         {
             DBG_Printf(DBG_INFO, "[ERROR] - Value #%d for object 'clusters' is no number or too large. Skipping entry...\n", counter);
             continue;

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -1057,6 +1057,7 @@ void DeRestPluginPrivate::configToMap(const ApiRequest &req, QVariantMap &map)
     map["networkopenduration"] = gwNetworkOpenDuration;
     map["timeformat"] = gwTimeFormat;
     map["whitelist"] = whitelist;
+    map["lightlastseeninterval"] = gwLightLastSeenInterval;
     map["linkbutton"] = gwLinkButton;
     map["portalservices"] = false;
     map["websocketport"] = static_cast<double>(gwConfig["websocketport"].toUInt());


### PR DESCRIPTION
- Fix `lightlastseeninterval` not displayed via REST API
Using the parameter works, but it's not returned via GET on `config` resource.
- Allow all clusters to be used for button maps