### PR TITLE
Replace /group/0 group cast handing with broadcast

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -738,11 +738,16 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
     Group* group = getGroupForId(gwGroup0);
     if (!group)
     {
-        Group group;
-        group.setAddress(gwGroup0);
-        group.setName("All");
-        groups.push_back(group);
+        Group group0;
+        group0.setAddress(gwGroup0);
+        groups.push_back(group0);
+        group = &groups.back();
         queSaveDb(DB_GROUPS, DB_LONG_SAVE_DELAY);
+    }
+
+    if (group && group->name() != QLatin1String("__All"))
+    {
+        group->setName(QLatin1String("__All")); // don't clash with user groups named "All"
     }
 
     connect(apsCtrl, SIGNAL(apsdeDataConfirm(const deCONZ::ApsDataConfirm&)),

--- a/rest_groups.cpp
+++ b/rest_groups.cpp
@@ -763,6 +763,12 @@ int DeRestPluginPrivate::setGroupState(const ApiRequest &req, ApiResponse &rsp)
     taskRef.req.setDstEndpoint(0xFF); // broadcast endpoint
     taskRef.req.setSrcEndpoint(getSrcEndpoint(0, taskRef.req));
 
+    if (group->address() == gwGroup0)
+    {
+        taskRef.req.setDstAddressMode(deCONZ::ApsNwkAddress);
+        taskRef.req.dstAddress().setNwk(deCONZ::BroadcastRxOnWhenIdle);
+    }
+
     bool ok;
     QVariant var = Json::parse(req.content, ok);
     QVariantMap map = var.toMap();

--- a/rest_groups.cpp
+++ b/rest_groups.cpp
@@ -1767,7 +1767,7 @@ int DeRestPluginPrivate::deleteGroup(const ApiRequest &req, ApiResponse &rsp)
 
     userActivity();
 
-    if (!group || (group->state() == Group::StateDeleted) || (group->address() == gwGroup0))
+    if (!group || group->state() != Group::StateNormal || group->address() == gwGroup0)
     {
         rsp.httpStatus = HttpStatusNotFound;
         rsp.list.append(errorToMap(ERR_RESOURCE_NOT_AVAILABLE, QString("/groups/%1").arg(id), QString("resource, /groups/%1, not available").arg(id)));


### PR DESCRIPTION
Currently `/group/0` is treated as a Zigbee group with id `0xfff0`. This causes various problems like devices sending unwanted reports to this group and other devices reacting to these. The group also occupied an addition group slot on each device.

The PR makes the following changes:
- Sends all commands directed to `/group/0` as a broadcast to all routers where rxOnWhenIdle = true;
- Removes Zigbee group `0xfff0` which represented `/group/0` from devices if it is found via *Get Group Membership Request*;
- The internal name of `/group/0` was changed from "All" to "__All" so that users are able to create a group named "All".

It should be noted that the usage of `/group/0` in general is discouraged since for example in moderate complex networks with lots of different devices the reception of on/off command might cause devices other than lights to turn on/off. Creating explicit groups via the REST API provides finer control on which devices should receive a command.

Replaces PR: https://github.com/dresden-elektronik/deconz-rest-plugin/pull/3966

Issue: https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3744