### PR TITLE
FIX : missing Temperature and Setpoint Value return for Hama (Tuya) TRV 

### DIFF
--- a/tuya.cpp
+++ b/tuya.cpp
@@ -1010,6 +1010,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                     {
                         //Can be Temperature for some device
                         if (productId == "Tuya_THD SEA801-ZIGBEE TRV" ||
+                            productId == "Tuya_THD Smart radiator TRV" ||
                             productId == "Tuya_THD WZB-TRVL TRV")
                         {
                             qint16 temp = static_cast<qint16>(data & 0xFFFF) * 10;
@@ -1029,6 +1030,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                     {
                         //can be setpoint for some device
                         if (productId == "Tuya_THD SEA801-ZIGBEE TRV" ||
+                            productId == "Tuya_THD Smart radiator TRV" ||
                             productId == "Tuya_THD WZB-TRVL TRV")
                         {
                             qint16 temp = static_cast<qint16>(data & 0xFFFF) * 10;


### PR DESCRIPTION
Model : 
- _TYST11_yw7cahqs
- _TZE200_yw7cahqs

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/4841

Can change value using API, but value are not updated if using manualy the device.