### PR TITLE
Fix Electrical Measurement cluster readings

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -3475,7 +3475,8 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 }
                 else if (sensor.modelId() == QLatin1String("ZB-ONOFFPlug-D0005") ||
                          sensor.modelId() == QLatin1String("Plug-230V-ZB3.0") ||
-                         sensor.modelId() == QLatin1String("lumi.switch.b1naus01"))
+                         sensor.modelId() == QLatin1String("lumi.switch.b1naus01") ||
+                         sensor.manufacturer() == QLatin1String("Legrand"))
                 {
                     hasVoltage = false;
                 }

--- a/poll_manager.cpp
+++ b/poll_manager.cpp
@@ -408,24 +408,10 @@ void PollManager::pollTimerFired()
     }
     else if (suffix == RStatePower)
     {
-        bool NotOnlyPower = true;
         clusterId = ELECTRICAL_MEASUREMENT_CLUSTER_ID;
         attributes.push_back(0x050b); // Active Power
-        item = r->item(RAttrModelId);
-        if (item && !item->toString().startsWith(QLatin1String("Plug"))) //Osram plug
-        {
-            NotOnlyPower = false;
-        }
-        item = r->item(RAttrManufacturerName);
-        if (item && !item->toString().startsWith(QLatin1String("Legrand")))  // All legrand Devices
-        {
-            NotOnlyPower = false;
-        }
-        if (NotOnlyPower)
-        {
-            attributes.push_back(0x0505); // RMS Voltage
-            attributes.push_back(0x0508); // RMS Current
-        }
+        attributes.push_back(0x0505); // RMS Voltage
+        attributes.push_back(0x0508); // RMS Current
     }
     else if (suffix == RAttrModelId)
     {


### PR DESCRIPTION
No need to filter attributes per device, if attributes aren't available they won't be read a second time, as this is checked later on.

Fixes Blitzwolf BW-SHP13 ZHAPower sensor updates.
Issue: https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3788