### PR TITLE
Add basic support for Danfoss Icon Zigbee Module

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1374,6 +1374,51 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             return sendConfigureReportingRequest(bt, {rq, rq2, rq3}) || // Use OR because of manuf. specific attributes
                    sendConfigureReportingRequest(bt, {rq4, rq5});
         }
+        else if (sensor && (sensor->modelId() == QLatin1String("0x8020") || // Danfoss RT24V Display thermostat
+                            sensor->modelId() == QLatin1String("0x8021") || // Danfoss RT24V Display thermostat with floor sensor
+                            sensor->modelId() == QLatin1String("0x8030") || // Danfoss RTbattery Display thermostat
+                            sensor->modelId() == QLatin1String("0x8031") || // Danfoss RTbattery Display thermostat with infrared
+                            sensor->modelId() == QLatin1String("0x8034") || // Danfoss RTbattery Dial thermostat
+                            sensor->modelId() == QLatin1String("0x8035")))  // Danfoss RTbattery Dial thermostat with infrared
+        {
+            rq.dataType = deCONZ::Zcl16BitInt;
+            rq.attributeId = 0x0000;         // Local temperature
+            rq.minInterval = 60;
+            rq.maxInterval = 3600;
+            rq.reportableChange16bit = 50;
+
+            ConfigureReportingRequest rq2;
+            rq2.dataType = deCONZ::Zcl8BitBitMap;
+            rq2.attributeId = 0x0002;        // Occupancy
+            rq2.minInterval = 60;
+            rq2.maxInterval = 43200;
+            rq2.reportableChange8bit = 1;
+
+            ConfigureReportingRequest rq3;
+            rq3.dataType = deCONZ::Zcl16BitInt;
+            rq3.attributeId = 0x0012;        // Occupied heating setpoint
+            rq3.minInterval = 1;
+            rq3.maxInterval = 43200;
+            rq3.reportableChange16bit = 1;
+
+            ConfigureReportingRequest rq4;
+            rq4.dataType = deCONZ::Zcl16BitInt;
+            rq4.attributeId = 0x0014;        // Unoccupied heating setpoint
+            rq4.minInterval = 1;
+            rq4.maxInterval = 43200;
+            rq4.reportableChange16bit = 1;
+
+            ConfigureReportingRequest rq5;
+            rq5.dataType = deCONZ::Zcl8BitBitMap;
+            rq5.attributeId = 0x4110;        // Danfoss Output Status
+            rq5.minInterval = 60;
+            rq5.maxInterval = 3600;
+            rq5.reportableChange8bit = 1;
+            rq5.manufacturerCode = VENDOR_DANFOSS;
+
+            return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4}) || // Use OR because of manuf. specific attributes
+            sendConfigureReportingRequest(bt, {rq5});
+        }
         else if (sensor && sensor->modelId() == QLatin1String("902010/32")) // Bitron thermostat
         {
             rq.dataType = deCONZ::Zcl16BitInt;
@@ -1605,8 +1650,14 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq.maxInterval = 900;        // value used by Hue bridge
             rq.reportableChange8bit = 4; // value used by Hue bridge
         }
