### PR TITLE
Fix for missing Tradfri remote button events

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1126,7 +1126,13 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
                     }
                     else
                     {
-                        sensorNode = 0; // not supported
+                        sensorNode = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), ind.srcEndpoint());
+
+                        if (sensorNode)
+                        {
+                            DBG_Printf(DBG_INFO_L2, "[WARNING] - Missing cluster in sensor fingerprint: 0x%016llX - 0x%04X (%s), endpoint: 0x%02X, cluster: 0x%04X, payload: %s, zclSeq: %u\n",
+                                        ind.srcAddress().ext(), ind.srcAddress().nwk(), qPrintable(sensorNode->modelId()), ind.srcEndpoint(), ind.clusterId(), qPrintable(zclFrame.payload().toHex().toUpper()), zclFrame.sequenceNumber());
+                        }
                     }
                 }
             }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6006,6 +6006,12 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
             }
         }
 
+        // Add clusters used, but not exposed to sensors
+        if (modelId == QLatin1String("TRADFRI remote control"))
+        {
+            fpSwitch.outClusters.push_back(SCENE_CLUSTER_ID);
+        }
+
         if (!isDeviceSupported(node, modelId))
         {
             continue;

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6007,9 +6007,17 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
         }
 
         // Add clusters used, but not exposed to sensors
-        if (modelId == QLatin1String("TRADFRI remote control"))
+        if (modelId == QLatin1String("TRADFRI remote control") || modelId == QLatin1String("Remote Control N2"))
         {
             fpSwitch.outClusters.push_back(SCENE_CLUSTER_ID);
+        }
+        else if (modelId == QLatin1String("Adurolight_NCC"))
+        {
+            fpSwitch.outClusters.push_back(ADUROLIGHT_CLUSTER_ID);
+        }
+        else if (modelId == QLatin1String("E1E-G7F"))
+        {
+            fpSwitch.outClusters.push_back(SENGLED_CLUSTER_ID);
         }
 
         if (!isDeviceSupported(node, modelId))


### PR DESCRIPTION
This PR fixes the missing button events upon < and > press. Most likely, a handful of further devices is affected by this as well.

The root cause is that for the newer 2.X firmware, the device doesn't natively expose the _scene_ cluster (only used on APS layer), which is hence not considered in the sensor fingerprint. Further devices where a cluster is not hidden, but not included in the sensor fingerprint, could be affected as well. As a consequence, the newly inttroduced `getSensorNodeForAddressEndpointAndCluster()` cannot select the correct sensor. The subsequent code has a more or less appropriate fallback to select the fitting sensor, but gets discarded.