### PR TITLE
Fix IKEA KADRILJ and FYRTUR roller blind reporting

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2833,6 +2833,7 @@ void DeRestPluginPrivate::setLightNodeStaticCapabilities(LightNode *lightNode)
     }
 
     ResourceItem *item = nullptr;
+    const QString modelId = lightNode->modelId();
 
     if (lightNode->manufacturerCode() == VENDOR_LEDVANCE &&
             (lightNode->modelId() == QLatin1String("BR30 RGBW") ||
@@ -2920,6 +2921,15 @@ void DeRestPluginPrivate::setLightNodeStaticCapabilities(LightNode *lightNode)
         lightNode->addItem(DataTypeUInt16, RStateHue);
         lightNode->addItem(DataTypeUInt8, RStateSat);
         lightNode->addItem(DataTypeString, RStateEffect)->setValue(RStateEffectValues[R_EFFECT_NONE]);
+    }
+    else if (modelId == QLatin1String("KADRILJ roller blind"))
+    {
+        item = lightNode->addItem(DataTypeBool, RAttrSleeper);
+        if (item)
+        {
+            item->setValue(false);
+            item->setIsPublic(false);
+        }
     }
 }
 

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2922,7 +2922,8 @@ void DeRestPluginPrivate::setLightNodeStaticCapabilities(LightNode *lightNode)
         lightNode->addItem(DataTypeUInt8, RStateSat);
         lightNode->addItem(DataTypeString, RStateEffect)->setValue(RStateEffectValues[R_EFFECT_NONE]);
     }
-    else if (modelId == QLatin1String("KADRILJ roller blind"))
+    else if (modelId.startsWith(QLatin1String("KADRILJ")) ||
+             modelId.startsWith(QLatin1String("FYRTUR")))
     {
         item = lightNode->addItem(DataTypeBool, RAttrSleeper);
         if (item)

--- a/resource.cpp
+++ b/resource.cpp
@@ -33,6 +33,7 @@ const char *RAttrClass = "attr/class";
 const char *RAttrId = "attr/id";
 const char *RAttrUniqueId = "attr/uniqueid";
 const char *RAttrProductId = "attr/productid";
+const char *RAttrSleeper = "attr/sleeper";
 const char *RAttrSwVersion = "attr/swversion";
 const char *RAttrLastAnnounced = "attr/lastannounced";
 const char *RAttrLastSeen = "attr/lastseen";
@@ -220,6 +221,7 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RAttrId));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RAttrUniqueId));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RAttrProductId));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, RAttrSleeper));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, RAttrSwVersion));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeTime, RAttrLastAnnounced));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeTime, RAttrLastSeen));

--- a/resource.h
+++ b/resource.h
@@ -48,6 +48,7 @@ extern const char *RAttrClass;
 extern const char *RAttrId;
 extern const char *RAttrUniqueId;
 extern const char *RAttrProductId;
+extern const char *RAttrSleeper;
 extern const char *RAttrSwVersion;
 extern const char *RAttrLastAnnounced;
 extern const char *RAttrLastSeen;

--- a/window_covering.cpp
+++ b/window_covering.cpp
@@ -98,7 +98,7 @@ void DeRestPluginPrivate::handleWindowCoveringClusterIndication(const deCONZ::Ap
         return;
     }
 
-    deCONZ::NumericUnion numericValue;
+    deCONZ::NumericUnion numericValue{};
     quint16 attrid = 0x0000;
     quint8 attrTypeId = 0x00;
     quint8 attrValue = 0x00;
@@ -116,6 +116,8 @@ void DeRestPluginPrivate::handleWindowCoveringClusterIndication(const deCONZ::Ap
     {
         updateType = NodeValue::UpdateByZclReport;
     }
+
+    const QString modelId = lightNode->modelId();
 
     // Read ZCL reporting and ZCL Read Attributes Response
     if (updateType != NodeValue::UpdateInvalid)
@@ -163,15 +165,15 @@ void DeRestPluginPrivate::handleWindowCoveringClusterIndication(const deCONZ::Ap
 
                 quint8 lift = attrValue;
                 // Reverse value for somes curtains
-                if (lightNode->modelId().startsWith(QLatin1String("lumi.curtain")) ||
-                    lightNode->modelId() == QLatin1String("D10110") ||
-                    lightNode->modelId() == QLatin1String("Motor Controller"))
+                if (modelId.startsWith(QLatin1String("lumi.curtain")) ||
+                    modelId == QLatin1String("D10110") ||
+                    modelId == QLatin1String("Motor Controller"))
                 {
                     lift = 100 - lift;
                 }
                 // Reverse value for Legrand but only for old value
-                if ((lightNode->modelId() == QLatin1String("Shutter SW with level control")) ||
-                    (lightNode->modelId() == QLatin1String("Shutter switch with neutral")) )
+                else if (modelId == QLatin1String("Shutter SW with level control") ||
+                         modelId == QLatin1String("Shutter switch with neutral"))
                 {
                     bool bStatus = false;
                     uint nHex = lightNode->swBuildId().toUInt(&bStatus,16);
@@ -181,9 +183,9 @@ void DeRestPluginPrivate::handleWindowCoveringClusterIndication(const deCONZ::Ap
                     }
                 }
                 // Reverse for some tuya covering
-                if ((R_GetProductId(lightNode) == QLatin1String("11830304 Switch")) ||
-                    (R_GetProductId(lightNode) == QLatin1String("Zigbee curtain switch")) ||
-                    (R_GetProductId(lightNode) == QLatin1String("QS-Zigbee-C01 Module")) )
+                else if (R_GetProductId(lightNode) == QLatin1String("11830304 Switch") ||
+                         R_GetProductId(lightNode) == QLatin1String("Zigbee curtain switch") ||
+                         R_GetProductId(lightNode) == QLatin1String("QS-Zigbee-C01 Module"))
                 {
                     lift = 100 - lift;
                 }

--- a/window_covering.cpp
+++ b/window_covering.cpp
@@ -155,8 +155,6 @@ void DeRestPluginPrivate::handleWindowCoveringClusterIndication(const deCONZ::Ap
                     return;
             }
 
-            NodeValue::UpdateType updateType = NodeValue::UpdateByZclReport;
-
             if (attrid == 0x0008) // current CurrentPositionLiftPercentage 0-100
             {
                 // Update value in the GUI.


### PR DESCRIPTION
The reporting could stop when the device rejoins the network for various reasons like parent loss or transmission errors.

This PR:
- Marks KADRIL and FYRTUR roller blinds as light sleeper with the new non public `ResourceItem` "attr/sleeper" (borrowed from Device code);
- Support polling light sleeper *Window Covering* devices `state.lift` while reporting isn't setup;
- Fix window covering update by ZCL report / read attributes value (was always set to by report);
- Fix reconfiguration of window covering bindings and ZCL reporting.

Issue: https://github.com/dresden-elektronik/deconz-rest-plugin/issues/1121