### PR TITLE
Improve sendConfigureReportingRequest() performance

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -862,10 +862,23 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
     const QDateTime now = QDateTime::currentDateTime();
     ConfigureReportingRequest rq;
 
-    LightNode *lightNode = dynamic_cast<LightNode *>(bt.restNode);
-    const quint16 manufacturerCode = lightNode ? lightNode->manufacturerCode() : 0;
+    const LightNode *lightNode = dynamic_cast<LightNode *>(bt.restNode);
+    Sensor *sensor = dynamic_cast<Sensor *>(bt.restNode);
 
-    if (bt.binding.clusterId == BOSCH_AIR_QUALITY_CLUSTER_ID && bt.restNode->node()->nodeDescriptor().manufacturerCode() == VENDOR_BOSCH2)
+    const Resource *r = [lightNode, sensor]() -> const Resource* {
+        if (lightNode) return lightNode;
+        else           return sensor;
+    }();
+
+    if (!r || !r->item(RAttrModelId))
+    {
+        return false;
+    }
+
+    const QString modelId = r->item(RAttrModelId)->toString();
+    const quint16 manufacturerCode = bt.restNode->node()->nodeDescriptor().manufacturerCode();
+
+    if (bt.binding.clusterId == BOSCH_AIR_QUALITY_CLUSTER_ID && manufacturerCode == VENDOR_BOSCH2)
     {
         return false; // nothing todo
     }
@@ -891,8 +904,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             processed++;
         }
 
-        const Sensor *sensor = static_cast<Sensor *>(bt.restNode);
-        if (sensor && sensor->modelId().startsWith(QLatin1String("SML00"))) // Hue motion sensor
+        if (modelId.startsWith(QLatin1String("SML00"))) // Hue motion sensor
         {
             if (bt.restNode->getZclValue(bt.binding.clusterId, 0x0030, bt.binding.srcEndpoint).clusterId != bt.binding.clusterId)
             {
@@ -917,9 +929,9 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
     else if (bt.binding.clusterId == IAS_ZONE_CLUSTER_ID)
     {
         // zone status reporting only supported by some devices
-        if (bt.restNode->node()->nodeDescriptor().manufacturerCode() != VENDOR_CENTRALITE &&
-            bt.restNode->node()->nodeDescriptor().manufacturerCode() != VENDOR_C2DF &&
-            bt.restNode->node()->nodeDescriptor().manufacturerCode() != VENDOR_SAMJIN)
+        if (manufacturerCode != VENDOR_CENTRALITE &&
+            manufacturerCode != VENDOR_C2DF &&
+            manufacturerCode != VENDOR_SAMJIN)
         {
             return false;
         }
@@ -932,9 +944,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             bt.restNode->setZclValue(NodeValue::UpdateInvalid, bt.binding.srcEndpoint, bt.binding.clusterId, IAS_ZONE_CLUSTER_ATTR_ZONE_STATUS_ID, dummy);
         }
 
-        const Sensor *sensor = dynamic_cast<Sensor *>(bt.restNode);
-
-        if (sensor->type() == QLatin1String("ZHAOpenClose") && sensor->modelId().startsWith(QLatin1String("multi")))
+        if (sensor && sensor->type() == QLatin1String("ZHAOpenClose") && modelId.startsWith(QLatin1String("multi")))
         {
             // Only configure periodic reports, as events are already sent though zone status change notification commands
             rq.minInterval = 300;
@@ -961,13 +971,11 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
     }
     else if (bt.binding.clusterId == ILLUMINANCE_MEASUREMENT_CLUSTER_ID)
     {
-        Sensor *sensor = dynamic_cast<Sensor *>(bt.restNode);
-
         rq.dataType = deCONZ::Zcl16BitUint;
         rq.attributeId = 0x0000;         // measured value
 
-        if (sensor && (sensor->modelId().startsWith(QLatin1String("MOSZB-1")) ||            // Develco motion sensor
-                       sensor->modelId().startsWith(QLatin1String("MotionSensor51AU"))))    // Aurora (Develco) motion sensor
+        if (modelId.startsWith(QLatin1String("MOSZB-1")) ||           // Develco motion sensor
+            modelId.startsWith(QLatin1String("MotionSensor51AU")))    // Aurora (Develco) motion sensor
         {
             rq.minInterval = 0;
             rq.maxInterval = 600;
@@ -983,19 +991,17 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
     }
     else if (bt.binding.clusterId == TEMPERATURE_MEASUREMENT_CLUSTER_ID)
     {
-        Sensor *sensor = dynamic_cast<Sensor *>(bt.restNode);
-
         rq.dataType = deCONZ::Zcl16BitInt;
         rq.attributeId = 0x0000;       // measured value
 
-        if (sensor && (sensor->modelId().startsWith(QLatin1String("AQSZB-1")) ||         // Develco air quality sensor
-                       sensor->modelId().startsWith(QLatin1String("SMSZB-1")) ||         // Develco smoke sensor
-                       sensor->modelId().startsWith(QLatin1String("HESZB-1")) ||         // Develco heat sensor
-                       sensor->modelId().startsWith(QLatin1String("MOSZB-1")) ||         // Develco motion sensor
-                       sensor->modelId().startsWith(QLatin1String("WISZB-1")) ||         // Develco window sensor
-                       sensor->modelId().startsWith(QLatin1String("FLSZB-1")) ||         // Develco water leak sensor
-                       sensor->modelId().startsWith(QLatin1String("ZHMS101")) ||         // Wattle (Develco) magnetic sensor
-                       sensor->modelId().startsWith(QLatin1String("MotionSensor51AU")))) // Aurora (Develco) motion sensor
+        if (modelId.startsWith(QLatin1String("AQSZB-1")) ||         // Develco air quality sensor
+            modelId.startsWith(QLatin1String("SMSZB-1")) ||         // Develco smoke sensor
+            modelId.startsWith(QLatin1String("HESZB-1")) ||         // Develco heat sensor
+            modelId.startsWith(QLatin1String("MOSZB-1")) ||         // Develco motion sensor
+            modelId.startsWith(QLatin1String("WISZB-1")) ||         // Develco window sensor
+            modelId.startsWith(QLatin1String("FLSZB-1")) ||         // Develco water leak sensor
+            modelId.startsWith(QLatin1String("ZHMS101")) ||         // Wattle (Develco) magnetic sensor
+            modelId.startsWith(QLatin1String("MotionSensor51AU")))  // Aurora (Develco) motion sensor
         {
             rq.minInterval = 60;           // according to technical manual
             rq.maxInterval = 600;          // according to technical manual
@@ -1012,9 +1018,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
     }
     else if (bt.binding.clusterId == THERMOSTAT_CLUSTER_ID)
     {
-        Sensor *sensor = dynamic_cast<Sensor *>(bt.restNode);
-
-        if (sensor && sensor->modelId().startsWith(QLatin1String("SPZB"))) // Eurotronic Spirit
+        if (modelId.startsWith(QLatin1String("SPZB"))) // Eurotronic Spirit
         {
             rq.dataType = deCONZ::Zcl16BitInt;
             rq.attributeId = 0x0000;        // Local Temperature
@@ -1062,7 +1066,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4}) || // Use OR because of manuf. specific attributes
                    sendConfigureReportingRequest(bt, {rq5, rq6});
         }
-        else if (sensor && sensor->modelId() == QLatin1String("Thermostat")) // eCozy
+        else if (modelId == QLatin1String("Thermostat")) // eCozy
         {
             rq.dataType = deCONZ::Zcl16BitInt;
             rq.attributeId = 0x0000;        // Local Temperature
@@ -1079,7 +1083,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
 
             return sendConfigureReportingRequest(bt, {rq, rq2});
         }
-        else if (sensor && sensor->modelId() == QLatin1String("Super TR")) // Elko Super TR
+        else if (modelId == QLatin1String("Super TR")) // Elko Super TR
         {
             rq.dataType = deCONZ::Zcl16BitInt;
             rq.attributeId = 0x0000;        // Local temperature
@@ -1121,7 +1125,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
 
             return sendConfigureReportingRequest(bt, {rq, rq2, rq4, rq5, rq6, rq7});
         }
-        else if (sensor && sensor->modelId() == QLatin1String("SORB")) // Stelpro Orleans Fan
+        else if (modelId == QLatin1String("SORB")) // Stelpro Orleans Fan
         {
             rq.dataType = deCONZ::Zcl16BitInt;
             rq.attributeId = 0x0000;         // Local Temperature
@@ -1152,7 +1156,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
 
             return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4});
         }
-        else if (sensor && sensor->modelId().startsWith(QLatin1String("STZB402"))) // Stelpro baseboard thermostat
+        else if (modelId.startsWith(QLatin1String("STZB402"))) // Stelpro baseboard thermostat
         {
             rq.dataType = deCONZ::Zcl16BitInt;
             rq.attributeId = 0x0000;         // Local Temperature
@@ -1176,7 +1180,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
 
             return sendConfigureReportingRequest(bt, {rq, rq2, rq3});
         }
-        else if (sensor && sensor->modelId() == QLatin1String("Zen-01")) // Zen
+        else if (modelId == QLatin1String("Zen-01")) // Zen
         {
             rq.dataType = deCONZ::Zcl16BitInt;
             rq.attributeId = 0x0000;        // Local Temperature
@@ -1214,9 +1218,9 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
 
             return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4, rq5});
         }
