### PR TITLE
IKEA STYRBAR and Minor changes

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2693,6 +2693,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId().startsWith(QLatin1String("S2")) ||
         // IKEA
         sensor->modelId().startsWith(QLatin1String("TRADFRI")) ||
+        sensor->modelId().startsWith(QLatin1String("Remote Control N2")) || // STYRBAR
         sensor->modelId().startsWith(QLatin1String("FYRTUR")) ||
         sensor->modelId().startsWith(QLatin1String("KADRILJ")) ||
         sensor->modelId().startsWith(QLatin1String("SYMFONISK")) ||
@@ -3483,9 +3484,11 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
     }
     // IKEA Trådfri on/off switch
     // IKEA Trådfri shortcut button
+    // IKEA STYRBAR
     // Sonoff SNZB-01
     else if (sensor->modelId().startsWith(QLatin1String("TRADFRI on/off switch")) ||
              sensor->modelId().startsWith(QLatin1String("TRADFRI SHORTCUT Button")) ||
+             sensor->modelId().startsWith(QLatin1String("Remote Control N2")) ||
              sensor->modelId().startsWith(QLatin1String("WB01")) ||
              sensor->modelId().startsWith(QLatin1String("WB-01")))
     {
@@ -3828,6 +3831,7 @@ void DeRestPluginPrivate::checkSensorGroup(Sensor *sensor)
         sensor->modelId().startsWith(QLatin1String("Z3-1BRL")) || // Lutron Aurora FoH smart dimmer
         sensor->modelId().startsWith(QLatin1String("TRADFRI on/off switch")) ||
         sensor->modelId().startsWith(QLatin1String("TRADFRI SHORTCUT Button")) ||
+        sensor->modelId().startsWith(QLatin1String("Remote Control N2")) || // STYRBAR
         sensor->modelId().startsWith(QLatin1String("TRADFRI open/close remote")) ||
         sensor->modelId().startsWith(QLatin1String("TRADFRI motion sensor")) ||
         sensor->modelId().startsWith(QLatin1String("TRADFRI remote control")) ||

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -3485,15 +3485,11 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
         clusters.push_back(SCENE_CLUSTER_ID);
         srcEndpoints.push_back(sensor->fingerPrint().endpoint);
     }
-    // IKEA Trådfri on/off switch
-    // IKEA Trådfri shortcut button
-    // IKEA STYRBAR
-    // Sonoff SNZB-01
+    // IKEA
     else if (sensor->modelId().startsWith(QLatin1String("TRADFRI on/off switch")) ||
              sensor->modelId().startsWith(QLatin1String("TRADFRI SHORTCUT Button")) ||
-             sensor->modelId().startsWith(QLatin1String("Remote Control N2")) ||
-             sensor->modelId().startsWith(QLatin1String("WB01")) ||
-             sensor->modelId().startsWith(QLatin1String("WB-01")))
+             // sensor->modelId().startsWith(QLatin1String("SYMFONISK")) ||
+             sensor->modelId().startsWith(QLatin1String("Remote Control N2")))
     {
         clusters.push_back(ONOFF_CLUSTER_ID);
         srcEndpoints.push_back(sensor->fingerPrint().endpoint);
@@ -3511,13 +3507,12 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
         clusters.push_back(LEVEL_CLUSTER_ID);
         srcEndpoints.push_back(sensor->fingerPrint().endpoint);
     }
