### PR TITLE
Make sensor Websocket push logic independent from absolute time stamps

### DIFF
--- a/resource.cpp
+++ b/resource.cpp
@@ -430,6 +430,7 @@ ResourceItem::ResourceItem(const ResourceItem &other)
 /*! Move constructor. */
 ResourceItem::ResourceItem(ResourceItem &&other) :
     m_isPublic(other.m_isPublic),
+    m_flags(other.m_flags),
     m_num(other.m_num),
     m_numPrev(other.m_numPrev),
     m_str(nullptr),
@@ -457,6 +458,26 @@ ResourceItem::~ResourceItem()
     }
 }
 
+/*! Returns true when a value has been set but not pushed upstream. */
+bool ResourceItem::needPushSet() const
+{
+    return (m_flags & FlagNeedPushSet) > 0;
+}
+
+/*! Returns true when a value has been set and is different from previous
+    but not pushed upstream.
+ */
+bool ResourceItem::needPushChange() const
+{
+    return (m_flags & FlagNeedPushChange) > 0;
+}
+
+/*! Clears set and changed push flags, called after value has been pushed to upstream. */
+void ResourceItem::clearNeedPush()
+{
+    m_flags &= ~static_cast<quint16>(FlagNeedPushSet | FlagNeedPushChange);
+}
+
 /*! Copy assignment. */
 ResourceItem &ResourceItem::operator=(const ResourceItem &other)
 {
@@ -467,6 +488,7 @@ ResourceItem &ResourceItem::operator=(const ResourceItem &other)
     }
 
     m_isPublic = other.m_isPublic;
+    m_flags = other.m_flags;
     m_num = other.m_num;
     m_numPrev = other.m_numPrev;
     m_rid = other.m_rid;
@@ -504,6 +526,7 @@ ResourceItem &ResourceItem::operator=(ResourceItem &&other)
     }
 
     m_isPublic = other.m_isPublic;
+    m_flags = other.m_flags;
     m_num = other.m_num;
     m_numPrev = other.m_numPrev;
     m_rid = other.m_rid;
@@ -615,10 +638,12 @@ bool ResourceItem::setValue(const QString &val)
     if (m_str)
     {
         m_lastSet = QDateTime::currentDateTime();
+        m_flags |= FlagNeedPushSet;
         if (*m_str != val)
         {
             *m_str = val;
             m_lastChanged = m_lastSet;
+            m_flags |= FlagNeedPushChange;
         }
         return true;
     }
@@ -639,11 +664,13 @@ bool ResourceItem::setValue(qint64 val)
 
     m_lastSet = QDateTime::currentDateTime();
     m_numPrev = m_num;
+    m_flags |= FlagNeedPushSet;
 
     if (m_num != val)
     {
         m_num = val;
         m_lastChanged = m_lastSet;
+        m_flags |= FlagNeedPushChange;
     }
 
     return true;
@@ -667,10 +694,12 @@ bool ResourceItem::setValue(const QVariant &val)
         if (m_str)
         {
             m_lastSet = now;
+            m_flags |= FlagNeedPushSet;
             if (*m_str != val.toString())
             {
                 *m_str = val.toString();
                 m_lastChanged = m_lastSet;
+                m_flags |= FlagNeedPushChange;
             }
             return true;
         }
@@ -679,11 +708,13 @@ bool ResourceItem::setValue(const QVariant &val)
     {
         m_lastSet = now;
         m_numPrev = m_num;
+        m_flags |= FlagNeedPushSet;
 
         if (m_num != val.toBool())
         {
             m_num = val.toBool();
             m_lastChanged = m_lastSet;
+            m_flags |= FlagNeedPushChange;
         }
         return true;
     }
@@ -697,11 +728,13 @@ bool ResourceItem::setValue(const QVariant &val)
             {
                 m_lastSet = now;
                 m_numPrev = m_num;
+                m_flags |= FlagNeedPushSet;
 
                 if (m_num != dt.toMSecsSinceEpoch())
                 {
                     m_num = dt.toMSecsSinceEpoch();
                     m_lastChanged = m_lastSet;
+                    m_flags |= FlagNeedPushChange;
                 }
                 return true;
             }
