### PR TITLE
Raise C++ version to C++14

### DIFF
--- a/de_web.pro
+++ b/de_web.pro
@@ -57,7 +57,7 @@ unix:!macx {
 TEMPLATE        = lib
 CONFIG         += plugin \
                += debug_and_release \
-               += c++11 \
+               += c++14 \
                -= qtquickcompiler
 
 QT             += network


### PR DESCRIPTION
Compared to C++11 it brings mainly some improvements for lambda `auto` deduction and `constexpr`.

Since we still support Raspbian Stretch C++17 isn't in reach until 2024.