### PR TITLE
Raise short database save delay from 5 seconds to 1 minute

### DIFF
--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -478,7 +478,7 @@ using namespace deCONZ::literals;
 
 #define DB_HUGE_SAVE_DELAY  (60 * 60 * 1000) // 60 minutes
 #define DB_LONG_SAVE_DELAY  (15 * 60 * 1000) // 15 minutes
-#define DB_SHORT_SAVE_DELAY (5 *  1 * 1000) // 5 seconds
+#define DB_SHORT_SAVE_DELAY (1 *  60 * 1000) // 1 minute
 
 #define DB_CONNECTION_TTL (60 * 15) // 15 minutes
 


### PR DESCRIPTION
Writing to the SD card every 5 seconds due lights and sensor updates blocks the whole application way too often, sometimes for seconds.

Since the database is saved on clean deCONZ shutdown anyway the only drawback of the increased delay is the loss of 1 minute data in case of power failure.