### PR TITLE
Disable IAS zone status reporting for Samjin Button

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -950,6 +950,11 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
             rq.minInterval = 300;
             rq.maxInterval = 3600;
         }
+        else if (sensor && sensor->type() == QLatin1String("ZHASwitch") && modelId == QLatin1String("button"))
+        {
+            rq.minInterval = 65535; // Disable reporting so devices must not be reset to not have it
+            rq.maxInterval = 65535; // configured at all. Should be changed in future to explicitly exclude device from reporting.
+        }
         else
         {
             rq.minInterval = 300;


### PR DESCRIPTION
This should, in conjunction with PR #4765, prevent 1002 ghost events.

In #4232, it has been suggested to manually disable attribute reporting for IAS zone status to prevent the unwanted events. This has been reported not to be effective. Apparently, this was due to the fact that the code to trigger any attribute reporting configuration disrespects the value for disablement and consequently "resets" and re-configures reporting.

With this PR, attributing will always be set to "disabled" upon reoccurring configuration thereby ensuring persistence. This is primarily intended to prevent any re-paring of the device. 