### PR TITLE
Expose `RConfigDelay` instead of `RConfigDuration` for Develco motion sensors

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -3276,7 +3276,8 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             {
                 clusterId = clusterId ? clusterId : OCCUPANCY_SENSING_CLUSTER_ID;
                 if (sensor.modelId().startsWith(QLatin1String("FLS")) ||
-                    sensor.modelId().startsWith(QLatin1String("SML00")))
+                    sensor.modelId().startsWith(QLatin1String("SML00")) ||
+                    sensor.modelId().startsWith(QLatin1String("MOSZB-1")))
                 {
                     // TODO write and recover min/max to db
                     deCONZ::NumericUnion dummy;
@@ -3313,6 +3314,11 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 item->setValue(0);
                 item = sensor.addItem(DataTypeUInt8, RConfigSensitivityMax);
                 item->setValue(R_SENSITIVITY_MAX_DEFAULT);
+            }
+            else if (sensor.modelId().startsWith(QLatin1String("MOSZB-1")) && clusterId == OCCUPANCY_SENSING_CLUSTER_ID) // Develco/frient motion sensor
+            {
+                sensor.addItem(DataTypeUInt16, RConfigDelay)->setValue(0);
+                sensor.addItem(DataTypeUInt16, RConfigPending)->setValue(0);
             }
             else
             {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6695,20 +6695,29 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
         {
             clusterId = ONOFF_CLUSTER_ID;
         }
-        item = sensorNode.addItem(DataTypeBool, RStatePresence);
-        item->setValue(false);
-        item = sensorNode.addItem(DataTypeUInt16, RConfigDuration);
-        if (modelId.startsWith(QLatin1String("tagv4"))) // SmartThings Arrival sensor
+        sensorNode.addItem(DataTypeBool, RStatePresence)->setValue(false);
+
+        if (modelId.startsWith(QLatin1String("MOSZB-1")) && clusterId == OCCUPANCY_SENSING_CLUSTER_ID)
         {
-            item->setValue(310); // Sensor will be configured to report every 5 minutes
-        }
-        else if (modelId.startsWith(QLatin1String("lumi.sensor_motion"))) // reporting under motion varies between 60 - 90 seconds
-        {
-            item->setValue(90);
+            sensorNode.addItem(DataTypeUInt16, RConfigDelay)->setValue(0);
+            sensorNode.addItem(DataTypeUInt16, RConfigPending)->setValue(0);
         }
         else
         {
-            item->setValue(60); // default 60 seconds
+            item = sensorNode.addItem(DataTypeUInt16, RConfigDuration);
+
+            if (modelId.startsWith(QLatin1String("tagv4"))) // SmartThings Arrival sensor
+            {
+                item->setValue(310); // Sensor will be configured to report every 5 minutes
+            }
+            else if (modelId.startsWith(QLatin1String("lumi.sensor_motion"))) // reporting under motion varies between 60 - 90 seconds
+            {
+                item->setValue(90);
+            }
+            else
+            {
+                item->setValue(60); // default 60 seconds
+            }
         }
     }
     else if (sensorNode.type().endsWith(QLatin1String("OpenClose")))

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -862,7 +862,8 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                             offsetUpdated = true;
                             offset += item->toNumber();
                         }
-                        else if (rid.suffix == RConfigDelay && sensor->modelId().startsWith(QLatin1String("SML00"))) // Hue motion sensor
+                        else if (rid.suffix == RConfigDelay && (sensor->modelId().startsWith(QLatin1String("SML00")) || // Hue motion sensor
+                                                                sensor->modelId().startsWith(QLatin1String("MOSZB-1"))))// Develco/frient motion sensor
                         {
                             pendingMask |= R_PENDING_DELAY;
                             sensor->enableRead(WRITE_DELAY);


### PR DESCRIPTION
Develco/frient motion sensors MOSZB-1XX currently have `RConfigDuration` exposed to set presence from `true` to `false`. However, this is not necessary, as the device sends an attribute report with occupancy `false` when no motion is detected within the timeframe specified in `PIR Occupied To Unoccupied Delay` (0x0010). Based on that, `RConfigDelay` is the more accurate choice to set the desired timeframe when the sensor should report unoccupied state.

As the same mechanism like for the Hue motion sensors will be used, `RConfigPending` will also be exposed for the occupancy sensor endpoints. The presence sensor based on the IAS Zone cluster will keep `RConfigDuration`.