### PR TITLE
Allow Tuya devices to poll onOff attribute

### DIFF
--- a/poll_manager.cpp
+++ b/poll_manager.cpp
@@ -277,17 +277,8 @@ void PollManager::pollTimerFired()
 
     if (suffix == RStateOn && lightNode)
     {
-        item = r->item(RAttrModelId);
-
-        if (UseTuyaCluster(lightNode->manufacturer()))
-        {
-            //Thoses devices haven't cluster 0006, and use Cluster specific
-        }
-        else
-        {
-            clusterId = ONOFF_CLUSTER_ID;
-            attributes.push_back(0x0000); // onOff
-        }
+        clusterId = ONOFF_CLUSTER_ID;
+        attributes.push_back(0x0000); // onOff
     }
     else if (suffix == RStateBri && isOn)
     {


### PR DESCRIPTION
This should generally be allowed for Tuya devices as well. The code handles any non-existance, so no polling will occur if the on/off cluster doesn't exist.