### PR TITLE
Fix for Xiaomi lightnodes not getting a proper rx()

### DIFF
--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -216,6 +216,7 @@ using namespace deCONZ::literals;
 #define SAMJIN_CLUSTER_ID                     0xFC02
 #define SENGLED_CLUSTER_ID                    0xFC10
 #define LEGRAND_CONTROL_CLUSTER_ID            0xFC40
+#define XIAOMI_CLUSTER_ID                     0xFCC0
 #define XAL_CLUSTER_ID                        0xFCCE
 #define BOSCH_AIR_QUALITY_CLUSTER_ID          quint16(0xFDEF)
 


### PR DESCRIPTION
Only whitelisted lightnodes were previously allowed to get rx() updated. This is now generally allowed, but only whitelisted devices get `RStateOn` updated based on special reporting.

Xiaomi cluster has been added as well (XIAOMI_CLUSTER_ID) and is now taken into account for sensor creation

References #2583 #4139 #4238