### PR TITLE
Support delete device and its REST resources

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -5556,6 +5556,42 @@ void DeRestPluginPrivate::getZigbeeConfigDb(QVariantList &out)
     closeDb();
 }
 
+/*! Deletes a device from the database.
+
+    Due the foreign keys this affects the tables:
+    - device
+    - device_descriptors
+    - device_gui
+    - source_routes
+    - source_route_hops
+ */
+void DeRestPluginPrivate::deleteDeviceDb(const QString &uniqueId)
+{
+    DBG_Assert(!uniqueId.isEmpty());
+
+    openDb();
+    DBG_Assert(db);
+    if (!db)
+    {
+        return;
+    }
+
+    char *errmsg = nullptr;
+    const auto sql = QString("DELETE FROM devices WHERE mac = '%1'").arg(uniqueId);
+    int rc = sqlite3_exec(db, sql.toUtf8().constData(), NULL, NULL, &errmsg);
+
+    if (rc != SQLITE_OK)
+    {
+        if (errmsg)
+        {
+            DBG_Printf(DBG_ERROR, "DB sqlite3_exec failed: %s, error: %s, line: %d\n", qPrintable(sql), errmsg, __LINE__);
+            sqlite3_free(errmsg);
+        }
+    }
+
+    closeDb();
+}
+
 /*! Put working ZigBee configuration in database for later recovery or fail safe operations.
     - An entry is only added when different from last entry.
     - Entries are only added, never modified, this way errors or unwanted changes can be debugged.

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -13529,24 +13529,14 @@ void DeRestPluginPrivate::nodeEvent(const deCONZ::NodeEvent &event)
     case deCONZ::NodeEvent::NodeDeselected:
         break;
 
-    case deCONZ::NodeEvent::NodeRemoved:
+    case deCONZ::NodeEvent::NodeRemoved: // deleted via GUI
     {
-        std::vector<LightNode>::iterator i = nodes.begin();
-        std::vector<LightNode>::iterator end = nodes.end();
-
-        for (; i != end; ++i)
+#if DECONZ_LIB_VERSION >= 0x011001
+        if (event.node() && event.node()->address().nwk() != 0x0000)
         {
-            if (i->address().ext() == event.node()->address().ext())
-            {
-                if (i->state() != LightNode::StateNormal)
-                {
-                    continue;
-                }
-
-                DBG_Printf(DBG_INFO, "LightNode removed %s\n", qPrintable(event.node()->address().toStringExt()));
-                nodeZombieStateChanged(event.node());
-            }
+            restDevices->deleteDevice(event.node()->address().ext());
         }
+#endif
     }
         break;
 

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1658,6 +1658,7 @@ public:
     void updateZigBeeConfigDb();
     void getLastZigBeeConfigDb(QString &out);
     void getZigbeeConfigDb(QVariantList &out);
+    void deleteDeviceDb(const QString &uniqueId);
 
     void checkConsistency();
 

--- a/reset_device.cpp
+++ b/reset_device.cpp
@@ -106,6 +106,7 @@ void DeRestPluginPrivate::checkResetState()
         lastNodeAddressExt = 0;
     }
 
+    const auto now = QDateTime::currentDateTime();
     std::vector<Sensor>::iterator si = sensors.begin();
     std::vector<Sensor>::iterator si_end = sensors.end();
 
@@ -113,9 +114,9 @@ void DeRestPluginPrivate::checkResetState()
     {
         if (si->isAvailable() && si->resetRetryCount() > 0 && si->node())
         {
-            if (!si->node()->nodeDescriptor().receiverOnWhenIdle())
+            if (!si->node()->nodeDescriptor().receiverOnWhenIdle() && si->lastRx().secsTo(now) > 6)
             {
-                // not supported yet
+                // wait until awake
                 continue;
             }
 

--- a/rest_devices.cpp
+++ b/rest_devices.cpp
@@ -69,8 +69,7 @@ bool deleteSensor(Sensor *sensor, DeRestPluginPrivate *plugin)
         sensor->setNeedSaveDatabase(true);
         sensor->setResetRetryCount(10);
 
-        Event e(sensor->prefix(), REventDeleted, sensor->id());
-        plugin->enqueueEvent(e);
+        plugin->enqueueEvent(Event(sensor->prefix(), REventDeleted, sensor->id()));
         return true;
     }
 
@@ -103,8 +102,7 @@ bool deleteLight(LightNode *lightNode, DeRestPluginPrivate *plugin)
             }
         }
 
-        Event e(lightNode->prefix(), REventDeleted, lightNode->id());
-        plugin->enqueueEvent(e);
+        plugin->enqueueEvent(Event(lightNode->prefix(), REventDeleted, lightNode->id()));
         return true;
     }
 
@@ -136,8 +134,10 @@ bool RestDevices::deleteDevice(quint64 extAddr)
     if (count > 0)
     {
         plugin->queSaveDb(DB_SENSORS | DB_LIGHTS | DB_GROUPS | DB_SCENES, DB_SHORT_SAVE_DELAY);
-        plugin->deleteDeviceDb(plugin->generateUniqueId(extAddr, 0, 0));
     }
+
+    // delete device entry, regardless if REST resources exists
+    plugin->deleteDeviceDb(plugin->generateUniqueId(extAddr, 0, 0));
 
     return count > 0;
 }

--- a/rest_devices.h
+++ b/rest_devices.h
@@ -30,6 +30,8 @@ public:
     explicit RestDevices(QObject *parent = nullptr);
     int handleApi(const ApiRequest &req, ApiResponse &rsp);
 
+    bool deleteDevice(quint64 extAddr);
+
 private:
     int getAllDevices(const ApiRequest &req, ApiResponse &rsp);
     int getDevice(const ApiRequest &req, ApiResponse &rsp);


### PR DESCRIPTION
The new `deleteDevice(extAddress)` function has following side effects:

- Delete all related Sensor and LightNodes;
- Delete device related entries from database;
- Send ZDP Mgmt_Leave_req to device to remove it from network (also sleeping end-devices).

Coming with v2.11.0 this can be invoked from the GUI via <key>Delete</key> key or node context menu.

![image](https://user-images.githubusercontent.com/383386/114106238-9d057e80-98ce-11eb-8b2a-fc9c52b467d8.png)

