### PR TITLE
Add silabs3MacPrefix for Lidl/Silvercrest Smart Window or Door Sensor

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -381,6 +381,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_NONE, "eaxp72v", ikea2MacPrefix }, // Tuya TRV Wesmartify Thermostat Essentials Premium
     { VENDOR_NONE, "88teujp", silabs8MacPrefix }, // SEA802-Zigbee
     { VENDOR_NONE, "fvq6avy", silabs7MacPrefix }, // Revolt NX-4911-675 Thermostat
+    { VENDOR_HEIMAN, "TY0203", silabs3MacPrefix }, // Lidl/Silvercrest Smart Window or Door Sensor
     { VENDOR_HEIMAN, "TY0203", silabs7MacPrefix }, // Lidl/Silvercrest Smart Window or Door Sensor
     { VENDOR_HEIMAN, "TY0202", silabs3MacPrefix }, // Lidl/Silvercrest Smart Motion Sensor
     { VENDOR_HEIMAN, "TY0202", silabs7MacPrefix }, // Lidl/Silvercrest Smart Motion Sensor


### PR DESCRIPTION
This adds the silabs3MacPrefix prefix on mac address for the Lidl/Silvercrest Smart Window or Door Sensor (`TY0203`) to add it as supported device.

Some details on my sensor with mac address `ec:1b:bd:ff:fe:95` (via the zll.db sqlite3 db):
```
ZHAOpenClose|TY0203|SILVERCREST|ec:1b:bd:ff:fe:95:4d:e7-01-0500|
```
Thus making it not part of the supported silabs7MacPrefix prefix (`0xbc33ac0000000000ULL`). This PR makes sure this device is supported so I can add this Silvercrest/Lidl sensor without issues to the list of sensors in Deconz.