### PR TITLE
Initial support for ZGP PTM216Z switch 

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1878,7 +1878,14 @@ void DeRestPluginPrivate::gpDataIndication(const deCONZ::GpDataIndication &ind)
 
             if (sensorNode.name().isEmpty())
             {
-                sensorNode.setName(QString("Hue Tap %2").arg(sensorNode.id()));
+                if (sensorNode.modelId() == QLatin1String("FOHSWITCH"))
+                {
+                    sensorNode.setName(QString("FoH Switch %2").arg(sensorNode.id()));
+                }
+                else
+                {
+                    sensorNode.setName(QString("Hue Tap %2").arg(sensorNode.id()));
+                }
             }
 
             checkSensorGroup(&sensorNode);

--- a/green_power.h
+++ b/green_power.h
@@ -25,6 +25,12 @@
   #define DBG_ZGP DBG_INFO  // DBG_ZGP didn't exist before version v2.8.x
 #endif
 
+enum ZgpDeviceId
+{
+    GpDeviceIdOnOffSwitch = 0x02,
+    GpDeviceIdGenericSwitch = 0x07
+};
+
 using GpKey_t = std::array<unsigned char, GP_SECURITY_KEY_SIZE>;
 
 GpKey_t GP_DecryptSecurityKey(quint32 sourceID, const GpKey_t &securityKey);


### PR DESCRIPTION
Treated as Friends of Hue switch, but this module works differently as the known FoH switches when parsing messages.
No test done yet if and how it works with the Philips Hue bridge.

Therefore the `modelid` and `manufacturername` might need to change in future versions.

**Button Events**

x is the button number 1...8

x000  Initial press
x001  Hold
x002  Short release
x003  Long release