### PR TITLE
Resource code simplify

### DIFF
--- a/resource.cpp
+++ b/resource.cpp
@@ -1010,7 +1010,7 @@ void ResourceItem::inRule(int ruleHandle)
 }
 
 /*! Returns the rules handles in which the resource item is involved. */
-const std::vector<int> ResourceItem::rulesInvolved() const
+const std::vector<int> &ResourceItem::rulesInvolved() const
 {
     return m_rulesInvolved;
 }

--- a/resource.cpp
+++ b/resource.cpp
@@ -598,34 +598,20 @@ ResourceItem::ResourceItem(const ResourceItem &other)
 }
 
 /*! Move constructor. */
-ResourceItem::ResourceItem(ResourceItem &&other) :
-    m_isPublic(other.m_isPublic),
-    m_flags(other.m_flags),
-    m_num(other.m_num),
-    m_numPrev(other.m_numPrev),
-    m_str(nullptr),
-    m_rid(other.m_rid),
-    m_lastSet(std::move(other.m_lastSet)),
-    m_lastChanged(std::move(other.m_lastChanged)),
-    m_rulesInvolved(std::move(other.m_rulesInvolved))
+ResourceItem::ResourceItem(ResourceItem &&other) noexcept
 {
-    if (other.m_str) // release
-    {
-        m_str = other.m_str;
-        other.m_str = nullptr;
-    }
-
-    other.m_rid = &rInvalidItemDescriptor;
+    *this = std::move(other);
 }
 
 /*! Destructor. */
-ResourceItem::~ResourceItem()
+ResourceItem::~ResourceItem() noexcept
 {
     if (m_str)
     {
         delete m_str;
         m_str = nullptr;
     }
+    m_rid = &rInvalidItemDescriptor;
 }
 
 /*! Returns true when a value has been set but not pushed upstream. */
@@ -687,7 +673,7 @@ ResourceItem &ResourceItem::operator=(const ResourceItem &other)
 }
 
 /*! Move assignment. */
-ResourceItem &ResourceItem::operator=(ResourceItem &&other)
+ResourceItem &ResourceItem::operator=(ResourceItem &&other) noexcept
 {
     // self assignment?
     if (this == &other)
@@ -1059,13 +1045,9 @@ Resource::Resource(const Resource &other) :
 }
 
 /*! Move constructor. */
-Resource::Resource(Resource &&other) :
-    lastStatePush(std::move(other.lastStatePush)),
-    lastAttrPush(std::move(other.lastAttrPush)),
-    m_prefix(other.m_prefix),
-    m_rItems(std::move(other.m_rItems))
+Resource::Resource(Resource &&other) noexcept
 {
-    other.m_prefix = RInvalidSuffix;
+    *this = std::move(other);
 }
 
 /*! Copy assignment. */
@@ -1082,7 +1064,7 @@ Resource &Resource::operator=(const Resource &other)
 }
 
 /*! Move assignment. */
-Resource &Resource::operator=(Resource &&other)
+Resource &Resource::operator=(Resource &&other) noexcept
 {
     if (this != &other)
     {

--- a/resource.h
+++ b/resource.h
@@ -287,7 +287,7 @@ public:
     const QDateTime &lastChanged() const;
     void setTimeStamps(const QDateTime &t);
     void inRule(int ruleHandle);
-    const std::vector<int> rulesInvolved() const;
+    const std::vector<int> &rulesInvolved() const;
     bool isPublic() const;
     void setIsPublic(bool isPublic);
 

--- a/resource.h
+++ b/resource.h
@@ -266,11 +266,11 @@ class ResourceItem
 
 public:
     ResourceItem(const ResourceItem &other);
-    ResourceItem(ResourceItem &&other);
+    ResourceItem(ResourceItem &&other) noexcept;
     ResourceItem(const ResourceItemDescriptor &rid);
     ResourceItem &operator=(const ResourceItem &other);
-    ResourceItem &operator=(ResourceItem &&other);
-    ~ResourceItem();
+    ResourceItem &operator=(ResourceItem &&other) noexcept;
+    ~ResourceItem() noexcept;
     bool needPushSet() const;
     bool needPushChange() const;
     void clearNeedPush();
@@ -311,9 +311,9 @@ public:
     Resource(const char *prefix);
     ~Resource() = default;
     Resource(const Resource &other);
-    Resource(Resource &&other);
+    Resource(Resource &&other) noexcept;
     Resource &operator=(const Resource &other);
-    Resource &operator=(Resource &&other);
+    Resource &operator=(Resource &&other) noexcept;
     const char *prefix() const;
     ResourceItem *addItem(ApiDataType type, const char *suffix);
     void removeItem(const char *suffix);


### PR DESCRIPTION
- Remove duplicated code by reusing `Resource` and `ResourceItem` move assignment operator in move constructor;
- `ResourceItem::rulesInvolved()` return by const reference rather when copy the `std::vector<int>`.