### PR TITLE
Initial support for Xiaomi Aqara T1 Cube

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -3172,7 +3172,8 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             item = sensor.addItem(DataTypeInt32, RStateButtonEvent);
             item->setValue(0);
 
-            if (sensor.modelId().startsWith(QLatin1String("lumi.sensor_cube")))
+            if (sensor.modelId().startsWith(QLatin1String("lumi.sensor_cube")) ||
+                sensor.modelId() == QLatin1String("lumi.remote.cagl01"))
             {
                 sensor.addItem(DataTypeInt32, RStateGesture);
             }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -3531,6 +3531,14 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
                         {
                             str = QLatin1String("CM10ZW");
                         }
+                        else if (str == QLatin1String("lumi.remote.cagl01")) // Xiaomi T1 Aqara cube, falsely creates a on/off light
+                        {
+                            // TODO remove this code when DDF is ready
+                            lightNode->setState(LightNode::StateDeleted);
+                            lightNode->setNeedSaveDatabase(true);
+                            queSaveDb(DB_LIGHTS, DB_LONG_SAVE_DELAY);
+                            break;
+                        }
 
                         if (item && !str.isEmpty() && str != item->toString())
                         {

--- a/resource.cpp
+++ b/resource.cpp
@@ -523,6 +523,9 @@ static const ProductMap products[] =
     {"_TZE200_d0yu2xgi", "TS0601", "NEO/Tuya", "NAS-AB02B0 Siren"},
     {"_TZ3000_m0vaazab", "TS0207", "Tuya", "Tuya_RPT Repeater"},
 
+    // Xiaomi
+    {"LUMI", "lumi.remote.cagl01", "Xiaomi", "Aqara T1 Cube"},
+
     {nullptr, nullptr, nullptr, nullptr}
 };
 


### PR DESCRIPTION
Note: This PR requires a newer firmware, since the device only exposes required endpoints when the coordinator *Node Descriptor* has the Xiaomi manufacturer code set to 0x115F: [deCONZ_ConBeeII_0x266b0700.bin.GCF](http://deconz.dresden-elektronik.de/deconz-firmware/deCONZ_ConBeeII_0x266b0700.bin.GCF)

The PR contains a fix to query  *Basic Cluster* attributes like manufacturer name for newer Xiaomi Zigbee 3.0 devices.
The Xiaomi Aqara T1 Cube exposes the same API and button events as the older Xiaomi Aqara Cube does.

```json
{
   "1": {
    "config": {
        "battery": 100,
        "on": true,
        "reachable": true,
        "temperature": 2500
    },
    "ep": 2,
    "etag": "2c4057c509efa2d9e42d30a5697331d6",
    "lastseen": "2021-04-29T23:26Z",
    "manufacturername": "LUMI",
    "mode": 1,
    "modelid": "lumi.remote.cagl01",
    "name": "Mi Magic Cube",
    "state": {
        "buttonevent": 1003,
        "gesture": 3,
        "lastupdated": "2021-04-29T23:26:02.467"
    },
    "swversion": "20200327",
    "type": "ZHASwitch",
    "uniqueid": "04:cf:8c:df:3c:80:0d:1e-02-0012"
  },
  "2": {
    "config": {
        "battery": 100,
        "on": true,
        "reachable": true,
        "temperature": 2500
    },
    "ep": 3,
    "etag": "aa413cc38589fbb8c94c1b83867ea437",
    "lastseen": "2021-04-29T23:26Z",
    "manufacturername": "LUMI",
    "mode": 1,
    "modelid": "lumi.remote.cagl01",
    "name": "Mi Magic Cube",
    "state": {
        "buttonevent": -6828,
        "gesture": 8,
        "lastupdated": "2021-04-29T23:26:58.391"
    },
    "swversion": "20200327",
    "type": "ZHASwitch",
    "uniqueid": "04:cf:8c:df:3c:80:0d:1e-03-000c"
  }
}
```
