### PR TITLE
Various smaller bugfixes

### DIFF
--- a/button_maps.json
+++ b/button_maps.json
@@ -878,7 +878,7 @@
         "sunricherMap": {
             "vendor": "Sunricher",
             "doc": "Wireless switches from Sunricher, Namron and EcoDim",
-            "modelids": ["ED-10010", "ED-10011", "ED-10012", "ED-10013", "ED-10014", "ED-10015", "ZG2833K", "ZG2835", "4512700", "4512701", "4512702", "4512703", "4512705", "4512714", "4512719", "4512720", "4512721", "4512722"],
+            "modelids": ["ED-10010", "ED-10011", "ED-10012", "ED-10013", "ED-10014", "ED-10015", "ZG2833K8_EU05", "ZG2835", "4512700", "4512701", "4512702", "4512703", "4512705", "4512714", "4512719", "4512720", "4512721", "4512722"],
             "map": [
                 [1, "0x01", "ONOFF", "ON", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],
                 [1, "0x01", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_HOLD", "Move up (with on/off)"],

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4643,6 +4643,8 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                 }
                 else if (ind.clusterId() == SENGLED_CLUSTER_ID)
                 {
+                    ok = false;
+                    
                     if (buttonMap.zclParam0 == pl0)
                     {
                         ok = true;

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -8957,7 +8957,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
 
                                 if (item)
                                 {
-                                    item->setValue((qint16) power); // in W
+                                    item->setValue(power); // in W
                                     enqueueEvent(Event(RSensors, RStatePower, i->id(), item));
                                     updated = true;
                                 }

--- a/general.xml
+++ b/general.xml
@@ -2599,9 +2599,9 @@ controller device, that supports a keypad and LCD screen.</description>
 					<attribute id="0x0031" name="Sensitivity max." type="u8" default="0" access="rw" required="o" mfcode="0x100b"></attribute>
 				</attribute-set>
 				<attribute-set id="0xfc00" description="Develco Specific" mfcode="0x1015">
-					<attribute id="0xfc00" name="ArmThreshold_MinTemperature" type="sint16" access="rw" range="0x954d,0x7ffe" required="m" mfcode="0x1015"></attribute>
-					<attribute id="0xfc01" name="ArmThreshold_MaxTemperature" type="sint16" access="rw" range="0x954d,0x7ffe" required="m" mfcode="0x1015"></attribute>
-					<attribute id="0xfc02" name="Target Level" type="uint16" access="rw" range="0x0002,0xfffd" required="m" mfcode="0x1015"></attribute>
+					<attribute id="0xfc00" name="ArmThreshold_MinTemperature" type="s16" access="rw" range="0x954d,0x7ffe" required="m" mfcode="0x1015"></attribute>
+					<attribute id="0xfc01" name="ArmThreshold_MaxTemperature" type="s16" access="rw" range="0x954d,0x7ffe" required="m" mfcode="0x1015"></attribute>
+					<attribute id="0xfc02" name="Target Level" type="u16" access="rw" range="0x0002,0xfffd" required="m" mfcode="0x1015"></attribute>
 				</attribute-set>
 			</server>
 			<client>

--- a/general.xml
+++ b/general.xml
@@ -2585,6 +2585,9 @@ controller device, that supports a keypad and LCD screen.</description>
 					<attribute id="0x0011" name="PIR Unoccupied To Occupied Delay" type="u16" range="0x00,0xfffe" access="rw" required="o" default="0x00">
 						<description>The PIRUnoccupiedToOccupiedDelay attribute is 16-bits in length and specifies the time delay, in seconds, before the PIR sensor changes to its unoccupied state when the sensed area becomes occupied.</description>
 					</attribute>
+					<attribute id="0x0012" name="PIR Unoccupied To Occupied Threshold" type="u8" range="0x01,0xfe" access="rw" required="o" default="0x01">
+						<description>The PIRUnoccupiedToOccupiedThreshold attribute is 8 bits in length and specifies the number of movement detection events that must occur in the period PIRUnoccupiedToOccupiedDelay, before the PIR sensor changes to its occupied state.</description>
+					</attribute>
 				</attribute-set>
 				<attribute-set id="0x0020" description="Ultrasonic configuration">
 					<attribute id="0x0020" name="Ultrasonic Occupied To Unoccupied Delay" type="u8" range="0x00,0xfe" access="rw" required="o" default="0x00">

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -2143,11 +2143,11 @@ int DeRestPluginPrivate::setWarningDeviceState(const ApiRequest &req, ApiRespons
             if (taskRef.lightNode->modelId().startsWith(QLatin1String("902010/24")) ||
                 taskRef.lightNode->modelId() == QLatin1String("902010/29"))
             {
-                task.options = 0x12;
+                task.options = 0x12;    // Warning mode 1 (burglar), no Strobe, Very high sound
             }
             else if (taskRef.lightNode->modelId() == QLatin1String("SIRZB-110"))    // Doesn't support strobe
             {
-                task.options = 0x13;
+                task.options = 0x13;    // Warning mode 1 (burglar), no Strobe, Very high sound
             }
             task.duration = 1;
         }
@@ -2157,11 +2157,11 @@ int DeRestPluginPrivate::setWarningDeviceState(const ApiRequest &req, ApiRespons
             if (taskRef.lightNode->modelId().startsWith(QLatin1String("902010/24")) ||
                 taskRef.lightNode->modelId() == QLatin1String("902010/29"))
             {
-                task.options = 0x12;
+                task.options = 0x12;    // Warning mode 1 (burglar), no Strobe, Very high sound
             }
             else if (taskRef.lightNode->modelId() == QLatin1String("SIRZB-110"))    // Doesn't support strobe
             {
-                task.options = 0x13;
+                task.options = 0x13;    // Warning mode 1 (burglar), no Strobe, Very high sound
             }
             task.duration = onTime > 0 ? onTime : 300;
         }

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -2145,6 +2145,10 @@ int DeRestPluginPrivate::setWarningDeviceState(const ApiRequest &req, ApiRespons
             {
                 task.options = 0x12;
             }
+            else if (taskRef.lightNode->modelId() == QLatin1String("SIRZB-110"))    // Doesn't support strobe
+            {
+                task.options = 0x13;
+            }
             task.duration = 1;
         }
         else if (alert == "lselect")
@@ -2154,6 +2158,10 @@ int DeRestPluginPrivate::setWarningDeviceState(const ApiRequest &req, ApiRespons
                 taskRef.lightNode->modelId() == QLatin1String("902010/29"))
             {
                 task.options = 0x12;
+            }
+            else if (taskRef.lightNode->modelId() == QLatin1String("SIRZB-110"))    // Doesn't support strobe
+            {
+                task.options = 0x13;
             }
             task.duration = onTime > 0 ? onTime : 300;
         }

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -2143,7 +2143,7 @@ int DeRestPluginPrivate::setWarningDeviceState(const ApiRequest &req, ApiRespons
             if (taskRef.lightNode->modelId().startsWith(QLatin1String("902010/24")) ||
                 taskRef.lightNode->modelId() == QLatin1String("902010/29"))
             {
-                task.options = 0x12;    // Warning mode 1 (burglar), no Strobe, Very high sound
+                task.options = 0x12;    // Warning mode 1 (burglar), no Strobe, high sound
             }
             else if (taskRef.lightNode->modelId() == QLatin1String("SIRZB-110"))    // Doesn't support strobe
             {
@@ -2157,7 +2157,7 @@ int DeRestPluginPrivate::setWarningDeviceState(const ApiRequest &req, ApiRespons
             if (taskRef.lightNode->modelId().startsWith(QLatin1String("902010/24")) ||
                 taskRef.lightNode->modelId() == QLatin1String("902010/29"))
             {
-                task.options = 0x12;    // Warning mode 1 (burglar), no Strobe, Very high sound
+                task.options = 0x12;    // Warning mode 1 (burglar), no Strobe, high sound
             }
             else if (taskRef.lightNode->modelId() == QLatin1String("SIRZB-110"))    // Doesn't support strobe
             {

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1753,7 +1753,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                 }
                 else if (rid.suffix == RConfigSwingMode)
                 {
-                    if (map[pi.key()].type() == QVariant::String && map[pi.key()].toString().size() <= 19)
+                    if (map[pi.key()].type() == QVariant::String)
                     {
                         if (sensor->modelId() == QLatin1String("AC201"))
                         {

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1820,10 +1820,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                             else if (modeSet == "smart") { mode = 0x06; }
                             else
                             {
-                                rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/sensors/%1/config/%2").arg(id).arg(pi.key()).toHtmlEscaped(),
-                                                   QString("invalid value, %1, for parameter %2").arg(map[pi.key()].toString()).arg(pi.key()).toHtmlEscaped()));
-                                rsp.httpStatus = HttpStatusBadRequest;
-                                return REQ_READY_SEND;
+                                rspItemState[QString("error unknown fan mode for %1").arg(sensor->modelId())] = map[pi.key()];
                             }
 
                             if (mode < 7)

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -3179,9 +3179,9 @@ void DeRestPluginPrivate::checkSensorStateTimerFired()
                     DBG_Printf(DBG_INFO, "sensor %s (%s): disable presence\n", qPrintable(sensor->id()), qPrintable(sensor->modelId()));
                     item->setValue(false);
                     sensor->updateStateTimestamp();
-                    Event e(RSensors, RStatePresence, sensor->id(), item);
-                    enqueueEvent(e);
+                    enqueueEvent(Event(RSensors, RStatePresence, sensor->id(), item));
                     enqueueEvent(Event(RSensors, RStateLastUpdated, sensor->id()));
+                    updateSensorEtag(sensor);
                     for (quint16 clusterId : sensor->fingerPrint().inClusters)
                     {
                         if (sensor->modelId().startsWith(QLatin1String("TRADFRI")))
@@ -3206,9 +3206,9 @@ void DeRestPluginPrivate::checkSensorStateTimerFired()
                         item->setValue(S_BUTTON_1 + S_BUTTON_ACTION_HOLD);
                         DBG_Printf(DBG_INFO, "[INFO] - Button %u Hold %s\n", item->toNumber(), qPrintable(sensor->modelId()));
                         sensor->updateStateTimestamp();
-                        Event e(RSensors, RStateButtonEvent, sensor->id(), item);
-                        enqueueEvent(e);
+                        enqueueEvent(Event(RSensors, RStateButtonEvent, sensor->id(), item));
                         enqueueEvent(Event(RSensors, RStateLastUpdated, sensor->id()));
+                        updateSensorEtag(sensor);
                     }
                 }
                 else if (sensor->modelId() == QLatin1String("FOHSWITCH"))
@@ -3224,9 +3224,9 @@ void DeRestPluginPrivate::checkSensorStateTimerFired()
                         item->setValue(btn + S_BUTTON_ACTION_HOLD);
                         DBG_Printf(DBG_INFO, "FoH switch button %d Hold %s\n", item->toNumber(), qPrintable(sensor->modelId()));
                         sensor->updateStateTimestamp();
-                        Event e(RSensors, RStateButtonEvent, sensor->id(), item);
-                        enqueueEvent(e);
+                        enqueueEvent(Event(RSensors, RStateButtonEvent, sensor->id(), item));
                         enqueueEvent(Event(RSensors, RStateLastUpdated, sensor->id()));
+                        updateSensorEtag(sensor);
                     }
                 }
                 else if (!item && sensor->modelId().startsWith(QLatin1String("lumi.vibration")) && sensor->type() == QLatin1String("ZHAVibration"))
@@ -3239,6 +3239,7 @@ void DeRestPluginPrivate::checkSensorStateTimerFired()
                         sensor->updateStateTimestamp();
                         enqueueEvent(Event(RSensors, RStateVibration, sensor->id(), item));
                         enqueueEvent(Event(RSensors, RStateLastUpdated, sensor->id()));
+                        updateSensorEtag(sensor);
                     }
                 }
 

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1820,7 +1820,10 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                             else if (modeSet == "smart") { mode = 0x06; }
                             else
                             {
-                                rspItemState[QString("error unknown fan mode for %1").arg(sensor->modelId())] = map[pi.key()];
+                                rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/sensors/%1/config/%2").arg(id).arg(pi.key()).toHtmlEscaped(),
+                                                   QString("invalid value, %1, for parameter %2").arg(map[pi.key()].toString()).arg(pi.key()).toHtmlEscaped()));
+                                rsp.httpStatus = HttpStatusBadRequest;
+                                return REQ_READY_SEND;
                             }
 
                             if (mode < 7)


### PR DESCRIPTION
- Correct data type typos in general.xml
- Use dedicated modelID ZG2833K8_EU05 in button_maps.json (#4439 #4429)
- Add some missing etag updates (#4451)
- Relocate code for RConfigSwingMode to actually be considered (#3374)
- Don't cast power values for Instantaneous Demand
- Enable Develco SIRZB-110 to emit audio using state.alert (#4432)
- Add PIR Unoccupied To Occupied Threshold to general.xml
- Fix button events for Sengled E1E-G7F switch (#4413)