### PR TITLE
Fix ResourceItem setValue(QString) for DataTypeTime

### DIFF
--- a/resource.cpp
+++ b/resource.cpp
@@ -651,6 +651,11 @@ bool ResourceItem::setValue(const QString &val)
 {
     if (m_str)
     {
+        if (m_rid->type == DataTypeTime)
+        {
+            return setValue(QVariant(val));
+        }
+
         m_lastSet = QDateTime::currentDateTime();
         m_flags |= FlagNeedPushSet;
         if (*m_str != val)
@@ -736,10 +741,14 @@ bool ResourceItem::setValue(const QVariant &val)
     {
         if (val.type() == QVariant::String)
         {
-            QDateTime dt = QDateTime::fromString(val.toString(), QLatin1String("yyyy-MM-ddTHH:mm:ss"));
+            const auto str = val.toString();
+            auto fmt = str.contains('.') ? QLatin1String("yyyy-MM-ddTHH:mm:ss.zzz")
+                                         : QLatin1String("yyyy-MM-ddTHH:mm:ss");
+            auto dt = QDateTime::fromString(str, fmt);
 
             if (dt.isValid())
             {
+                dt.setTimeSpec(Qt::UTC);
                 m_lastSet = now;
                 m_numPrev = m_num;
                 m_flags |= FlagNeedPushSet;


### PR DESCRIPTION
When not using the `setValue(QVariant)` or `setValue(qint64)` the internal `m_num` wasn't updated.

This PR properly sets the `m_num` value. Allowed input formats are "yyyy-MM-ddTHH:mm:ss.zzz" and "yyyy-MM-ddTHH:mm:ss", the time is assumed to be in UTC.

Note that regardless of the input format `toString()` and `toVariant().toString()` always return UTC format "yyyy-MM-ddTHH:mm:ss.zzz".

The issue was detected in a work in progress unit test https://github.com/manup/deconz-rest-plugin/blob/device_descriptions/tests/101-resourceitem-dt-time.cpp