### PR TITLE
Add support for Tuya 4gang switch, issue #4810

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2950,6 +2950,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId().startsWith(QLatin1String("TS0041")) ||
         sensor->modelId().startsWith(QLatin1String("TS0044")) ||
         sensor->modelId().startsWith(QLatin1String("TS0222")) || // TYZB01 light sensor 
+        sensor->modelId().startsWith(QLatin1String("TS004F")) || // 4 Gang Tuya ZigBee Wireless 12 Scene Switch
         // Tuyatec
         sensor->modelId().startsWith(QLatin1String("RH3040")) ||
         sensor->modelId().startsWith(QLatin1String("RH3001")) ||
@@ -3802,6 +3803,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
         srcEndpoints.push_back(sensor->fingerPrint().endpoint);
     }
     else if (sensor->modelId().startsWith(QLatin1String("RGBgenie ZB-5")) || // RGBgenie remote control
+             sensor->manufacturer() == QLatin1String("_TZ3000_xabckq1v") || // 4 Gang Tuya ZigBee Wireless 12 Scene Switch
              sensor->modelId().startsWith(QLatin1String("ZBT-DIMController-D0800"))) // Mueller-Licht tint dimmer
     {
         clusters.push_back(ONOFF_CLUSTER_ID);

--- a/button_maps.json
+++ b/button_maps.json
@@ -999,11 +999,11 @@
                 [1, "0x01", "ONOFF", "ON", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "B1"],
                 [1, "0x01", "ONOFF", "OFF", "1", "S_BUTTON_2", "S_BUTTON_ACTION_SHORT_RELEASED", "B2"],
                 [1, "0x01", "LEVEL_CONTROL", "STEP", "0", "S_BUTTON_3", "S_BUTTON_ACTION_SHORT_RELEASED", "B3"],
-                [1, "0x02", "LEVEL_CONTROL", "STEP", "1", "S_BUTTON_4", "S_BUTTON_ACTION_SHORT_RELEASED", "B4"],
-                [1, "0x02", "LEVEL_CONTROL", "MOVE", "0", "S_BUTTON_2", "S_BUTTON_ACTION_HOLD", "B2H"],
-                [1, "0x02", "LEVEL_CONTROL", "STOP", "0", "S_BUTTON_2", "S_BUTTON_ACTION_SHORT_RELEASED", "B2R"],
-                [1, "0x02", "LEVEL_CONTROL", "MOVE", "1", "S_BUTTON_3", "S_BUTTON_ACTION_HOLD", "B3L"],
-                [1, "0x02", "LEVEL_CONTROL", "STOP", "1", "S_BUTTON_3", "S_BUTTON_ACTION_SHORT_RELEASED", "B3R"]
+                [1, "0x01", "LEVEL_CONTROL", "STEP", "1", "S_BUTTON_4", "S_BUTTON_ACTION_SHORT_RELEASED", "B4"],
+                [1, "0x01", "LEVEL_CONTROL", "MOVE", "0", "S_BUTTON_3", "S_BUTTON_ACTION_HOLD", "B3H"],
+                [1, "0x01", "LEVEL_CONTROL", "STOP", "0", "S_BUTTON_3", "S_BUTTON_ACTION_SHORT_RELEASED", "B3R"],
+                [1, "0x01", "LEVEL_CONTROL", "MOVE", "1", "S_BUTTON_4", "S_BUTTON_ACTION_HOLD", "B4L"],
+                [1, "0x01", "LEVEL_CONTROL", "STOP", "1", "S_BUTTON_4", "S_BUTTON_ACTION_SHORT_RELEASED", "B4R"]
             ]
         },
         "legrandSwitchRemote": {

--- a/button_maps.json
+++ b/button_maps.json
@@ -975,7 +975,7 @@
         "Tuya3gangMap": {
             "vendor": "Tuya",
             "doc": "3-gang remote",
-            "modelids": ["_TZ3000_bi6lpsew", "_TZ3400_keyjhapk", "_TYZB02_key8kk7r", "_TZ3400_keyjqthh", "_TZ3400_key8kk7r", "_TZ3000_vp6clf9d", "_TYZB02_keyjqthh", "_TZ3000_peszejy7", "_TZ3000_qzjcsmar", "_TZ3000_owgcnkrh", "_TZ3000_adkvzooy", "_TZ3000_arfwfgoa", "_TZ3000_a7ouggvs", "_TZ3000_rrjr1q0u", "_TZ3000_abci1hiu", "_TZ3000_dfgbtub0", "_TZ3000_xabckq1v"],
+            "modelids": ["_TZ3000_bi6lpsew", "_TZ3400_keyjhapk", "_TYZB02_key8kk7r", "_TZ3400_keyjqthh", "_TZ3400_key8kk7r", "_TZ3000_vp6clf9d", "_TYZB02_keyjqthh", "_TZ3000_peszejy7", "_TZ3000_qzjcsmar", "_TZ3000_owgcnkrh", "_TZ3000_adkvzooy", "_TZ3000_arfwfgoa", "_TZ3000_a7ouggvs", "_TZ3000_rrjr1q0u", "_TZ3000_abci1hiu", "_TZ3000_dfgbtub0"],
             "map": [
                 [1, "0x01", "ONOFF", "0xfd", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "B1 short"],
                 [1, "0x01", "ONOFF", "0xfd", "1", "S_BUTTON_1", "S_BUTTON_ACTION_DOUBLE_PRESS", "B1 double"],
@@ -989,6 +989,21 @@
                 [1, "0x04", "ONOFF", "0xfd", "0", "S_BUTTON_4", "S_BUTTON_ACTION_SHORT_RELEASED", "B4 short"],
                 [1, "0x04", "ONOFF", "0xfd", "1", "S_BUTTON_4", "S_BUTTON_ACTION_DOUBLE_PRESS", "B4 double"],
                 [1, "0x04", "ONOFF", "0xfd", "2", "S_BUTTON_4", "S_BUTTON_ACTION_LONG_RELEASED", "B4 long"]
+            ]
+        },
+        "TuyaDimmerMap": {
+            "vendor": "Tuya",
+            "doc": "4-gang remote",
+            "modelids": ["_TZ3000_xabckq1v"],
+            "map": [
+                [1, "0x01", "ONOFF", "ON", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "B1"],
+                [1, "0x01", "ONOFF", "OFF", "1", "S_BUTTON_2", "S_BUTTON_ACTION_SHORT_RELEASED", "B2"],
+                [1, "0x01", "LEVEL_CONTROL", "STEP", "0", "S_BUTTON_3", "S_BUTTON_ACTION_SHORT_RELEASED", "B3"],
+                [1, "0x02", "LEVEL_CONTROL", "STEP", "1", "S_BUTTON_4", "S_BUTTON_ACTION_SHORT_RELEASED", "B4"],
+                [1, "0x02", "LEVEL_CONTROL", "MOVE", "0", "S_BUTTON_2", "S_BUTTON_ACTION_HOLD", "B2H"],
+                [1, "0x02", "LEVEL_CONTROL", "STOP", "0", "S_BUTTON_2", "S_BUTTON_ACTION_SHORT_RELEASED", "B2R"],
+                [1, "0x02", "LEVEL_CONTROL", "MOVE", "1", "S_BUTTON_3", "S_BUTTON_ACTION_HOLD", "B3L"],
+                [1, "0x02", "LEVEL_CONTROL", "STOP", "1", "S_BUTTON_3", "S_BUTTON_ACTION_SHORT_RELEASED", "B3R"]
             ]
         },
         "legrandSwitchRemote": {


### PR DESCRIPTION
Add support for 4-gang switch by Tuya named "_TZ3000_xabckq1v"

Most credits go to @Smanar, only finally fixed some button numbers, and together we debugged/corrected EP numbers.
Unfortunately, only 6 of advertised 12 scene possibilities are working yet. Double press doesn't send events, as does long press on the left two buttons. But better than nothing.
