### PR TITLE
Update QList iterators and prevent copy of Simple Descriptor

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2578,8 +2578,8 @@ void DeRestPluginPrivate::checkLightBindingsForAttributeReporting(LightNode *lig
         return;
     }
 
-    QList<deCONZ::ZclCluster>::const_iterator i = lightNode->haEndpoint().inClusters().begin();
-    QList<deCONZ::ZclCluster>::const_iterator end = lightNode->haEndpoint().inClusters().end();
+    auto i = lightNode->haEndpoint().inClusters().begin();
+    const auto end = lightNode->haEndpoint().inClusters().end();
 
     int tasksAdded = 0;
     QDateTime now = QDateTime::currentDateTime();
@@ -3390,16 +3390,14 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         quint8 srcEndpoint = sensor->fingerPrint().endpoint;
 
         {  // some clusters might not be on fingerprint endpoint (power configuration), search in other simple descriptors
-            deCONZ::SimpleDescriptor *sd= sensor->node()->getSimpleDescriptor(srcEndpoint);
+            deCONZ::SimpleDescriptor *sd = sensor->node()->getSimpleDescriptor(srcEndpoint);
             if (!sd || !sd->cluster(*i, deCONZ::ServerCluster))
             {
-                for (int j = 0; j < sensor->node()->simpleDescriptors().size(); j++)
+                for (auto &sd2 : sensor->node()->simpleDescriptors())
                 {
-                    sd = &sensor->node()->simpleDescriptors()[j];
-
-                    if (sd && sd->cluster(*i, deCONZ::ServerCluster))
+                    if (sd2.cluster(*i, deCONZ::ServerCluster))
                     {
-                        srcEndpoint = sd->endpoint();
+                        srcEndpoint = sd2.endpoint();
                         break;
                     }
                 }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2088,7 +2088,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
     QString manufacturer;
 
     //Make 2 fakes device for tuya switches
-    if (node->nodeDescriptor().manufacturerCode() == VENDOR_EMBER && !node->simpleDescriptors().isEmpty())
+    if (node->nodeDescriptor().manufacturerCode() == VENDOR_EMBER && !node->simpleDescriptors().empty())
     {
         const deCONZ::SimpleDescriptor *sd = &node->simpleDescriptors()[0];
         bool hasColorCluster = false;
@@ -2099,7 +2099,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
         )
         {
 
-            for (int c = 0; c < sd->inClusters().size(); c++)
+            for (size_t c = 0; c < sd->inClusters().size(); c++)
             {
                 if (sd->inClusters()[c].id() == TUYA_CLUSTER_ID) { hasTuyaCluster = true; }
                 if (sd->inClusters()[c].id() == COLOR_CLUSTER_ID) { hasColorCluster = true; }
@@ -2129,14 +2129,14 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
                 //remove useless cluster
                 if (false)
                 {
-					QList<deCONZ::ZclCluster> &cl = sd1.inClusters();
+                    auto &cl = sd1.inClusters();
 					cl.clear();
 
 					for (const deCONZ::ZclCluster &cl2 : sd2.inClusters())
 					{
 						if (cl2.id() == TUYA_CLUSTER_ID)
 						{
-							cl.append(cl2);
+                            cl.push_back(cl2);
 						}
 					}
 			    }
@@ -2151,8 +2151,8 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
         }
     }
 
-    QList<deCONZ::SimpleDescriptor>::const_iterator i = node->simpleDescriptors().constBegin();
-    QList<deCONZ::SimpleDescriptor>::const_iterator end = node->simpleDescriptors().constEnd();
+    auto i = node->simpleDescriptors().cbegin();
+    const auto end = node->simpleDescriptors().cend();
 
     for (;i != end; ++i)
     {
@@ -2161,7 +2161,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
         bool hasServerColor = false;
         bool hasIASWDCluster = false;
 
-        for (int c = 0; c < i->inClusters().size(); c++)
+        for (size_t c = 0; c < i->inClusters().size(); c++)
         {
             if      (i->inClusters()[c].id() == ONOFF_CLUSTER_ID) { hasServerOnOff = true; }
             else if (i->inClusters()[c].id() == LEVEL_CLUSTER_ID) { hasServerLevel = true; }
@@ -2380,7 +2380,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
             }
         }
 
-        if (!i->inClusters().isEmpty())
+        if (!i->inClusters().empty())
         {
             if (i->profileId() == HA_PROFILE_ID)
             {
@@ -3118,8 +3118,8 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
         return lightNode;
     }
 
-    QList<deCONZ::SimpleDescriptor>::const_iterator i = event.node()->simpleDescriptors().constBegin();
-    QList<deCONZ::SimpleDescriptor>::const_iterator end = event.node()->simpleDescriptors().constEnd();
+    auto i = event.node()->simpleDescriptors().cbegin();
+    const auto end = event.node()->simpleDescriptors().cend();
 
     for (;i != end; ++i)
     {
@@ -3128,7 +3128,7 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
             continue;
         }
 
-        if (i->inClusters().isEmpty())
+        if (i->inClusters().empty())
         {
             continue;
         }
@@ -3205,8 +3205,8 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
         // copy whole endpoint as reference
         lightNode->setHaEndpoint(*i);
 
-        QList<deCONZ::ZclCluster>::const_iterator ic = lightNode->haEndpoint().inClusters().constBegin();
-        QList<deCONZ::ZclCluster>::const_iterator endc = lightNode->haEndpoint().inClusters().constEnd();
+        auto ic = lightNode->haEndpoint().inClusters().cbegin();
+        const auto endc = lightNode->haEndpoint().inClusters().cend();
 
         NodeValue::UpdateType updateType = NodeValue::UpdateInvalid;
         if (event.event() == deCONZ::NodeEvent::UpdatedClusterDataZclRead)
@@ -5078,8 +5078,8 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
     // check for new sensors
     QString modelId;
     QString manufacturer;
-    QList<deCONZ::SimpleDescriptor>::const_iterator i = node->simpleDescriptors().constBegin();
-    QList<deCONZ::SimpleDescriptor>::const_iterator end = node->simpleDescriptors().constEnd();
+    auto i = node->simpleDescriptors().cbegin();
+    const auto end = node->simpleDescriptors().cend();
 
     // Trust and iHorn specific
     if (node->nodeDescriptor().manufacturerCode() == VENDOR_JENNIC && modelId.isEmpty() && i != end)
@@ -5139,8 +5139,8 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
         SensorFingerprint fpDoorLockSensor;
 
         {   // scan server clusters of endpoint
-            QList<deCONZ::ZclCluster>::const_iterator ci = i->inClusters().constBegin();
-            QList<deCONZ::ZclCluster>::const_iterator cend = i->inClusters().constEnd();
+            auto ci = i->inClusters().cbegin();
+            const auto cend = i->inClusters().cend();
             for (; ci != cend; ++ci)
             {
                 switch (ci->id())
@@ -5916,8 +5916,8 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
         }
 
         {   // scan client clusters of endpoint
-            QList<deCONZ::ZclCluster>::const_iterator ci = i->outClusters().constBegin();
-            QList<deCONZ::ZclCluster>::const_iterator cend = i->outClusters().constEnd();
+            auto ci = i->outClusters().cbegin();
+            const auto cend = i->outClusters().cend();
             for (; ci != cend; ++ci)
             {
                 switch (ci->id())
@@ -7177,10 +7177,9 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
         }
         else if (node->endpoints().size() >= 2)
         {
-            deCONZ::SimpleDescriptor sd;
-
             // has light endpoint?
-            if (node->copySimpleDescriptor(0x12, &sd) == 0)
+            const deCONZ::SimpleDescriptor *sd = getSimpleDescriptor(node, 0x12);
+            if (sd)
             {
                 sensorNode.setMode(Sensor::ModeDimmer);
             }
@@ -7623,8 +7622,8 @@ void DeRestPluginPrivate::checkUpdatedFingerPrint(const deCONZ::Node *node, quin
         return;
     }
 
-    deCONZ::SimpleDescriptor sd;
-    if (node->copySimpleDescriptor(endpoint, &sd) != 0)
+    const deCONZ::SimpleDescriptor *sd = getSimpleDescriptor(node, endpoint);
+    if (!sd)
     {
         return;
     }
@@ -7660,7 +7659,9 @@ void DeRestPluginPrivate::checkUpdatedFingerPrint(const deCONZ::Node *node, quin
 
             for (size_t c = 0; !update && c < fp.inClusters.size(); c++)
             {
-                if (sd.cluster(fp.inClusters[c], deCONZ::ServerCluster))
+                quint16 cl = fp.inClusters[c];
+                if (std::find_if(sd->inClusters().cbegin(), sd->inClusters().cend(), [cl](const auto &inCluster){ return inCluster.id() == cl; }
+                                 ) != sd->inClusters().cend())
                 {
                     update = true;
                     break;
@@ -7669,7 +7670,9 @@ void DeRestPluginPrivate::checkUpdatedFingerPrint(const deCONZ::Node *node, quin
 
             for (size_t c = 0; !update && c < fp.outClusters.size(); c++)
             {
-                if (sd.cluster(fp.outClusters[c], deCONZ::ClientCluster))
+                quint16 cl = fp.outClusters[c];
+                if (std::find_if(sd->outClusters().cbegin(), sd->outClusters().cend(), [cl](const auto &outCluster){ return outCluster.id() == cl; }
+                                 ) != sd->inClusters().cend())
                 {
                     update = true;
                     break;
@@ -7687,8 +7690,8 @@ void DeRestPluginPrivate::checkUpdatedFingerPrint(const deCONZ::Node *node, quin
 
             DBG_Printf(DBG_INFO, "change 0x%016llX finger print ep: 0x%02X --> 0x%02X\n", i->address().ext(), fp.endpoint, endpoint);
 
-            fp.endpoint = sd.endpoint();
-            fp.profileId = sd.profileId();
+            fp.endpoint = sd->endpoint();
+            fp.profileId = sd->profileId();
 
             updateSensorEtag(&*i);
             i->setUniqueId(generateUniqueId(i->address().ext(), fp.endpoint, clusterId));
@@ -7989,11 +7992,11 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
             }
         }
 
-        deCONZ::SimpleDescriptor sd;
-        if (event.node()->copySimpleDescriptor(event.endpoint(), &sd) == 0)
+        const deCONZ::SimpleDescriptor *sd = getSimpleDescriptor(event.node(), event.endpoint());
+        if (sd)
         {
-            QList<deCONZ::ZclCluster>::const_iterator ic = sd.inClusters().constBegin();
-            QList<deCONZ::ZclCluster>::const_iterator endc = sd.inClusters().constEnd();
+            auto ic = sd->inClusters().cbegin();
+            const auto endc = sd->inClusters().cend();
 
             for (; ic != endc; ++ic)
             {
@@ -10324,8 +10327,8 @@ deCONZ::ZclCluster *DeRestPluginPrivate::getInCluster(deCONZ::Node *node, uint8_
 
     if (sd)
     {
-        QList<deCONZ::ZclCluster>::iterator i = sd->inClusters().begin();
-        QList<deCONZ::ZclCluster>::iterator end = sd->inClusters().end();
+        auto i = sd->inClusters().begin();
+        auto end = sd->inClusters().end();
 
         for (; i != end; ++i)
         {
@@ -10669,7 +10672,7 @@ bool DeRestPluginPrivate::processZclAttributes(Sensor *sensorNode)
         return false;
     }
 
-    if (sensorNode->node()->simpleDescriptors().isEmpty())
+    if (sensorNode->node()->simpleDescriptors().empty())
     {
         return false;
     }
@@ -12825,8 +12828,8 @@ void DeRestPluginPrivate::nodeEvent(const deCONZ::NodeEvent &event)
         {
             return;
         }
-        deCONZ::SimpleDescriptor sd;
-        if (event.node()->copySimpleDescriptor(event.endpoint(), &sd) != 0)
+        const deCONZ::SimpleDescriptor *sd = getSimpleDescriptor(event.node(), event.endpoint());
+        if (!sd)
         {
             return;
         }
@@ -12834,10 +12837,10 @@ void DeRestPluginPrivate::nodeEvent(const deCONZ::NodeEvent &event)
         QByteArray data;
         QDataStream stream(&data, QIODevice::WriteOnly);
         stream.setByteOrder(QDataStream::LittleEndian);
-        sd.writeToStream(stream);
-        if (!data.isEmpty() && sd.deviceId() != 0xffff)
+        sd->writeToStream(stream);
+        if (!data.isEmpty() && sd->deviceId() != 0xffff)
         {
-            pushZdpDescriptorDb(event.node()->address().ext(), sd.endpoint(), ZDP_SIMPLE_DESCRIPTOR_CLID, data);
+            pushZdpDescriptorDb(event.node()->address().ext(), sd->endpoint(), ZDP_SIMPLE_DESCRIPTOR_CLID, data);
         }
     }
         break;
@@ -15730,9 +15733,8 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
             {
                 ep = node->endpoints()[i]; // search
 
-                for (int j = 0; j < node->simpleDescriptors().size(); j++)
+                for (const auto &sd : node->simpleDescriptors())
                 {
-                    const deCONZ::SimpleDescriptor &sd = node->simpleDescriptors()[j];
                     if (sd.endpoint() == ep && sd.deviceId() != 0xffff)
                     {
                         ep = 0;
@@ -18090,12 +18092,12 @@ uint8_t DeRestPluginPrivate::endpoint()
 
         for (quint8 ep : eps)
         {
-            deCONZ::SimpleDescriptor sd;
-            if (node->copySimpleDescriptor(ep, &sd) == 0)
+            const deCONZ::SimpleDescriptor *sd = getSimpleDescriptor(node, ep);
+            if (sd)
             {
-                if (sd.profileId() == HA_PROFILE_ID)
+                if (sd->profileId() == HA_PROFILE_ID)
                 {
-                    haEndpoint = sd.endpoint();
+                    haEndpoint = ep;
                     return haEndpoint;
                 }
             }

--- a/light_node.cpp
+++ b/light_node.cpp
@@ -381,8 +381,8 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
     // check if std otau cluster present in endpoint
     if (otauClusterId() == 0)
     {
-        QList<deCONZ::ZclCluster>::const_iterator it = endpoint.outClusters().constBegin();
-        QList<deCONZ::ZclCluster>::const_iterator end = endpoint.outClusters().constEnd();
+        auto it = endpoint.outClusters().cbegin();
+        const auto end = endpoint.outClusters().cend();
 
         for (; it != end; ++it)
         {
@@ -410,12 +410,12 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
     // initial setup
     if (!isInitialized)
     {
-        quint16 deviceId = haEndpoint().deviceId();
+        quint16 deviceId = endpoint.deviceId();
         QString ltype = QLatin1String("Unknown");
 
         {
-            QList<deCONZ::ZclCluster>::const_iterator i = endpoint.inClusters().constBegin();
-            QList<deCONZ::ZclCluster>::const_iterator end = endpoint.inClusters().constEnd();
+            auto i = endpoint.inClusters().cbegin();
+            const auto end = endpoint.inClusters().cend();
 
             for (; i != end; ++i)
             {
@@ -509,9 +509,9 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
                 {
                     if (modelId() != QLatin1String("lumi.light.aqcn02"))
                     {
-                        QList<deCONZ::ZclCluster>::const_iterator ic = haEndpoint().inClusters().constBegin();
-                        std::vector<deCONZ::ZclAttribute>::const_iterator ia = ic->attributes().begin();
-                        std::vector<deCONZ::ZclAttribute>::const_iterator enda = ic->attributes().end();
+                        auto ic = endpoint.inClusters().cbegin();
+                        auto ia = ic->attributes().cbegin();
+                        const auto enda = ic->attributes().cend();
                         isWindowCovering = true;
                         bool hasLift = true; // set default to lift
                         bool hasTilt = false;
@@ -590,7 +590,7 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
             }
         }
 
-        if (haEndpoint().profileId() == HA_PROFILE_ID)
+        if (endpoint.profileId() == HA_PROFILE_ID)
         {
 
             if ((manufacturerCode() == VENDOR_LEGRAND) && isWindowCovering)
@@ -648,7 +648,7 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
                 break;
             }
         }
-        else if (haEndpoint().profileId() == ZLL_PROFILE_ID)
+        else if (endpoint.profileId() == ZLL_PROFILE_ID)
         {
             switch (deviceId)
             {
@@ -667,7 +667,7 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
                 break;
             }
         }
-        else if (haEndpoint().profileId() == DIN_PROFILE_ID)
+        else if (endpoint.profileId() == DIN_PROFILE_ID)
         {
             switch (deviceId)
             {

--- a/light_node.cpp
+++ b/light_node.cpp
@@ -366,7 +366,14 @@ void LightNode::rx()
  */
 const deCONZ::SimpleDescriptor &LightNode::haEndpoint() const
 {
-    return m_haEndpoint;
+    const auto *sd = m_haEndpoint < 255 ? getSimpleDescriptor(m_node, m_haEndpoint) : nullptr;
+    if (sd)
+    {
+        return *sd;
+    }
+
+    static deCONZ::SimpleDescriptor invalidEndpoint; // TODO hack
+    return invalidEndpoint;
 }
 
 /*! Sets the lights HA endpoint descriptor.
@@ -375,8 +382,8 @@ const deCONZ::SimpleDescriptor &LightNode::haEndpoint() const
 void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
 {
     bool isWindowCovering = false;
-    bool isInitialized = m_haEndpoint.isValid();
-    m_haEndpoint = endpoint;
+    bool isInitialized = m_haEndpoint < 255;
+    m_haEndpoint = endpoint.endpoint();
 
     // check if std otau cluster present in endpoint
     if (otauClusterId() == 0)

--- a/light_node.h
+++ b/light_node.h
@@ -94,7 +94,7 @@ private:
     std::vector<GroupInfo> m_groups;
     bool m_colorLoopActive;
     uint8_t m_colorLoopSpeed;
-    deCONZ::SimpleDescriptor m_haEndpoint;
+    quint8 m_haEndpoint = 255;
     uint8_t m_groupCount;
     uint8_t m_sceneCapacity;
 };

--- a/poll_manager.cpp
+++ b/poll_manager.cpp
@@ -492,10 +492,10 @@ void PollManager::pollTimerFired()
     if (clusterId != 0xffff)
     {
         bool found = false;
-        deCONZ::SimpleDescriptor sd;
-        if (restNode->node()->copySimpleDescriptor(pitem.endpoint, &sd) == 0)
+        const deCONZ::SimpleDescriptor *sd = getSimpleDescriptor(restNode->node(), pitem.endpoint);
+        if (sd)
         {
-            for (const auto &cl : sd.inClusters())  // Loop through clusters
+            for (const auto &cl : sd->inClusters())  // Loop through clusters
             {
                 if (cl.id() == clusterId)
                 {

--- a/rest_node_base.cpp
+++ b/rest_node_base.cpp
@@ -406,3 +406,21 @@ void RestNodeBase::rx()
 {
     m_lastRx = QDateTime::currentDateTime();
 }
+
+const deCONZ::SimpleDescriptor *getSimpleDescriptor(const deCONZ::Node *node, quint8 ep)
+{
+    if (!node)
+    {
+        return nullptr;
+    }
+
+    const auto i = std::find_if(node->simpleDescriptors().cbegin(), node->simpleDescriptors().cend(),
+                                [ep](const auto &sd){ return sd.endpoint() == ep; });
+
+    if (i != node->simpleDescriptors().cend())
+    {
+        return &*i;
+    }
+
+    return nullptr;
+}

--- a/rest_node_base.h
+++ b/rest_node_base.h
@@ -90,8 +90,9 @@ public:
     const QDateTime &lastRx() const;
     void rx();
 
-private:
+protected:
     deCONZ::Node *m_node;
+private:
     deCONZ::Address m_addr;
     QString m_id;
     QString m_uid;
@@ -108,5 +109,7 @@ private:
     std::vector<NodeValue> m_values;
     QTime m_invalidTime;
 };
+
+const deCONZ::SimpleDescriptor *getSimpleDescriptor(const deCONZ::Node *node, quint8 ep);
 
 #endif // REST_NODE_BASE_H


### PR DESCRIPTION
In v2.12.0-beta various `QList` containers in the deCONZ library are replaced by `std::vector`. `QList` is way slower than `std::vector` and more badly has the habit of detaching an allocating extra memory when iterated over a non const container.

Not copying Simple Descriptors has an significant impact since this was done very frequently and caused needless copies of all clusters and attributes and their `QStrings`, going into the millions after just 10 minutes. With this PR only a const pointer to the Simple Descriptor in core is used.