-        else if ( (sensor && sensor->modelId() == QLatin1String("eTRV0100")) || // Danfoss Ally
-                  (sensor && sensor->modelId() == QLatin1String("TRV001") ))
+        else if (sensor && (sensor->modelId() == QLatin1String("eTRV0100") || // Danfoss Ally
+                            sensor->modelId() == QLatin1String("TRV001") ||   // Hive TRV
+                            sensor->modelId() == QLatin1String("0x8020") ||   // Danfoss RT24V Display thermostat
+                            sensor->modelId() == QLatin1String("0x8021") ||   // Danfoss RT24V Display thermostat with floor sensor
+                            sensor->modelId() == QLatin1String("0x8030") ||   // Danfoss RTbattery Display thermostat
+                            sensor->modelId() == QLatin1String("0x8031") ||   // Danfoss RTbattery Display thermostat with infrared
+                            sensor->modelId() == QLatin1String("0x8034") ||   // Danfoss RTbattery Dial thermostat
+                            sensor->modelId() == QLatin1String("0x8035")))    // Danfoss RTbattery Dial thermostat with infrared
         {
             rq.minInterval = 3600;         // Vendor defaults
             rq.maxInterval = 43200;        // Vendor defaults
@@ -2827,6 +2878,12 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId() == QLatin1String("DS01") ||
         // Danfoss
         sensor->modelId() == QLatin1String("eTRV0100") ||
+        sensor->modelId() == QLatin1String("0x8020") ||
+        sensor->modelId() == QLatin1String("0x8021") ||
+        sensor->modelId() == QLatin1String("0x8030") ||
+        sensor->modelId() == QLatin1String("0x8031") ||
+        sensor->modelId() == QLatin1String("0x8034") ||
+        sensor->modelId() == QLatin1String("0x8035") ||
         // LIDL
         sensor->modelId() == QLatin1String("HG06323")
         )

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -419,7 +419,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_ALERTME, "SLR2", computimeMacPrefix }, // Hive   Heating Receiver 2 channel
     { VENDOR_ALERTME, "SLR2b", computimeMacPrefix }, // Hive   Heating Receiver 2 channel second version
     { VENDOR_ALERTME, "SLT2", computimeMacPrefix }, // Hive thermostat
-    { VENDOR_DANFOSS, "TRV001", silabs2MacPrefix }, // Hive thermostat (From Danfoos)
+    { VENDOR_DANFOSS, "TRV001", silabs2MacPrefix }, // Hive thermostat (From Danfoss)
     { VENDOR_SUNRICHER, "45127", silabs2MacPrefix }, // Namron 1/2/4-ch remote controller
     { VENDOR_SENGLED_OPTOELEC, "E13-", zhejiangMacPrefix }, // Sengled PAR38 Bulbs
     { VENDOR_SENGLED_OPTOELEC, "E1D-", zhejiangMacPrefix }, // Sengled contact sensor
@@ -445,6 +445,12 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_NONE, "TH01", tiMacPrefix }, // Sonoff SNZB-02
     { VENDOR_NONE, "DS01", tiMacPrefix }, // Sonoff SNZB-04
     { VENDOR_DANFOSS, "eTRV0100", silabs2MacPrefix }, // Danfoss Ally thermostat
+    { VENDOR_DANFOSS, "0x8020", silabs6MacPrefix }, // Danfoss RT24V Display thermostat
+    { VENDOR_DANFOSS, "0x8021", silabs6MacPrefix }, // Danfoss RT24V Display thermostat with floor sensor
+    { VENDOR_DANFOSS, "0x8030", silabs6MacPrefix }, // Danfoss RTbattery Display thermostat
+    { VENDOR_DANFOSS, "0x8031", silabs6MacPrefix }, // Danfoss RTbattery Display thermostat with infrared
+    { VENDOR_DANFOSS, "0x8034", silabs6MacPrefix }, // Danfoss RTbattery Dial thermostat
+    { VENDOR_DANFOSS, "0x8035", silabs6MacPrefix }, // Danfoss RTbattery Dial thermostat with infrared
     { VENDOR_LDS, "ZBT-CCTSwitch-D0001", silabs2MacPrefix }, // Leedarson remote control
     { VENDOR_KWIKSET, "SMARTCODE_CONVERT_GEN1", zenMacPrefix }, // Kwikset 914 ZigBee smart lock
     { VENDOR_EMBER, "TS1001", silabs5MacPrefix }, // LIDL Livarno Lux Remote Control HG06323
@@ -5316,6 +5322,12 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     else if (node->nodeDescriptor().manufacturerCode() == VENDOR_KWIKSET)
                     {
                     }
