### PR TITLE
Make Regulation SetPoint Offset usable as offset for Danfoss Ally

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -3709,7 +3709,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     // Supported with Danfoss firmware version 1.08
                     sensor.addItem(DataTypeBool, RConfigScheduleOn)->setValue(false);
                     sensor.addItem(DataTypeString, RConfigSchedule);
-                    sensor.addItem(DataTypeInt16, RConfigExternalTemperatureSensor);
+                    sensor.addItem(DataTypeInt16, RConfigExternalTemperatureSensor)->setValue(0);
                     sensor.addItem(DataTypeBool, RConfigExternalWindowOpen)->setValue(false);
                 }
                 else if (sensor.modelId() == QLatin1String("AC201")) // OWON AC201 Thermostat

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -7012,7 +7012,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                 // Supported with Danfoss firmware version 1.08
                 sensorNode.addItem(DataTypeBool, RConfigScheduleOn)->setValue(false);
                 sensorNode.addItem(DataTypeString, RConfigSchedule);
-                sensorNode.addItem(DataTypeInt16, RConfigExternalTemperatureSensor);
+                sensorNode.addItem(DataTypeInt16, RConfigExternalTemperatureSensor)->setValue(0);
                 sensorNode.addItem(DataTypeBool, RConfigExternalWindowOpen)->setValue(false);
             }
             else if (modelId == QLatin1String("AC201")) // OWON AC201 Thermostat

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1218,8 +1218,8 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                     }
                     else if (ok && (sensor->modelId() == QLatin1String("eTRV0100") || sensor->modelId() == QLatin1String("TRV001")))
                     {
-                        if      (offset <= -25) { offset = -25; }
-                        else if (offset >= 25)  { offset = 25; }
+                        if      (offset < -25) { offset = -25; }
+                        else if (offset > 25)  { offset = 25; }
                         
                         if (addTaskThermostatReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, VENDOR_DANFOSS, 0x404B, deCONZ::Zcl8BitInt, offset))
                         {
@@ -1235,8 +1235,8 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                     }
                     else if (ok)
                     {
-                        if      (offset <= -25) { offset = -25; }
-                        else if (offset >= 25)  { offset = 25; }
+                        if      (offset < -25) { offset = -25; }
+                        else if (offset > 25)  { offset = 25; }
                         
                         if (addTaskThermostatReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, 0, 0x0010, deCONZ::Zcl8BitInt, offset))
                         {

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1216,22 +1216,42 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                             return REQ_READY_SEND;
                         }
                     }
-                    else
+                    else if (ok && (sensor->modelId() == QLatin1String("eTRV0100") || sensor->modelId() == QLatin1String("TRV001")))
                     {
-                        if (ok && addTaskThermostatReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, 0, 0x0010, deCONZ::Zcl8BitInt, offset))
+                        if      (offset <= -25) { offset = -25; }
+                        else if (offset >= 25)  { offset = 25; }
+                        
+                        if (addTaskThermostatReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, VENDOR_DANFOSS, 0x404B, deCONZ::Zcl8BitInt, offset))
                         {
-                            rspItemState[QString("set %1").arg(rid.suffix)] = offset;
-                            rspItem["success"] = rspItemState;
+                            updated = true;
                         }
                         else
                         {
-                            rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/sensors/%1/%2").arg(id).arg(rid.suffix), QString("could not set attribute")));
+                            rsp.list.append(errorToMap(ERR_ACTION_ERROR, QString("/sensors/%1/config/%2").arg(id).arg(pi.key()),
+                                                       QString("Could not set attribute")));
+                            rsp.httpStatus = HttpStatusBadRequest;
+                            return REQ_READY_SEND;
+                        }
+                    }
+                    else if (ok)
+                    {
+                        if      (offset <= -25) { offset = -25; }
+                        else if (offset >= 25)  { offset = 25; }
+                        
+                        if (addTaskThermostatReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, 0, 0x0010, deCONZ::Zcl8BitInt, offset))
+                        {
+                            updated = true;
+                        }
+                        else
+                        {
+                            rsp.list.append(errorToMap(ERR_ACTION_ERROR, QString("/sensors/%1/config/%2").arg(id).arg(pi.key()),
+                                                       QString("Could not set attribute")));
                             rsp.httpStatus = HttpStatusBadRequest;
                             return REQ_READY_SEND;
                         }
                     }
                 }
