### PR TITLE
Fix loading backup on Chrome (and Safari?) regression

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -17760,7 +17760,7 @@ int DeRestPlugin::handleHttpRequest(const QHttpRequestHeader &hdr, QTcpSocket *s
             {
                 start += 4;
                 // after file content the boundary ends with:
-                int end = data.indexOf("\r\n-----------", start);
+                int end = data.indexOf("\r\n------", start);
 
                 if (end != -1 && start < end)
                 {


### PR DESCRIPTION
Webkit boundary marker uses only 6 dashes.

Related PR: https://github.com/dresden-elektronik/deconz-rest-plugin/pull/4916
Issue: https://github.com/dresden-elektronik/phoscon-app-beta/issues/391 and https://github.com/dresden-elektronik/deconz-rest-plugin/issues/4962