### PR TITLE
Introduce getSensorNodeForAddressEndpointAndCluster()

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -9815,12 +9815,12 @@ Sensor *DeRestPluginPrivate::getSensorNodeForAddressEndpointAndCluster(const deC
     for (Sensor &sensor: sensors)
     {
         if (sensor.deletedState() != Sensor::StateNormal || !sensor.node())                             { continue; }
+        if (sensor.fingerPrint().endpoint != ep)                                                        { continue; }
         if (!isSameAddress(sensor.address(), addr))                                                     { continue; }
         if (sensor.fingerPrint().hasInCluster(cluster) || sensor.fingerPrint().hasOutCluster(cluster))  { }
         else                                                                                            { continue; }
 
-        if (sensor.fingerPrint().endpoint != ep)    { continue; }
-        else                                        { return &sensor; }
+        return &sensor;
     }
     return nullptr;
 }

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1422,6 +1422,7 @@ public:
     void updateSensorNode(const deCONZ::NodeEvent &event);
     void updateSensorLightLevel(Sensor &sensor, quint16 measuredValue);
     bool isDeviceSupported(const deCONZ::Node *node, const QString &modelId);
+    Sensor *getSensorNodeForAddressEndpointAndCluster(const deCONZ::Address &addr, quint8 ep, quint16 cluster);
     Sensor *getSensorNodeForAddressAndEndpoint(const deCONZ::Address &addr, quint8 ep, const QString &type);
     Sensor *getSensorNodeForAddressAndEndpoint(const deCONZ::Address &addr, quint8 ep);
     Sensor *getSensorNodeForAddress(quint64 extAddr);

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1422,6 +1422,7 @@ public:
     void updateSensorNode(const deCONZ::NodeEvent &event);
     void updateSensorLightLevel(Sensor &sensor, quint16 measuredValue);
     bool isDeviceSupported(const deCONZ::Node *node, const QString &modelId);
+    bool isSameAddress(const deCONZ::Address &a, const deCONZ::Address &b);
     Sensor *getSensorNodeForAddressEndpointAndCluster(const deCONZ::Address &addr, quint8 ep, quint16 cluster);
     Sensor *getSensorNodeForAddressAndEndpoint(const deCONZ::Address &addr, quint8 ep, const QString &type);
     Sensor *getSensorNodeForAddressAndEndpoint(const deCONZ::Address &addr, quint8 ep);


### PR DESCRIPTION
This function provides the ability to choose a sensor more precisely than both functions `getSensorNodeForAddressAndEndpoint()`. The first implementation (which doesn't use the sensor type as argument) returns the first sensor found, which is problematic if more than one "sensor-worthy" cluster is available on one endpoint. The second implementation (which uses the sensor type as argument) is more accurate, but can only handle one sensor type (e.g. there's multiple sensor types based on IAS zone cluster).

The proposed function would eliminate both weaknesses, however, it relies on the correctness of a sensor's fingerprint. In this regard, some minor updates on the corresponding code might be required.

Presumably, the following code passage could be removed as a consequence as well:

https://github.com/dresden-elektronik/deconz-rest-plugin/blob/db673839f8cf4ec867bb9471cf79477299c5a794/de_web_plugin.cpp#L1040-L1051

**Example on improved sensor selection:**
```
21:04:23:953 [TEST] - 0x000D6FFFFE400CE4 Sensor selected: 00:0d:6f:ff:fe:40:0c:e4-01-0500, LastRx: Mi. März 10 21:04:23 2021...
21:04:23:953 [TEST] - 0x000D6FFFFE400CE4 APSDE data indication details: EP: 0x01, Cluster: 0x0400...
21:04:23:953 [TEST] - 0x000D6FFFFE400CE4 Correct sensor: 00:0d:6f:ff:fe:40:0c:e4-01-0400, LastRx: Mi. März 10 21:04:23 2021...
```

As small caveat remains: As of now, basic cluster and power configuration clusters (which occur in each sensor of multi-sensor devices) are not exclusively added to the sensor fingerprints. In those cases, the function will just return the first sensor found. It also cannot handle cases, where just one sensor has been exposed for multiple endpoints (primarily/exclusively switches).

Supercedes #4034