-                if (rid.suffix == RConfigScheduleOn)
+                else if (rid.suffix == RConfigScheduleOn)
                 {
                     bool onoff = map[pi.key()].toBool();
                     bool ok = false;

--- a/thermostat.cpp
+++ b/thermostat.cpp
@@ -516,22 +516,22 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
                     sensor->modelId().startsWith(QLatin1String("AC201")))    // OWON
                 {
                     qint8 mode = attr.numericValue().s8;
-                    QString mode_set;
+                    QString modeSet;
 
-                    mode_set = QLatin1String("off");
-                    if ( mode == 0x01 ) { mode_set = QLatin1String("auto"); }
-                    else if ( mode == 0x03 ) { mode_set = QLatin1String("cool"); }
-                    else if ( mode == 0x04 ) { mode_set = QLatin1String("heat"); }
-                    else if ( mode == 0x05 ) { mode_set = QLatin1String("emergency heating"); }
-                    else if ( mode == 0x06 ) { mode_set = QLatin1String("precooling"); }
-                    else if ( mode == 0x07 ) { mode_set = QLatin1String("fan only"); }
-                    else if ( mode == 0x08 ) { mode_set = QLatin1String("dry"); }
-                    else if ( mode == 0x09 ) { mode_set = QLatin1String("sleep"); }
+                    if      (mode == 0x01) { modeSet = QLatin1String("auto"); }
+                    else if (mode == 0x03) { modeSet = QLatin1String("cool"); }
+                    else if (mode == 0x04) { modeSet = QLatin1String("heat"); }
+                    else if (mode == 0x05) { modeSet = QLatin1String("emergency heating"); }
+                    else if (mode == 0x06) { modeSet = QLatin1String("precooling"); }
+                    else if (mode == 0x07) { modeSet = QLatin1String("fan only"); }
+                    else if (mode == 0x08) { modeSet = QLatin1String("dry"); }
+                    else if (mode == 0x09) { modeSet = QLatin1String("sleep"); }
+                    else                   { modeSet = QLatin1String("off"); }
 
                     item = sensor->item(RConfigMode);
-                    if (item && !item->toString().isEmpty() && item->toString() != mode_set)
+                    if (item && !item->toString().isEmpty() && item->toString() != modeSet)
                     {
-                        item->setValue(mode_set);
+                        item->setValue(modeSet);
                         enqueueEvent(Event(RSensors, RConfigMode, sensor->id(), item));
                         configUpdated = true;
                     }
@@ -640,12 +640,12 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
                 qint8 mode = attr.numericValue().s8;
                 QString modeSet;
 
-                modeSet = QLatin1String("fully closed");
-                if      ( mode == 0x01 ) { modeSet = QLatin1String("fully closed"); }
-                else if ( mode == 0x02 ) { modeSet = QLatin1String("fully open"); }
-                else if ( mode == 0x03 ) { modeSet = QLatin1String("quarter open"); }
-                else if ( mode == 0x04 ) { modeSet = QLatin1String("half open"); }
-                else if ( mode == 0x05 ) { modeSet = QLatin1String("three quarters open"); }
+                if      (mode == 0x01) { modeSet = QLatin1String("fully closed"); }
+                else if (mode == 0x02) { modeSet = QLatin1String("fully open"); }
+                else if (mode == 0x03) { modeSet = QLatin1String("quarter open"); }
+                else if (mode == 0x04) { modeSet = QLatin1String("half open"); }
+                else if (mode == 0x05) { modeSet = QLatin1String("three quarters open"); }
+                else                   { modeSet = QLatin1String("fully closed"); }
 
                 item = sensor->item(RConfigSwingMode);
                 if (item && !item->toString().isEmpty() && item->toString() != modeSet)
@@ -664,17 +664,17 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
                 if (sensor->modelId().startsWith(QLatin1String("Super TR"))) // ELKO
                 {
                     quint8 mode = attr.numericValue().u8;
-                    QString mode_set;
+                    QString modeset;
 
-                    if ( mode == 0x00 ) { mode_set = QLatin1String("air sensor"); }
-                    else if ( mode == 0x01 ) { mode_set = QLatin1String("floor sensor"); }
-                    else if ( mode == 0x03 ) { mode_set = QLatin1String("floor protection"); }
+                    if      (mode == 0x00) { modeset = QLatin1String("air sensor"); }
+                    else if (mode == 0x01) { modeset = QLatin1String("floor sensor"); }
+                    else if (mode == 0x03) { modeset = QLatin1String("floor protection"); }
 
                     item = sensor->item(RConfigTemperatureMeasurement);
 
-                    if (item && item->toString() != mode_set)
+                    if (item && item->toString() != modeset)
                     {
-                        item->setValue(mode_set);
+                        item->setValue(modeset);
                         enqueueEvent(Event(RSensors, RConfigTemperatureMeasurement, sensor->id(), item));
                         configUpdated = true;
                     }
@@ -702,14 +702,14 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
                     }
 
                     // Set config/mode to have an adequate representation based on this attribute
-                    QString mode_set;
-                    if ( on == false ) { mode_set = QLatin1String("off"); }
-                    if ( on == true )  { mode_set = QLatin1String("heat"); }
+                    QString modeset;
+                    if (on == true)  { modeset = QLatin1String("heat"); }
+                    else             { modeset = QLatin1String("off"); }
 
                     item = sensor->item(RConfigMode);
-                    if (item && !item->toString().isEmpty() && item->toString() != mode_set)
+                    if (item && !item->toString().isEmpty() && item->toString() != modeset)
                     {
-                        item->setValue(mode_set);
+                        item->setValue(modeset);
                         enqueueEvent(Event(RSensors, RConfigMode, sensor->id(), item));
                         configUpdated = true;
                     }
@@ -746,6 +746,7 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
                 {
                     bool enabled = attr.numericValue().u8 > 0 ? true : false;
                     item = sensor->item(RConfigLocked);
+                    
                     if (item && item->toBool() != enabled)
                     {
                         item->setValue(enabled);
@@ -789,22 +790,22 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
                 else if (zclFrame.manufacturerCode() == VENDOR_DANFOSS)
                 {
                     quint8 windowmode = attr.numericValue().u8;
-                    QString windowmode_set;
+                    QString windowmodeSet;
 
-                    if      ( windowmode == 0x00 ) { windowmode_set = QLatin1String("Quarantine"); }
-                    else if ( windowmode == 0x01 ) { windowmode_set = QLatin1String("Closed"); }
-                    else if ( windowmode == 0x02 ) { windowmode_set = QLatin1String("Hold"); }
-                    else if ( windowmode == 0x03 ) { windowmode_set = QLatin1String("Open"); }
-                    else if ( windowmode == 0x04 ) { windowmode_set = QLatin1String("Open (external), closed (internal)"); }
+                    if      (windowmode == 0x00) { windowmodeSet = QLatin1String("Quarantine"); }
+                    else if (windowmode == 0x01) { windowmodeSet = QLatin1String("Closed"); }
+                    else if (windowmode == 0x02) { windowmodeSet = QLatin1String("Hold"); }
+                    else if (windowmode == 0x03) { windowmodeSet = QLatin1String("Open"); }
+                    else if (windowmode == 0x04) { windowmodeSet = QLatin1String("Open (external), closed (internal)"); }
 
                     item = sensor->item(RStateWindowOpen);
                     if (item && updateType == NodeValue::UpdateByZclReport)
                     {
                         stateUpdated = true;
                     }
-                    if (item && item->toString() != windowmode_set)
+                    if (item && item->toString() != windowmodeSet)
                     {
-                        item->setValue(windowmode_set);
+                        item->setValue(windowmodeSet);
                         enqueueEvent(Event(RSensors, RStateWindowOpen, sensor->id(), item));
                         stateUpdated = true;
                     }
@@ -818,7 +819,6 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
             {
                 if (zclFrame.manufacturerCode() == VENDOR_JENNIC)
                 {
-
                 }
             }
                 sensor->setZclValue(updateType, ind.srcEndpoint(), THERMOSTAT_CLUSTER_ID, attrId, attr.numericValue());
@@ -830,6 +830,7 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
                 {
                     qint16 heatSetpoint = attr.numericValue().s16;
                     item = sensor->item(RConfigHeatSetpoint);
+                    
                     if (item)
                     {
                         if (updateType == NodeValue::UpdateByZclReport)
@@ -851,6 +852,7 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
                 {
                     bool enabled = attr.numericValue().u8 > 0 ? true : false;
                     item = sensor->item(RConfigExternalWindowOpen);
+                    
                     if (item && item->toBool() != enabled)
                     {
                         item->setValue(enabled);

--- a/thermostat.cpp
+++ b/thermostat.cpp
@@ -436,8 +436,9 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
 
             case 0x0010: // Local Temperature Calibration (offset in 0.1 °C steps, from -2,5 °C to +2,5 °C)
             {
-                qint8 config = attr.numericValue().s8 * 10;
+                qint16 config = attr.numericValue().s8 * 10;
                 item = sensor->item(RConfigOffset);
+                
                 if (item && item->toNumber() != config)
                 {
                     item->setValue(config);
@@ -790,6 +791,7 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
                     quint8 windowmode = attr.numericValue().u8;
                     QString windowmode_set;
 
+                    if ( windowmode == 0x00 ) { windowmode_set = QString("Quarantine"); }
                     if ( windowmode == 0x01 ) { windowmode_set = QString("Closed"); }
                     if ( windowmode == 0x02 ) { windowmode_set = QString("Hold"); }
                     if ( windowmode == 0x03 ) { windowmode_set = QString("Open"); }
@@ -958,6 +960,21 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
                             configUpdated = true;
                         }
                     }
+                }
+                sensor->setZclValue(updateType, ind.srcEndpoint(), THERMOSTAT_CLUSTER_ID, attrId, attr.numericValue());
+            }
+                break;
+
+            case 0x404B: // Regulation SetPoint Offset (offset in 0.1 °C steps, from -2,5 °C to +2,5 °C)
+            {
+                qint16 config = attr.numericValue().s8 * 10;
+                item = sensor->item(RConfigOffset);
+
+                if (item && item->toNumber() != config)
+                {
+                    item->setValue(config);
+                    enqueueEvent(Event(RSensors, RConfigOffset, sensor->id(), item));
+                    configUpdated = true;
                 }
                 sensor->setZclValue(updateType, ind.srcEndpoint(), THERMOSTAT_CLUSTER_ID, attrId, attr.numericValue());
             }

--- a/thermostat.cpp
+++ b/thermostat.cpp
@@ -518,15 +518,15 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
                     qint8 mode = attr.numericValue().s8;
                     QString mode_set;
 
-                    mode_set = QString("off");
-                    if ( mode == 0x01 ) { mode_set = QString("auto"); }
-                    if ( mode == 0x03 ) { mode_set = QString("cool"); }
-                    if ( mode == 0x04 ) { mode_set = QString("heat"); }
-                    if ( mode == 0x05 ) { mode_set = QString("emergency heating"); }
-                    if ( mode == 0x06 ) { mode_set = QString("precooling"); }
-                    if ( mode == 0x07 ) { mode_set = QString("fan only"); }
-                    if ( mode == 0x08 ) { mode_set = QString("dry"); }
-                    if ( mode == 0x09 ) { mode_set = QString("sleep"); }
+                    mode_set = QLatin1String("off");
+                    if ( mode == 0x01 ) { mode_set = QLatin1String("auto"); }
+                    else if ( mode == 0x03 ) { mode_set = QLatin1String("cool"); }
+                    else if ( mode == 0x04 ) { mode_set = QLatin1String("heat"); }
+                    else if ( mode == 0x05 ) { mode_set = QLatin1String("emergency heating"); }
+                    else if ( mode == 0x06 ) { mode_set = QLatin1String("precooling"); }
+                    else if ( mode == 0x07 ) { mode_set = QLatin1String("fan only"); }
+                    else if ( mode == 0x08 ) { mode_set = QLatin1String("dry"); }
+                    else if ( mode == 0x09 ) { mode_set = QLatin1String("sleep"); }
 
                     item = sensor->item(RConfigMode);
                     if (item && !item->toString().isEmpty() && item->toString() != mode_set)
@@ -641,7 +641,7 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
                 QString modeSet;
 
                 modeSet = QLatin1String("fully closed");
-                if ( mode == 0x01 ) { modeSet = QLatin1String("fully closed"); }
+                if      ( mode == 0x01 ) { modeSet = QLatin1String("fully closed"); }
                 else if ( mode == 0x02 ) { modeSet = QLatin1String("fully open"); }
                 else if ( mode == 0x03 ) { modeSet = QLatin1String("quarter open"); }
                 else if ( mode == 0x04 ) { modeSet = QLatin1String("half open"); }
@@ -666,9 +666,9 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
                     quint8 mode = attr.numericValue().u8;
                     QString mode_set;
 
-                    if ( mode == 0x00 ) { mode_set = QString("air sensor"); }
-                    if ( mode == 0x01 ) { mode_set = QString("floor sensor"); }
-                    if ( mode == 0x03 ) { mode_set = QString("floor protection"); }
+                    if ( mode == 0x00 ) { mode_set = QLatin1String("air sensor"); }
+                    else if ( mode == 0x01 ) { mode_set = QLatin1String("floor sensor"); }
+                    else if ( mode == 0x03 ) { mode_set = QLatin1String("floor protection"); }
 
                     item = sensor->item(RConfigTemperatureMeasurement);
 
@@ -703,8 +703,8 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
 
                     // Set config/mode to have an adequate representation based on this attribute
                     QString mode_set;
-                    if ( on == false ) { mode_set = QString("off"); }
-                    if ( on == true ) { mode_set = QString("heat"); }
+                    if ( on == false ) { mode_set = QLatin1String("off"); }
+                    if ( on == true )  { mode_set = QLatin1String("heat"); }
 
                     item = sensor->item(RConfigMode);
                     if (item && !item->toString().isEmpty() && item->toString() != mode_set)
@@ -791,11 +791,11 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
                     quint8 windowmode = attr.numericValue().u8;
                     QString windowmode_set;
 
-                    if ( windowmode == 0x00 ) { windowmode_set = QString("Quarantine"); }
-                    if ( windowmode == 0x01 ) { windowmode_set = QString("Closed"); }
-                    if ( windowmode == 0x02 ) { windowmode_set = QString("Hold"); }
-                    if ( windowmode == 0x03 ) { windowmode_set = QString("Open"); }
-                    if ( windowmode == 0x04 ) { windowmode_set = QString("Open (external), closed (internal)"); }
+                    if      ( windowmode == 0x00 ) { windowmode_set = QLatin1String("Quarantine"); }
+                    else if ( windowmode == 0x01 ) { windowmode_set = QLatin1String("Closed"); }
+                    else if ( windowmode == 0x02 ) { windowmode_set = QLatin1String("Hold"); }
+                    else if ( windowmode == 0x03 ) { windowmode_set = QLatin1String("Open"); }
+                    else if ( windowmode == 0x04 ) { windowmode_set = QLatin1String("Open (external), closed (internal)"); }
 
                     item = sensor->item(RStateWindowOpen);
                     if (item && updateType == NodeValue::UpdateByZclReport)


### PR DESCRIPTION
This PR allows setting the manufacturer specific attribute 0x404B (Regulation SetPoint Offset) via the offset resource item exposed through REST API. It has an allowed range of +-2.5° C. Using it will basically make the thermostat over-/underheat accoding to the set value, thereby automatically adjusting the set heat setpoint.

Includes some further minor enhancements.