### PR TITLE
Don't expose config.pending "mode"; remove nonsense IAS debug logging for non IAS devices

### DIFF
--- a/ias_zone.cpp
+++ b/ias_zone.cpp
@@ -637,12 +637,11 @@ void DeRestPluginPrivate::checkIasEnrollmentStatus(Sensor *sensor)
     ResourceItem *itemIasState = sensor->item(RConfigEnrolled); // holds per device IAS state variable
     ResourceItem *itemPending = sensor->item(RConfigPending);
 
-    DBG_Assert(itemIasState);
-    DBG_Assert(itemPending);
-
     if (!itemIasState || !itemPending)
     {
-        return; // all IAS devices should have this
+        // All IAS devices should have these items.
+        // Bail out early for non IAS devices.
+        return;
     }
 
     IAS_EnsureValidState(itemIasState);

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -2543,10 +2543,6 @@ bool DeRestPluginPrivate::sensorToMap(const Sensor *sensor, QVariantMap &map, co
                 {
                     pending.append("usertest");
                 }
-                if (value & R_PENDING_MODE)
-                {
-                    pending.append(QLatin1String("mode"));
-                }
                 config[key] = pending;
             }
             else if (rid.suffix == RConfigLastChangeSource)


### PR DESCRIPTION
The hereby removed `config.pending` "mode"  was exposed to the REST-API in 98a6217 but provides currently no value and causes confusion.

