### PR TITLE
Refactor getFreeSensorId(); fix reuse of deleted sensor ids

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -23,6 +23,8 @@ static const char *pragmaPageCount = "PRAGMA page_count";
 static const char *pragmaPageSize = "PRAGMA page_size";
 static const char *pragmaFreeListCount = "PRAGMA freelist_count";
 
+static sqlite3 *db = nullptr; // TODO should be member of Database class
+
 struct DB_Callback {
   DeRestPluginPrivate *d = nullptr;
   LightNode *lightNode = nullptr;
@@ -950,6 +952,11 @@ void DeRestPluginPrivate::pushZclValueDb(quint64 extAddress, quint8 endpoint, qu
     dbQueryQueue.push_back(sql);
 }
 
+bool DeRestPluginPrivate::dbIsOpen() const
+{
+    return db != nullptr;
+}
+
 /*! Opens/creates sqlite database.
  */
 void DeRestPluginPrivate::openDb()
@@ -967,7 +974,7 @@ void DeRestPluginPrivate::openDb()
     if (rc != SQLITE_OK) {
         // failed
         DBG_Printf(DBG_ERROR, "Can't open database: %s\n", sqlite3_errmsg(db));
-        db = 0;
+        db = nullptr;
         return;
     }
 
@@ -5408,7 +5415,7 @@ void DeRestPluginPrivate::closeDb()
         int ret = sqlite3_close(db);
         if (ret == SQLITE_OK)
         {
-            db = 0;
+            db = nullptr;
 #ifdef Q_OS_LINUX
             QElapsedTimer measTimer;
             measTimer.restart();

--- a/database.cpp
+++ b/database.cpp
@@ -4283,7 +4283,7 @@ static int sqliteGetAllSensorIdsCallback(void *user, int ncols, char **colval , 
     {
         if (colval[i] && (colval[i][0] != '\0'))
         {
-            if (strcmp(colname[i], "id") == 0)
+            if (strcmp(colname[i], "sid") == 0)
             {
                 bool ok;
                 int id = QString(colval[i]).toInt(&ok);

--- a/database.cpp
+++ b/database.cpp
@@ -4406,7 +4406,7 @@ int getFreeSensorId()
             {
                 bool ok;
                 const int sid = c.id().toInt(&ok);
-                if (ok && std::find(sensorIds.begin(), sensorIds.end(), sid) == sensorIds.end())
+                if (ok && std::find(sensorIds.cbegin(), sensorIds.cend(), sid) == sensorIds.cend())
                 {
                     sensorIds.push_back(sid);
                 }
@@ -4440,7 +4440,7 @@ int getFreeSensorId()
 
     while (sid < 10000)
     {
-        const auto result = std::find(sensorIds.begin(), sensorIds.end(), sid);
+        const auto result = std::find(sensorIds.cbegin(), sensorIds.cend(), sid);
 
         if (result == sensorIds.end())
         {

--- a/database.cpp
+++ b/database.cpp
@@ -4405,10 +4405,10 @@ int getFreeSensorId()
             if (c.resource() == RSensors)
             {
                 bool ok;
-                const int id = c.id().toInt(&ok);
-                if (ok && std::find(sensorIds.begin(), sensorIds.end(), id) == sensorIds.end())
+                const int sid = c.id().toInt(&ok);
+                if (ok && std::find(sensorIds.begin(), sensorIds.end(), sid) == sensorIds.end())
                 {
-                    sensorIds.push_back(id);
+                    sensorIds.push_back(sid);
                 }
             }
         }
@@ -4434,23 +4434,23 @@ int getFreeSensorId()
 
     // 'append' only, start with largest known id
     // skip daylight sensor.id 1000 from earlier versions to keep id value low as possible
-    const auto startId = std::find_if(sensorIds.rbegin(), sensorIds.rend(), [](int id) { return id < 1000; });
+    const auto startId = std::find_if(sensorIds.rbegin(), sensorIds.rend(), [](int sid) { return sid < 1000; });
 
-    int id = (startId != sensorIds.rend()) ? *startId : 1;
+    int sid = (startId != sensorIds.rend()) ? *startId : 1;
 
-    while (id < 10000)
+    while (sid < 10000)
     {
-        const auto result = std::find(sensorIds.begin(), sensorIds.end(), id);
+        const auto result = std::find(sensorIds.begin(), sensorIds.end(), sid);
 
         if (result == sensorIds.end())
         {
-            return id;
+            return sid;
         }
 
-        id++;
+        sid++;
     }
 
-    return id;
+    return sid;
 }
 
 /*! Saves the current auth with apikey to the database.

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -618,7 +618,7 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
 //    gwScanner->startScan();
 
     QString dataPath = deCONZ::getStorageLocation(deCONZ::ApplicationsDataLocation);
-    db = 0;
+
     saveDatabaseItems = 0;
     saveDatabaseIdleTotalCounter = 0;
     dbZclValueMaxAge = 0; // default disable
@@ -18843,7 +18843,7 @@ bool DeRestPluginPrivate::exportConfiguration()
     ttlDataBaseConnection = 0;
     closeDb();
 
-    if (db)
+    if (dbIsOpen())
     {
         DBG_Printf(DBG_ERROR, "backup: failed to export - database busy\n");
         return false; // might be busy
@@ -19100,7 +19100,7 @@ bool DeRestPluginPrivate::importConfiguration()
     saveDatabaseItems |= DB_NOSAVE;
     closeDb();
 
-    if (db)
+    if (dbIsOpen())
     {
         DBG_Printf(DBG_ERROR, "backup: failed to import - database busy\n");
         return false; // database might be busy
@@ -19379,7 +19379,7 @@ bool DeRestPluginPrivate::resetConfiguration(bool resetGW, bool deleteDB)
     saveDatabaseItems |= DB_NOSAVE;
     closeDb();
 
-    if (db)
+    if (dbIsOpen())
     {
         DBG_Printf(DBG_ERROR, "backup: failed to import - database busy\n");
         return false; // database might be busy

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -904,6 +904,12 @@ DeRestPluginPrivate::~DeRestPluginPrivate()
     }
 }
 
+DeRestPluginPrivate *DeRestPluginPrivate::instance()
+{
+    DBG_Assert(plugin);
+    return plugin;
+}
+
 /*! APSDE-DATA.indication callback.
     \param ind - the indication primitive
     \note Will be called from the main application for each incoming indication.

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -468,6 +468,7 @@ using namespace deCONZ::literals;
 #define J2000_EPOCH 1
 
 void getTime(quint32 *time, qint32 *tz, quint32 *dstStart, quint32 *dstEnd, qint32 *dstShift, quint32 *standardTime, quint32 *localTime, quint8 mode);
+int getFreeSensorId(); // TODO needs to be part of a Database class
 
 extern const quint64 macPrefixMask;
 
@@ -1633,7 +1634,6 @@ public:
     void loadLightDataFromDb(LightNode *lightNode, QVariantList &ls, qint64 fromTime, int max);
     void loadAllGatewaysFromDb();
     int getFreeLightId();
-    int getFreeSensorId();
     void saveDb();
     void saveApiKey(QString apikey);
     void closeDb();
@@ -1649,7 +1649,6 @@ public:
     int saveDatabaseIdleTotalCounter;
     QString sqliteDatabaseName;
     std::vector<int> lightIds;
-    std::vector<int> sensorIds;
     std::vector<QString> dbQueryQueue;
     qint64 dbZclValueMaxAge;
     QTimer *databaseTimer;

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1611,6 +1611,7 @@ public:
     void refreshDeviceDb(const deCONZ::Address &addr);
     void pushZdpDescriptorDb(quint64 extAddress, quint8 endpoint, quint16 type, const QByteArray &data);
     void pushZclValueDb(quint64 extAddress, quint8 endpoint, quint16 clusterId, quint16 attributeId, qint64 data);
+    bool dbIsOpen() const;
     void openDb();
     void readDb();
     void loadAuthFromDb();
@@ -1643,7 +1644,6 @@ public:
 
     void checkConsistency();
 
-    sqlite3 *db;
     int ttlDataBaseConnection; // when idleTotalCounter becomes greater the DB will be closed
     int saveDatabaseItems;
     int saveDatabaseIdleTotalCounter;

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1032,6 +1032,8 @@ public:
     DeRestPluginPrivate(QObject *parent = 0);
     ~DeRestPluginPrivate();
 
+    static DeRestPluginPrivate *instance();
+
     // REST API authorisation
     void initAuthentication();
     bool allowedToCreateApikey(const ApiRequest &req, ApiResponse &rsp, QVariantMap &map);


### PR DESCRIPTION
- Make it a free standing function, since there is no Database class yet. This is a forecast to remove database code dependency of the plugin, which will ultimately result in a proper testable Database class;
- Remove sqliteGetAllSensorIdsCallback() dependency from plugin class;
- Make `sensorIds` a local variable since it's only used here;
- Modernize code and and reduce unperformant code paths;
- Ensure new sensor ids only grow, don't reuse sensor ids which where formerly deleted.

Code has been tested in debugger for various cases.

The PR also fixes that formerly deleted sensor ids from the database were reused under certain conditions. Which was the whole point to actually access the database in this function, but it never worked. I'm not sure if this is too useful other than to prevent clients which still somehow access old ids getting confused by new completely different sensors with the same id. If that isn't needed the code can be simplified to not use the database at all.

