### PR TITLE
Add support for AduroSmart Eria SmartPlog 3001

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -3051,7 +3051,8 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         // LIDL
         sensor->modelId() == QLatin1String("HG06323") ||
         // Eria
-        sensor->modelId() == QLatin1String("Adurolight_NCC")
+        sensor->modelId() == QLatin1String("Adurolight_NCC") ||
+        sensor->modelId() == QLatin1String("AD-SmartPlug3001")
         )
     {
         deviceSupported = true;

--- a/button_maps.json
+++ b/button_maps.json
@@ -1372,6 +1372,15 @@
                 [1, "0x01", "ADUROLIGHT", "COMMAND_0", "0x0002", "S_BUTTON_3", "S_BUTTON_ACTION_SHORT_RELEASED", "Dim down"],
                 [1, "0x01", "ADUROLIGHT", "COMMAND_0", "0x0003", "S_BUTTON_4", "S_BUTTON_ACTION_SHORT_RELEASED", "Off"]
             ]
+        },
+        "aduroSmartEriaMap": {
+            "vendor": "AduroSmart Eria Manufacturing",
+            "doc": "AduroSmart Eria Smart Plug",
+            "modelids": ["AD-SmartPlug3001"],
+            "map": [
+                [1, "0x01", "ADUROLIGHT", "COMMAND_0", "0x0000", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],
+                [1, "0x01", "ADUROLIGHT", "COMMAND_0", "0x0001", "S_BUTTON_2", "S_BUTTON_ACTION_SHORT_RELEASED", "Off"]
+            ]
         }
     }
 }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -306,6 +306,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_JENNIC, "CSW_ADUROLIGHT", jennicMacPrefix }, // Trust contact sensor ZMST-808
     { VENDOR_JENNIC, "ZYCT-202", jennicMacPrefix }, // Trust remote control ZYCT-202 (older model)
     { VENDOR_ADUROLIGHT, "ZLL-NonColorController", jennicMacPrefix }, // Trust remote control ZYCT-202 (newer model)
+    { VENDOR_ADUROLIGHT, "AD-SmartPlug3001", jennicMacPrefix }, // AduroSmart Eira SmartPlug 3001
     { VENDOR_INNR, "RC 110", jennicMacPrefix }, // innr remote RC 110
     { VENDOR_VISONIC, "MCT-340", emberMacPrefix }, // Visonic MCT-340 E temperature/motion
     { VENDOR_SUNRICHER, "ED-1001", silabs2MacPrefix }, // EcoDim wireless switches
@@ -12115,6 +12116,7 @@ void DeRestPluginPrivate::handleZclAttributeReportIndication(const deCONZ::ApsDa
             existDevicesWithVendorCodeForMacPrefix(ind.srcAddress(), VENDOR_IKEA) ||
             existDevicesWithVendorCodeForMacPrefix(ind.srcAddress(), VENDOR_OSRAM_STACK) ||
             existDevicesWithVendorCodeForMacPrefix(ind.srcAddress(), VENDOR_JENNIC) ||
+            existDevicesWithVendorCodeForMacPrefix(ind.srcAddress(), VENDOR_ADUROLIGHT) ||
             existDevicesWithVendorCodeForMacPrefix(ind.srcAddress(), VENDOR_SI_LABS) ||
             existDevicesWithVendorCodeForMacPrefix(ind.srcAddress(), VENDOR_CENTRALITE))
     {

--- a/electrical_measurement.cpp
+++ b/electrical_measurement.cpp
@@ -92,6 +92,7 @@ void DeRestPluginPrivate::handleElectricalMeasurementClusterIndication(const deC
                         modelId.startsWith(QLatin1String("outlet")) ||                        // Samsung SmartThings IM6001-OTP/IM6001-OTP01
                         modelId == QLatin1String("3200-Sgb") ||                               // Samsung/Centralite smart outlet
                         modelId == QLatin1String("3200-de") ||                                // Samsung/Centralite smart outlet
+                        modelId == QLatin1String("AD-SmartPlug3001") ||                       // AduroSmart Eira SmartPlug 3001
                         modelId.startsWith(QLatin1String("lumi.switch.n0agl1")) ||            // Xiaomi Aqara Single Switch Module T1 (With Neutral)
                         modelId.startsWith(QLatin1String("lumi.switch.b1naus01")))            // Xiaomi ZB3.0 Smart Wall Switch
                     {
@@ -139,6 +140,7 @@ void DeRestPluginPrivate::handleElectricalMeasurementClusterIndication(const deC
                         modelId.startsWith(QLatin1String("SMRZB-1")) ||                                // Develco smart cable
                         modelId.startsWith(QLatin1String("SKHMP30")) ||                                // GS smart plug
                         modelId == QLatin1String("Smart16ARelay51AU") ||                               // Aurora (Develco) smart plug
+                        modelId == QLatin1String("AD-SmartPlug3001") ||                                // AduroSmart Eira SmartPlug 3001
                         modelId == QLatin1String("PoP"))                                               // Apex Smart Plug
                     {
                         voltage = static_cast<quint16>(round((double)voltage / 100.0)); // 0.01V -> V
@@ -188,6 +190,7 @@ void DeRestPluginPrivate::handleElectricalMeasurementClusterIndication(const deC
                         modelId.startsWith(QLatin1String("ROB_200")) ||                           // ROBB Smarrt micro dimmer
                         modelId.startsWith(QLatin1String("Micro Smart Dimmer")) ||                // Sunricher Micro Smart Dimmer
                         modelId == QLatin1String("Connected socket outlet") ||                    // Niko smart socket
+                        modelId == QLatin1String("AD-SmartPlug3001") ||                           // AduroSmart Eira SmartPlug 3001
                         modelId == QLatin1String("SMRZB-1") ||                                    // Develco smart cable
                         modelId.startsWith(QLatin1String("S1")) ||                                // Ubisys S1/S1-R
                         modelId.startsWith(QLatin1String("S2")) ||                                // Ubisys S2/S2-R


### PR DESCRIPTION
Relates to issue #4920 

Disclaimer: I am **very** new to DeCONZ-REST-API source and am not 100% sure these changes are correct. They do however work properly for my Smart Plugs w/ DeCONZ v2.11.5.

![scrot-herer-1621956247](https://user-images.githubusercontent.com/1305017/119524646-1faea400-bd7e-11eb-9a47-c857a05a1042.png)

Especially not sure about the `button_maps.json` changes and the line at +12119 in `de_web_plugin.cpp`.

Some metrics are not reported back but are visible in DeCONZ GUI:
* AC Frequency
* Power Factor

Not sure if any other smart plugs report these, could not find any references.

Please feel free to give constructive feedback and/or ammend changes.