-        else if ((sensor && sensor->modelId().startsWith(QLatin1String("SLR2"))) || // Hive
-                 (sensor && sensor->modelId() == QLatin1String("SLR1b")) ||         // Hive
-                 (sensor && sensor->modelId().startsWith(QLatin1String("TH112"))))  // Sinope
+        else if (modelId.startsWith(QLatin1String("SLR2")) || // Hive
+                 modelId == QLatin1String("SLR1b") ||         // Hive
+                 modelId.startsWith(QLatin1String("TH112")))  // Sinope
         {
             rq.dataType = deCONZ::Zcl16BitInt;
             rq.attributeId = 0x0000;       // local temperature
@@ -1247,7 +1251,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
 
             return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4});
         }
-        else if (sensor && sensor->modelId().startsWith(QLatin1String("3157100"))) // Centralite Pearl
+        else if (modelId.startsWith(QLatin1String("3157100"))) // Centralite Pearl
         {
             rq.dataType = deCONZ::Zcl16BitInt;
             rq.attributeId = 0x0000;        // Local Temperature
@@ -1285,7 +1289,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
 
             return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4, rq5});
         }
-        else if (sensor && sensor->modelId() == QLatin1String("AC201")) // OWON AC201 Thermostat
+        else if (modelId == QLatin1String("AC201")) // OWON AC201 Thermostat
         {
             rq.dataType = deCONZ::Zcl16BitInt;
             rq.attributeId = 0x0000;         // Local Temperature
@@ -1323,7 +1327,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
 
             return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4, rq5});
         }
-        else if (sensor && sensor->modelId() == QLatin1String("PR412C")) // OWON PCT502 Thermostat
+        else if (modelId == QLatin1String("PR412C")) // OWON PCT502 Thermostat
         {
             rq.dataType = deCONZ::Zcl16BitInt;
             rq.attributeId = 0x0000;         // Local Temperature
@@ -1333,7 +1337,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
 
             return sendConfigureReportingRequest(bt, {rq});
         }
-        else if (sensor && sensor->modelId() == QLatin1String("iTRV")) // Drayton Wiser Radiator Thermostat
+        else if (modelId == QLatin1String("iTRV")) // Drayton Wiser Radiator Thermostat
         {
             rq.dataType = deCONZ::Zcl16BitInt;
             rq.attributeId = 0x0000;         // Local Temperature
@@ -1371,8 +1375,8 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
 
             return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4, rq5});
         }
-        else if ( (sensor && sensor->modelId() == QLatin1String("eTRV0100")) || // Danfoss Ally
-                  (sensor && sensor->modelId() == QLatin1String("TRV001")) )    // Hive TRV
+        else if (modelId == QLatin1String("eTRV0100") || // Danfoss Ally
+                 modelId == QLatin1String("TRV001"))     // Hive TRV
         {
             rq.dataType = deCONZ::Zcl16BitInt;
             rq.attributeId = 0x0000;       // local temperature
@@ -1413,12 +1417,12 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             return sendConfigureReportingRequest(bt, {rq, rq2, rq3}) || // Use OR because of manuf. specific attributes
                    sendConfigureReportingRequest(bt, {rq4, rq5});
         }
-        else if (sensor && (sensor->modelId() == QLatin1String("0x8020") || // Danfoss RT24V Display thermostat
-                            sensor->modelId() == QLatin1String("0x8021") || // Danfoss RT24V Display thermostat with floor sensor
-                            sensor->modelId() == QLatin1String("0x8030") || // Danfoss RTbattery Display thermostat
-                            sensor->modelId() == QLatin1String("0x8031") || // Danfoss RTbattery Display thermostat with infrared
-                            sensor->modelId() == QLatin1String("0x8034") || // Danfoss RTbattery Dial thermostat
-                            sensor->modelId() == QLatin1String("0x8035")))  // Danfoss RTbattery Dial thermostat with infrared
+        else if (sensor && (modelId == QLatin1String("0x8020") || // Danfoss RT24V Display thermostat
+                            modelId == QLatin1String("0x8021") || // Danfoss RT24V Display thermostat with floor sensor
+                            modelId == QLatin1String("0x8030") || // Danfoss RTbattery Display thermostat
+                            modelId == QLatin1String("0x8031") || // Danfoss RTbattery Display thermostat with infrared
+                            modelId == QLatin1String("0x8034") || // Danfoss RTbattery Dial thermostat
+                            modelId == QLatin1String("0x8035")))  // Danfoss RTbattery Dial thermostat with infrared
         {
             rq.dataType = deCONZ::Zcl16BitInt;
             rq.attributeId = 0x0000;         // Local temperature
@@ -1456,9 +1460,9 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq5.manufacturerCode = VENDOR_DANFOSS;
 
             return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4}) || // Use OR because of manuf. specific attributes
