### PR TITLE
Enhancements for Bitron thermostat 902010/32

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1439,7 +1439,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq3.attributeId = 0x0012;        // Occupied heating setpoint
             rq3.minInterval = 1;
             rq3.maxInterval = 600;
-            rq3.reportableChange8bit = 1;
+            rq3.reportableChange16bit = 50;
 
             ConfigureReportingRequest rq4;
             rq4.dataType = deCONZ::Zcl8BitEnum;

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1426,22 +1426,36 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq.minInterval = 0;
             rq.maxInterval = 300;
             rq.reportableChange16bit = 10;
-
+            
             ConfigureReportingRequest rq2;
-            rq2.dataType = deCONZ::Zcl8BitUint;
-            rq2.attributeId = 0x0012;        // Occupied heating setpoint
+            rq2.dataType = deCONZ::Zcl16BitInt;
+            rq2.attributeId = 0x0011;        // Occupied cooling setpoint
             rq2.minInterval = 1;
             rq2.maxInterval = 600;
-            rq2.reportableChange8bit = 1;
+            rq2.reportableChange16bit = 50;
 
             ConfigureReportingRequest rq3;
-            rq3.dataType = deCONZ::Zcl8BitEnum;
-            rq3.attributeId = 0x001C;        // Thermostat mode
+            rq3.dataType = deCONZ::Zcl16BitInt;
+            rq3.attributeId = 0x0012;        // Occupied heating setpoint
             rq3.minInterval = 1;
             rq3.maxInterval = 600;
-            rq3.reportableChange8bit = 0xff;
+            rq3.reportableChange8bit = 1;
 
-            return sendConfigureReportingRequest(bt, {rq, rq2, rq3});
+            ConfigureReportingRequest rq4;
+            rq4.dataType = deCONZ::Zcl8BitEnum;
+            rq4.attributeId = 0x001B;        // Control Sequence of operation
+            rq4.minInterval = 1;
+            rq4.maxInterval = 600;
+            rq4.reportableChange8bit = 0xff;
+
+            ConfigureReportingRequest rq5;
+            rq5.dataType = deCONZ::Zcl8BitEnum;
+            rq5.attributeId = 0x001C;        // Thermostat mode
+            rq5.minInterval = 1;
+            rq5.maxInterval = 600;
+            rq5.reportableChange8bit = 0xff;
+
+            return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4, rq5});
         }
         else if (sensor && sensor->modelId().startsWith(QLatin1String("TH112"))) // Sinope Thermostat TH1123ZB & TH1124ZB
         {

--- a/database.cpp
+++ b/database.cpp
@@ -3539,7 +3539,6 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 if (sensor.modelId().startsWith(QLatin1String("SLR2")) ||   // Hive
                     sensor.modelId() == QLatin1String("SLR1b") ||           // Hive
                     sensor.modelId().startsWith(QLatin1String("TH112")) ||  // Sinope
-                    sensor.modelId() == QLatin1String("902010/32") ||       // Bitron
                     R_GetProductId(&sensor) == QLatin1String("Tuya_THD SEA801-ZIGBEE TRV") ||
                     R_GetProductId(&sensor) == QLatin1String("Tuya_THD HY369 TRV") ||
                     R_GetProductId(&sensor) == QLatin1String("Tuya_THD HY368 TRV") ||
@@ -3614,6 +3613,14 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     sensor.addItem(DataTypeBool, RConfigDisplayFlipped)->setValue(false);
                     sensor.addItem(DataTypeBool, RConfigLocked)->setValue(false);
                     sensor.addItem(DataTypeString, RConfigMode);
+                }
+                else if (sensor.modelId() == QLatin1String("902010/32"))  // Bitron
+                {
+                    sensor.addItem(DataTypeString, RConfigMode);
+                    sensor.addItem(DataTypeUInt8, RConfigControlSequence)->setValue(4);
+                    sensor.addItem(DataTypeInt16, RConfigCoolSetpoint);
+                    sensor.addItem(DataTypeBool, RConfigScheduleOn)->setValue(false);
+                    sensor.addItem(DataTypeString, RConfigSchedule);
                 }
                 else if (sensor.modelId() == QLatin1String("Super TR"))   // ELKO
                 {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6586,7 +6586,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             if (sensorNode.modelId().startsWith(QLatin1String("SLR2")) ||   // Hive
                 sensorNode.modelId() == QLatin1String("SLR1b") ||           // Hive
                 sensorNode.modelId().startsWith(QLatin1String("TH112")) ||  // Sinope
-                sensorNode.modelId() == QLatin1String("902010/32") ||       // Bitron
                 R_GetProductId(&sensorNode) == QLatin1String("Tuya_THD SEA801-ZIGBEE TRV") ||
                 R_GetProductId(&sensorNode) == QLatin1String("Tuya_THD WZB-TRVL TRV") ||
                 R_GetProductId(&sensorNode) == QLatin1String("Tuya_THD Smart radiator TRV") ||
@@ -6659,6 +6658,14 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                 sensorNode.addItem(DataTypeBool, RConfigDisplayFlipped)->setValue(false);
                 sensorNode.addItem(DataTypeBool, RConfigLocked)->setValue(false);
                 sensorNode.addItem(DataTypeString, RConfigMode);
+            }
+            else if (sensorNode.modelId() == QLatin1String("902010/32"))  // Bitron
+            {
+                sensorNode.addItem(DataTypeString, RConfigMode);
+                sensorNode.addItem(DataTypeUInt8, RConfigControlSequence)->setValue(4);
+                sensorNode.addItem(DataTypeInt16, RConfigCoolSetpoint);
+                sensorNode.addItem(DataTypeBool, RConfigScheduleOn)->setValue(false);
+                sensorNode.addItem(DataTypeString, RConfigSchedule);
             }
             else if (sensorNode.modelId() == QLatin1String("Super TR"))   // ELKO
             {

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -260,6 +260,14 @@ using namespace deCONZ::literals;
 #define IAS_ZONE_TYPE_VIBRATION_SENSOR        0x002d
 #define IAS_ZONE_TYPE_WARNING_DEVICE          0x0225
 
+// Thermostat cluster, Control Sequence of Operation (0x001B)
+#define COOLING_ONLY                            0x00
+#define COOLING_WITH_REHEAT                     0x01
+#define HEATING_ONLY                            0x02
+#define HEATING_WITH_REHEAT                     0x03
+#define COOLING_AND_HEATING_4PIPES              0x04
+#define COOLING_AND_HEATING_4PIPES_WITH_REHEAT  0x05
+
 // IAS Setup states
 #define IAS_STATE_INIT                 0
 #define IAS_STATE_ENROLLED             1 // finished

--- a/resource.cpp
+++ b/resource.cpp
@@ -121,6 +121,7 @@ const char *RConfigColorCapabilities = "config/colorcapabilities";
 const char *RConfigCtMin = "config/ctmin";
 const char *RConfigCtMax = "config/ctmax";
 const char *RConfigConfigured = "config/configured";
+const char *RConfigControlSequence = "config/controlsequence";
 const char *RConfigCoolSetpoint = "config/coolsetpoint";
 const char *RConfigDelay = "config/delay";
 const char *RConfigDisplayFlipped = "config/displayflipped";
@@ -290,6 +291,7 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigCtMin));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigCtMax));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, RConfigConfigured));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, RConfigControlSequence));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeInt16, RConfigCoolSetpoint, 700, 3500));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, RConfigDelay));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, RConfigDisplayFlipped));

