### PR TITLE
Remove global TaskItems in thermostat and window covering modules

### DIFF
--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1869,6 +1869,10 @@ public:
     // schedules
     QTimer *scheduleTimer;
     std::vector<Schedule> schedules;
+    TaskItem taskScheduleTimer;
+
+    // window covering
+    TaskItem calibrationTask;
 
     // webhooks
     QNetworkAccessManager *webhookManager = nullptr;

--- a/thermostat.cpp
+++ b/thermostat.cpp
@@ -299,7 +299,6 @@ void DeRestPluginPrivate::updateThermostatSchedule(Sensor *sensor, quint8 newWee
 
 
 // static const QStringList weekday({"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Away"});
-static TaskItem taskScheduleTimer;
 static int dayofweekTimer = 0;
 
 /*! Handle packets related to the ZCL Thermostat cluster.

--- a/window_covering.cpp
+++ b/window_covering.cpp
@@ -77,7 +77,6 @@
 
 int calibrationStep = 0;
 int operationalStatus = 0;
-TaskItem calibrationTask;
 
 /*! Handle packets related to the ZCL Window Covering cluster.
     \param ind the APS level data indication containing the ZCL packet


### PR DESCRIPTION
Move them as members into plugin object. The destructors of `TaskItem` would be called after main application quits, this clashes with new APS and ZCL allocator pools and would cause a crash.