+                    // Don't create entries for the following Danfoss in-room thermostats
+                    else if(modelId == QLatin1String("0x8020") ||
+                            modelId == QLatin1String("0x8030") ||
+                            modelId == QLatin1String("0x8034"))
+                    {
+                    }
                     else
                     {
                         fpTemperatureSensor.inClusters.push_back(ci->id());
@@ -7703,6 +7715,22 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                         i->modelId().startsWith(QLatin1String("ZG2835"))) // SR-ZG2835 Zigbee Rotary Switch
                                     {
                                         bat = ia->numericValue().u8;
+                                    }
+
+                                    if (i->modelId() == QLatin1String("0x8020") || // Danfoss RT24V Display thermostat
+                                        i->modelId() == QLatin1String("0x8021") || // Danfoss RT24V Display thermostat with floor sensor
+                                        i->modelId() == QLatin1String("0x8030") || // Danfoss RTbattery Display thermostat
+                                        i->modelId() == QLatin1String("0x8031") || // Danfoss RTbattery Display thermostat with infrared
+                                        i->modelId() == QLatin1String("0x8034") || // Danfoss RTbattery Dial thermostat
+                                        i->modelId() == QLatin1String("0x8035"))   // Danfoss RTbattery Dial thermostat with infrared
+                                    {
+                                        // The Danfoss Icon Zigbee module exposes each in-room thermostat in its controller
+                                        // as an endpoint. Each endpoint has the battery measurement for the device it represents.
+                                        // This check makes sure none of the other endpoints get their battery value overwritten.
+                                        if (event.endpoint() != i->fingerPrint().endpoint)
+                                        {
+                                            continue;
+                                        }
                                     }
 
                                     if (item->toNumber() != bat)
@@ -17661,6 +17689,12 @@ void DeRestPlugin::idleTimerFired()
                                 sensorNode->modelId().startsWith(QLatin1String("TH112")) ||     // Sinope devices
                                 sensorNode->modelId().startsWith(QLatin1String("TH1300ZB")) ||  // Sinope devices
                                 sensorNode->modelId().startsWith(QLatin1String("eTRV0100")) ||  // Danfoss Ally
+                                sensorNode->modelId().startsWith(QLatin1String("0x8020")) ||    // Danfoss RT24V Display thermostat
+                                sensorNode->modelId().startsWith(QLatin1String("0x8021")) ||    // Danfoss RT24V Display thermostat with floor sensor
+                                sensorNode->modelId().startsWith(QLatin1String("0x8030")) ||    // Danfoss RTbattery Display thermostat
+                                sensorNode->modelId().startsWith(QLatin1String("0x8031")) ||    // Danfoss RTbattery Display thermostat with infrared
+                                sensorNode->modelId().startsWith(QLatin1String("0x8034")) ||    // Danfoss RTbattery Dial thermostat
+                                sensorNode->modelId().startsWith(QLatin1String("0x8035")) ||    // Danfoss RTbattery Dial thermostat with infrared
                                 sensorNode->modelId().startsWith(QLatin1String("Zen-01")) ||    // Zen
                                 sensorNode->modelId().startsWith(QLatin1String("Super TR")) ||  // Elko
                                 sensorNode->modelId().startsWith(QLatin1String("AC201")) ||     // Owon

--- a/general.xml
+++ b/general.xml
@@ -1920,6 +1920,32 @@ Note: It does not clear or delete previous weekly schedule programming configura
 			<attribute id="0x401C" name="System mode" type="enum8" access="rw" required="m"></attribute>
 		</attribute-set>
 
