### PR TITLE
Fix SEGV on button press without deCONZ::Node available

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4853,8 +4853,9 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                     ResourceItem *item = sensor->item(RStateButtonEvent);
                     if (item)
                     {
-                        if (sensor->node()->nodeDescriptor().manufacturerCode() == VENDOR_PHILIPS ||
-                            sensor->node()->nodeDescriptor().manufacturerCode() == VENDOR_IKEA)
+                        if (sensor->node() &&
+                            (sensor->node()->nodeDescriptor().manufacturerCode() == VENDOR_PHILIPS ||
+                             sensor->node()->nodeDescriptor().manufacturerCode() == VENDOR_IKEA))
                         {
                         }
                         else if (item->toNumber() == buttonMap.button && ind.dstAddressMode() == deCONZ::ApsGroupAddress)


### PR DESCRIPTION
Access to `sensor->node()` wasn't checked for nullptr and could crash when a button was pressed for a sensor which doesn't have the node set.

- SEGV since v2.11.0  PR: https://github.com/dresden-elektronik/deconz-rest-plugin/pull/4627
- Related issue: https://github.com/dresden-elektronik/deconz-rest-plugin/issues/4766