### PR TITLE
Disable notifications if the config/on is false for sensor.

### DIFF
--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -3348,8 +3348,8 @@ void DeRestPluginPrivate::handleSensorEvent(const Event &e)
         sensorCheckFast = CHECK_SENSOR_FAST_ROUNDS;
     }
 
-    // push sensor state updates through websocket
-    if (strncmp(e.what(), "state/", 6) == 0)
+    // push sensor state updates through websocket, but only if config/on = true
+    if (strncmp(e.what(), "state/", 6) == 0  && sensor->item(RConfigOn)->toBool())
     {
         ResourceItem *item = sensor->item(e.what());
         if (item && item->isPublic())


### PR DESCRIPTION
Disable notification if the config/on is false, but only for "state".
Usefull for exemple for power consumption entry if we don't use them, it realy lighten websocket notifications.