### PR TITLE
Prevent too early idle timer callback

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -17055,7 +17055,8 @@ DeRestPlugin::DeRestPlugin(QObject *parent) :
     connect(m_readAttributesTimer, SIGNAL(timeout()),
             this, SLOT(checkZclAttributeTimerFired()));
 
-    m_idleTimer->start(1000);
+    m_idleTimer->start(IDLE_TIMER_INTERVAL);
+    d->idleTimer.start();
 }
 
 /*! The plugin deconstructor.
@@ -17074,6 +17075,15 @@ DeRestPlugin::~DeRestPlugin()
  */
 void DeRestPlugin::idleTimerFired()
 {
+    // Use extra QElapsedTimer since QTimer seems sometimes to
+    // fire in < 1 sec. intervals (after database write?).
+    if (d->idleTimer.elapsed() < (IDLE_TIMER_INTERVAL - 50)) // -50 : don't be too strict
+    {
+        DBG_Printf(DBG_INFO, "Skip idle timer callback, too early: elapsed %lld msec\n", d->idleTimer.elapsed());
+        return;
+    }
+    d->idleTimer.start();
+
     d->idleTotalCounter++;
     d->idleLastActivity++;
 

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -77,6 +77,7 @@ using namespace deCONZ::literals;
 
 #define ERR_DEVICE_SCENES_TABLE_FULL   402 // de extension
 
+#define IDLE_TIMER_INTERVAL 1000
 #define IDLE_LIMIT 30
 #define IDLE_READ_LIMIT 120
 #define IDLE_USER_LIMIT 20
@@ -2033,6 +2034,7 @@ public:
     QTime queryTime;
     deCONZ::ApsController *apsCtrl;
     uint groupTaskNodeIter; // Iterates through nodes array
+    QElapsedTimer idleTimer;
     int idleTotalCounter; // sys timer
     int idleLimit;
     int idleUpdateZigBeeConf; //


### PR DESCRIPTION
In some cases like database read/writes the QTimer callback was called too early.
This could mess up time based triggering of rules.

Issue: https://github.com/dresden-elektronik/deconz-rest-plugin/issues/4106