### PR TITLE
Use QLatin1String for all HTTP header queries

### DIFF
--- a/authorisation.cpp
+++ b/authorisation.cpp
@@ -77,9 +77,9 @@ void DeRestPluginPrivate::initAuthentication()
  */
 bool DeRestPluginPrivate::allowedToCreateApikey(const ApiRequest &req, ApiResponse &rsp, QVariantMap &map)
 {
-    if (req.hdr.hasKey("Authorization"))
+    if (req.hdr.hasKey(QLatin1String("Authorization")))
     {
-        QStringList ls = req.hdr.value("Authorization").split(' ');
+        QStringList ls = req.hdr.value(QLatin1String("Authorization")).split(' ');
         if ((ls.size() > 1) && ls[0] == "Basic")
         {
             QString enc = encryptString(ls[1]);
@@ -163,9 +163,9 @@ void DeRestPluginPrivate::authorise(ApiRequest &req, ApiResponse &rsp)
             // fill in useragent string if not already exist
             if (i->useragent.isEmpty())
             {
-                if (req.hdr.hasKey("User-Agent"))
+                if (req.hdr.hasKey(QLatin1String("User-Agent")))
                 {
-                    i->useragent = req.hdr.value("User-Agent");
+                    i->useragent = req.hdr.value(QLatin1String("User-Agent"));
                     DBG_Printf(DBG_HTTP, "set useragent '%s' for apikey '%s'\n", qPrintable(i->useragent), qPrintable(i->apikey));
                 }
             }

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -1117,9 +1117,9 @@ int DeRestPluginPrivate::getFullState(const ApiRequest &req, ApiResponse &rsp)
     checkRfConnectState();
 
     // handle ETag
-    if (req.hdr.hasKey("If-None-Match"))
+    if (req.hdr.hasKey(QLatin1String("If-None-Match")))
     {
-        QString etag = req.hdr.value("If-None-Match");
+        QString etag = req.hdr.value(QLatin1String("If-None-Match"));
 
         if (gwConfigEtag == etag)
         {
@@ -1278,9 +1278,9 @@ int DeRestPluginPrivate::getConfig(const ApiRequest &req, ApiResponse &rsp)
     checkRfConnectState();
 
     // handle ETag
-    if (req.hdr.hasKey("If-None-Match"))
+    if (req.hdr.hasKey(QLatin1String("If-None-Match")))
     {
-        QString etag = req.hdr.value("If-None-Match");
+        QString etag = req.hdr.value(QLatin1String("If-None-Match"));
 
         if (gwConfigEtag == etag)
         {
@@ -1305,9 +1305,9 @@ int DeRestPluginPrivate::getBasicConfig(const ApiRequest &req, ApiResponse &rsp)
     checkRfConnectState();
 
     // handle ETag
-    if (req.hdr.hasKey("If-None-Match"))
+    if (req.hdr.hasKey(QLatin1String("If-None-Match")))
     {
-        QString etag = req.hdr.value("If-None-Match");
+        QString etag = req.hdr.value(QLatin1String("If-None-Match"));
 
         if (gwConfigEtag == etag)
         {
@@ -1319,9 +1319,9 @@ int DeRestPluginPrivate::getBasicConfig(const ApiRequest &req, ApiResponse &rsp)
     basicConfigToMap(req, rsp.map);
 
     // include devicename attribute in web based requests
-    if (!apsCtrl->getParameter(deCONZ::ParamDeviceName).isEmpty() && req.hdr.hasKey("User-Agent"))
+    if (!apsCtrl->getParameter(deCONZ::ParamDeviceName).isEmpty() && req.hdr.hasKey(QLatin1String("User-Agent")))
     {
-        const QString ua = req.hdr.value("User-Agent");
+        const QString ua = req.hdr.value(QLatin1String("User-Agent"));
         if (ua.startsWith(QLatin1String("Mozilla"))) // all browser UA start with Mozilla/5.0
         {
             rsp.map["devicename"] = apsCtrl->getParameter(deCONZ::ParamDeviceName);

--- a/rest_groups.cpp
+++ b/rest_groups.cpp
@@ -114,9 +114,9 @@ int DeRestPluginPrivate::getAllGroups(const ApiRequest &req, ApiResponse &rsp)
     rsp.httpStatus = HttpStatusOk;
 
     // handle ETag
-    if (req.hdr.hasKey("If-None-Match"))
+    if (req.hdr.hasKey(QLatin1String("If-None-Match")))
     {
-        QString etag = req.hdr.value("If-None-Match");
+        QString etag = req.hdr.value(QLatin1String("If-None-Match"));
 
         if (gwGroupsEtag == etag)
         {
@@ -384,9 +384,9 @@ int DeRestPluginPrivate::getGroupAttributes(const ApiRequest &req, ApiResponse &
     }
 
     // handle ETag
-    if (req.hdr.hasKey("If-None-Match"))
+    if (req.hdr.hasKey(QLatin1String("If-None-Match")))
     {
-        QString etag = req.hdr.value("If-None-Match");
+        QString etag = req.hdr.value(QLatin1String("If-None-Match"));
 
         if (group->etag == etag)
         {

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -107,9 +107,9 @@ int DeRestPluginPrivate::getAllLights(const ApiRequest &req, ApiResponse &rsp)
     rsp.httpStatus = HttpStatusOk;
 
     // handle ETag
-    if (req.hdr.hasKey("If-None-Match"))
+    if (req.hdr.hasKey(QLatin1String("If-None-Match")))
     {
-        QString etag = req.hdr.value("If-None-Match");
+        QString etag = req.hdr.value(QLatin1String("If-None-Match"));
 
         if (gwLightsEtag == etag)
         {
@@ -471,9 +471,9 @@ int DeRestPluginPrivate::getLightState(const ApiRequest &req, ApiResponse &rsp)
     }
 
     // handle ETag
-    if (req.hdr.hasKey("If-None-Match"))
+    if (req.hdr.hasKey(QLatin1String("If-None-Match")))
     {
-        QString etag = req.hdr.value("If-None-Match");
+        QString etag = req.hdr.value(QLatin1String("If-None-Match"));
 
         if (lightNode->etag == etag)
         {

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -108,9 +108,9 @@ int DeRestPluginPrivate::getAllSensors(const ApiRequest &req, ApiResponse &rsp)
     rsp.httpStatus = HttpStatusOk;
 
     // handle ETag
-    if (req.hdr.hasKey("If-None-Match"))
+    if (req.hdr.hasKey(QLatin1String("If-None-Match")))
     {
-        QString etag = req.hdr.value("If-None-Match");
+        QString etag = req.hdr.value(QLatin1String("If-None-Match"));
 
         if (gwSensorsEtag == etag)
         {
@@ -184,9 +184,9 @@ int DeRestPluginPrivate::getSensor(const ApiRequest &req, ApiResponse &rsp)
     }
 
     // handle ETag
-    if (req.hdr.hasKey("If-None-Match"))
+    if (req.hdr.hasKey(QLatin1String("If-None-Match")))
     {
-        QString etag = req.hdr.value("If-None-Match");
+        QString etag = req.hdr.value(QLatin1String("If-None-Match"));
 
         if (sensor->etag == etag)
         {


### PR DESCRIPTION
This is preparation for a refactored QHttpRequestHeader class which uses static strings wherever possible.

A call like `hasKey("If-None-Match")` implicitly creates a QString since the method expects a `const QString&`.  This leads to a operator new call in QString. Since we mostly just have static strings this can be avoided alltogether.