### PR TITLE
Align VOC concentration on Sensirion documented levels for air quality

### DIFF
--- a/air_quality.cpp
+++ b/air_quality.cpp
@@ -91,12 +91,12 @@ void DeRestPluginPrivate::handleAirQualityClusterIndication(const deCONZ::ApsDat
             {
                 QString airquality = QLatin1String("none");
 
-                if (levelPpb <= 65)                      { airquality = QLatin1String("excellent"); }
-                if (levelPpb > 65 && levelPpb <= 220)    { airquality = QLatin1String("good"); }
-                if (levelPpb > 220 && levelPpb <= 660)   { airquality = QLatin1String("moderate"); }
-                if (levelPpb > 660 && levelPpb <= 2200)  { airquality = QLatin1String("poor"); }
-                if (levelPpb > 2200 && levelPpb <= 5500) { airquality = QLatin1String("unhealthy"); }
-                if (levelPpb > 5500 )                    { airquality = QLatin1String("out of scale"); }
+                if (levelPpb <= 300)                       { airquality = QLatin1String("excellent"); }
+                if (levelPpb > 300 && levelPpb <= 1000)    { airquality = QLatin1String("good"); }
+                if (levelPpb > 1000 && levelPpb <= 3000)   { airquality = QLatin1String("moderate"); }
+                if (levelPpb > 3000 && levelPpb <= 10000)  { airquality = QLatin1String("poor"); }
+                if (levelPpb > 10000 && levelPpb <= 25000) { airquality = QLatin1String("unhealthy"); }
+                if (levelPpb > 25000 )                     { airquality = QLatin1String("out of scale"); }
 
                 ResourceItem *item = sensor->item(RStateAirQuality);
                 if (item)


### PR DESCRIPTION
Previously, the scaling has been aligned with Develco documentation for Develco AQSZB-110 and Bosch Air sensors. As this has apparently been revised and also taking the referenced documentation into account, the levels are now aligned on German Federal Environmental Agency (Sensirion_Gas_Sensors_SGP3x_TVOC_Concept.pdf).

Based on that, the sensor measurements now appear to be more reasonable.