### PR TITLE
Added support for an other Revision of Orvibo Motion Sensor SN10ZW

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -341,6 +341,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_JENNIC, "Adurolight_NCC", jennicMacPrefix}, // Eria Adurosmart Wireless Dimming Switch
     { VENDOR_JENNIC, "VOC_Sensor", jennicMacPrefix}, // LifeControl Enviroment sensor
     { VENDOR_JENNIC, "SN10ZW", jennicMacPrefix }, // ORVIBO motion sensor
+    { VENDOR_NONE, "SN10ZW", tiMacPrefix }, // ORVIBO motion sensor (other Revision ???)
     { VENDOR_OSRAM_STACK, "SF20", heimanMacPrefix }, // ORVIBO SF20 smoke sensor
     // Danalock support
     { VENDOR_DANALOCK, "V3", danalockMacPrefix}, // Danalock Smart Lock
@@ -2661,11 +2662,19 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
         }
 
         // "translate" ORVIBO vendor name
+		if (lightNode.manufacturer() == QString("\u6B27\u745E"))
+        {
+            lightNode.setManufacturerName(QLatin1String("Orvibo"));
+            lightNode.setNeedSaveDatabase(true);
+        }
+        
+        // "translate" ORVIBO vendor name
         if (lightNode.manufacturer() == QString("欧瑞博"))
         {
             lightNode.setManufacturerName(QLatin1String("ORVIBO"));
             lightNode.setNeedSaveDatabase(true);
         }
+        
         // replace ORVIBO model IDs
         if (lightNode.modelId() == QLatin1String("abb71ca5fe1846f185cfbda554046cce"))
         {
@@ -3410,9 +3419,13 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
                             }
                             str = QLatin1String(device->manufacturername);
                         }
+						if (str == QString("\u6B27\u745E"))
+                        {
+                            str = QLatin1String("Orvibo");
+                        }
                         if (str == QString("欧瑞博"))
                         {
-                            str = QLatin1String("ORVIBO");
+                            str = QLatin1String("Orvibo");
                         }
 
                         if (!str.isEmpty() && str != lightNode->manufacturer())
@@ -4987,9 +5000,10 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                             {
                                 modelId = j->toString().trimmed();
                                 // replace ORVIBO model ID
-                                if (modelId == QLatin1String("895a2d80097f4ae2b2d40500d5e03dcc"))
+                                if (modelId == QLatin1String("895a2d80097f4ae2b2d40500d5e03dcc") || modelId == QLatin1String("585fdfb8c2304119a2432e9845cf2623"))
                                 {
                                     modelId = QLatin1String("SN10ZW motion sensor");
+									manufacturer = QLatin1String("Orvibo");
                                 }
                                 else if (modelId == QLatin1String("b5db59bfd81e4f1f95dc57fdbba17931"))
                                 {
@@ -5235,6 +5249,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                              modelId == QLatin1String("3041") ||                      // NYCE motion sensor
                              modelId.startsWith(QLatin1String("902010/22")) ||        // Bitron motion sensor
                              modelId.startsWith(QLatin1String("SN10ZW")) ||           // ORVIBO motion sensor
+							 //modelId == QLatin1String("585fdfb8c2304119a2432e9845cf2623") ||
                              modelId.startsWith(QLatin1String("MOSZB-1")) ||          // Develco motion sensor
                              modelId.startsWith(QLatin1String("MotionSensor51AU")) || // Aurora (Develco) motion sensor
                              modelId.startsWith(QLatin1String("MOT003")) ||           // Hive motion sensor
@@ -5340,6 +5355,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                                         else
                                         {
                                             fpAlarmSensor.inClusters.push_back(ci->id());
+                                            
                                         }
                                         break;
                                 }
@@ -8574,7 +8590,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     continue;
                                 }
 
-                                if (str == QLatin1String("895a2d80097f4ae2b2d40500d5e03dcc"))
+                                if (str == QLatin1String("895a2d80097f4ae2b2d40500d5e03dcc") || str == QLatin1String("585fdfb8c2304119a2432e9845cf2623"))
                                 {
                                     str = QLatin1String("SN10ZW motion sensor");
                                 }


### PR DESCRIPTION
Added support for an other unknown Revision of Orvibo Motion Sensor SN10ZW
I added new device in supported devices because it differs in MAC prefix and also in the vendor id, i added also the different model id and the slightly different manufacturer name.

Note that this sensor sends its feedback to endpoint 0x0A and not like normal to endpoint 0x01