### PR TITLE
Add introspection REST API for state and config attributes

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -17819,7 +17819,7 @@ int DeRestPlugin::handleHttpRequest(const QHttpRequestHeader &hdr, QTcpSocket *s
             {
                 ret = d->getFullState(req, rsp);
             }
-            else if (path[2] == QLatin1String("devices"))
+            else if (hdr.pathAt(2) == QLatin1String("devices"))
             {
                 ret = d->restDevices->handleApi(req, rsp);
             }

--- a/rest_devices.cpp
+++ b/rest_devices.cpp
@@ -192,10 +192,8 @@ int RestDevices::getDevice(const ApiRequest &req, ApiResponse &rsp)
 
     for (const Sensor &s : plugin->sensors)
     {
-        if (s.uniqueId().indexOf(uniqueid) != 0)
-        {
-            continue;
-        }
+        if (s.uniqueId().indexOf(uniqueid) != 0) { continue; }
+        if (s.type().startsWith(QLatin1String("CLIP"))) { continue; }
 
         if (manufacturer.isEmpty() && !s.manufacturer().isEmpty()) { manufacturer = s.manufacturer(); }
         if (modelid.isEmpty() && !s.modelId().isEmpty()) { modelid = s.modelId(); }

--- a/rest_devices.cpp
+++ b/rest_devices.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2019 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2013-2021 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -9,13 +9,11 @@
  */
 
 #include <QString>
-#include <QTcpSocket>
-#include <QUrlQuery>
 #include <QVariantMap>
 #include <QProcess>
 #include "de_web_plugin.h"
 #include "de_web_plugin_private.h"
-#include "json.h"
+#include "product_match.h"
 #include "rest_devices.h"
 #include "utils/utils.h"
 
@@ -44,12 +42,22 @@ int RestDevices::handleApi(const ApiRequest &req, ApiResponse &rsp)
     {
         return getDevice(req, rsp);
     }
+    // GET /api/<apikey>/devices/<uniuqueid>/introspect
+    else if (req.hdr.pathComponentsCount() == 5 && req.hdr.httpMethod() == HttpGet && req.hdr.pathAt(4) == QLatin1String("introspect"))
+    {
+        return RIS_GetDeviceIntrospect(req, rsp);
+    }
+    // GET /api/<apikey>/devices/<uniqueid>/[<prefix>/]<item>/introspect
+    else if (req.hdr.pathComponentsCount() > 5 && req.hdr.httpMethod() == HttpGet &&
+             req.hdr.pathAt(req.hdr.pathComponentsCount() - 1) == QLatin1String("introspect"))
+    {
+        return RIS_GetDeviceItemIntrospect(req, rsp);
+    }
     // PUT /api/<apikey>/devices/<uniqueid>/installcode
     else if (req.hdr.pathComponentsCount() == 5 && req.hdr.httpMethod() == HttpPut && req.hdr.pathAt(4) == QLatin1String("installcode"))
     {
         return putDeviceInstallCode(req, rsp);
     }
-
 
     return REQ_NOT_HANDLED;
 }
@@ -211,6 +219,243 @@ int RestDevices::getDevice(const ApiRequest &req, ApiResponse &rsp)
     if (!manufacturer.isEmpty()) { rsp.map["manufacturername"] = manufacturer; }
     if (!modelid.isEmpty()) { rsp.map["modelid"] = modelid; }
     if (!swversion.isEmpty()) { rsp.map["swversion"] = swversion; }
+
+    return REQ_READY_SEND;
+}
+
+/*! GET /api/<apikey>/devices/<uniqueid>/introspect
+    \return REQ_READY_SEND
+            REQ_NOT_HANDLED
+
+    Unstable API to experiment: don't use in production!
+ */
+int RIS_GetDeviceIntrospect(const ApiRequest &req, ApiResponse &rsp)
+{
+    Q_UNUSED(req)
+    rsp.str = QLatin1String("[\"introspect\": false]");
+    return REQ_READY_SEND;
+}
+
+/*! Returns string form of a ApiDataType.
+ */
+QLatin1String RIS_DataTypeToString(ApiDataType type)
+{
+    static const std::array<QLatin1String, 14> map = {
+         QLatin1String("unknown"),
+         QLatin1String("bool"),
+         QLatin1String("uint8"),
+         QLatin1String("uint16"),
+         QLatin1String("uint32"),
+         QLatin1String("uint64"),
+         QLatin1String("int8"),
+         QLatin1String("int16"),
+         QLatin1String("int32"),
+         QLatin1String("int64"),
+         QLatin1String("double"),
+         QLatin1String("string"),
+         QLatin1String("time"),
+         QLatin1String("timepattern")
+    };
+
+    if (type < map.size())
+    {
+
+        return map[type];
+    }
+
+    return map[0];
+}
+
+/*! Returns string form of \c state/buttonevent action part.
+ */
+QLatin1String RIS_ButtonEventActionToString(int buttonevent)
+{
+    const uint action = buttonevent % 1000;
+
+    static std::array<QLatin1String, 11> map = {
+         QLatin1String("INITIAL_PRESS"),
+         QLatin1String("HOLD"),
+         QLatin1String("SHORT_RELEASE"),
+         QLatin1String("LONG_RELEASE"),
+         QLatin1String("DOUBLE_PRESS"),
+         QLatin1String("TREBLE_PRESS"),
+         QLatin1String("QUADRUPLE_PRESS"),
+         QLatin1String("SHAKE"),
+         QLatin1String("DROP"),
+         QLatin1String("TILT"),
+         QLatin1String("MANY_PRESS")
+    };
+
+    if (action < map.size())
+    {
+
+        return map[action];
+    }
+
+    return QLatin1String("UNKNOWN");
+}
+
+/*! Returns generic introspection for a \c ResourceItem.
+ */
+QVariantMap RIS_IntrospectGenericItem(const ResourceItemDescriptor &rid)
+{
+    QVariantMap result;
+
+    result[QLatin1String("type")] = RIS_DataTypeToString(rid.type);
+
+    if (rid.validMin != 0 || rid.validMax != 0)
+    {
+        result[QLatin1String("minval")] = rid.validMin;
+        result[QLatin1String("maxval")] = rid.validMax;
+    }
+
+    return result;
+}
+
+/*! Returns introspection for \c state/buttonevent.
+ */
+QVariantMap RIS_IntrospectButtonEventItem(const ResourceItemDescriptor &rid, const Resource *r)
+{
+    QVariantMap result = RIS_IntrospectGenericItem(rid);
+
+    Q_ASSERT(r->prefix() == RSensors);
+    const auto *sensor = static_cast<const Sensor*>(r);
+
+    if (!sensor)
+    {
+        return result;
+    }
+
+    // TODO dependency on plugin needs to be removed to make this testable
+    const auto &buttonMapButtons = plugin->buttonMeta;
+    const auto &buttonMapData = plugin->buttonMaps;
+    const auto &buttonMapForModelId = plugin->buttonProductMap;
+
+    const auto *buttonData = BM_ButtonMapForProduct(productHash(r), buttonMapData, buttonMapForModelId);
+
+    if (!buttonData)
+    {
+        return result;
+    }
+
+    int buttonBits = 0; // button 1 = 1 << 1, button 2 = 1 << 2 ...
+
+    {
+        QVariantMap values;
+
+        for (const auto &btn : buttonData->buttons)
+        {
+            buttonBits |= 1 << int(btn.button / 1000);
+
+            QVariantMap m;
+            m[QLatin1String("button")] = int(btn.button / 1000);
+            m[QLatin1String("action")] = RIS_ButtonEventActionToString(btn.button);
+            values[QString::number(btn.button)] = m;
+        }
+        result[QLatin1String("values")] = values;
+    }
+
+    const auto buttonsMeta = std::find_if(buttonMapButtons.cbegin(), buttonMapButtons.cend(),
+                                          [buttonData](const auto &meta){ return meta.buttonMapRef.hash == buttonData->buttonMapRef.hash; });
+
+    QVariantMap buttons;
+
+    if (buttonsMeta != buttonMapButtons.cend())
+    {
+        for (const auto &button : buttonsMeta->buttons)
+        {
+            QVariantMap m;
+            m[QLatin1String("name")] = button.name;
+            buttons[QString::number(button.button)] = m;
+        }
+    }
+    else // fallback if no "buttons" is defined in the button map, generate a generic one
+    {
+        for (int i = 1 ; i < 32; i++)
+        {
+            if (buttonBits & (1 << i))
+            {
+                QVariantMap m;
+                m[QLatin1String("name")] = QString("Button %1").arg(i);
+                buttons[QString::number(i)] = m;
+            }
+        }
+    }
+
+    result[QLatin1String("buttons")] = buttons;
+
+    return result;
+}
+
+/*! /api/<apikey>/devices/<uniqueid>/[<prefix>/]<item>/introspect
+
+    Fills ResourceItemDescriptor \p rid for the '[<prefix>/]<item>' part of the URL.
+
+    \note The verification that the URL has enough segments must be done by the caller.
+*/
+bool RIS_ResourceItemDescriptorFromHeader(const QHttpRequestHeader &hdr, ResourceItemDescriptor *rid)
+{
+    const char *beg = hdr.pathAt(4).data();
+    const char *end = hdr.pathAt(hdr.pathComponentsCount() - 2).end();
+
+    if (beg && end && beg < end)
+    {
+        const QLatin1String suffix(beg, end - beg);
+
+        if (getResourceItemDescriptor(suffix, *rid))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/*! Returns the Resource for a given \p uniqueid.
+ */
+static Resource *resourceForUniqueId(const QLatin1String &uniqueid)
+{
+    Resource *r = plugin->getResource(RSensors, uniqueid);
+
+    if (!r)
+    {
+        plugin->getResource(RLights, uniqueid);
+    }
+
+    return r;
+}
+
+/*! GET /api/<apikey>/devices/<uniqueid>/[<prefix>/]<item>/introspect
+    \return REQ_READY_SEND
+            REQ_NOT_HANDLED
+ */
+int RIS_GetDeviceItemIntrospect(const ApiRequest &req, ApiResponse &rsp)
+{
+    rsp.httpStatus = HttpStatusOk;
+    const Resource *r = resourceForUniqueId(req.hdr.pathAt(3));
+
+    if (!r)
+    {
+        rsp.httpStatus = HttpStatusNotFound;
+        return REQ_READY_SEND;
+    }
+
+    ResourceItemDescriptor rid;
+
+    if (!RIS_ResourceItemDescriptorFromHeader(req.hdr, &rid))
+    {
+        rsp.httpStatus = HttpStatusNotFound;
+        return REQ_READY_SEND;
+    }
+
+    if (rid.suffix == RStateButtonEvent)
+    {
+        rsp.map = RIS_IntrospectButtonEventItem(rid, r);
+    }
+    else
+    {
+        rsp.map = RIS_IntrospectGenericItem(rid);
+    }
 
     return REQ_READY_SEND;
 }

--- a/rest_devices.cpp
+++ b/rest_devices.cpp
@@ -34,23 +34,18 @@ RestDevices::RestDevices(QObject *parent) :
  */
 int RestDevices::handleApi(const ApiRequest &req, ApiResponse &rsp)
 {
-    if (req.path[2] != QLatin1String("devices"))
-    {
-        return REQ_NOT_HANDLED;
-    }
-
     // GET /api/<apikey>/devices
-    if ((req.path.size() == 3) && (req.hdr.method() == QLatin1String("GET")))
+    if (req.hdr.pathComponentsCount() == 3 && req.hdr.httpMethod() == HttpGet)
     {
         return getAllDevices(req, rsp);
     }
     // GET /api/<apikey>/devices/<uniqueid>
-    else if ((req.path.size() == 4) && (req.hdr.method() == QLatin1String("GET")))
+    else if (req.hdr.pathComponentsCount() == 4 && req.hdr.httpMethod() == HttpGet)
     {
         return getDevice(req, rsp);
     }
     // PUT /api/<apikey>/devices/<uniqueid>/installcode
-    else if ((req.path.size() == 5) && (req.hdr.method() == QLatin1String("PUT")) && (req.path[4] == QLatin1String("installcode")))
+    else if (req.hdr.pathComponentsCount() == 5 && req.hdr.httpMethod() == HttpPut && req.hdr.pathAt(4) == QLatin1String("installcode"))
     {
         return putDeviceInstallCode(req, rsp);
     }

--- a/rest_devices.h
+++ b/rest_devices.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2019 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2013-2021 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -39,5 +39,9 @@ private:
 
     DeRestPluginPrivate *plugin;
 };
+
+// Resource Introspection (RIS)
+int RIS_GetDeviceIntrospect(const ApiRequest &req, ApiResponse &rsp);
+int RIS_GetDeviceItemIntrospect(const ApiRequest &req, ApiResponse &rsp);
 
 #endif // REST_DEVICES_H


### PR DESCRIPTION
Most usable is the `state/buttonevent` introspection. Other items can be queried as well but don't provide much details yet.
Implemented uses free functions to be able to write tests. This PR sits on top of PR https://github.com/dresden-elektronik/deconz-rest-plugin/pull/4932

Example request for IKEA 5 buttons remote:

```
/api/<apikey>/devices/<uniqueid>/state/buttonevent/introspect
```

```json
{
  "type":"int32",
  "buttons": {
    "1": {"name": "Large middle button"},
    "2": {"name": "Top dimm up button"},
    "3": {"name": "Bottom dimm down button"},
    "4": {"name": "Left arrow button"},
    "5": {"name": "Right arrow button"}
  },
  "values": {
    "1001": {"action": "HOLD", "button":1},
    "1002": {"action": "SHORT_RELEASE", "button": 1},
    "2001": {"action": "HOLD", "button": 2},
    "2002": {"action": "SHORT_RELEASE", "button": 2},
    "2003": {"action": "LONG_RELEASE", "button": 2},
    "3001": {"action": "HOLD", "button": 3},
    "3002": {"action": "SHORT_RELEASE", "button": 3},
    "3003": {"action": "LONG_RELEASE", "button": 3},
    "4001": {"action": "HOLD", "button": 4},
    "4002": {"action": "SHORT_RELEASE", "button": 4},
    "4003": {"action": "LONG_RELEASE", "button": 4},
    "5001": {"action": "HOLD", "button": 5},
    "5002": {"action": "SHORT_RELEASE", "button": 5},
    "5003": {"action": "LONG_RELEASE", "button": 5}
  }
}
```

