### PR TITLE
Improve lights and sensor deletion

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -4858,11 +4858,11 @@ void DeRestPluginPrivate::saveDb()
 
             i->setNeedSaveDatabase(false);
 
-            /*
             if (i->state() == LightNode::StateDeleted)
             {
                 // delete LightNode from db (if exist)
-                QString sql = QString("DELETE FROM nodes WHERE id='%1'").arg(i->id());
+                QString sql = QString("DELETE FROM nodes WHERE mac='%1'").arg(i->uniqueId());
+                sql.append(QString("; DELETE FROM devices WHERE mac = '%1'").arg(generateUniqueId(i->address().ext(), 0, 0)));
 
                 errmsg = NULL;
                 rc = sqlite3_exec(db, sql.toUtf8().constData(), NULL, NULL, &errmsg);
@@ -4878,9 +4878,6 @@ void DeRestPluginPrivate::saveDb()
 
                 continue;
             }
-            */
-
-            QString lightState((i->state() == LightNode::StateDeleted ? "deleted" : "normal"));
 
             std::vector<GroupInfo>::const_iterator gi = i->groups().begin();
             std::vector<GroupInfo>::const_iterator gend = i->groups().end();
@@ -4894,6 +4891,7 @@ void DeRestPluginPrivate::saveDb()
                 }
             }
 
+            const QString lightState = "normal";
             QString ritems = i->resourceItemsToJson();
             QString sql = QString(QLatin1String("REPLACE INTO nodes (id, state, mac, name, groups, endpoint, modelid, manufacturername, swbuildid, ritems) VALUES ('%1', '%2', '%3', '%4', '%5', '%6', '%7', '%8', '%9', '%10')"))
                     .arg(i->id())
@@ -4906,11 +4904,6 @@ void DeRestPluginPrivate::saveDb()
                     .arg(i->manufacturer())
                     .arg(i->swBuildId())
                     .arg(ritems);
-
-            if (i->state() == LightNode::StateDeleted)
-            {
-                sql.append(QString("; DELETE FROM devices WHERE mac = '%1'").arg(generateUniqueId(i->address().ext(), 0, 0)));
-            }
 
             DBG_Printf(DBG_INFO_L2, "DB sql exec %s\n", qPrintable(sql));
             errmsg = NULL;
@@ -5288,11 +5281,11 @@ void DeRestPluginPrivate::saveDb()
 
             i->setNeedSaveDatabase(false);
 
-            /*
             if (i->deletedState() == Sensor::StateDeleted)
             {
                 // delete sensor from db (if exist)
-                QString sql = QString("DELETE FROM sensors WHERE sid='%1'").arg(sid);
+                QString sql = QString("DELETE FROM sensors WHERE uniqueid='%1'").arg(i->uniqueId());
+                sql.append(QString("; DELETE FROM devices WHERE mac = '%1'").arg(generateUniqueId(i->address().ext(), 0, 0)));
 
                 errmsg = NULL;
                 rc = sqlite3_exec(db, sql.toUtf8().constData(), NULL, NULL, &errmsg);
@@ -5308,11 +5301,11 @@ void DeRestPluginPrivate::saveDb()
 
                 continue;
             }
-            */
+
             QString stateJSON = i->stateToString();
             QString configJSON = i->configToString();
             QString fingerPrintJSON = i->fingerPrint().toString();
-            QString deletedState((i->deletedState() == Sensor::StateDeleted ? "deleted" : "normal"));
+            const QString deletedState = "normal";
 
             QString sql = QString(QLatin1String("REPLACE INTO sensors (sid, name, type, modelid, manufacturername, uniqueid, swversion, state, config, fingerprint, deletedState, mode) VALUES ('%1', '%2', '%3', '%4', '%5', '%6', '%7', '%8', '%9', '%10', '%11', '%12')"))
                     .arg(i->id())
@@ -5327,11 +5320,6 @@ void DeRestPluginPrivate::saveDb()
                     .arg(fingerPrintJSON)
                     .arg(deletedState)
                     .arg(QString::number(i->mode()));
-
-            if (i->deletedState() == Sensor::StateDeleted)
-            {
-                sql.append(QString("; DELETE FROM devices WHERE mac = '%1'").arg(generateUniqueId(i->address().ext(), 0, 0)));
-            }
 
             DBG_Printf(DBG_INFO_L2, "DB sql exec %s\n", qPrintable(sql));
             errmsg = NULL;

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2606,7 +2606,11 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
             else if (!(searchLightsState == SearchLightsActive || permitJoinFlag))
             {
                 // don't add new light node when search is not active
-                return;
+                // except Node Descriptor is known
+                if (node->nodeDescriptor().isNull())
+                {
+                    return;
+                }
             }
 
             openDb();

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2606,11 +2606,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
             else if (!(searchLightsState == SearchLightsActive || permitJoinFlag))
             {
                 // don't add new light node when search is not active
-                // except Node Descriptor is known
-                if (node->nodeDescriptor().isNull())
-                {
-                    return;
-                }
+                return;
             }
 
             openDb();


### PR DESCRIPTION
When deleting a light or sensor, don't store entries with state 'deleted' but purge a device completely. 

Since deCONZ 2.10.4 **one** of the following conditions must be met to create a `deCONZ::Node`:
1. Permit Join is enabled and messages are received from an unknown node (Device Announce etc.);
2. A `device` table entry exists and a Node Descriptor can be retrieved from `device_descriptors` table or as fallback from older `session.default` file;
3. A not deleted entry in `nodes` or `sensors` tables exist.

This is done in order to prevent reappearance of deleted nodes.

-------

~~This PR also enables creation of light nodes even if light search isn't running anymore, but minimal required data has already been queried from the device (Node Descriptor and Simple Descriptors).~~

~~The reason this came up is that in larger installations where >100 devices where joined successfully and appeared in the GUI some of these weren't processed completely and light resources where missing albeit the device was already joined during a *Permit Join* enabled phase.~~