-            sendConfigureReportingRequest(bt, {rq5});
+                   sendConfigureReportingRequest(bt, {rq5});
         }
-        else if (sensor && sensor->modelId() == QLatin1String("902010/32")) // Bitron thermostat
+        else if (modelId == QLatin1String("902010/32")) // Bitron thermostat
         {
             rq.dataType = deCONZ::Zcl16BitInt;
             rq.attributeId = 0x0000;         // local temperature
@@ -1496,7 +1500,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
 
             return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4, rq5});
         }
-        else if (sensor && sensor->modelId().startsWith(QLatin1String("TH112"))) // Sinope Thermostat TH1123ZB & TH1124ZB
+        else if (modelId.startsWith(QLatin1String("TH112"))) // Sinope Thermostat TH1123ZB & TH1124ZB
         {
             rq.dataType = deCONZ::Zcl16BitInt;
             rq.attributeId = 0x0000;         // Local Temperature
@@ -1527,7 +1531,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
 
             return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4});
         }
-        else if (sensor && sensor->modelId() == QLatin1String("TH1300ZB")) // Sinope thermostat
+        else if (modelId == QLatin1String("TH1300ZB")) // Sinope thermostat
         {
             rq.dataType = deCONZ::Zcl16BitInt;
             rq.attributeId = 0x0000;       // local temperature
@@ -1558,7 +1562,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
 
             return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4});
         }
-        else if (sensor && sensor->modelId() == QLatin1String("ALCANTARA2 D1.00P1.01Z1.00")) // Alcantara 2 acova
+        else if (modelId == QLatin1String("ALCANTARA2 D1.00P1.01Z1.00")) // Alcantara 2 acova
         {
             rq.dataType = deCONZ::Zcl16BitInt;
             rq.attributeId = 0x0000;         // Local Temperature
@@ -1598,14 +1602,11 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq.reportableChange16bit = 10;
             return sendConfigureReportingRequest(bt, {rq});
         }
