### PR TITLE
Eria adurolight remote support

### DIFF
--- a/button_maps.json
+++ b/button_maps.json
@@ -52,7 +52,8 @@
         "COLOR_CONTROL": 768,
         "IAS_ZONE": 1280,
         "IAS_ACE": 1281,
-        "SENGLED": 64528
+        "SENGLED": 64528,
+        "ADUROLIGHT": 64716
 	},
 	"commands": {
         "DOOR_LOCK": {
@@ -115,6 +116,9 @@
             "ATTRIBUTE_REPORT": 10
         },
         "SENGLED": {
+            "COMMAND_0": 0
+        },
+        "ADUROLIGHT": {
             "COMMAND_0": 0
         }
 	},
@@ -1257,6 +1261,17 @@
                 [1, "0x01", "ONOFF", "TOGGLE", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],
                 [1, "0x01", "LEVEL_CONTROL", "STEP", "0", "S_BUTTON_2", "S_BUTTON_ACTION_SHORT_RELEASED", "Dim up"],
                 [1, "0x01", "LEVEL_CONTROL", "STEP", "1", "S_BUTTON_3", "S_BUTTON_ACTION_SHORT_RELEASED", "Dim down"]
+            ]
+        },
+        "aduroMap": {
+            "vendor": "Adurolight Manufacturing",
+            "doc": "Eria Adurosmart Wireless Dimming Switch",
+            "modelids": ["Adurolight_NCC"],
+            "map": [
+                [1, "0x01", "ADUROLIGHT", "COMMAND_0", "000000", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],
+                [1, "0x01", "ADUROLIGHT", "COMMAND_0", "000100", "S_BUTTON_2", "S_BUTTON_ACTION_SHORT_RELEASED", "Dim up"],
+                [1, "0x01", "ADUROLIGHT", "COMMAND_0", "000200", "S_BUTTON_3", "S_BUTTON_ACTION_SHORT_RELEASED", "Dim down"],
+                [1, "0x01", "ADUROLIGHT", "COMMAND_0", "000300", "S_BUTTON_4", "S_BUTTON_ACTION_SHORT_RELEASED", "Off"]
             ]
         }
     }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5623,7 +5623,10 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                 case SCENE_CLUSTER_ID:
                 case WINDOW_COVERING_CLUSTER_ID:
                 {
-                    if (modelId == QLatin1String("ZYCT-202") || modelId == QLatin1String("ZLL-NonColorController"))
+                    if (modelId == QLatin1String("ZYCT-202") ||
+                        modelId == QLatin1String("ZLL-NonColorController") ||
+                        // Eria Adurosmart Wireless Dimming Switch.
+                        modelId == QLatin1String("Adurolight_NCC"))
                     {
                         fpSwitch.outClusters.push_back(ci->id());
                     }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4677,7 +4677,8 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                     }
 
                 }
-                else if (ind.clusterId() == SENGLED_CLUSTER_ID)
+                else if (ind.clusterId() == SENGLED_CLUSTER_ID ||
+                         ind.clusterId() == ADUROLIGHT_CLUSTER_ID))
                 {
                     if (buttonMap.zclParam0 == pl0)
                     {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5643,9 +5643,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                 case WINDOW_COVERING_CLUSTER_ID:
                 {
                     if (modelId == QLatin1String("ZYCT-202") ||
-                        modelId == QLatin1String("ZLL-NonColorController") ||
-                        // Eria Adurosmart Wireless Dimming Switch.
-                        modelId == QLatin1String("Adurolight_NCC"))
+                        modelId == QLatin1String("ZLL-NonColorController"))
                     {
                         fpSwitch.outClusters.push_back(ci->id());
                     }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -336,7 +336,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_KONKE, "3AFE220103020000", konkeMacPrefix }, // Konke Kit Pro-BS Temp Humidity Sensor ver ???
     { VENDOR_EMBER, "3AFE130104020015", konkeMacPrefix }, // Konke Kit Pro-Door Entry Sensor
     { VENDOR_NONE, "RICI01", tiMacPrefix}, // LifeControl smart plug
-    { VENDOR_JENNIC, "Adurolight_NCC", jennicMacPrefix}, // Eria Adurosmart Wireless Dimming Switch
+    { VENDOR_ADUROLIGHT, "Adurolight_NCC", jennicMacPrefix}, // Eria Adurosmart Wireless Dimming Switch
     { VENDOR_JENNIC, "VOC_Sensor", jennicMacPrefix}, // LifeControl Enviroment sensor
     { VENDOR_JENNIC, "SN10ZW", jennicMacPrefix }, // ORVIBO motion sensor
     { VENDOR_OSRAM_STACK, "SF20", heimanMacPrefix }, // ORVIBO SF20 smoke sensor

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -215,6 +215,7 @@ using namespace deCONZ::literals;
 #define UBISYS_DEVICE_SETUP_CLUSTER_ID        0xFC00
 #define SAMJIN_CLUSTER_ID                     0xFC02
 #define SENGLED_CLUSTER_ID                    0xFC10
+#define ADUROLIGHT_CLUSTER_ID                 0xFCCC
 #define LEGRAND_CONTROL_CLUSTER_ID            0xFC40
 #define XIAOMI_CLUSTER_ID                     0xFCC0
 #define XAL_CLUSTER_ID                        0xFCCE


### PR DESCRIPTION
Refer to issues: #1730 and #3383

Refer to previous Pull Request #4211

These changes allow the Eria Adurosmart remote to send events for each button press.

From what I can tell there is no distinction from the remote for holding the button or double clicking, so this just provides simple button presses.