### PR TITLE
Fix : covering direction for some Tuya blind

### DIFF
--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1903,6 +1903,12 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
 
         if (cluster == TUYA_CLUSTER_ID)
         {
+            // Reverse side for open/close command
+            if (R_GetProductId(taskRef.lightNode) == QLatin1String("Tuya_COVD M515EGB"))
+            {
+                targetOpen = !targetOpen;
+            }
+
             if (targetOpen)
             {
                 ok = sendTuyaRequest(task, TaskTuyaRequest, DP_TYPE_ENUM, DP_IDENTIFIER_CONTROL, QByteArray("\x02", 1));

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1904,12 +1904,13 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
         if (cluster == TUYA_CLUSTER_ID)
         {
             // Reverse side for open/close command
+            bool targetOpen2 = targetOpen;
             if (R_GetProductId(taskRef.lightNode) == QLatin1String("Tuya_COVD M515EGB"))
             {
-                targetOpen = !targetOpen;
+                targetOpen2 = !targetOpen;
             }
 
-            if (targetOpen)
+            if (targetOpen2)
             {
                 ok = sendTuyaRequest(task, TaskTuyaRequest, DP_TYPE_ENUM, DP_IDENTIFIER_CONTROL, QByteArray("\x02", 1));
             }


### PR DESCRIPTION
Concern model :
-  _TZE200_xuzcvlku
-  _TZE200_nueqqe6k

The "bri"/"lift" command is working, the return too, but the command "open" alone have wrong direction side.
https://github.com/dresden-elektronik/deconz-rest-plugin/issues/4840