--- a/resource.h
+++ b/resource.h
@@ -128,6 +128,7 @@ extern const char *RConfigColorCapabilities;
 extern const char *RConfigCtMin;
 extern const char *RConfigCtMax;
 extern const char *RConfigConfigured;
+extern const char *RConfigControlSequence;
 extern const char *RConfigCoolSetpoint;
 extern const char *RConfigDelay;
 extern const char *RConfigDisplayFlipped;

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -2130,7 +2130,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                             return REQ_READY_SEND;
                         }
 
-                        if (mode > 0 && mode < 6)
+                        if (controlSequence != 0)
                         {
                             if (addTaskThermostatReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, 0, 0x001B, deCONZ::Zcl8BitEnum, controlSequence))
                             {

--- a/thermostat.cpp
+++ b/thermostat.cpp
@@ -483,6 +483,29 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
             }
                 break;
 
+            case 0x001B: // Control Sequence of Operation
+            {
+                quint16 controlSequence = attr.numericValue().u16;
+                quint8 mode = 0;
+
+                if      (controlSequence == COOLING_ONLY)                           { mode = 1; }
+                else if (controlSequence == COOLING_WITH_REHEAT)                    { mode = 2; }
+                else if (controlSequence == HEATING_ONLY)                           { mode = 3; }
+                else if (controlSequence == HEATING_WITH_REHEAT)                    { mode = 4; }
+                else if (controlSequence == COOLING_AND_HEATING_4PIPES)             { mode = 5; }
+                else if (controlSequence == COOLING_AND_HEATING_4PIPES_WITH_REHEAT) { mode = 6; }
+
+                item = sensor->item(RConfigControlSequence);
+                if (item && item->toNumber() != mode && mode > 0 && mode <= 6)
+                {
+                    item->setValue(mode);
+                    enqueueEvent(Event(RSensors, RConfigControlSequence, sensor->id(), item));
+                    configUpdated = true;
+                }
+                sensor->setZclValue(updateType, ind.srcEndpoint(), THERMOSTAT_CLUSTER_ID, attrId, attr.numericValue());
+            }
+                break;
+
             case 0x001C: // System Mode
             {
                 if (sensor->modelId().startsWith(QLatin1String("SLR2")) ||   // Hive


### PR DESCRIPTION
- Expose `RConfigCoolSetpoint`
- Introduce `RConfigControlSequence` to API for usage with thermostats
- Correct wrong data type in occupied heating setpoint reporting