### PR TITLE
Add initial support for ORVIBO open/close sensor SM11

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2768,6 +2768,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         // ORVIBO
         sensor->modelId().startsWith(QLatin1String("SN10ZW")) ||
         sensor->modelId().startsWith(QLatin1String("SF2")) ||
+        sensor->modelId() == QLatin1String("e70f96b3773a4c9283c6862dbafb6a99") ||
         // Netvox
         sensor->modelId().startsWith(QLatin1String("Z809A")) ||
         // Samsung SmartPlug 2019

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -339,6 +339,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_JENNIC, "Adurolight_NCC", jennicMacPrefix}, // Eria Adurosmart Wireless Dimming Switch
     { VENDOR_JENNIC, "VOC_Sensor", jennicMacPrefix}, // LifeControl Enviroment sensor
     { VENDOR_JENNIC, "SN10ZW", jennicMacPrefix }, // ORVIBO motion sensor
+    { VENDOR_JENNIC, "e70f96b3773a4c9283c6862dbafb6a99", jennicMacPrefix }, // ORVIBO open/close sensor SM11
     { VENDOR_OSRAM_STACK, "SF20", heimanMacPrefix }, // ORVIBO SF20 smoke sensor
     // Danalock support
     { VENDOR_DANALOCK, "V3", danalockMacPrefix}, // Danalock Smart Lock
@@ -5146,20 +5147,21 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     {
                         fpCarbonMonoxideSensor.inClusters.push_back(ci->id());
                     }
-                    else if (modelId.startsWith(QLatin1String("DOOR_")) ||            // Heiman door/window sensor
-                             modelId.startsWith(QLatin1String("Door")) ||             // Heiman door/window sensor (newer model)
-                             modelId == QLatin1String("3AFE130104020015") ||          // Konke door/window sensor
-                             modelId.startsWith(QLatin1String("902010/21")) ||        // Bitron door/window sensor
-                             modelId.startsWith(QLatin1String("WISZB-1")) ||          // Develco door/window sensor
-                             modelId.startsWith(QLatin1String("ZHMS101")) ||          // Wattle (Develco) door/window sensor
-                             modelId.startsWith(QLatin1String("4655BC0")) ||          // Ecolink contact sensor
-                             modelId.startsWith(QLatin1String("3300")) ||             // Centralite contact sensor
-                             modelId == QLatin1String("lumi.sensor_magnet.agl02") ||  // Xiaomi Aqara T1 open/close sensor MCCGQ12LM
-                             modelId == QLatin1String("E1D-G73") ||                   // Sengled contact sensor
-                             modelId == QLatin1String("DS01") ||                      // Sonoff SNZB-04
-                             modelId == QLatin1String("GMB-HAS-DW-B01") ||            // GamaBit Ltd. Window/Door Sensor
-                             modelId == QLatin1String("TY0203") ||                    // lidl / SilverCrest
-                             modelId == QLatin1String("RH3001"))                      // Tuya/Blitzwolf BW-IS2 door/window sensor
+                    else if (modelId.startsWith(QLatin1String("DOOR_")) ||                      // Heiman door/window sensor
+                             modelId.startsWith(QLatin1String("Door")) ||                       // Heiman door/window sensor (newer model)
+                             modelId == QLatin1String("3AFE130104020015") ||                    // Konke door/window sensor
+                             modelId == QLatin1String("e70f96b3773a4c9283c6862dbafb6a99") ||    // Orvibo door/window sensor
+                             modelId.startsWith(QLatin1String("902010/21")) ||                  // Bitron door/window sensor
+                             modelId.startsWith(QLatin1String("WISZB-1")) ||                    // Develco door/window sensor
+                             modelId.startsWith(QLatin1String("ZHMS101")) ||                    // Wattle (Develco) door/window sensor
+                             modelId.startsWith(QLatin1String("4655BC0")) ||                    // Ecolink contact sensor
+                             modelId.startsWith(QLatin1String("3300")) ||                       // Centralite contact sensor
+                             modelId == QLatin1String("lumi.sensor_magnet.agl02") ||            // Xiaomi Aqara T1 open/close sensor MCCGQ12LM
+                             modelId == QLatin1String("E1D-G73") ||                             // Sengled contact sensor
+                             modelId == QLatin1String("DS01") ||                                // Sonoff SNZB-04
+                             modelId == QLatin1String("GMB-HAS-DW-B01") ||                      // GamaBit Ltd. Window/Door Sensor
+                             modelId == QLatin1String("TY0203") ||                              // lidl / SilverCrest
+                             modelId == QLatin1String("RH3001"))                                // Tuya/Blitzwolf BW-IS2 door/window sensor
                     {
                         fpOpenCloseSensor.inClusters.push_back(ci->id());
                     }


### PR DESCRIPTION
See #4403

When support has been added, you should enter sensor search in Phoscon and pair the device. However, you also need to keep an eye on deconz GUI for the device to show up, as the manufacturer name and model ID might not be read automatically. When it appears in deconz GUI, you need to read the basic cluster's attributes while sensor search is still running (which is the case even when Phoscon already issued the greenish success message) for the sensor resource to be created.