### PR TITLE
Change Lidl/Silvercrest Smart Wireless Door Bell from ZHASwitch to ZHAAlarm resource

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -3831,6 +3831,14 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             item = sensor.addItem(DataTypeString, RConfigAlert);
             item->setValue(R_ALERT_DEFAULT);
         }
+        else if (((sensor.modelId() == QLatin1String("TS0211") && sensor.manufacturer() == QLatin1String("_TZ1800_ladpngdx")) ||
+                 (sensor.modelId() == QLatin1String("HG06668") && sensor.manufacturer() == QLatin1String("LIDL Silvercrest"))) &&
+                 sensor.type().endsWith(QLatin1String("Switch")))
+        {
+            sensor.setType(QLatin1String("ZHAAlarm"));
+            sensor.addItem(DataTypeBool, RStateAlarm)->setValue(false);
+            sensor.removeItem(RStateButtonEvent);
+        }
         else if (sensor.modelId() == QLatin1String("lumi.sensor_magnet.agl02") || // skip
                  sensor.modelId() == QLatin1String("lumi.flood.agl02"))
         {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5316,6 +5316,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     else if (modelId == QLatin1String("WarningDevice") ||               // Heiman siren
                              modelId == QLatin1String("SZ-SRN12N") ||                   // Sercomm siren
                              modelId == QLatin1String("SIRZB-1") ||                     // Develco siren
+                             modelId == QLatin1String("TS0211") ||                      // Lidl/Silvercrest Smart Wireless Door Bell
                              modelId == QLatin1String("902010/29"))                     // Bitron outdoor siren
                     {
                         fpAlarmSensor.inClusters.push_back(ci->id());
@@ -5325,7 +5326,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                         fpVibrationSensor.inClusters.push_back(ci->id());
                     }
                     else if ((manufacturer == QLatin1String("Samjin") && modelId == QLatin1String("button")) ||
-                              modelId == QLatin1String("Keyfob-ZB3.0") || modelId == QLatin1String("TS0211"))
+                              modelId == QLatin1String("Keyfob-ZB3.0"))
                     {
                         fpSwitch.inClusters.push_back(ci->id());
                     }


### PR DESCRIPTION
This device is technically an alarm sensor and should be treated as such. By doing that, all assiciated IAS attributes will be exposed as supported by the device. Any triggering in automation systems must then be done on the `alarm` resource item.

For this take to take effect in environments where the device is already in use, a deCONZ restart would be required.