-
     }
     else if (bt.binding.clusterId == THERMOSTAT_UI_CONFIGURATION_CLUSTER_ID)
     {
-        Sensor *sensor = dynamic_cast<Sensor *>(bt.restNode);
-
-        if (sensor && (sensor->modelId() == QLatin1String("eTRV0100") || // Danfoss Ally
-                       sensor->modelId() == QLatin1String("TRV001")))    // Hive TRV
+        if (modelId == QLatin1String("eTRV0100") || // Danfoss Ally
+            modelId == QLatin1String("TRV001"))     // Hive TRV
         {
             rq.dataType = deCONZ::Zcl8BitEnum;
             rq.attributeId = 0x0001;       // Keypad Lockout
@@ -1624,12 +1625,12 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             return sendConfigureReportingRequest(bt, {rq}) || // Use OR because of manuf. specific attributes
                    sendConfigureReportingRequest(bt, {rq2});
         }
-        else if (sensor && (sensor->modelId() == QLatin1String("SORB") ||               // Stelpro Orleans Fan
-                            sensor->modelId() == QLatin1String("TH1300ZB") ||           // Sinope thermostat
-                            sensor->modelId() == QLatin1String("PR412C") ||             // Owon thermostat
-                            sensor->modelId() == QLatin1String("iTRV") ||               // Drayton Wiser Radiator Thermostat
-                            sensor->modelId().startsWith(QLatin1String("3157100")) ||   // Centralite pearl
-                            sensor->modelId().startsWith(QLatin1String("STZB402"))))    // Stelpro baseboard thermostat
+        else if (modelId == QLatin1String("SORB") ||               // Stelpro Orleans Fan
+                 modelId == QLatin1String("TH1300ZB") ||           // Sinope thermostat
+                 modelId == QLatin1String("PR412C") ||             // Owon thermostat
+                 modelId == QLatin1String("iTRV") ||               // Drayton Wiser Radiator Thermostat
+                 modelId.startsWith(QLatin1String("3157100")) ||   // Centralite pearl
+                 modelId.startsWith(QLatin1String("STZB402")))     // Stelpro baseboard thermostat
         {
             rq.dataType = deCONZ::Zcl8BitEnum;
             rq.attributeId = 0x0001;       // Keypad Lockout
@@ -1642,10 +1643,8 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
     }
     else if (bt.binding.clusterId == DIAGNOSTICS_CLUSTER_ID)
     {
-        Sensor *sensor = dynamic_cast<Sensor *>(bt.restNode);
-
-        if (sensor && (sensor->modelId() == QLatin1String("eTRV0100") || // Danfoss Ally
-                       sensor->modelId() == QLatin1String("TRV001")))    // Hive TRV
+        if (modelId == QLatin1String("eTRV0100") || // Danfoss Ally
+            modelId == QLatin1String("TRV001"))     // Hive TRV
         {
             rq.dataType = deCONZ::Zcl16BitBitMap;
             rq.attributeId = 0x4000;        // SW error code
@@ -1658,10 +1657,8 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
     }
     else if (bt.binding.clusterId == FAN_CONTROL_CLUSTER_ID)
     {
-        Sensor *sensor = dynamic_cast<Sensor *>(bt.restNode);
-
-        if (sensor && (sensor->modelId() == QLatin1String("AC201") ||               // OWON AC201 Thermostat
-                       sensor->modelId().startsWith(QLatin1String("3157100"))))     // Centralite pearl
+        if (modelId == QLatin1String("AC201") ||            // OWON AC201 Thermostat
+            modelId.startsWith(QLatin1String("3157100")))   // Centralite pearl
         {
             rq.dataType = deCONZ::Zcl8BitEnum;
             rq.attributeId = 0x0000;        // Fan mode
@@ -1673,16 +1670,14 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
     }
     else if (bt.binding.clusterId == RELATIVE_HUMIDITY_CLUSTER_ID)
     {
-        Sensor *sensor = dynamic_cast<Sensor *>(bt.restNode);
-
         rq.dataType = deCONZ::Zcl16BitUint;
         rq.attributeId = 0x0000;       // measured value
         rq.minInterval = 10;
         rq.maxInterval = 300;
         rq.reportableChange16bit = 100; // resolution: 1%
 
-        if (sensor && (sensor->modelId().startsWith(QLatin1String("AQSZB-1")) ||   // Develco air quality sensor
-                       sensor->modelId().startsWith(QLatin1String("HMSZB-1"))))    // Develco temp/hum sensor
+        if (modelId.startsWith(QLatin1String("AQSZB-1")) ||  // Develco air quality sensor
+            modelId.startsWith(QLatin1String("HMSZB-1")))    // Develco temp/hum sensor
         {
             rq.minInterval = 60;
             rq.maxInterval = 600;
@@ -1709,76 +1704,74 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
     }
     else if (bt.binding.clusterId == POWER_CONFIGURATION_CLUSTER_ID)
     {
-        Sensor *sensor = dynamic_cast<Sensor *>(bt.restNode);
-
         // Thoses device use only Attribute 0x0000 for tension and 0x001 for frequency
-        if ((sensor->modelId() == QLatin1String("SLP2")) ||
-            (sensor->modelId() == QLatin1String("SLP2b")))
+        if (modelId == QLatin1String("SLP2") ||
+            modelId == QLatin1String("SLP2b"))
         {
             return false;
         }
 
         rq.dataType = deCONZ::Zcl8BitUint;
         rq.attributeId = 0x0021;   // battery percentage remaining
-        if (sensor && (sensor->modelId().startsWith(QLatin1String("SML00")) || // Hue motion sensor
-                       sensor->modelId().startsWith(QLatin1String("SPZB"))))   // Eurotronic Spirit
+        if (modelId.startsWith(QLatin1String("SML00")) || // Hue motion sensor
+            modelId.startsWith(QLatin1String("SPZB")))   // Eurotronic Spirit
         {
             rq.minInterval = 7200;       // value used by Hue bridge
             rq.maxInterval = 7200;       // value used by Hue bridge
             rq.reportableChange8bit = 0; // value used by Hue bridge
         }
-        else if (sensor && sensor->modelId().startsWith(QLatin1String("RWL02"))) // Hue dimmer switch
+        else if (modelId.startsWith(QLatin1String("RWL02"))) // Hue dimmer switch
         {
             rq.minInterval = 300;        // value used by Hue bridge
             rq.maxInterval = 300;        // value used by Hue bridge
             rq.reportableChange8bit = 0; // value used by Hue bridge
         }
-        else if (sensor && (sensor->modelId().startsWith(QLatin1String("ROM00")) || // Hue smart button
-                            sensor->modelId().startsWith(QLatin1String("RDM00")))) // Hue wall switch module
+        else if (modelId.startsWith(QLatin1String("ROM00")) || // Hue smart button
+                 modelId.startsWith(QLatin1String("RDM00")))   // Hue wall switch module
         {
             rq.minInterval = 900;        // value used by Hue bridge
             rq.maxInterval = 900;        // value used by Hue bridge
             rq.reportableChange8bit = 2; // value used by Hue bridge
         }
-        else if (sensor && sensor->modelId().startsWith(QLatin1String("Z3-1BRL"))) // Lutron Aurora Friends-of-Hue dimmer switch
+        else if (modelId.startsWith(QLatin1String("Z3-1BRL"))) // Lutron Aurora Friends-of-Hue dimmer switch
         {
             rq.minInterval = 900;        // value used by Hue bridge
             rq.maxInterval = 900;        // value used by Hue bridge
             rq.reportableChange8bit = 4; // value used by Hue bridge
         }
-        else if (sensor && (sensor->modelId() == QLatin1String("eTRV0100") || // Danfoss Ally
-                            sensor->modelId() == QLatin1String("TRV001") ||   // Hive TRV
-                            sensor->modelId() == QLatin1String("0x8020") ||   // Danfoss RT24V Display thermostat
-                            sensor->modelId() == QLatin1String("0x8021") ||   // Danfoss RT24V Display thermostat with floor sensor
-                            sensor->modelId() == QLatin1String("0x8030") ||   // Danfoss RTbattery Display thermostat
-                            sensor->modelId() == QLatin1String("0x8031") ||   // Danfoss RTbattery Display thermostat with infrared
-                            sensor->modelId() == QLatin1String("0x8034") ||   // Danfoss RTbattery Dial thermostat
-                            sensor->modelId() == QLatin1String("0x8035")))    // Danfoss RTbattery Dial thermostat with infrared
+        else if (modelId == QLatin1String("eTRV0100") || // Danfoss Ally
+                 modelId == QLatin1String("TRV001") ||   // Hive TRV
+                 modelId == QLatin1String("0x8020") ||   // Danfoss RT24V Display thermostat
+                 modelId == QLatin1String("0x8021") ||   // Danfoss RT24V Display thermostat with floor sensor
+                 modelId == QLatin1String("0x8030") ||   // Danfoss RTbattery Display thermostat
+                 modelId == QLatin1String("0x8031") ||   // Danfoss RTbattery Display thermostat with infrared
+                 modelId == QLatin1String("0x8034") ||   // Danfoss RTbattery Dial thermostat
+                 modelId == QLatin1String("0x8035"))     // Danfoss RTbattery Dial thermostat with infrared
         {
             rq.minInterval = 3600;         // Vendor defaults
             rq.maxInterval = 43200;        // Vendor defaults
             rq.reportableChange8bit = 2;   // Vendor defaults
         }
-        else if (sensor && (sensor->modelId().startsWith(QLatin1String("ED-1001")) || // EcoDim switches
-                            sensor->modelId().startsWith(QLatin1String("45127")) ||   // Namron switches
-                            sensor->modelId().startsWith(QLatin1String("S57003")) ||  // SLC switches
-                            sensor->modelId().startsWith(QLatin1String("FNB56-")) ||  // Feibit devices
-                            sensor->modelId().startsWith(QLatin1String("FB56-"))))    // Feibit devices
+        else if (modelId.startsWith(QLatin1String("ED-1001")) || // EcoDim switches
+                 modelId.startsWith(QLatin1String("45127")) ||   // Namron switches
+                 modelId.startsWith(QLatin1String("S57003")) ||  // SLC switches
+                 modelId.startsWith(QLatin1String("FNB56-")) ||  // Feibit devices
+                 modelId.startsWith(QLatin1String("FB56-")))     // Feibit devices
         {
             rq.minInterval = 3600;
             rq.maxInterval = 43200;
             rq.reportableChange8bit = 1;
         }
-        else if (sensor && (sensor->modelId() == QLatin1String("HG06323") || // LIDL
-                            sensor->modelId() == QLatin1String("lumi.sensor_magnet.agl02") || // Xiaomi Aqara T1 open/close sensor MCCGQ12LM
-                            sensor->modelId() == QLatin1String("lumi.flood.agl02")))          // Xiaomi Aqara T1 water leak sensor SJCGQ12LM
+        else if (modelId == QLatin1String("HG06323") || // LIDL
+                 modelId == QLatin1String("lumi.sensor_magnet.agl02") || // Xiaomi Aqara T1 open/close sensor MCCGQ12LM
+                 modelId == QLatin1String("lumi.flood.agl02"))           // Xiaomi Aqara T1 water leak sensor SJCGQ12LM
         {
             rq.minInterval = 7200;
             rq.maxInterval = 7200;
             rq.reportableChange8bit = 1;
         }
         else if (sensor && (sensor->manufacturer().startsWith(QLatin1String("Climax")) ||
-                            sensor->modelId().startsWith(QLatin1String("902010/23"))))
+                            modelId.startsWith(QLatin1String("902010/23"))))
         {
             rq.attributeId = 0x0035; // battery alarm mask
             rq.dataType = deCONZ::Zcl8BitBitMap;
@@ -1786,52 +1779,52 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq.maxInterval = 1800;
             rq.reportableChange8bit = 0xFF;
         }
-        else if (sensor && (sensor->modelId() == QLatin1String("Motion Sensor-A") ||
-                            sensor->modelId() == QLatin1String("tagv4") ||
-                            sensor->modelId() == QLatin1String("motionv4") ||
-                            sensor->modelId() == QLatin1String("moisturev4") ||
-                            sensor->modelId() == QLatin1String("multiv4") ||
-                            sensor->modelId() == QLatin1String("RFDL-ZB-MS") ||
-                            sensor->modelId() == QLatin1String("SZ-DWS04") ||
-                            sensor->modelId() == QLatin1String("Zen-01") ||
-                            sensor->modelId() == QLatin1String("Bell") ||
-                            sensor->modelId() == QLatin1String("ISW-ZPR1-WP13") ||
-                            sensor->modelId() == QLatin1String("SLT2") ||
-                            sensor->modelId() == QLatin1String("TS0202") || // Tuya sensor
-                            sensor->modelId() == QLatin1String("3AFE14010402000D") || // Konke presence sensor
-                            sensor->modelId() == QLatin1String("3AFE28010402000D") || // Konke presence sensor
-                            sensor->modelId().startsWith(QLatin1String("GZ-PIR02")) ||          // Sercomm motion sensor
-                            sensor->modelId().startsWith(QLatin1String("SZ-WTD02N_CAR")) ||     // Sercomm water sensor
-                            sensor->modelId().startsWith(QLatin1String("3300")) ||          // Centralite contatc sensor
-                            sensor->modelId().startsWith(QLatin1String("3315")) ||
-                            sensor->modelId().startsWith(QLatin1String("3157100")) ||
-                            sensor->modelId().startsWith(QLatin1String("4655BC0"))))
+        else if (modelId == QLatin1String("Motion Sensor-A") ||
+                 modelId == QLatin1String("tagv4") ||
+                 modelId == QLatin1String("motionv4") ||
+                 modelId == QLatin1String("moisturev4") ||
+                 modelId == QLatin1String("multiv4") ||
+                 modelId == QLatin1String("RFDL-ZB-MS") ||
+                 modelId == QLatin1String("SZ-DWS04") ||
+                 modelId == QLatin1String("Zen-01") ||
+                 modelId == QLatin1String("Bell") ||
+                 modelId == QLatin1String("ISW-ZPR1-WP13") ||
+                 modelId == QLatin1String("SLT2") ||
+                 modelId == QLatin1String("TS0202") || // Tuya sensor
+                 modelId == QLatin1String("3AFE14010402000D") || // Konke presence sensor
+                 modelId == QLatin1String("3AFE28010402000D") || // Konke presence sensor
+                 modelId.startsWith(QLatin1String("GZ-PIR02")) ||          // Sercomm motion sensor
+                 modelId.startsWith(QLatin1String("SZ-WTD02N_CAR")) ||     // Sercomm water sensor
+                 modelId.startsWith(QLatin1String("3300")) ||          // Centralite contatc sensor
+                 modelId.startsWith(QLatin1String("3315")) ||
+                 modelId.startsWith(QLatin1String("3157100")) ||
+                 modelId.startsWith(QLatin1String("4655BC0")))
         {
             rq.attributeId = 0x0020;   // battery voltage
             rq.minInterval = 3600;
             rq.maxInterval = 3600;
             rq.reportableChange8bit = 0;
         }
-        else if (sensor && (sensor->modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
-                            sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
-                            sensor->modelId().startsWith(QLatin1String("Switch 4x-LIGHTIFY")) || // Osram 4 button remote
-                            sensor->modelId().startsWith(QLatin1String("Switch-LIGHTIFY"))) ) // Osram 4 button remote
+        else if (modelId.startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
+                 modelId.startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
+                 modelId.startsWith(QLatin1String("Switch 4x-LIGHTIFY")) ||    // Osram 4 button remote
+                 modelId.startsWith(QLatin1String("Switch-LIGHTIFY")))         // Osram 4 button remote
         {
             rq.attributeId = 0x0020;
             rq.minInterval = 21600;
             rq.maxInterval = 21600;
             rq.reportableChange8bit = 0;
         }
-        else if (sensor && (sensor->modelId().startsWith(QLatin1String("AQSZB-1")) ||         // Develco air quality sensor
-                            sensor->modelId().startsWith(QLatin1String("SMSZB-1")) ||         // Develco smoke sensor
-                            sensor->modelId().startsWith(QLatin1String("HESZB-1")) ||         // Develco heat sensor
-                            sensor->modelId().startsWith(QLatin1String("MOSZB-1")) ||         // Develco motion sensor
-                            sensor->modelId().startsWith(QLatin1String("WISZB-1")) ||         // Develco window sensor
-                            sensor->modelId().startsWith(QLatin1String("FLSZB-1")) ||         // Develco water leak sensor
-                            sensor->modelId().startsWith(QLatin1String("SIRZB-1")) ||         // Develco siren
-                            sensor->modelId().startsWith(QLatin1String("HMSZB-1")) ||         // Develco temp/hum sensor
-                            sensor->modelId().startsWith(QLatin1String("ZHMS101")) ||         // Wattle (Develco) magnetic sensor
-                            sensor->modelId().startsWith(QLatin1String("MotionSensor51AU")))) // Aurora (Develco) motion sensor
+        else if (modelId.startsWith(QLatin1String("AQSZB-1")) ||         // Develco air quality sensor
+                 modelId.startsWith(QLatin1String("SMSZB-1")) ||         // Develco smoke sensor
+                 modelId.startsWith(QLatin1String("HESZB-1")) ||         // Develco heat sensor
+                 modelId.startsWith(QLatin1String("MOSZB-1")) ||         // Develco motion sensor
+                 modelId.startsWith(QLatin1String("WISZB-1")) ||         // Develco window sensor
+                 modelId.startsWith(QLatin1String("FLSZB-1")) ||         // Develco water leak sensor
+                 modelId.startsWith(QLatin1String("SIRZB-1")) ||         // Develco siren
+                 modelId.startsWith(QLatin1String("HMSZB-1")) ||         // Develco temp/hum sensor
+                 modelId.startsWith(QLatin1String("ZHMS101")) ||         // Wattle (Develco) magnetic sensor
+                 modelId.startsWith(QLatin1String("MotionSensor51AU")))  // Aurora (Develco) motion sensor
         {
             rq.attributeId = 0x0020;   // battery voltage
             rq.minInterval = 300;      // according to technical manual
@@ -1880,7 +1873,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq.maxInterval = 180;
         }
         else if (existDevicesWithVendorCodeForMacPrefix(bt.restNode->address(), VENDOR_XAL) ||
-                 bt.restNode->node()->nodeDescriptor().manufacturerCode() == VENDOR_XAL)
+                 manufacturerCode == VENDOR_XAL)
         {
             rq.minInterval = 5;
             rq.maxInterval = 3600;
@@ -1901,27 +1894,25 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
     }
     else if (bt.binding.clusterId == METERING_CLUSTER_ID)
     {
-        Sensor *sensor = dynamic_cast<Sensor *>(bt.restNode);
-
         rq.dataType = deCONZ::Zcl48BitUint;
         rq.attributeId = 0x0000; // Curent Summation Delivered
         rq.minInterval = 1;
         rq.maxInterval = 300;
-        if (sensor && (sensor->modelId() == QLatin1String("SmartPlug") ||               // Heiman
-                       sensor->modelId() == QLatin1String("SKHMP30-I1") ||              // GS smart plug
-                       sensor->modelId().startsWith(QLatin1String("E13-")) ||           // Sengled PAR38 Bulbs
-                       sensor->modelId().startsWith(QLatin1String("Z01-A19")) ||        // Sengled smart led
-                       sensor->modelId() == QLatin1String("Connected socket outlet")))  // Niko smart socket
+        if (modelId == QLatin1String("SmartPlug") ||               // Heiman
+            modelId == QLatin1String("SKHMP30-I1") ||              // GS smart plug
+            modelId.startsWith(QLatin1String("E13-")) ||           // Sengled PAR38 Bulbs
+            modelId.startsWith(QLatin1String("Z01-A19")) ||        // Sengled smart led
+            modelId == QLatin1String("Connected socket outlet"))   // Niko smart socket
         {
             rq.reportableChange48bit = 10; // 0.001 kWh (1 Wh)
         }
-        else if (sensor && (sensor->modelId() == QLatin1String("SZ-ESW01-AU"))) // Sercomm / Telstra smart plug
+        else if (modelId == QLatin1String("SZ-ESW01-AU")) // Sercomm / Telstra smart plug
         {
             rq.reportableChange48bit = 1000; // 0.001 kWh (1 Wh)
         }
-        else if (sensor && (sensor->modelId().startsWith(QLatin1String("ROB_200")) ||            // ROBB Smarrt micro dimmer
-                            sensor->modelId().startsWith(QLatin1String("Micro Smart Dimmer")) || // Sunricher Micro Smart Dimmer
-                            sensor->modelId().startsWith(QLatin1String("SPW35Z"))))              // RT-RK OBLO SPW35ZD0 smart plug
+        else if (modelId.startsWith(QLatin1String("ROB_200")) ||            // ROBB Smarrt micro dimmer
+                 modelId.startsWith(QLatin1String("Micro Smart Dimmer")) || // Sunricher Micro Smart Dimmer
+                 modelId.startsWith(QLatin1String("SPW35Z")))               // RT-RK OBLO SPW35ZD0 smart plug
         {
             rq.reportableChange48bit = 3600; // 0.001 kWh (1 Wh)
         }
@@ -1935,15 +1926,15 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq2.attributeId = 0x0400; // Instantaneous Demand
         rq2.minInterval = 1;
         rq2.maxInterval = 300;
-        if (sensor && (sensor->modelId() == QLatin1String("SmartPlug") ||        // Heiman
-                       sensor->modelId() == QLatin1String("902010/25") ||        // Bitron
-                       sensor->modelId() == QLatin1String("SKHMP30-I1") ||       // GS smart plug
-                       sensor->modelId().startsWith(QLatin1String("Z01-A19")) || // Sengled smart led
-                       sensor->modelId() == QLatin1String("160-01")))            // Plugwise smart plug
+        if (modelId == QLatin1String("SmartPlug") ||        // Heiman
+            modelId == QLatin1String("902010/25") ||        // Bitron
+            modelId == QLatin1String("SKHMP30-I1") ||       // GS smart plug
+            modelId.startsWith(QLatin1String("Z01-A19")) || // Sengled smart led
+            modelId == QLatin1String("160-01"))             // Plugwise smart plug
         {
             rq2.reportableChange24bit = 10; // 1 W
         }
-        else if (sensor && (sensor->modelId() == QLatin1String("SZ-ESW01-AU"))) // Sercomm / Telstra smart plug
+        else if (modelId == QLatin1String("SZ-ESW01-AU")) // Sercomm / Telstra smart plug
         {
             rq2.reportableChange24bit = 1000; // 1 W
         }
@@ -1956,21 +1947,19 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
     }
     else if (bt.binding.clusterId == ELECTRICAL_MEASUREMENT_CLUSTER_ID)
     {
-        Sensor *sensor = dynamic_cast<Sensor *>(bt.restNode);
-
         rq.dataType = deCONZ::Zcl16BitInt;
         rq.attributeId = 0x050B; // Active power
         rq.minInterval = 1;
         rq.maxInterval = 300;
-        if (sensor && (sensor->modelId() == QLatin1String("SmartPlug") ||   // Heiman
-                       sensor->modelId() == QLatin1String("SKHMP30-I1") ||  // GS smart plug
-                       sensor->modelId() == QLatin1String("SZ-ESW01-AU") || // Sercomm / Telstra smart plug
-                       sensor->modelId() == QLatin1String("Connected socket outlet") || // Niko smart socket
-                       sensor->modelId().startsWith(QLatin1String("ROB_200")) || // ROBB Smarrt micro dimmer
-                       sensor->modelId().startsWith(QLatin1String("Micro Smart Dimmer")) || // Sunricher Micro Smart Dimmer
-                       sensor->modelId().startsWith(QLatin1String("lumi.plug.maeu")) || // Xiaomi Aqara ZB3.0 smart plug
-                       sensor->modelId().startsWith(QLatin1String("lumi.switch.n0agl1")) || // Xiaomi Aqara Single Switch Module T1 (With Neutral)
-                       sensor->modelId().startsWith(QLatin1String("lumi.switch.b1naus01")))) // Xiaomi ZB3.0 Smart Wall Switch
+        if (modelId == QLatin1String("SmartPlug") ||                   // Heiman
+            modelId == QLatin1String("SKHMP30-I1") ||                  // GS smart plug
+            modelId == QLatin1String("SZ-ESW01-AU") ||                 // Sercomm / Telstra smart plug
+            modelId == QLatin1String("Connected socket outlet") ||     // Niko smart socket
+            modelId.startsWith(QLatin1String("ROB_200")) ||            // ROBB Smarrt micro dimmer
+            modelId.startsWith(QLatin1String("Micro Smart Dimmer")) || // Sunricher Micro Smart Dimmer
+            modelId.startsWith(QLatin1String("lumi.plug.maeu")) ||     // Xiaomi Aqara ZB3.0 smart plug
+            modelId.startsWith(QLatin1String("lumi.switch.n0agl1")) || // Xiaomi Aqara Single Switch Module T1 (With Neutral)
+            modelId.startsWith(QLatin1String("lumi.switch.b1naus01"))) // Xiaomi ZB3.0 Smart Wall Switch
         {
             rq.reportableChange16bit = 10; // 1 W
         }
@@ -1984,23 +1973,23 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq2.attributeId = 0x0505; // RMS Voltage
         rq2.minInterval = 1;
         rq2.maxInterval = 300;
-        if (sensor && (sensor->modelId() == QLatin1String("SmartPlug") ||           // Heiman
-                       sensor->modelId() == QLatin1String("PoP") ||                 // Apex Smart Plug
-                       sensor->modelId() == QLatin1String("SKHMP30-I1") ||          // GS smart plug
-                       sensor->modelId() == QLatin1String("SMRZB-1") ||             // Develco smart cable
-                       sensor->modelId() == QLatin1String("Smart16ARelay51AU") ||   // Aurora (Develco) smart plug
-                       sensor->modelId().startsWith(QLatin1String("SPLZB-1"))))     // Develco smart plug
+        if (modelId == QLatin1String("SmartPlug") ||           // Heiman
+            modelId == QLatin1String("PoP") ||                 // Apex Smart Plug
+            modelId == QLatin1String("SKHMP30-I1") ||          // GS smart plug
+            modelId == QLatin1String("SMRZB-1") ||             // Develco smart cable
+            modelId == QLatin1String("Smart16ARelay51AU") ||   // Aurora (Develco) smart plug
+            modelId.startsWith(QLatin1String("SPLZB-1")))      // Develco smart plug
         {
             rq2.reportableChange16bit = 100; // 1 V
         }
-        else if (sensor && sensor->modelId() == QLatin1String("SZ-ESW01-AU")) // Sercomm / Telstra smart plug
+        else if (modelId == QLatin1String("SZ-ESW01-AU")) // Sercomm / Telstra smart plug
         {
             rq2.reportableChange16bit = 125; // 1 V
         }
-        else if (sensor && (sensor->modelId().startsWith(QLatin1String("ROB_200")) || // ROBB Smarrt micro dimmer
-                            sensor->modelId().startsWith(QLatin1String("Micro Smart Dimmer")) || // Sunricher Micro Smart Dimmer
-                            sensor->modelId() == QLatin1String("Connected socket outlet") || // Niko smart socket
-                            sensor->modelId().startsWith(QLatin1String("TH112")))) // Sinope Thermostats
+        else if (modelId.startsWith(QLatin1String("ROB_200")) ||            // ROBB Smarrt micro dimmer
+                 modelId.startsWith(QLatin1String("Micro Smart Dimmer")) || // Sunricher Micro Smart Dimmer
+                 modelId == QLatin1String("Connected socket outlet") ||     // Niko smart socket
+                 modelId.startsWith(QLatin1String("TH112")))                // Sinope Thermostats
         {
             rq2.reportableChange16bit = 10; // 1 V
         }
@@ -2014,23 +2003,23 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq3.attributeId = 0x0508; // RMS Current
         rq3.minInterval = 1;
         rq3.maxInterval = 300;
-        if (sensor && (sensor->modelId() == QLatin1String("SP 120") ||                  // innr
-                       sensor->modelId() == QLatin1String("PoP") ||                     // Apex Smart Plug
-                       sensor->modelId() == QLatin1String("DoubleSocket50AU") ||        // Aurora
-                       sensor->modelId().startsWith(QLatin1String("SPLZB-1")) ||        // Develco smart plug
-                       sensor->modelId() == QLatin1String("Smart16ARelay51AU") ||       // Aurora (Develco) smart plug
-                       sensor->modelId() == QLatin1String("SZ-ESW01-AU") ||             // Sercomm / Telstra smart plug
-                       sensor->modelId() == QLatin1String("Connected socket outlet") || // Niko smart socket
-                       sensor->modelId() == QLatin1String("SMRZB-1") ||                 // Develco smart cable
-                       sensor->modelId() == QLatin1String("TS0121")))                   // Tuya / Blitzwolf
+        if (modelId == QLatin1String("SP 120") ||                  // innr
+            modelId == QLatin1String("PoP") ||                     // Apex Smart Plug
+            modelId == QLatin1String("DoubleSocket50AU") ||        // Aurora
+            modelId.startsWith(QLatin1String("SPLZB-1")) ||        // Develco smart plug
+            modelId == QLatin1String("Smart16ARelay51AU") ||       // Aurora (Develco) smart plug
+            modelId == QLatin1String("SZ-ESW01-AU") ||             // Sercomm / Telstra smart plug
+            modelId == QLatin1String("Connected socket outlet") || // Niko smart socket
+            modelId == QLatin1String("SMRZB-1") ||                 // Develco smart cable
+            modelId == QLatin1String("TS0121"))                    // Tuya / Blitzwolf
         {
             rq3.reportableChange16bit = 100; // 0.1 A
         }
-        else if (sensor && (sensor->modelId() == QLatin1String("SmartPlug") ||        // Heiman
-                            sensor->modelId().startsWith(QLatin1String("EMIZB-1")) || // Develco EMI
-                            sensor->modelId() == QLatin1String("SKHMP30-I1") ||       // GS smart plug
-                            sensor->modelId().startsWith(QLatin1String("SPW35Z")) ||  // RT-RK OBLO SPW35ZD0 smart plug
-                            sensor->modelId() == QLatin1String("TH1300ZB")))          // Sinope thermostat
+        else if (modelId == QLatin1String("SmartPlug") ||        // Heiman
+                 modelId.startsWith(QLatin1String("EMIZB-1")) || // Develco EMI
+                 modelId == QLatin1String("SKHMP30-I1") ||       // GS smart plug
+                 modelId.startsWith(QLatin1String("SPW35Z")) ||  // RT-RK OBLO SPW35ZD0 smart plug
+                 modelId == QLatin1String("TH1300ZB"))           // Sinope thermostat
         {
             rq3.reportableChange16bit = 10; // 0.1 A
         }
@@ -2039,7 +2028,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq3.reportableChange16bit = 1; // 0.1 A
         }
 
-        if (sensor && sensor->modelId() == QLatin1String("TH1300ZB"))
+        if (modelId == QLatin1String("TH1300ZB"))
         {
             ConfigureReportingRequest rq4;
             rq4.dataType = deCONZ::Zcl16BitUint;
@@ -2169,25 +2158,19 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
     }
     else if (bt.binding.clusterId == SAMJIN_CLUSTER_ID)
     {
-        Sensor *sensor = dynamic_cast<Sensor*>(bt.restNode);
-        if (!sensor)
-        {
-            return false;
-        }
-
         // based on https://github.com/SmartThingsCommunity/SmartThingsPublic/blob/master/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy
-        if (sensor->type() == QLatin1String("ZHAVibration"))
+        if (sensor && sensor->type() == QLatin1String("ZHAVibration"))
         {
-            const quint16 manufacturerCode = sensor->manufacturer() == QLatin1String("Samjin") ? VENDOR_SAMJIN
+            const quint16 manufacturerCode2 = sensor->manufacturer() == QLatin1String("Samjin") ? VENDOR_SAMJIN
                 : sensor->manufacturer() == QLatin1String("SmartThings") ? VENDOR_PHYSICAL : VENDOR_CENTRALITE;
-            const quint16 minInterval = manufacturerCode == VENDOR_SAMJIN ? 0 : 1;
+            const quint16 minInterval = manufacturerCode2 == VENDOR_SAMJIN ? 0 : 1;
 
             rq.dataType = deCONZ::Zcl8BitBitMap;
             rq.attributeId = 0x0010; // active
-            rq.minInterval = manufacturerCode == VENDOR_SAMJIN ? 0 : 10;
+            rq.minInterval = manufacturerCode2 == VENDOR_SAMJIN ? 0 : 10;
             rq.maxInterval = 3600;
             rq.reportableChange8bit = 0xFF;
-            rq.manufacturerCode = manufacturerCode;
+            rq.manufacturerCode = manufacturerCode2;
 
             ConfigureReportingRequest rq1;
             rq1.dataType = deCONZ::Zcl16BitInt;
@@ -2195,7 +2178,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq1.minInterval = minInterval;
             rq1.maxInterval = 3600;
             rq1.reportableChange16bit = 1;
-            rq1.manufacturerCode = manufacturerCode;
+            rq1.manufacturerCode = manufacturerCode2;
 
             ConfigureReportingRequest rq2;
             rq2.dataType = deCONZ::Zcl16BitInt;
@@ -2203,7 +2186,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq2.minInterval = minInterval;
             rq2.maxInterval = 3600;
             rq2.reportableChange16bit = 1;
-            rq2.manufacturerCode = manufacturerCode;
+            rq2.manufacturerCode = manufacturerCode2;
 
             ConfigureReportingRequest rq3;
             rq3.dataType = deCONZ::Zcl16BitInt;
@@ -2211,7 +2194,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq3.minInterval = minInterval;
             rq3.maxInterval = 3600;
             rq3.reportableChange16bit = 1;
-            rq3.manufacturerCode = manufacturerCode;
+            rq3.manufacturerCode = manufacturerCode2;
 
             return sendConfigureReportingRequest(bt, {rq, rq1, rq2, rq3});
         }
@@ -2257,14 +2240,9 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
 
         return sendConfigureReportingRequest(bt, {rq});
     }
-    else if (bt.binding.clusterId == BASIC_CLUSTER_ID) {
-        Sensor *sensor = dynamic_cast<Sensor*>(bt.restNode);
-        if (!sensor)
-        {
-            return false;
-        }
-
-        if (sensor->modelId().startsWith(QLatin1String("RDM00"))) // Hue wall switch module
+    else if (bt.binding.clusterId == BASIC_CLUSTER_ID && sensor)
+    {
+        if (modelId.startsWith(QLatin1String("RDM00"))) // Hue wall switch module
         {
             deCONZ::NumericUnion dummy;
             dummy.u64 = 0;
@@ -2295,7 +2273,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
 
             return sendConfigureReportingRequest(bt, {rq});
         }
-        else if (sensor->modelId().startsWith(QLatin1String("SML00")) && // Hue motion sensor
+        else if (modelId.startsWith(QLatin1String("SML00")) && // Hue motion sensor
                  sensor->type() == QLatin1String("ZHAPresence"))
         {
             deCONZ::NumericUnion dummy;
@@ -2347,12 +2325,10 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
     }
     else if (bt.binding.clusterId == VENDOR_CLUSTER_ID)
     {
-        Sensor *sensor = dynamic_cast<Sensor *>(bt.restNode);
-
-        if (sensor && (sensor->modelId().startsWith(QLatin1String("RWL02")) || // Hue dimmer switch
-                       sensor->modelId().startsWith(QLatin1String("ROM00")) || // Hue smart button
-                       sensor->modelId().startsWith(QLatin1String("RDM00")) || // Hue wall switch module
-                       sensor->modelId().startsWith(QLatin1String("Z3-1BRL")))) // Lutron Aurora Friends-of-Hue dimmer switch
+        if (sensor && (modelId.startsWith(QLatin1String("RWL02")) || // Hue dimmer switch
+                       modelId.startsWith(QLatin1String("ROM00")) || // Hue smart button
+                       modelId.startsWith(QLatin1String("RDM00")) || // Hue wall switch module
+                       modelId.startsWith(QLatin1String("Z3-1BRL")))) // Lutron Aurora Friends-of-Hue dimmer switch
         {
             deCONZ::NumericUnion val;
             val.u64 = 0;
@@ -2365,7 +2341,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
                 val2.maxInterval = 60 * 60 * 8; // prevent further check for 8 hours
             }
         }
-        else if (sensor && sensor->modelId() == QLatin1String("de_spect")) // dresden elektronik spectral sensor
+        else if (modelId == QLatin1String("de_spect")) // dresden elektronik spectral sensor
         {
             rq.dataType = deCONZ::Zcl8BitUint;
             rq.attributeId = 0x0000; // sensor enabled
@@ -2402,9 +2378,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
     }
     else if (bt.binding.clusterId == DEVELCO_AIR_QUALITY_CLUSTER_ID)
     {
-        Sensor *sensor = dynamic_cast<Sensor *>(bt.restNode);
-
-        if (sensor && sensor->modelId() == QLatin1String("AQSZB-110")) // Develco air quality sensor
+        if (modelId == QLatin1String("AQSZB-110")) // Develco air quality sensor
         {
             rq.dataType = deCONZ::Zcl16BitUint;
             rq.attributeId = 0x0000;       // Measured value


### PR DESCRIPTION
Calls like `sensor->modelId()` iterate over all `ResourceItem` and their descriptors to get the actual item.

This PR caches the `modelId` at the beginning of the function. Most redundant checks for sensor pointer where removed as well. Further the `manufacturerCode` from `bt.restNode->node()->nodeDescriptor().manufacturerCode()` is cached.