+        <!-- Danfoss manufacturer specific -->
+        <attribute-set id="0x4100" description="Danfoss specific" mfcode="0x1246">
+            <attribute id="0x4100" name="Room Status Code" type="enum16" default="0x0000" access="r" required="o" mfcode="0x1246">
+                <value name="No Error" value="0x0000"></value>
+                <value name="Missing RT" value="0x0101"></value>
+                <value name="RT Touch Error" value="0x0201"></value>
+                <value name="Floor Sensor Short Circuit" value="0x0401"></value>
+                <value name="Floor Sensor Disconnected" value="0x0801"></value>
+            </attribute>
+            <attribute id="0x4110" name="Output Status" type="enum8" default="0x00" access="r" required="o" mfcode="0x1246">
+                <value name="Inactive" value="0x00"></value>
+                <value name="Active" value="0x01"></value>
+            </attribute>
+            <attribute id="0x4120" name="Room Floor Sensor Mode" type="enum8" default="0x00" access="r" required="o" mfcode="0x1246">
+                <value name="Comfort Mode" value="0x00"></value>
+                <value name="Floor Sensor Mode" value="0x01"></value>
+                <value name="Dual Mode" value="0x02"></value>
+            </attribute>
+            <attribute id="0x4121" name="Floor Minimum Setpoint" type="s16" default="0x0708" access="rw" required="o" mfcode="0x1246"></attribute>
+            <attribute id="0x4121" name="Floor Maximum Setpoint" type="s16" default="0x0DAC" access="rw" required="o" mfcode="0x1246"></attribute>
+            <attribute id="0x4130" name="Schedule Type Used" type="enum8" default="0x00" access="rw" required="o" mfcode="0x1246">
+                <value name="Regular Schedule" value="0x00"></value>
+                <value name="Vacation Schedule" value="0x01"></value>
+            </attribute>
+        </attribute-set>
+
 		<command id="0x00" dir="recv" name="Setpoint Raise/Lower" required="m">
 			<description>This command increases (or decreases) the setpoint(s) by amount, in steps of 0.1°C.</description>
 			<payload>

--- a/thermostat.cpp
+++ b/thermostat.cpp
@@ -925,6 +925,37 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
             }
                 break;
 
+            // Manufacturer Specific for Danfoss Icon Floor Heating Controller
+            case 0x4110:  // Danfoss Output Status
+            {
+                if (sensor->modelId() == QLatin1String("0x8020") || // Danfoss RT24V Display thermostat
+                    sensor->modelId() == QLatin1String("0x8021") || // Danfoss RT24V Display thermostat with floor sensor
+                    sensor->modelId() == QLatin1String("0x8030") || // Danfoss RTbattery Display thermostat
+                    sensor->modelId() == QLatin1String("0x8031") || // Danfoss RTbattery Display thermostat with infrared
+                    sensor->modelId() == QLatin1String("0x8034") || // Danfoss RTbattery Dial thermostat
+                    sensor->modelId() == QLatin1String("0x8035"))   // Danfoss RTbattery Dial thermostat with infrared
+                {
+                    quint8 outputStatus = attr.numericValue().u8;
+                    bool on = outputStatus > 0;
+                    item = sensor->item(RStateOn);
+                    if (item)
+                    {
+                        if (updateType == NodeValue::UpdateByZclReport)
+                        {
+                            stateUpdated = true;
+                        }
+                        if (item->toBool() != on)
+                        {
+                            item->setValue(on);
+                            enqueueEvent(Event(RSensors, RStateOn, sensor->id(), item));
+                            stateUpdated = true;
+                        }
+                    }
+                }
+                sensor->setZclValue(updateType, ind.srcEndpoint(), THERMOSTAT_CLUSTER_ID, attrId, attr.numericValue());
+            }
+                break;
+
             default:
                 break;
             }


### PR DESCRIPTION
Resolves #4273 

The device is a bit tricky to join. It's basically a bridge exposing each In-Room Thermostat in a Danfoss Icon floor heating controller as an endpoint. It takes a while for all the simple descriptors and clusters to be read (the Danfoss literature suggests up to 3 minutes), so the process sometimes fails in Phoscon. I've had success by starting the "Add Sensor" process in Phoscon, and then manually reading the "Node Descriptor" and "Simple Descriptors" in the GUI, once a node for it shows up, followed by manually reading the Basic cluster for each endpoint. The bindings aren't setup reliably - I wonder if it has something to do with the device taking so long to setup.

The REST API exposes the sensor nodes correctly, but they don't show up in the sensor list in Phoscon (though the device does show up if one manually types the node's IEEE address into the URL). I'm not too worried about this - I just assumed that Phoscon couldn't handle sensors with endpoints.