### PR TITLE
Streamline attribute reporting config and align polling

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1797,7 +1797,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
                  bt.restNode->node()->nodeDescriptor().manufacturerCode() == VENDOR_XAL)
         {
             rq.minInterval = 5;
-            rq.maxInterval = 3600;
+            rq.maxInterval = 1200;
         }
         else if (manufacturerCode == VENDOR_IKEA)
         {
@@ -2534,9 +2534,9 @@ void DeRestPluginPrivate::checkLightBindingsForAttributeReporting(LightNode *lig
                     continue;
                 }
 
-                quint16 maxInterval = val.maxInterval > 0 && val.maxInterval < 65535 ? val.maxInterval : (10 * 60);
+                quint16 maxInterval = val.maxInterval > 0 && val.maxInterval < 65535 ? (val.maxInterval * 3 / 2) : (60 * 6);
 
-                if (val.timestampLastReport.isValid() && val.timestampLastReport.secsTo(now) < (maxInterval * 1.2))
+                if (val.timestampLastReport.isValid() && val.timestampLastReport.secsTo(now) < maxInterval)
                 {
                     bindingExists = true;
                     break;
@@ -3283,10 +3283,9 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
             }
         }
 
-        quint16 maxInterval = (val.maxInterval > 0) ? (val.maxInterval * 3 / 2) : (60 * 45);
+        quint16 maxInterval = val.maxInterval > 0 && val.maxInterval < 65535 ? (val.maxInterval * 3 / 2) : (60 * 15);
 
-        if (val.timestampLastReport.isValid() &&
-            val.timestampLastReport.secsTo(now) < maxInterval) // got update in timely manner
+        if (val.timestampLastReport.isValid() && val.timestampLastReport.secsTo(now) < maxInterval) // got update in timely manner
         {
             DBG_Printf(DBG_INFO_L2, "binding for attribute reporting of ep: 0x%02X cluster 0x%04X seems to be active\n", val.endpoint, *i);
             continue;

--- a/poll_manager.cpp
+++ b/poll_manager.cpp
@@ -510,11 +510,6 @@ void PollManager::pollTimerFired()
                                 NodeValue &val = restNode->getZclValue(clusterId, attrId);
                                 quint16 maxInterval = val.maxInterval > 0 && val.maxInterval < 65535 ? (val.maxInterval * 3 / 2) : reportWaitTime;
 
-                                // This lines mean IKEA is never polled (or just once)?
-                                if (lightNode && lightNode->manufacturerCode() == VENDOR_IKEA && val.timestamp.isValid())
-                                {
-                                    fresh++; // rely on reporting for ikea lights
-                                }
                                 // This should truely compensates missing reports and poll at startup until a report comes in, prevents unnecessary polling
                                 else if (val.timestampLastReport.isValid() && val.timestampLastReport.secsTo(now) < maxInterval)
                                 {


### PR DESCRIPTION
This PR is intended to streamline the behavior in `checkLightBindingsForAttributeReporting()` and `checkSensorBindingsForAttributeReporting()` to check if the corresponding bindings exist and require attribute reporting.

For both functions, a grace time of `(val.maxInterval * 3 / 2)` is now given (the resources must have the `maxInterval` already set internally), so that basically 2 reports are allowed to have gone MIA before configuring the reporting again. Otherwise, a default value will be assumed (60 * 6 secs for lights, 60 * 15 secs for sensors (previously 60 * 45)).

All this also has been better aligned with the poll manager, which takes the same code as `checkLightBindingsForAttributeReporting()`. This should ensure light nodes get a proper fall back to polling, in case no reports come in after `(val.maxInterval * 3 / 2)`.

Some XAL related code has been removed as is seemed to be duplicate code, but required a slight amendment of the maxInterval value (now 1200 instead of 3600) to reflect the initial polling conditions.

All in all, this should prevent some unnecessary requests to set up reporting configration and prevent unnecessary polling of light nodes based on a larger maxInterval of the previous allowed 6 minutes (e.g. light nodes maxInterval is configured to 10 mins, but with the old code, it always gets polled after 6 mins. New code would allow for up to 2 missed maxInterval 10 mins reports before falling back to polling).