### PR TITLE
QHttpRequestHeader use QLatin1String methods

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -17631,7 +17631,7 @@ int DeRestPlugin::handleHttpRequest(const QHttpRequestHeader &hdr, QTcpSocket *s
 
     if (DBG_IsEnabled(DBG_HTTP))
     {
-        DBG_Printf(DBG_HTTP, "HTTP API %s %s - %s\n", qPrintable(hdr.method()), qPrintable(hdr.url().toString()), qPrintable(sock->peerAddress().toString()));
+        DBG_Printf(DBG_HTTP, "HTTP API %s %s - %s\n", qPrintable(hdr.method()), qPrintable(hdr.url()), qPrintable(sock->peerAddress().toString()));
     }
 
     if(hdr.hasKey(QLatin1String("Content-Type")) &&
@@ -17660,7 +17660,7 @@ int DeRestPlugin::handleHttpRequest(const QHttpRequestHeader &hdr, QTcpSocket *s
         }
     }
 
-    QStringList path = hdr.path().split(QLatin1String("/"), QString::SkipEmptyParts);
+    QStringList path = QString(hdr.path()).split(QLatin1String("/"), QString::SkipEmptyParts);
     ApiRequest req(hdr, path, sock, content);
     req.mode = d->gwHueMode ? ApiModeHue : ApiModeNormal;
 

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -337,7 +337,7 @@ bool DeRestPluginPrivate::lightToMap(const ApiRequest &req, const LightNode *lig
         {
             QVariantMap links;
             QVariantMap self;
-            self["href"] = QString("%1/%2").arg(req.hdr.url().path()).arg(lightNode->uniqueId());
+            self["href"] = QString("%1/%2").arg(req.hdr.path()).arg(lightNode->uniqueId());
             links["self"] = self;
             map["_links"] = links;
         }

--- a/rest_schedules.cpp
+++ b/rest_schedules.cpp
@@ -1351,7 +1351,7 @@ void DeRestPluginPrivate::scheduleTimerFired()
             }
 
             QHttpRequestHeader hdr(method, address);
-            QStringList path = hdr.path().split('/', QString::SkipEmptyParts);
+            QStringList path = QString(hdr.path()).split('/', QString::SkipEmptyParts);
 
             ApiRequest req(hdr, path, nullptr, content);
             ApiResponse rsp; // dummy


### PR DESCRIPTION
The upcoming version returns `QLatin1String` values instead `QString`. Note the path splitting in the plugin will be removed in near future, since this is already done by the new `QHttpRequestHeader` without the `QString` overhead.