### PR TITLE
Add utils module; move generateUniqueId() into it

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -10,6 +10,7 @@
 
 #include "de_web_plugin.h"
 #include "de_web_plugin_private.h"
+#include "utils/utils.h"
 
 #define MAX_ACTIVE_BINDING_TASKS 3
 

--- a/database.cpp
+++ b/database.cpp
@@ -18,6 +18,7 @@
 #include "gateway.h"
 #include "json.h"
 #include "product_match.h"
+#include "utils/utils.h"
 
 static const char *pragmaUserVersion = "PRAGMA user_version";
 static const char *pragmaPageCount = "PRAGMA page_count";
@@ -4029,7 +4030,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
 
         if (extAddr != 0)
         {
-            QString uid = d->generateUniqueId(extAddr, endpoint, clusterId);
+            const QString uid = generateUniqueId(extAddr, endpoint, clusterId);
 
             if (uid != sensor.uniqueId())
             {

--- a/de_web.pro
+++ b/de_web.pro
@@ -124,6 +124,7 @@ HEADERS  = bindings.h \
            scene.h \
            sensor.h \
            tuya.h \
+           utils/utils.h \
            websocket_server.h
 
 SOURCES  = air_quality.cpp \
@@ -189,6 +190,7 @@ SOURCES  = air_quality.cpp \
            appliances.cpp \
            reset_device.cpp \
            rest_userparameter.cpp \
+           utils/utils.cpp \
            zcl_tasks.cpp \
            window_covering.cpp \
            websocket_server.cpp \

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -44,6 +44,7 @@
 #include "product_match.h"
 #include "rest_devices.h"
 #include "read_files.h"
+#include "utils/utils.h"
 #ifdef ARCH_ARM
   #include <unistd.h>
   #include <sys/reboot.h>
@@ -18920,51 +18921,6 @@ uint8_t DeRestPluginPrivate::endpoint()
     }
 
     return 1;
-}
-
-QString DeRestPluginPrivate::generateUniqueId(quint64 extAddress, quint8 endpoint, quint16 clusterId)
-{
-    union _a
-    {
-        quint8 bytes[8];
-        quint64 mac;
-    } a;
-    a.mac = extAddress;
-    int ret = -1;
-    char buf[64];
-
-    if (clusterId != 0 && endpoint != 0xf2)
-    {
-        ret = snprintf(buf, sizeof(buf), "%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x-%02x-%04x",
-                    a.bytes[7], a.bytes[6], a.bytes[5], a.bytes[4],
-                    a.bytes[3], a.bytes[2], a.bytes[1], a.bytes[0],
-                    endpoint, clusterId);
-
-    }
-    else if (endpoint != 0)
-    {
-        ret = snprintf(buf, sizeof(buf), "%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x-%02x",
-                    a.bytes[7], a.bytes[6], a.bytes[5], a.bytes[4],
-                    a.bytes[3], a.bytes[2], a.bytes[1], a.bytes[0],
-                    endpoint);
-    }
-    else
-    {
-        ret = snprintf(buf, sizeof(buf), "%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x",
-                    a.bytes[7], a.bytes[6], a.bytes[5], a.bytes[4],
-                    a.bytes[3], a.bytes[2], a.bytes[1], a.bytes[0]);
-    }
-    Q_ASSERT(ret > 0);
-    Q_ASSERT(static_cast<size_t>(ret) < sizeof(buf));
-
-    if (ret < 0 || static_cast<size_t>(ret) >= sizeof(buf))
-    {
-        DBG_Printf(DBG_ERROR, "failed to generate uuid, buffer too small\n");
-        Q_ASSERT(0);
-        return QString();
-    }
-
-    return QString::fromLatin1(buf);
 }
 
 /*! Returns the name of this plugin.

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1492,7 +1492,6 @@ public:
     void pushClientForClose(QTcpSocket *sock, int closeTimeout, const QHttpRequestHeader &hdr);
 
     uint8_t endpoint();
-    QString generateUniqueId(quint64 extAddress, quint8 endpoint, quint16 clusterId);
 
     // Task interface
     bool addTask(const TaskItem &task);

--- a/rest_devices.cpp
+++ b/rest_devices.cpp
@@ -17,6 +17,7 @@
 #include "de_web_plugin_private.h"
 #include "json.h"
 #include "rest_devices.h"
+#include "utils/utils.h"
 
 RestDevices::RestDevices(QObject *parent) :
     QObject(parent)
@@ -137,7 +138,7 @@ bool RestDevices::deleteDevice(quint64 extAddr)
     }
 
     // delete device entry, regardless if REST resources exists
-    plugin->deleteDeviceDb(plugin->generateUniqueId(extAddr, 0, 0));
+    plugin->deleteDeviceDb(generateUniqueId(extAddr, 0, 0));
 
     return count > 0;
 }

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -18,6 +18,7 @@
 #include "de_web_plugin_private.h"
 #include "json.h"
 #include "product_match.h"
+#include "utils/utils.h"
 
 /*! Sensors REST API broker.
     \param req - request data

--- a/utils/utils.cpp
+++ b/utils/utils.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ */
+
+#include <deconz/dbg_trace.h>
+#include "utils.h"
+
+/*! Generates a new uniqueid in various formats based on the input parameters.
+
+    extAddress           endpoint  cluster    result
+
+    0x1a22334455667788   0x00      0x0000     1a:22:33:44:55:66:77:88
+    0x1a22334455667788   0x01      0x0000     1a:22:33:44:55:66:77:88-01
+    0x1a22334455667788   0x01      0x0500     1a:22:33:44:55:66:77:88-01-0500
+    0x1a22334455667788   0xf2      0x0000     1a:22:33:44:55:66:77:88-f2
+
+    special ZGP endpoint (0xf2) case with cluster ignored
+
+    0x1a22334455667788   0xf2      0x0500     1a:22:33:44:55:66:77:88-f2
+
+    \param extAddress - MAC address part
+    \param endpoint - Endpoint part, ignored if 0
+    \param clusterId - ClusterId part, ignored if 0 or endpoint is 0xf2
+ */
+QString generateUniqueId(quint64 extAddress, quint8 endpoint, quint16 clusterId)
+{
+    union _a
+    {
+        quint8 bytes[8];
+        quint64 mac;
+    } a;
+    a.mac = extAddress;
+    int ret = -1;
+    char buf[64];
+
+    if (clusterId != 0 && endpoint != 0xf2)
+    {
+        ret = snprintf(buf, sizeof(buf), "%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x-%02x-%04x",
+                    a.bytes[7], a.bytes[6], a.bytes[5], a.bytes[4],
+                    a.bytes[3], a.bytes[2], a.bytes[1], a.bytes[0],
+                    endpoint, clusterId);
+
+    }
+    else if (endpoint != 0)
+    {
+        ret = snprintf(buf, sizeof(buf), "%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x-%02x",
+                    a.bytes[7], a.bytes[6], a.bytes[5], a.bytes[4],
+                    a.bytes[3], a.bytes[2], a.bytes[1], a.bytes[0],
+                    endpoint);
+    }
+    else
+    {
+        ret = snprintf(buf, sizeof(buf), "%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x",
+                    a.bytes[7], a.bytes[6], a.bytes[5], a.bytes[4],
+                    a.bytes[3], a.bytes[2], a.bytes[1], a.bytes[0]);
+    }
+    Q_ASSERT(ret > 0);
+    Q_ASSERT(static_cast<size_t>(ret) < sizeof(buf));
+
+    if (ret < 0 || static_cast<size_t>(ret) >= sizeof(buf))
+    {
+        DBG_Printf(DBG_ERROR, "failed to generate uuid, buffer too small\n");
+        Q_ASSERT(0);
+        return QString();
+    }
+
+    return QString::fromLatin1(buf);
+}
+

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2021 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ */
+
+#ifndef UTILS_H
+#define UTILS_H
+
+#include <QString>
+
+QString generateUniqueId(quint64 extAddress, quint8 endpoint, quint16 clusterId);
+
+#endif // UTILS_H


### PR DESCRIPTION
Since the function doesn't use any members of plugin it can be free standing. And other modules which use it don't need to depend on plugin.

Nothing fancy just removing dependency on plugin.