### PR TITLE
Hue dimmer switch (2021), Livarno Lux lights

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5655,7 +5655,10 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                 {
                     sensor = nullptr;
                 }
-                fpSwitch.endpoint = 2;
+                if (modelId != QLatin1String("RWL022")) // new model with one endpoint
+                {
+                    fpSwitch.endpoint = 2;
+                }
             }
 
             if (modelId.startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -455,7 +455,7 @@ static const lidlDevice lidlDevices[] = { // Sorted by zigbeeManufacturerName
     { "_TZ3000_oborybow", "TS0502A", "LIDL Livarno Lux", "HG06492B" }, // CT Light (E14)
     { "_TZ3000_odygigth", "TS0505A", "LIDL Livarno Lux", "HG06106B" }, // RGB Light (E14)
     { "_TZ3000_riwp3k79", "TS0505A", "LIDL Livarno Lux", "HG06104A" }, // LED Light Strip
-    // { "_TZE200_s8gkrkxk", "TS0601",  "LIDL Livarno Lux", "HG06467" }, // Smart LED String Lights (EU)
+    { "_TZE200_s8gkrkxk", "TS0601",  "LIDL Livarno Lux", "HG06467" }, // Smart LED String Lights (EU)
     { nullptr, nullptr, nullptr, nullptr }
 };
 
@@ -14705,10 +14705,10 @@ void DeRestPluginPrivate::handlePhilipsClusterIndication(const deCONZ::ApsDataIn
             {
                 button *= 1000;
                 button += event;
-                
+
                 DBG_Printf(DBG_INFO, "[INFO] - Button %u - %s endpoint: 0x%02X cluster: PHILIPS_SPECIFIC (0x%04X)\n", button,
                            qPrintable(sensorNode->modelId()), ind.srcEndpoint(), ind.clusterId());
-                
+
                 ResourceItem *item = sensorNode->item(RStateButtonEvent);
                 if (item)
                 {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6717,7 +6717,10 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
 
         if (modelId.startsWith(QLatin1String("RWL02"))) // Hue dimmer switch
         {
-            sensorNode.fingerPrint().endpoint = 2;
+            if (modelId != QLatin1String("RWL022")) // new model with one endpoint
+            {
+                sensorNode.fingerPrint().endpoint = 2;
+            }
             clusterId = VENDOR_CLUSTER_ID;
 
             if (!sensorNode.fingerPrint().hasInCluster(POWER_CONFIGURATION_CLUSTER_ID))

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5648,6 +5648,16 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
             fpSwitch.deviceId = i->deviceId();
             fpSwitch.profileId = i->profileId();
 
+            if (modelId.startsWith(QLatin1String("RWL02")))
+            {
+                sensor = getSensorNodeForAddress(node->address().ext()); // former created with with endpoint 1
+                if (sensor && sensor->deletedState() != Sensor::StateNormal)
+                {
+                    sensor = nullptr;
+                }
+                fpSwitch.endpoint = 2;
+            }
+
             if (modelId.startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
                 modelId.startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
                 modelId.startsWith(QLatin1String("Switch 4x-LIGHTIFY")) || // Osram 4 button remote

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -448,8 +448,10 @@ static const lidlDevice lidlDevices[] = { // Sorted by zigbeeManufacturerName
     { "_TYZB01_bngwdjsr", "TS1001",  "LIDL Livarno Lux", "HG06323" }, // Remote Control
     { "_TZ3000_1obwwnmq", "TS011F",  "LIDL Silvercrest", "HG06338" }, // Smart USB Extension Lead (EU)
     { "_TZ3000_49qchf10", "TS0502A", "LIDL Livarno Lux", "HG06492C" }, // CT Light (E27)
+    { "_TZ3000_9cpuaca6", "TS0505A", "LIDL Livarno Lux", "14148906L" }, // Stimmungsleuchte
     { "_TZ3000_dbou1ap4", "TS0505A", "LIDL Livarno Lux", "HG06106C" }, // RGB Light (E27)
     { "_TZ3000_el5kt5im", "TS0502A", "LIDL Livarno Lux", "HG06492A" }, // CT Light (GU10)
+    { "_TZ3000_gek6snaj", "TS0505A", "LIDL Livarno Lux", "14149506L" }, // Lichtleiste
     { "_TZ3000_kdi2o9m6", "TS011F",  "LIDL Silvercrest", "HG06337" }, // Smart plug (EU)
     { "_TZ3000_kdpxju99", "TS0505A", "LIDL Livarno Lux", "HG06106A" }, // RGB Light (GU10)
     { "_TZ3000_oborybow", "TS0502A", "LIDL Livarno Lux", "HG06492B" }, // CT Light (E14)

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5646,16 +5646,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
             fpSwitch.deviceId = i->deviceId();
             fpSwitch.profileId = i->profileId();
 
-            if (modelId.startsWith(QLatin1String("RWL02")))
-            {
-                sensor = getSensorNodeForAddress(node->address().ext()); // former created with with endpoint 1
-                if (sensor && sensor->deletedState() != Sensor::StateNormal)
-                {
-                    sensor = nullptr;
-                }
-                fpSwitch.endpoint = 2;
-            }
-
             if (modelId.startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
                 modelId.startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
                 modelId.startsWith(QLatin1String("Switch 4x-LIGHTIFY")) || // Osram 4 button remote

--- a/general.xml
+++ b/general.xml
@@ -346,7 +346,7 @@
 				<value name="Name Support" value="7"></value>
 			</attribute>
 			<attribute id="0x0001" name="IKEA Scene" type="u32" access="rw" required="m" showas="hex" mfcode="0x117c">
-				
+
 			</attribute>
 			<command id="00" dir="recv" name="Add group" required="m" response="0x00">
 				<description>Add a group to the device.</description>
@@ -708,7 +708,7 @@
 			</attribute>
 			<attribute id = "0x000f" name="Unknown" type="bmp8" access="rw" required="o">
 				<description>IKEA specific.</description>
-			</attribute>			
+			</attribute>
 			<attribute id="0x4000" name="PowerOn Level" type="u8" access="rw" required="o">
 			</attribute>
 			<command id="0x00" dir="recv" name="Move to Level" required="m">
@@ -3465,6 +3465,31 @@ devices can operate on either battery or mains power, and can have a wide variet
 			</client>
 		</cluster>
 
+    <!-- Hue -->
+    <cluster id="0xfc00" name="Hue" mfcode="0x100b">
+      <description>Hue-specific cluster.</description>
+      <server>
+        <command id="0x00" dir="send" name="Button Action Notification" required="m">
+          <payload>
+            <attribute id="0x0000" type="u16" name="Button" required="m"/>
+            <attribute id="0x0001" type="enum8" name="Type" required="m">
+              <value name="Push" value="0x00"/>
+              <value name="Rotary" value="0x01"/>
+            </attribute>
+            <attribute id="0x0002" type="u8" name="" showas="hex" required="m"/>
+            <attribute id="0x0003" type="enum8" name="Action" required="m">
+              <value name="Press" value="0x00"/>
+              <value name="Hold" value="0x01"/>
+              <value name="Release" value="0x02"/>
+              <value name="Long Release" value="0x03"/>
+            </attribute>
+            <attribute id="0x0004" type="u8" name="" showas="hex" required="m"/>
+            <attribute id="0x0000" type="u16" name="Duration" required="m"/>
+          </payload>
+        </command>
+      </server>
+    </cluster>
+
 		<!-- Tuya -->
 		<cluster id="0xef00" name="Tuya specific Cluster" mfcode="0x1002">
 			<description>Tuya Specific clusters.</description>
@@ -3673,7 +3698,7 @@ Contactor > On/off=0003 - HP/HC=0004</description>
 		<!-- LUMI -->
 		<cluster id="0xfcc0" name="Lumi specific" mfcode="0x115f">
 			<description>Lumi specific attributes.
-            
+
 Note - Aqara Opple switches have 2 modes of operation (0x0009): Switch all devices (0), event based switching (1).
 Child lock off: 0 - false, 1 - true
 Report Consumer Connected: 1 - false, 0 - true
@@ -3713,7 +3738,7 @@ Attribute 0x0205 has range between 1 and 50 only</description>
 			<client>
 			</client>
 		</cluster>
-        
+
 		<!-- SINOPE -->
 		<cluster id="0xff01" name="Sinope specific" mfcode="0x119c">
 			<description>Sinope specific attributes.
@@ -3863,7 +3888,7 @@ Outdoor Temp to Display Timeout: set 30 for 'off' and 10800 for 'on'</descriptio
 		<!-- NIKO -->
 		<cluster id="0xfc00" name="Niko specific" mfcode="0x125f">
 			<description>Niko specific attributes.
-            
+
 LED color: 0 - off, 255 - white, 65280 - blue, 16711680 - red
 Child lock on: 0, Child lock off: 1
 LED on: 1, LED off: 0


### PR DESCRIPTION
- Add support for Hue dimmer switch (2021 model, RWL022), see #4287;
- Add _Manufacturer Name_/_Model Identifier_ translations for LIDL Livarno Lux light bar (Lichtleiste) and mood light (Stimmingsleuchte), see #4248;
- Add _Manufacturer Name_/_Model Identifier_ translations for LIDL Xmas lightstrip.