### PR TITLE
Small changes to fix macOS compilation

### DIFF
--- a/backup.cpp
+++ b/backup.cpp
@@ -12,6 +12,7 @@
 #include <QDir>
 #include <QFile>
 #include <QProcess>
+#include <array>
 #include <stack>
 #include <deconz.h>
 #include "backup.h"

--- a/de_web.pro
+++ b/de_web.pro
@@ -48,6 +48,14 @@ contains(QMAKE_SPEC_T,.*linux.*) {
     }
 }
 
+macx {
+    DEFINES += QT_NO_DEPRECATED_WARNINGS
+    CONFIG+=sdk_no_version_check
+
+    LIBS += -lsqlite3
+    DEFINES += HAS_SQLITE3
+}
+
 unix:LIBS +=  -L../.. -ldeCONZ
 
 unix:!macx {

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1018,8 +1018,9 @@ public:
 
     Helper to simplify HTTP REST request handling.
  */
-struct ApiResponse
+class ApiResponse
 {
+public:
     QString etag;
     const char *httpStatus;
     const char *contentType;


### PR DESCRIPTION
* Add `std::array` include for clang;
* Change `ApiResponse` from struct to class to fix forward declaration and make the type consistent to `ApiRequest`;
* Disable deprecated warning (addressed later);
* Disable Qt SDK version is not tested on macOS version warning;
* Link to SQLite3 (can be installed via Homebrew).