### PR TITLE
Fix: Emit button event 1002 again for TRADFRI remote control after mode switch

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4608,7 +4608,7 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                         }
                     }
                 }
-                else if (ind.clusterId() == ONOFF_CLUSTER_ID && sensor->manufacturer() == QLatin1String("IKEA of Sweden") && sensor->previousCommandId == 0x09)
+                else if (ind.clusterId() == ONOFF_CLUSTER_ID && sensor->modelId() == QLatin1String("Remote Control N2") && sensor->previousCommandId == 0x09)
                 {
                     ok = false;
                 }


### PR DESCRIPTION
When pushing the on/off button of the switch approx. 5 seconds, the device changes the operational mode so that the arrow buttons do not send any commands on hold/long press. Under certain conditions (apparently when the arrow keys haven't been used before), this can lead to button event 1002 not being emitted, although the corresponding command is send.

As the respective code was intended for the STYRBAR remote, it is now restricted to that device.