### PR TITLE
Add subheadings for each cluster in the device template

### DIFF
--- a/.github/ISSUE_TEMPLATE/device-request.md
+++ b/.github/ISSUE_TEMPLATE/device-request.md
@@ -44,13 +44,34 @@ assignees: ''
   Required screenshots:
   - Endpoints and clusters of the node
   - Node Info panel
-  - Basic Cluster attributes in the Cluster Info panel.
 
   In the Cluster Info panel press "read" button to retreive the values. Please note that at least "Manufacturer Name" and "Model Identifier" must be populated with data (therefore, must not be empty), otherwise that information will not be usable. For battery powered devices, after pressing read it is required to wake-up the device by pressing a button or any other means of interaction.
 -->
 
 <!--
-  If available add screenshots of other clusters.
+  If available add screenshots of other clusters. Remove sections that are not available on your device.
 
   Relevant clusters are: Simple Metering, Electrical Measurement, Power Configuration, Thermostat, etc. You can typically spare Identify, Alarms, Device Temperature, On/Off. Please ensure data has been read prior to taking any screenshots.
 -->
+
+### Basic
+
+### Identify
+
+### Alarms
+
+### Device Temperature
+
+### Groups
+
+### Scenes
+
+### On/Off
+
+### Level Control
+
+### Color Control
+
+### Simple Metering
+
+### Diagnostics

--- a/.github/ISSUE_TEMPLATE/device-request.md
+++ b/.github/ISSUE_TEMPLATE/device-request.md
@@ -49,7 +49,7 @@ assignees: ''
 -->
 
 <!--
-  If available add screenshots of other clusters. Remove sections that are not available on your device.
+  If available add screenshots of other clusters. Please Remove sections that are not available on your device.
 
   Relevant clusters are: Simple Metering, Electrical Measurement, Power Configuration, Thermostat, etc. You can typically spare Identify, Alarms, Device Temperature, On/Off. Please ensure data has been read prior to taking any screenshots.
 -->

--- a/.github/ISSUE_TEMPLATE/device-request.md
+++ b/.github/ISSUE_TEMPLATE/device-request.md
@@ -75,3 +75,5 @@ assignees: ''
 ### Simple Metering
 
 ### Diagnostics
+
+### Other clusters that are not mentioned above


### PR DESCRIPTION
Following up from #4469.

When requesting device support for a new light, it wasn't clear to me what cluster screenshots are actually required.

I think we can simplify this by adding headings for each cluster (for easy anchors to links to each cluster screenshot), and then declare in comments for each one if or when it's required.

Could someone point me to other docs or post what clusters are required for what device types?