-    // IKEA SYMFONISK sound controller
-    // else if (sensor->modelId().startsWith(QLatin1String("SYMFONISK")))
-    // {
-    //     clusters.push_back(ONOFF_CLUSTER_ID);
-    //     clusters.push_back(LEVEL_CLUSTER_ID);
-    //     srcEndpoints.push_back(sensor->fingerPrint().endpoint);
-    // }
+    else if (sensor->modelId().startsWith(QLatin1String("WB01")) ||
+             sensor->modelId().startsWith(QLatin1String("WB-01")))
+    {
+        clusters.push_back(ONOFF_CLUSTER_ID);
+        srcEndpoints.push_back(sensor->fingerPrint().endpoint);
+    }
     // OSRAM 3 button remote
     else if (sensor->modelId().startsWith(QLatin1String("Lightify Switch Mini")) )
     {

--- a/button_maps.json
+++ b/button_maps.json
@@ -391,7 +391,12 @@
                 [4, "0x01", "LEVEL_CONTROL", "MOVE", "1", "S_BUTTON_3", "S_BUTTON_ACTION_SHORT_RELEASED", "Move down"],
                 [4, "0x01", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "1", "0", "0", "Stop_ down (with on/off)"],
                 [4, "0x01", "LEVEL_CONTROL", "MOVE_TO_LEVEL_WITH_ON_OFF", "0", "S_BUTTON_4", "S_BUTTON_ACTION_SHORT_RELEASED", "Move to level 0 (with on/off)"],
-                [4, "0x01", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "0", "0", "0", "Stop_ up (with on/off)"]
+                [1, "0x01", "LEVEL_CONTROL", "MOVE_TO_LEVEL_WITH_ON_OFF", "0xFF", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "Move to level 255 (with on/off)"],
+                [1, "0x01", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_HOLD", "Move up (with on/off)"],
+                [1, "0x01", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ up (with on/off)"],
+                [1, "0x01", "LEVEL_CONTROL", "MOVE_TO_LEVEL_WITH_ON_OFF", "0", "S_BUTTON_2", "S_BUTTON_ACTION_SHORT_RELEASED", "Move to level 0 (with on/off)"],
+                [1, "0x01", "LEVEL_CONTROL", "MOVE", "1", "S_BUTTON_2", "S_BUTTON_ACTION_HOLD", "Move down"],
+                [1, "0x01", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "1", "S_BUTTON_2", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ down (with on/off)"]
             ]
         },
         "ikeaMotionSensorMap": {

--- a/button_maps.json
+++ b/button_maps.json
@@ -996,7 +996,21 @@
                 [1, "0x06", "MULTISTATE_INPUT", "ATTRIBUTE_REPORT", "1", "S_BUTTON_6", "S_BUTTON_ACTION_SHORT_RELEASED", "Color cold press"],
                 [1, "0x06", "MULTISTATE_INPUT", "ATTRIBUTE_REPORT", "2", "S_BUTTON_6", "S_BUTTON_ACTION_DOUBLE_PRESS", "Color cold double press"],
                 [1, "0x06", "MULTISTATE_INPUT", "ATTRIBUTE_REPORT", "3", "S_BUTTON_6", "S_BUTTON_ACTION_TREBLE_PRESS", "Color cold triple press"],
-                [1, "0x06", "MULTISTATE_INPUT", "ATTRIBUTE_REPORT", "0xFF", "S_BUTTON_6", "S_BUTTON_ACTION_LONG_RELEASED", "Color cold long released"]
+                [1, "0x06", "MULTISTATE_INPUT", "ATTRIBUTE_REPORT", "0xFF", "S_BUTTON_6", "S_BUTTON_ACTION_LONG_RELEASED", "Color cold long released"],
+                [1, "0x01", "ONOFF", "OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "Off press"],
+                [1, "0x01", "ONOFF", "ON", "0", "S_BUTTON_2", "S_BUTTON_ACTION_SHORT_RELEASED", "On press"],
+                [1, "0x01", "LEVEL_CONTROL", "STEP", "1", "S_BUTTON_3", "S_BUTTON_ACTION_SHORT_RELEASED", "Dim down press"],
+                [1, "0x01", "LEVEL_CONTROL", "MOVE", "1", "S_BUTTON_3", "S_BUTTON_ACTION_HOLD", "Dim down hold"],
+                [1, "0x01", "LEVEL_CONTROL", "STOP", "1", "S_BUTTON_3", "S_BUTTON_ACTION_LONG_RELEASED", "Dim down long released"],
+                [1, "0x01", "LEVEL_CONTROL", "STEP", "0", "S_BUTTON_4", "S_BUTTON_ACTION_SHORT_RELEASED", "Dim up press"],
+                [1, "0x01", "LEVEL_CONTROL", "MOVE", "0", "S_BUTTON_4", "S_BUTTON_ACTION_HOLD", "Dim up hold"],
+                [1, "0x01", "LEVEL_CONTROL", "STOP", "0", "S_BUTTON_4", "S_BUTTON_ACTION_LONG_RELEASED", "Dim up long released"],
+                [1, "0x01", "COLOR_CONTROL", "STEP_COLOR_TEMPERATURE", "1", "S_BUTTON_5", "S_BUTTON_ACTION_SHORT_RELEASED", "Color warm press"],
+                [1, "0x01", "COLOR_CONTROL", "MOVE_COLOR_TEMPERATURE", "0x010F", "S_BUTTON_5", "S_BUTTON_ACTION_HOLD", "Color warm hold"],
+                [1, "0x01", "COLOR_CONTROL", "MOVE_COLOR_TEMPERATURE", "0x100F", "S_BUTTON_5", "S_BUTTON_ACTION_LONG_RELEASED", "Color warm long released"],
+                [1, "0x01", "COLOR_CONTROL", "STEP_COLOR_TEMPERATURE", "3", "S_BUTTON_6", "S_BUTTON_ACTION_SHORT_RELEASED", "Color cold press"],
+                [1, "0x01", "COLOR_CONTROL", "MOVE_COLOR_TEMPERATURE", "0x030F", "S_BUTTON_6", "S_BUTTON_ACTION_HOLD", "Color cold hold"],
+                [1, "0x01", "COLOR_CONTROL", "MOVE_COLOR_TEMPERATURE", "0x300F", "S_BUTTON_6", "S_BUTTON_ACTION_LONG_RELEASED", "Color cold long released"]
             ]
         },
         "legrandShutterSwitchRemote": {

--- a/button_maps.json
+++ b/button_maps.json
@@ -278,6 +278,31 @@
                 [3, "0x01", "SCENES", "IKEA_STOP_CT", "0", "S_BUTTON_5", "S_BUTTON_ACTION_LONG_RELEASED", "Stop ct warmer"]
             ]
         },
+        "ikeaStyrbarMap": {
+            "vendor": "IKEA",
+            "doc": "STYRBAR remote",
+            "modelids": ["Remote Control N2"],
+            "buttons": [
+                {"S_BUTTON_1": "Top dimm up button"},
+                {"S_BUTTON_2": "Bottom dimm down button"},
+                {"S_BUTTON_3": "Left arrow button"},
+                {"S_BUTTON_4": "Right arrow button"}
+            ],
+            "map": [
+                [1, "0x01", "ONOFF", "ON", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],
+                [1, "0x01", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_HOLD", "Move up (with on/off)"],
+                [1, "0x01", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ (with on/off)"],
+                [1, "0x01", "ONOFF", "OFF", "0", "S_BUTTON_2", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],
+                [1, "0x01", "LEVEL_CONTROL", "MOVE", "1", "S_BUTTON_2", "S_BUTTON_ACTION_HOLD", "Move down"],
+                [1, "0x01", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "1", "S_BUTTON_2", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ (with on/off)"],
+                [1, "0x01", "SCENES", "IKEA_STEP_CT", "1", "S_BUTTON_3", "S_BUTTON_ACTION_SHORT_RELEASED", "Step ct colder"],
+                [1, "0x01", "SCENES", "IKEA_MOVE_CT", "1", "S_BUTTON_3", "S_BUTTON_ACTION_HOLD", "Move ct colder"],
+                [1, "0x01", "SCENES", "IKEA_STOP_CT", "1", "S_BUTTON_3", "S_BUTTON_ACTION_LONG_RELEASED", "Stop ct colder"],
+                [1, "0x01", "SCENES", "IKEA_STEP_CT", "0", "S_BUTTON_4", "S_BUTTON_ACTION_SHORT_RELEASED", "Step ct warmer"],
+                [1, "0x01", "SCENES", "IKEA_MOVE_CT", "0", "S_BUTTON_4", "S_BUTTON_ACTION_HOLD", "Move ct warmer"],
+                [1, "0x01", "SCENES", "IKEA_STOP_CT", "0", "S_BUTTON_4", "S_BUTTON_ACTION_LONG_RELEASED", "Stop ct warmer"]
+            ]
+        },
         "osramMiniRemoteMap": {
             "vendor": "OSRAM",
             "doc": "Lightify Switch Mini",

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4011,7 +4011,7 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
     }
     else if (sensor->modelId() == QLatin1String("TRADFRI wireless dimmer"))
     {
-        if (sensor->mode() != Sensor::ModeDimmer)
+        if (sensor->mode() != Sensor::ModeDimmer && sensor->mode() != Sensor::ModeScenes)
         {
             sensor->setMode(Sensor::ModeDimmer);
         }
@@ -4788,17 +4788,18 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                     ResourceItem *item = sensor->item(RStateButtonEvent);
                     if (item)
                     {
-                        if (item->toNumber() == buttonMap.button && ind.dstAddressMode() == deCONZ::ApsGroupAddress)
-                        {
-                            QDateTime now = QDateTime::currentDateTime();
-                            const auto dt = item->lastSet().msecsTo(now);
-
-                            if (dt > 0 && dt < 500)
-                            {
-                                DBG_Printf(DBG_INFO, "[INFO] - Button %u %s, discard too fast event (dt = %d) %s\n", buttonMap.button, qPrintable(cmd), static_cast<int>(dt), qPrintable(sensor->modelId()));
-                                break;
-                            }
-                        }
+                        // FIXME: whitelist the devices that need this logic - DO NOT APPLY TO ALL DEVICES
+                        // if (item->toNumber() == buttonMap.button && ind.dstAddressMode() == deCONZ::ApsGroupAddress)
+                        // {
+                        //     QDateTime now = QDateTime::currentDateTime();
+                        //     const auto dt = item->lastSet().msecsTo(now);
+                        //
+                        //     if (dt > 0 && dt < 500)
+                        //     {
+                        //         DBG_Printf(DBG_INFO, "[INFO] - Button %u %s, discard too fast event (dt = %d) %s\n", buttonMap.button, qPrintable(cmd), static_cast<int>(dt), qPrintable(sensor->modelId()));
+                        //         break;
+                        //     }
+                        // }
 
                         item->setValue(buttonMap.button);
 
@@ -7003,6 +7004,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
 
         if (modelId == QLatin1String("TRADFRI wireless dimmer"))
         {
+
             sensorNode.setMode(Sensor::ModeDimmer);
         }
         else

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4788,18 +4788,21 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                     ResourceItem *item = sensor->item(RStateButtonEvent);
                     if (item)
                     {
-                        // FIXME: whitelist the devices that need this logic - DO NOT APPLY TO ALL DEVICES
-                        // if (item->toNumber() == buttonMap.button && ind.dstAddressMode() == deCONZ::ApsGroupAddress)
-                        // {
-                        //     QDateTime now = QDateTime::currentDateTime();
-                        //     const auto dt = item->lastSet().msecsTo(now);
-                        //
-                        //     if (dt > 0 && dt < 500)
-                        //     {
-                        //         DBG_Printf(DBG_INFO, "[INFO] - Button %u %s, discard too fast event (dt = %d) %s\n", buttonMap.button, qPrintable(cmd), static_cast<int>(dt), qPrintable(sensor->modelId()));
-                        //         break;
-                        //     }
-                        // }
+                        if (sensor->node()->nodeDescriptor().manufacturerCode() == VENDOR_PHILIPS ||
+                            sensor->node()->nodeDescriptor().manufacturerCode() == VENDOR_IKEA)
+                        {
+                        }
+                        else if (item->toNumber() == buttonMap.button && ind.dstAddressMode() == deCONZ::ApsGroupAddress)
+                        {
+                            QDateTime now = QDateTime::currentDateTime();
+                            const auto dt = item->lastSet().msecsTo(now);
+
+                            if (dt > 0 && dt < 500)
+                            {
+                                DBG_Printf(DBG_INFO, "[INFO] - Button %u %s, discard too fast event (dt = %d) %s\n", buttonMap.button, qPrintable(cmd), static_cast<int>(dt), qPrintable(sensor->modelId()));
+                                break;
+                            }
+                        }
 
                         item->setValue(buttonMap.button);
 

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4714,6 +4714,15 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                         ok = true;
                     }
                 }
+                else if (ind.clusterId() == COLOR_CLUSTER_ID &&
+                         (zclFrame.commandId() == 0x4c))  // step color temperature
+                {
+                    ok = false;
+                    if (zclFrame.payload().size() >= 1 && buttonMap.zclParam0 == zclFrame.payload().at(0)) // direction
+                    {
+                        ok = true;
+                    }
+                }
                 else if (ind.clusterId() == COLOR_CLUSTER_ID && (zclFrame.commandId() == 0x01 ))  // Move hue command
                 {
                     // Only used by Osram devices currently
@@ -4741,7 +4750,7 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                 else if (ind.clusterId() == ADUROLIGHT_CLUSTER_ID)
                 {
                     ok = false;
-                    
+
                     if (buttonMap.zclParam0 == zclFrame.payload().at(1))
                     {
                         ok = true;

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -16894,6 +16894,7 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
                  sensor->modelId().startsWith(QLatin1String("TRADFRI SHORTCUT Button")) ||
                  sensor->modelId().startsWith(QLatin1String("TRADFRI open/close remote")) ||
                  sensor->modelId().startsWith(QLatin1String("TRADFRI remote control")) ||
+                 sensor->modelId().startsWith(QLatin1String("Remote Control N2")) ||
                  sensor->modelId().startsWith(QLatin1String("TRADFRI wireless dimmer")) ||
                  sensor->modelId().startsWith(QLatin1String("TRADFRI motion sensor")))
         {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4027,18 +4027,24 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
     }
     else if (sensor->modelId().startsWith(QLatin1String("TRADFRI on/off switch")) ||
              sensor->modelId().startsWith(QLatin1String("TRADFRI SHORTCUT Button")) ||
+             sensor->modelId().startsWith(QLatin1String("Remote Control N2")) ||
              sensor->modelId().startsWith(QLatin1String("TRADFRI open/close remote")) ||
              sensor->modelId().startsWith(QLatin1String("TRADFRI motion sensor")))
     {
         if (ind.dstAddressMode() == deCONZ::ApsGroupAddress && ind.dstAddress().group() == 0)
         {
-            checkClientCluster = true;
             ResourceItem *item = sensor->item(RConfigGroup);
             if (!item || (item && (item->toString() == QLatin1String("0") || item->toString().isEmpty())))
             {
                 // still default group, create unique group and binding
                 checkSensorGroup(sensor);
             }
+        }
+        checkReporting = true;
+        checkClientCluster = true;
+        if (ind.dstAddressMode() == deCONZ::ApsNwkAddress)
+        {
+            return;
         }
     }
     else if (sensor->modelId().startsWith(QLatin1String("SYMFONISK")))

--- a/general.xml
+++ b/general.xml
@@ -488,6 +488,27 @@
 					<attribute id="0x0001" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
 				</payload>
 			</command>
+      <command id="0x07" dir="recv" name="IKEA step" required="o" vendor="0x117c">
+        <description>Command sent by TRADFRI remote control on press left or right.  Set Direction to 1 for left or leave at 0 for right.  Leave the Unknown parameters at their default values.</description>
+        <payload>
+          <attribute id="0x0000" type="u8" name="Direction" required="m" default="0x0"></attribute>
+          <attribute id="0x0001" type="u8" name="Unknown" required="m" showas="hex" default="0x01"></attribute>
+          <attribute id="0x0002" type="u16" name="Unknown" required="m" showas="hex" default="0x000d"></attribute>
+        </payload>
+      </command>
+      <command id="0x08" dir="recv" name="IKEA move" required="o" vendor="0x117c">
+        <description>Command sent by TRADFRI remote control on hold left or right.  Set Direction to 1 for left or leave at 0 for right.  Leave the Unknown parameter at its default value.</description>
+        <payload>
+          <attribute id="0x0000" type="u8" name="Direction" required="m" default="0x0"></attribute>
+          <attribute id="0x0001" type="u16" name="Unknown" required="m" showas="hex" default="0x000d"></attribute>
+        </payload>
+      </command>
+      <command id="0x09" dir="recv" name="IKEA stop" required="o" vendor="0x117c">
+        <description>Command sent by TRADFRI remote control on release (after hold).  Leave the Unknown parameter at its default value.</description>
+        <payload>
+          <attribute id="0x0000" type="u16" name="Unknown" required="m" showas="hex" default="0x0000"></attribute>
+        </payload>
+      </command>
 		<!-- TODO -->
 		</server>
 		<client>


### PR DESCRIPTION
- Add support for IKEA STYRBAR, see #4572.
  - Whitelist device in `de_web_plugin.cpp`;
  - Add commands to `button_map.json`;
  - Hack in `checkSensorButtonEvent()` to ignore additional commands on holding left or right button (see issue);
  - Streamline code for SHORTCUT and SYMFONISK, in line with STYRBAR:
    - Only bind _OnOff_ client cluster to group;
    - Discard unicast from client cluster to prevent double button events;
    - Fix bugs in verifying bindings/reporting;
    - Remove unneeded code for binding SYMFONISK to coordinator, as it sends commands to coordinator already by default.
  - **TODO**: Check older IKEA end devices for double button events (haven't seen any reports, so don't expect any;
  - **TODO**: Check whether old wireless dimmer (with dial) sends commands to coordinator by default as well;
  - **TODO**: Check whether old IKEA end devices can do with one client binding as well.
- Add support for Aqara Opple in controller mode, see #4589.  No support for switching modes, though; you'll need to do this manually through the GUI (as describes in the issue)... every time deCONZ restarts;
  - Add commands to `button_map.json`;
  - Add support for _Step Color Temperature_ command in `checkSensorButtonEvent()`;
- Add to `general.xml` the IKEA-specific scene commands as sent by the TRADFRI remote control on the left and right buttons, so they can be sent from the GUI.  Still cannot get them to work, though...
- Add new button mapping for TRADFRI wireless dimmer, under `mode` 1, see [Wiki](https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/IKEA-controllers#ictc-g-1).
- Disable check for "too fast event", as this interferes with the correct function of several IKEA and Hue devices.