### PR TITLE
Fix: Use correct payload length for IAS ACE arm commands for Keyfobs

### DIFF
--- a/ias_ace.cpp
+++ b/ias_ace.cpp
@@ -50,7 +50,7 @@ void DeRestPluginPrivate::handleIasAceClusterIndication(const deCONZ::ApsDataInd
 
         stream >> armMode;
 
-        if (zclFrame.payload().length() == 6)
+        if (zclFrame.payload().length() == 3)
         {
             quint8 codeTemp;
             stream >> codeTemp;     // 0 for keyfobs or other devices not supporting any codes


### PR DESCRIPTION
For keyfobs, no arm response is send to an arm command, resulting in a retransmission of the initial command by the device. This is due to an incorrectly set ZCL payload length (6 instead of 3) which results in the command not being processed to generate the required response.