### PR TITLE
MAC prefix hygene

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -76,8 +76,7 @@ const quint64 macPrefixMask       = 0xffffff0000000000ULL;
 // New mac prefixes can be checked here: https://wintelguy.com/index.pl
 const quint64 legrandMacPrefix    = 0x0004740000000000ULL;
 const quint64 dishMacPrefix       = 0x0008890000000000ULL;
-const quint64 ikeaMacPrefix       = 0x000b570000000000ULL;
-const quint64 danalockMacPrefix   = 0x000b570000000000ULL; // note: same as ikeaMacPrefix
+const quint64 silabs1MacPrefix    = 0x000b570000000000ULL;
 const quint64 emberMacPrefix      = 0x000d6f0000000000ULL;
 const quint64 instaMacPrefix      = 0x000f170000000000ULL;
 const quint64 tiMacPrefix         = 0x00124b0000000000ULL;
@@ -90,7 +89,6 @@ const quint64 ubisysMacPrefix     = 0x001fee0000000000ULL;
 const quint64 computimeMacPrefix  = 0x001e5e0000000000ULL;
 const quint64 deMacPrefix         = 0x00212e0000000000ULL;
 const quint64 celMacPrefix        = 0x0022a30000000000ULL; // California Eastern Laboratories
-const quint64 keenhomeMacPrefix   = 0x0022a30000000000ULL;
 const quint64 zenMacPrefix        = 0x0024460000000000ULL;
 const quint64 heimanMacPrefix     = 0x0050430000000000ULL;
 const quint64 davicomMacPrefix    = 0x00606e0000000000ULL;
@@ -178,16 +176,16 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_DDEL, "Scene Switch", deMacPrefix },
     { VENDOR_DDEL, "FLS-NB1", deMacPrefix },
     { VENDOR_DDEL, "FLS-NB2", deMacPrefix },
-    { VENDOR_IKEA, "TRADFRI remote control", ikeaMacPrefix },
+    { VENDOR_IKEA, "TRADFRI remote control", silabs1MacPrefix },
     { VENDOR_IKEA, "TRADFRI remote control", silabsMacPrefix },
     { VENDOR_IKEA, "TRADFRI remote control", silabs2MacPrefix },
-    { VENDOR_IKEA, "TRADFRI motion sensor", ikeaMacPrefix },
-    { VENDOR_IKEA, "TRADFRI wireless dimmer", ikeaMacPrefix },
-    { VENDOR_IKEA, "TRADFRI on/off switch", ikeaMacPrefix },
+    { VENDOR_IKEA, "TRADFRI motion sensor", silabs1MacPrefix },
+    { VENDOR_IKEA, "TRADFRI wireless dimmer", silabs1MacPrefix },
+    { VENDOR_IKEA, "TRADFRI on/off switch", silabs1MacPrefix },
     { VENDOR_IKEA, "TRADFRI SHORTCUT Button", silabs4MacPrefix },
-    { VENDOR_IKEA, "TRADFRI open/close remote", ikeaMacPrefix },
-    { VENDOR_IKEA, "FYRTUR", ikeaMacPrefix }, // smart blind
-    { VENDOR_IKEA, "KADRILJ", ikeaMacPrefix }, // smart blind
+    { VENDOR_IKEA, "TRADFRI open/close remote", silabs1MacPrefix },
+    { VENDOR_IKEA, "FYRTUR", silabs1MacPrefix }, // smart blind
+    { VENDOR_IKEA, "KADRILJ", silabs1MacPrefix }, // smart blind
     { VENDOR_IKEA, "KADRILJ", silabs4MacPrefix }, // smart blind
     { VENDOR_IKEA, "SYMFONISK", ikea2MacPrefix }, // sound controller
     { VENDOR_IKEA, "Remote Control N2", silabs4MacPrefix}, // STYRBAR
@@ -289,8 +287,8 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_HEIMAN, "RC-EF-3.0", silabs5MacPrefix }, // Heiman IAS ACE remote control
     { VENDOR_LUTRON, "LZL4BWHL01", lutronMacPrefix }, // Lutron LZL-4B-WH-L01 Connected Bulb Remote
     { VENDOR_LUTRON, "Z3-1BRL", lutronMacPrefix }, // Lutron Aurora Friends-of-Hue dimmer
-    { VENDOR_KEEN_HOME , "SV01-", keenhomeMacPrefix}, // Keen Home Vent
-    { VENDOR_KEEN_HOME , "SV02-", keenhomeMacPrefix}, // Keen Home Vent
+    { VENDOR_KEEN_HOME , "SV01-", celMacPrefix}, // Keen Home Vent
+    { VENDOR_KEEN_HOME , "SV02-", celMacPrefix}, // Keen Home Vent
     { VENDOR_INNR, "SP 120", jennicMacPrefix}, // innr smart plug
     { VENDOR_JENNIC, "VMS_ADUROLIGHT", jennicMacPrefix }, // Trust motion sensor ZPIR-8000
     { VENDOR_JENNIC, "CSW_ADUROLIGHT", jennicMacPrefix }, // Trust contact sensor ZMST-808
