### PR TITLE
Tuya TS004x + avoid false multiple press events + send ZCL default response for switches

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -3842,7 +3842,7 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
         if (zclFrame.sequenceNumber() == sensor->previousSequenceNumber)
         {
             DBG_Printf(DBG_INFO, "[INFO] - Discard second event (seq-num = %d) %s\n", 
-                (int)sensor->previousSequenceNumber, qPrintable(sensor->modelId()));
+                static_cast<int>(sensor->previousSequenceNumber), qPrintable(sensor->modelId()));
             return;
         }
         sensor->previousSequenceNumber = zclFrame.sequenceNumber();
@@ -4641,7 +4641,7 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                             if (dt > 0 && dt < 500)
                             {
                                 DBG_Printf(DBG_INFO, "[INFO] - Discard too fast event (dt = %d) %s\n", 
-                                    (int)dt, qPrintable(sensor->modelId()));
+                                    static_cast<int>(dt), qPrintable(sensor->modelId()));
                                 break;
                             }
                         }
@@ -12483,7 +12483,8 @@ void DeRestPluginPrivate::sendZclDefaultResponse(const deCONZ::ApsDataIndication
 {
     deCONZ::ApsDataRequest apsReq;
 
-    DBG_Printf(DBG_INFO, "Send zcl default response %u, seqno: %u\n", (unsigned)status, (unsigned)zclFrame.sequenceNumber());
+    DBG_Printf(DBG_INFO, "Send zcl default response %u, seqno: %u\n",
+	       static_cast<unsigned>(status), static_cast<unsigned>(zclFrame.sequenceNumber()));
 
     // ZDP Header
     apsReq.dstAddress() = ind.srcAddress();

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4634,7 +4634,7 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                     ResourceItem *item = sensor->item(RStateButtonEvent);
                     if (item)
                     {
-                        if (item->toNumber() == buttonMap.button)
+                        if (item->toNumber() == buttonMap.button && item->lastSet().isValid())
                         {
                             QDateTime now = QDateTime::currentDateTime();
                             const auto dt = item->lastSet().msecsTo(now);
@@ -4642,7 +4642,7 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                             if (ind.dstAddressMode() == deCONZ::ApsGroupAddress && dt > 0 && dt < 500)
                             {
                                 DBG_Printf(DBG_INFO, "[INFO] - Discard too fast event (dt = %d) %s\n", 
-                                    dt, qPrintable(sensor->modelId()));
+                                    (int)dt, qPrintable(sensor->modelId()));
                                 break;
                             }
 
@@ -4652,7 +4652,7 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                             )
                             {
                                 DBG_Printf(DBG_INFO, "[INFO] - Discard second %s event (dt = %d) %s\n", 
-                                    qPrintable(sensor->manufacturer()), dt, qPrintable(sensor->modelId()));
+                                    qPrintable(sensor->manufacturer()), (int)dt, qPrintable(sensor->modelId()));
                                 break;
                             }
                         }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -11620,6 +11620,7 @@ void DeRestPluginPrivate::handleZclAttributeReportIndication(const deCONZ::ApsDa
         DBG_Printf(DBG_INFO_L2, "\tpayload: %s\n", qPrintable(zclFrame.payload().toHex()));
     }
 
+    DBG_Printf(DBG_INFO, "******* (a) ** send response %X ? %s (seq-num = %d)\n", (int)zclFrame.frameControl(), !(zclFrame.frameControl() & deCONZ::ZclFCDisableDefaultResponse) ? "yes" : "no", (int)zclFrame.sequenceNumber());
     if (!(zclFrame.frameControl() & deCONZ::ZclFCDisableDefaultResponse))
     {
         checkReporting = true;
@@ -14470,6 +14471,15 @@ void DeRestPluginPrivate::handleOnOffClusterIndication(const deCONZ::ApsDataIndi
     if (zclFrame.isDefaultResponse())
     {
         return;
+    }
+
+    // test to send default response:
+    DBG_Printf(DBG_INFO, "******* (b) ** send response %X ? %s (seq-num = %d)\n", (int)zclFrame.frameControl(), !(zclFrame.frameControl() & deCONZ::ZclFCDisableDefaultResponse) ? "yes" : "no", (int)zclFrame.sequenceNumber());
+    if ( !(zclFrame.frameControl() & deCONZ::ZclFCDisableDefaultResponse) &&
+         (ind.clusterId() == ONOFF_CLUSTER_ID) &&
+         (!(ind.dstAddress().isNwkBroadcast())) )
+    {
+        sendZclDefaultResponse(ind, zclFrame, deCONZ::ZclSuccessStatus);
     }
 
     bool dark = true;


### PR DESCRIPTION
This PR is an accumulation of several tasks and solves following problems:
 
- implements device request of Tuya TS004x (or Zemismart ZigBee Switch) ~as well as fixes mistaken pairing of the devices as a light~ (not a part of this PR now at @Smanar request)  (#3611);
- avoids false multiple press events fired for (unanswered) events with the same frame sequence number (#3611, #4227);
- implements sending of ZCL default response for switch devices expecting that (#3611, #4227), so prevent repeated ZCL frame from device and a latency (up to 3 seconds) before device becomes able to notify about next click, if it does not receive an ack.
