### PR TITLE
Button events check for duplicated sequence number (IKEA, Tuya and LIDL)

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4155,7 +4155,7 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
     if (zclFrame.sequenceNumber() == sensor->previousSequenceNumber)
     {
         // useful in general but limit scope to known problematic devices
-        if (sensor->manufacturer().startsWith(QLatin1String("IKEA")) || isTuyaManufacturerName(sensor->manufacturer()))
+        if (isTuyaManufacturerName(sensor->manufacturer()))
         {
             // deCONZ doesn't always send ZCL Default Response to unicast commands, or they can get lost.
             // in this case some devices re-send the command multiple times

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4155,7 +4155,10 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
     if (zclFrame.sequenceNumber() == sensor->previousSequenceNumber)
     {
         // useful in general but limit scope to known problematic devices
-        if (isTuyaManufacturerName(sensor->manufacturer()))
+        if (isTuyaManufacturerName(sensor->manufacturer()) ||
+            // TODO "HG06323" can likely be removed after testing,
+            // since the device only sends group casts and we don't expect this to trigger.
+            sensor->modelId() == QLatin1String("HG06323"))
         {
             // deCONZ doesn't always send ZCL Default Response to unicast commands, or they can get lost.
             // in this case some devices re-send the command multiple times

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4149,14 +4149,28 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
     }
     else if (sensor->modelId() == QLatin1String("HG06323")) // LIDL Remote Control
     {
-        // Probably needed because deCONZ doesn't send Default Response to unicast command.
-        if (zclFrame.sequenceNumber() == sensor->previousSequenceNumber)
-        {
-            return;
-        }
-        sensor->previousSequenceNumber = zclFrame.sequenceNumber();
         checkReporting = true;
     }
+
+    if (zclFrame.sequenceNumber() == sensor->previousSequenceNumber)
+    {
+        // useful in general but limit scope to known problematic devices
+        if (sensor->manufacturer().startsWith(QLatin1String("IKEA")) || isTuyaManufacturerName(sensor->manufacturer()))
+        {
+            // deCONZ doesn't always send ZCL Default Response to unicast commands, or they can get lost.
+            // in this case some devices re-send the command multiple times
+            DBG_Printf(DBG_INFO, "Discard duplicated zcl.cmd: 0x%02X, cluster: 0x%04X with zcl.seq: %u for %s / %s\n",
+                       zclFrame.commandId(), ind.clusterId(), zclFrame.sequenceNumber(), qPrintable(sensor->manufacturer()), qPrintable(sensor->modelId()));
+            return;
+        }
+        else // warn only
+        {
+            DBG_Printf(DBG_INFO, "Warning duplicated zcl.cmd: 0x%02X, cluster: 0x%04X with zcl.seq: %u for %s / %s\n",
+                       zclFrame.commandId(), ind.clusterId(), zclFrame.sequenceNumber(), qPrintable(sensor->manufacturer()), qPrintable(sensor->modelId()));
+        }
+    }
+
+    sensor->previousSequenceNumber = zclFrame.sequenceNumber();
 
     if (ind.dstAddressMode() == deCONZ::ApsGroupAddress && ind.dstAddress().group() != 0)
     {

--- a/sensor.h
+++ b/sensor.h
@@ -150,7 +150,7 @@ public:
     uint8_t previousDirection;
     quint16 previousCt;
     QDateTime durationDue;
-    uint8_t previousSequenceNumber;
+    uint16_t previousSequenceNumber = 0xffff;
     uint8_t previousCommandId;
     
 


### PR DESCRIPTION
* Limited to IKEA and Tuya devices (also LIDL) to discard duplicated commands;
* For all other devices a warning is printed so we can track the issue;
* Sensor.previousSequenceNumber changed to uint16_t with initial value 0xffff to not accidantly discard valid commands.

This PR is successor for https://github.com/dresden-elektronik/deconz-rest-plugin/pull/4265 but only addresses the duplicate switch events.

The whole ZCL Default Response needs to be fixed at a higher level for all handlers in a separate PR.