@@ -355,7 +353,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_JENNIC, "e70f96b3773a4c9283c6862dbafb6a99", jennicMacPrefix }, // ORVIBO open/close sensor SM11
     { VENDOR_OSRAM_STACK, "SF20", heimanMacPrefix }, // ORVIBO SF20 smoke sensor
     // Danalock support
-    { VENDOR_DANALOCK, "V3", danalockMacPrefix}, // Danalock Smart Lock
+    { VENDOR_DANALOCK, "V3", silabs1MacPrefix}, // Danalock Smart Lock
     // Schlage support
     { VENDOR_SCHLAGE, "BE468", schlageMacPrefix}, // Schlage BE468 Smart Lock
     { VENDOR_HEIMAN, "SF21", emberMacPrefix }, // ORVIBO SF21 smoke sensor

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -494,7 +494,7 @@ extern const quint64 embertecMacPrefix;
 extern const quint64 energyMiMacPrefix;
 extern const quint64 heimanMacPrefix;
 extern const quint64 zenMacPrefix;
-extern const quint64 ikeaMacPrefix;
+extern const quint64 silabs1MacPrefix;
 extern const quint64 ikea2MacPrefix;
 extern const quint64 silabsMacPrefix;
 extern const quint64 silabs2MacPrefix;
@@ -508,7 +508,6 @@ extern const quint64 silabs9MacPrefix;
 extern const quint64 instaMacPrefix;
 extern const quint64 boschMacPrefix;
 extern const quint64 jennicMacPrefix;
-extern const quint64 keenhomeMacPrefix;
 extern const quint64 lutronMacPrefix;
 extern const quint64 netvoxMacPrefix;
 extern const quint64 osramMacPrefix;
@@ -528,8 +527,6 @@ extern const quint64 computimeMacPrefix;
 extern const quint64 konkeMacPrefix;
 extern const quint64 ecozyMacPrefix;
 extern const quint64 zhejiangMacPrefix;
-// Danalock support
-extern const quint64 danalockMacPrefix;
 extern const quint64 schlageMacPrefix;
 
 inline bool existDevicesWithVendorCodeForMacPrefix(quint64 addr, quint16 vendor)
@@ -580,7 +577,7 @@ inline bool existDevicesWithVendorCodeForMacPrefix(quint64 addr, quint16 vendor)
             return prefix == deMacPrefix ||
                    prefix == silabs3MacPrefix;
         case VENDOR_IKEA:
-            return prefix == ikeaMacPrefix ||
+            return prefix == silabs1MacPrefix ||
                    prefix == silabsMacPrefix ||
                    prefix == silabs2MacPrefix ||
                    prefix == silabs4MacPrefix ||
@@ -600,7 +597,7 @@ inline bool existDevicesWithVendorCodeForMacPrefix(quint64 addr, quint16 vendor)
         case VENDOR_JENNIC:
             return prefix == jennicMacPrefix;
         case VENDOR_KEEN_HOME:
-            return prefix == keenhomeMacPrefix;
+            return prefix == celMacPrefix;
         case VENDOR_LGE:
             return prefix == emberMacPrefix;
         case VENDOR_LUTRON:
@@ -629,7 +626,7 @@ inline bool existDevicesWithVendorCodeForMacPrefix(quint64 addr, quint16 vendor)
         case VENDOR_SI_LABS:
             return prefix == silabsMacPrefix ||
                    prefix == energyMiMacPrefix ||
-                   prefix == ikeaMacPrefix; // belongs to SiLabs
+                   prefix == silabs1MacPrefix;
         case VENDOR_STELPRO:
             return prefix == xalMacPrefix;
         case VENDOR_UBISYS:
@@ -655,7 +652,7 @@ inline bool existDevicesWithVendorCodeForMacPrefix(quint64 addr, quint16 vendor)
         case VENDOR_COMPUTIME:
             return prefix == computimeMacPrefix;
         case VENDOR_DANALOCK:
-            return prefix == danalockMacPrefix;
+            return prefix == silabs1MacPrefix;
         case VENDOR_AXIS:
         case VENDOR_MMB:
             return prefix == zenMacPrefix;


### PR DESCRIPTION
- Removal of duplicate MAC prefix entries.
- Rename ikeaMacPrefix and danalockMacPrefix as silabs1MacPrefix
- Use celMacPrefix for keenhomeMacPrefix