### PR TITLE
Add initial product identifier map

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -4031,6 +4031,14 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     }
                 }
 
+                {
+                    auto *productId = sensor.item(RAttrProductId);
+                    if (productId)
+                    {
+                        productId->setIsPublic(false); // don't show in REST-API
+                    }
+                }
+
                 sensor.address().setExt(extAddr);
                 // append to cache if not already known
                 d->sensors.push_back(sensor);

--- a/resource.h
+++ b/resource.h
@@ -47,6 +47,7 @@ extern const char *RAttrType;
 extern const char *RAttrClass;
 extern const char *RAttrId;
 extern const char *RAttrUniqueId;
+extern const char *RAttrProductId;
 extern const char *RAttrSwVersion;
 extern const char *RAttrLastAnnounced;
 extern const char *RAttrLastSeen;
@@ -332,5 +333,6 @@ bool R_SetFlags1(ResourceItem *item, qint64 flags, const char *strFlags);
 #define R_ClearFlags(item, flags) R_ClearFlags1(item, flags, #flags)
 bool R_ClearFlags1(ResourceItem *item, qint64 flags, const char *strFlags);
 bool R_HasFlags(const ResourceItem *item, qint64 flags);
+const QString R_GetProductId(Resource *resource);
 
 #endif // RESOURCE_H


### PR DESCRIPTION
Helper for devices with cryptic manufacturer names and modelId.

This allows matching for more readable productId:
```cpp
   if (R_GetProductId(sensor) == QLatin1String("SEA801-ZIGBEE TRV"))
   {
   }
```

This is only an initial PR, the table will be filled in further PR's.