@@ -710,11 +743,13 @@ bool ResourceItem::setValue(const QVariant &val)
         {
             m_lastSet = now;
             m_numPrev = m_num;
+            m_flags |= FlagNeedPushSet;
 
             if (m_num != val.toDateTime().toMSecsSinceEpoch())
             {
                 m_num = val.toDateTime().toMSecsSinceEpoch();
                 m_lastChanged = m_lastSet;
+                m_flags |= FlagNeedPushChange;
             }
             return true;
         }
@@ -735,11 +770,13 @@ bool ResourceItem::setValue(const QVariant &val)
 
             m_lastSet = now;
             m_numPrev = m_num;
+            m_flags |= FlagNeedPushSet;
 
             if (m_num != n)
             {
                 m_num = n;
                 m_lastChanged = m_lastSet;
+                m_flags |= FlagNeedPushChange;
             }
             return true;
         }

--- a/resource.cpp
+++ b/resource.cpp
@@ -369,7 +369,6 @@ bool getResourceItemDescriptor(const QString &str, ResourceItemDescriptor &descr
 /*! Clears \p flags in \p item which must be a numeric value item.
     The macro is used to print the flag defines as human readable.
  */
-#define R_ClearFlags(item, flags) R_ClearFlags1(item, flags, #flags)
 bool R_ClearFlags1(ResourceItem *item, qint64 flags, const char *strFlags)
 {
     DBG_Assert(item);
@@ -391,7 +390,6 @@ bool R_ClearFlags1(ResourceItem *item, qint64 flags, const char *strFlags)
 /*! Sets \p flags in \p item which must be a numeric value item.
     The macro is used to print the flag defines as human readable.
  */
-#define R_SetFlags(item, flags) R_SetFlags1(item, flags, #flags)
 bool R_SetFlags1(ResourceItem *item, qint64 flags, const char *strFlags)
 {
     DBG_Assert(item);

--- a/resource.h
+++ b/resource.h
@@ -247,6 +247,12 @@ extern const ResourceItemDescriptor rInvalidItemDescriptor;
 
 class ResourceItem
 {
+    enum ItemFlags
+    {
+        FlagNeedPushSet     = 0x1, // set after a value has been set
+        FlagNeedPushChange  = 0x2  // set when new value different than previous
+    };
+
 public:
     ResourceItem(const ResourceItem &other);
     ResourceItem(ResourceItem &&other);
@@ -254,6 +260,9 @@ public:
     ResourceItem &operator=(const ResourceItem &other);
     ResourceItem &operator=(ResourceItem &&other);
     ~ResourceItem();
+    bool needPushSet() const;
+    bool needPushChange() const;
+    void clearNeedPush();
     const QString &toString() const;
     qint64 toNumber() const;
     qint64 toNumberPrevious() const;
@@ -275,6 +284,7 @@ private:
     ResourceItem() = delete;
 
     bool m_isPublic = true;
+    quint16 m_flags = 0; // bitmap of ResourceItem::ItemFlags
     qint64 m_num = 0;
     qint64 m_numPrev = 0;
     QString *m_str = nullptr;

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -156,7 +156,6 @@ Sensor::Sensor() :
 {
     QDateTime now = QDateTime::currentDateTime();
     lastStatePush = now;
-    lastConfigPush = now;
     durationDue = QDateTime();
 
     // common sensor items

--- a/sensor.h
+++ b/sensor.h
@@ -149,7 +149,6 @@ public:
     const std::vector<Sensor::ButtonMap> buttonMap(const QMap<QString, std::vector<Sensor::ButtonMap>> &buttonMapData, QMap<QString, QString> &buttonMapForModelId);
     uint8_t previousDirection;
     quint16 previousCt;
-    QDateTime lastConfigPush;
     QDateTime durationDue;
     uint8_t previousSequenceNumber;
     uint8_t previousCommandId;


### PR DESCRIPTION
* Prevent duplicated Websocket push events;
* Fix skipped Websocket push events when time stamps don't align due system time changes.

Issue: https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3707
