### PR TITLE
Fix handling of ZCL Default Response

### DIFF
--- a/aps_controller_wrapper.cpp
+++ b/aps_controller_wrapper.cpp
@@ -21,7 +21,7 @@ using namespace deCONZ::literals;
 //! Sends a ZCL Default Response based on parameters from the request in \p ind and \p zclFrame.
 static bool ZCL_SendDefaultResponse(deCONZ::ApsController *apsCtrl, const deCONZ::ApsDataIndication &ind, const deCONZ::ZclFrame &zclFrame, quint8 status)
 {
-   deCONZ::ApsDataRequest apsReq;
+    deCONZ::ApsDataRequest apsReq;
 
     // ZDP Header
     apsReq.dstAddress() = ind.srcAddress();
@@ -68,7 +68,7 @@ static bool ZCL_SendDefaultResponse(deCONZ::ApsController *apsCtrl, const deCONZ
     return apsCtrl->apsdeDataRequest(apsReq) == deCONZ::Success;
 }
 
-//! Returnes true if \p zclFrame requires a ZCL Default Response.
+//! Returns true if \p zclFrame requires a ZCL Default Response.
 static bool ZCL_NeedDefaultResponse(const deCONZ::ApsDataIndication &ind, const deCONZ::ZclFrame &zclFrame)
 {
     if (ind.dstAddressMode() == deCONZ::ApsNwkAddress) // only respond to unicast
@@ -82,7 +82,7 @@ static bool ZCL_NeedDefaultResponse(const deCONZ::ApsDataIndication &ind, const 
     return false;
 }
 
-//! Returnes true if \p req contains a specific or ZCL Default Response for \p indZclFrame.
+//! Returns true if \p req contains a specific or ZCL Default Response for \p indZclFrame.
 static bool ZCL_IsResponse(const deCONZ::ZclFrame &indZclFrame, const deCONZ::ApsDataRequest &req)
 {
     if (req.asdu().size() < 3) // need at least frame control | seqno | command id
@@ -113,7 +113,7 @@ static bool ZCL_IsResponse(const deCONZ::ZclFrame &indZclFrame, const deCONZ::Ap
         }
 
         // Request and response command ids can differ, match for sequence number _should_ be fine.
-        // If we see false positives, mappings needs to be created on per cluster base.
+        // If we see false positives, mappings need to be created on per cluster base.
         return true;
     }
 
@@ -172,7 +172,7 @@ ZclDefaultResponder::~ZclDefaultResponder()
     }
 }
 
-/*! During life time checks if \req is a response to the contained request.
+/*! During life time checks if \p req is a response to the contained request.
  */
 void ZclDefaultResponder::checkApsdeDataRequest(const deCONZ::ApsDataRequest &req)
 {

--- a/aps_controller_wrapper.cpp
+++ b/aps_controller_wrapper.cpp
@@ -144,7 +144,8 @@ ZclDefaultResponder::ZclDefaultResponder(ApsControllerWrapper *apsCtrlWrapper, c
     m_ind(ind),
     m_zclFrame(zclFrame)
 {
-    if (m_ind.profileId() != ZDP_PROFILE_ID)
+    // ZCL only and ignore OTA commands as these are handled by the OTA plugin
+    if (m_ind.profileId() != ZDP_PROFILE_ID && m_ind.clusterId() != 0x0019)
     {
         m_apsCtrlWrapper->registerZclDefaultResponder(this);
         m_state = State::Watch;

--- a/aps_controller_wrapper.cpp
+++ b/aps_controller_wrapper.cpp
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2021 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ */
+
+#include <deconz/zdp_profile.h>
+#include <deconz/aps_controller.h>
+#include <deconz/dbg_trace.h>
+#include <deconz/zcl.h>
+#include "utils/utils.h"
+#include "aps_controller_wrapper.h"
+
+// enable domain specific string literals
+using namespace deCONZ::literals;
+
+//! Sends a ZCL Default Response based on parameters from the request in \p ind and \p zclFrame.
+static bool ZCL_SendDefaultResponse(deCONZ::ApsController *apsCtrl, const deCONZ::ApsDataIndication &ind, const deCONZ::ZclFrame &zclFrame, quint8 status)
+{
+   deCONZ::ApsDataRequest apsReq;
+
+    // ZDP Header
+    apsReq.dstAddress() = ind.srcAddress();
+    apsReq.setDstAddressMode(ind.srcAddressMode());
+    apsReq.setDstEndpoint(ind.srcEndpoint());
+    apsReq.setSrcEndpoint(ind.dstEndpoint());
+    apsReq.setProfileId(ind.profileId());
+    apsReq.setRadius(0);
+    apsReq.setClusterId(ind.clusterId());
+    //apsReq.setTxOptions(deCONZ::ApsTxAcknowledgedTransmission);
+
+    deCONZ::ZclFrame outZclFrame;
+    outZclFrame.setSequenceNumber(zclFrame.sequenceNumber());
+    outZclFrame.setCommandId(deCONZ::ZclDefaultResponseId);
+
+    if (zclFrame.frameControl() & deCONZ::ZclFCDirectionServerToClient)
+    {
+        outZclFrame.setFrameControl(deCONZ::ZclFCProfileCommand | deCONZ::ZclFCDirectionClientToServer | deCONZ::ZclFCDisableDefaultResponse);
+    }
+    else
+    {
+        outZclFrame.setFrameControl(deCONZ::ZclFCProfileCommand | deCONZ::ZclFCDirectionServerToClient | deCONZ::ZclFCDisableDefaultResponse);
+    }
+
+    if (zclFrame.manufacturerCode_t() != 0x0000_mfcode)
+    {
+        outZclFrame.setFrameControl(outZclFrame.frameControl() | deCONZ::ZclFCManufacturerSpecific);
+        outZclFrame.setManufacturerCode(zclFrame.manufacturerCode_t());
+    }
+
+    { // ZCL payload
+        QDataStream stream(&outZclFrame.payload(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+        stream << zclFrame.commandId();
+        stream << status;
+    }
+
+    { // ZCL frame
+        QDataStream stream(&apsReq.asdu(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+        outZclFrame.writeToStream(stream);
+    }
+
+    return apsCtrl->apsdeDataRequest(apsReq) == deCONZ::Success;
+}
+
+//! Returnes true if \p zclFrame requires a ZCL Default Response.
+static bool ZCL_NeedDefaultResponse(const deCONZ::ApsDataIndication &ind, const deCONZ::ZclFrame &zclFrame)
+{
+    if (ind.dstAddressMode() == deCONZ::ApsNwkAddress) // only respond to unicast
+    {
+        if (!(zclFrame.frameControl() & deCONZ::ZclFCDisableDefaultResponse))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+//! Returnes true if \p req contains a specific or ZCL Default Response for \p indZclFrame.
+static bool ZCL_IsResponse(const deCONZ::ZclFrame &indZclFrame, const deCONZ::ApsDataRequest &req)
+{
+    if (req.asdu().size() < 3) // need at least frame control | seqno | command id
+    {
+        return false;
+    }
+
+    // frame control | [manufacturer code] | seqno | command id
+    quint8 seq;
+    quint8 commandId;
+
+    if (req.asdu().size() >= 5 && req.asdu().at(0) & deCONZ::ZclFCManufacturerSpecific)
+    {
+        seq = static_cast<quint8>(req.asdu().at(3));
+        commandId = static_cast<quint8>(req.asdu().at(4));
+    }
+    else
+    {
+        seq = static_cast<quint8>(req.asdu().at(1));
+        commandId = static_cast<quint8>(req.asdu().at(2));
+    }
+
+    if (seq == indZclFrame.sequenceNumber())
+    {
+        if (commandId == deCONZ::ZclDefaultResponseId)
+        {
+            return true;
+        }
+
+        // Request and response command ids can differ, match for sequence number _should_ be fine.
+        // If we see false positives, mappings needs to be created on per cluster base.
+        return true;
+    }
+
+    return false;
+}
+
+ApsControllerWrapper::ApsControllerWrapper(deCONZ::ApsController *ctrl) :
+    m_apsCtrl(ctrl)
+{
+
+}
+
+int ApsControllerWrapper::apsdeDataRequest(const deCONZ::ApsDataRequest &req)
+{
+    if (!m_apsCtrl)
+    {
+        return deCONZ::ErrorNotConnected;
+    }
+    if (m_zclDefaultResponder)
+    {
+        m_zclDefaultResponder->checkApsdeDataRequest(req);
+    }
+    return m_apsCtrl->apsdeDataRequest(req);
+}
+
+ZclDefaultResponder::ZclDefaultResponder(ApsControllerWrapper *apsCtrlWrapper, const deCONZ::ApsDataIndication &ind, const deCONZ::ZclFrame &zclFrame) :
+    m_apsCtrlWrapper(apsCtrlWrapper),
+    m_ind(ind),
+    m_zclFrame(zclFrame)
+{
+    if (m_ind.profileId() != ZDP_PROFILE_ID)
+    {
+        m_apsCtrlWrapper->registerZclDefaultResponder(this);
+        m_state = State::Watch;
+    }
+}
+
+/*! When the APS indication function ends this destructor sends the ZCL Default Response if needed (RAII).
+ */
+ZclDefaultResponder::~ZclDefaultResponder()
+{
+    if (m_state == State::Init) // ZDP indications
+    {
+        return;
+    }
+
+    m_apsCtrlWrapper->clearZclDefaultResponder();
+
+    if (m_state == State::Watch)
+    {
+        if (ZCL_NeedDefaultResponse(m_ind, m_zclFrame))
+        {
+            ZCL_SendDefaultResponse(m_apsCtrlWrapper->apsController(), m_ind, m_zclFrame, deCONZ::ZclSuccessStatus);
+        }
+    }
+}
+
+/*! During life time checks if \req is a response to the contained request.
+ */
+void ZclDefaultResponder::checkApsdeDataRequest(const deCONZ::ApsDataRequest &req)
+{
+    if (m_state != State::Watch) { return; }
+
+    if (!isSameAddress(m_ind.srcAddress(), req.dstAddress())) {  return; }
+    if (req.profileId() != m_ind.profileId()) {  return; }
+    if (req.clusterId() != m_ind.clusterId()) {  return; }
+
+    if (ZCL_NeedDefaultResponse(m_ind, m_zclFrame)) // check here since in constructor m_zclFrame isn't parsed yet
+    {
+        if (ZCL_IsResponse(m_zclFrame, req))
+        {
+            m_state = State::HasResponse;
+        }
+    }
+    else
+    {
+        m_state = State::NoResponseNeeded;
+    }
+}

--- a/aps_controller_wrapper.h
+++ b/aps_controller_wrapper.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ */
+
+#ifndef APS_CONTROLLER_WRAPPER_H
+#define APS_CONTROLLER_WRAPPER_H
+
+namespace  deCONZ {
+    class ApsController;
+    class ApsDataIndication;
+    class ApsDataRequest;
+    class ZclFrame;
+}
+
+class ApsControllerWrapper;
+
+/*! RAII helper to send a ZCL Default Response after APS indication if needed.
+
+    The class observes outgoing APS requests for specific responses for a request and
+    automatically sends a ZCL Default Response if no specifc response was send.
+ */
+class ZclDefaultResponder
+{
+public:
+    ZclDefaultResponder() = delete;
+    explicit ZclDefaultResponder(ApsControllerWrapper *apsCtrlWrapper, const deCONZ::ApsDataIndication &ind, const deCONZ::ZclFrame &zclFrame);
+    ~ZclDefaultResponder();
+    void checkApsdeDataRequest(const deCONZ::ApsDataRequest &req);
+
+private:
+    enum class State
+    {
+        Init,
+        NoResponseNeeded,
+        Watch,
+        HasResponse
+    };
+    ApsControllerWrapper *m_apsCtrlWrapper = nullptr;
+    const deCONZ::ApsDataIndication &m_ind;
+    const deCONZ::ZclFrame &m_zclFrame;
+    State m_state = State::Init;
+};
+
+/*! Wraps \c deCONZ::ApsController to intercept apsdeDataRequest().
+
+    The main purpose is to deterministic send ZCL Default Response if needed.
+ */
+class ApsControllerWrapper
+{
+public:
+    ApsControllerWrapper(deCONZ::ApsController *ctrl);
+    int apsdeDataRequest(const deCONZ::ApsDataRequest &req);
+    void registerZclDefaultResponder(ZclDefaultResponder *resp) { m_zclDefaultResponder = resp; }
+    void clearZclDefaultResponder() { m_zclDefaultResponder = nullptr; };
+    deCONZ::ApsController *apsController() { return m_apsCtrl; }
+
+private:
+    deCONZ::ApsController *m_apsCtrl = nullptr;
+    ZclDefaultResponder *m_zclDefaultResponder = nullptr;
+};
+
+#endif // APS_CONTROLLER_WRAPPER_H

--- a/basic.cpp
+++ b/basic.cpp
@@ -175,7 +175,7 @@ void DeRestPluginPrivate::sendBasicClusterResponse(const deCONZ::ApsDataIndicati
         outZclFrame.writeToStream(stream);
     }
 
-    if (apsCtrl && apsCtrl->apsdeDataRequest(req) != deCONZ::Success)
+    if (apsCtrlWrapper.apsdeDataRequest(req) != deCONZ::Success)
     {
         DBG_Printf(DBG_INFO, "Basic failed to send reponse\n");
     }

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -447,12 +447,6 @@ void DeRestPluginPrivate::handleZclConfigureReportingResponseIndication(const de
         allNodes.push_back(&l);
     }
 
-    // send DefaultResponse if not disabled
-    if (!(zclFrame.frameControl() & deCONZ::ZclFCDisableDefaultResponse))
-    {
-        sendZclDefaultResponse(ind, zclFrame, deCONZ::ZclSuccessStatus);
-    }
-
     for (RestNodeBase * restNode : allNodes)
     {
         if (restNode->address().ext() != ind.srcAddress().ext())
@@ -670,7 +664,7 @@ bool DeRestPluginPrivate::sendBindRequest(BindingTask &bt)
         return false;
     }
 
-    if (apsCtrl && (apsCtrl->apsdeDataRequest(apsReq) == deCONZ::Success))
+    if (apsCtrlWrapper.apsdeDataRequest(apsReq) == deCONZ::Success)
     {
         return true;
     }
@@ -827,7 +821,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt, const s
     }
 
 
-    if (apsCtrl && apsCtrl->apsdeDataRequest(apsReq) == deCONZ::Success)
+    if (apsCtrlWrapper.apsdeDataRequest(apsReq) == deCONZ::Success)
     {
         queryTime = queryTime.addSecs(1);
         return true;
@@ -4418,11 +4412,10 @@ void DeRestPluginPrivate::processUbisysC4Configuration(Sensor *sensor)
     stream.setByteOrder(QDataStream::LittleEndian);
     zclFrame.writeToStream(stream);
 
-    if (apsCtrl->apsdeDataRequest(req) == deCONZ::Success)
+    if (apsCtrlWrapper.apsdeDataRequest(req) == deCONZ::Success)
     {
 
     }
-
 }
 
 /*! Process binding related tasks queue every one second. */
@@ -5048,7 +5041,7 @@ void DeRestPluginPrivate::bindingTableReaderTimerFired()
             stream << i->index;
 
             // send
-            if (apsCtrl && apsCtrl->apsdeDataRequest(apsReq) == deCONZ::Success)
+            if (apsCtrlWrapper.apsdeDataRequest(apsReq) == deCONZ::Success)
             {
                 DBG_Printf(DBG_ZDP, "Mgmt_Bind_req id: %d to 0x%016llX send\n", i->apsReq.id(), i->apsReq.dstAddress().ext());
                 i->time.start();

--- a/change_channel.cpp
+++ b/change_channel.cpp
@@ -71,7 +71,7 @@ bool DeRestPluginPrivate::startChannelChange(quint8 channel)
 bool DeRestPluginPrivate::verifyChannel(quint8 channel)
 {
 
-    DBG_Assert(apsCtrl != 0);
+    DBG_Assert(apsCtrl != nullptr);
     if (!apsCtrl)
     {
         return false;
@@ -135,9 +135,9 @@ void DeRestPluginPrivate::changeChannel(quint8 channel)
     else if (ccRetries < 3)
     {
         DBG_Assert(channel >= 11 && channel <= 26);
-        if (apsCtrl && (channel >= 11) && (channel <= 26))
+        if (apsCtrl && channel >= 11 && channel <= 26)
         {
-            uint8_t nwkUpdateId = (apsCtrl->getParameter(deCONZ::ParamNetworkUpdateId));
+            uint8_t nwkUpdateId = apsCtrl->getParameter(deCONZ::ParamNetworkUpdateId);
             if (nwkUpdateId < 255)
             {
                 nwkUpdateId++;
@@ -173,7 +173,7 @@ void DeRestPluginPrivate::changeChannel(quint8 channel)
             stream << scanDuration;
             stream << nwkUpdateId;
 
-            if (apsCtrl && apsCtrl->apsdeDataRequest(req) == deCONZ::Success)
+            if (apsCtrlWrapper.apsdeDataRequest(req) == deCONZ::Success)
             {
                 channelChangeApsRequestId = req.id();
                 DBG_Printf(DBG_INFO, "change channel to %d, channel mask = 0x%08lX\n", channel, scanChannels);
@@ -285,7 +285,7 @@ void DeRestPluginPrivate::checkChannelChangeNetworkDisconnected()
         }
         else
         {
-            DBG_Assert(apsCtrl != 0);
+            DBG_Assert(apsCtrl != nullptr);
             if (apsCtrl)
             {
                 DBG_Printf(DBG_INFO, "disconnect from network failed, try again\n");

--- a/de_otau.cpp
+++ b/de_otau.cpp
@@ -195,7 +195,7 @@ void DeRestPluginPrivate::otauSendStdNotify(LightNode *node)
         zclFrame.writeToStream(stream);
     }
 
-    if (apsCtrl && apsCtrl->apsdeDataRequest(req) != deCONZ::Success)
+    if (apsCtrlWrapper.apsdeDataRequest(req) != deCONZ::Success)
     {
         DBG_Printf(DBG_INFO, "otau failed to send image notify request\n");
     }

--- a/de_web.pro
+++ b/de_web.pro
@@ -106,6 +106,7 @@ DEFINES += GW_MIN_DERFUSB23E0X_FW_VERSION=0x22030300
 DEFINES += GW_DEFAULT_NAME=\\\"Phoscon-GW\\\"
 
 HEADERS  = bindings.h \
+           aps_controller_wrapper.h \
            backup.h \
            button_maps.h \
            connectivity.h \
@@ -142,6 +143,7 @@ HEADERS  = bindings.h \
            websocket_server.h
 
 SOURCES  = air_quality.cpp \
+           aps_controller_wrapper.cpp \
            authorisation.cpp \
            backup.cpp \
            bindings.cpp \

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -22,6 +22,7 @@
 #endif
 #include <sqlite3.h>
 #include <deconz.h>
+#include "aps_controller_wrapper.h"
 #include "resource.h"
 #include "daylight.h"
 #include "event.h"
@@ -472,7 +473,6 @@ using namespace deCONZ::literals;
 
 void getTime(quint32 *time, qint32 *tz, quint32 *dstStart, quint32 *dstEnd, qint32 *dstShift, quint32 *standardTime, quint32 *localTime, quint8 mode);
 int getFreeSensorId(); // TODO needs to be part of a Database class
-bool isSameAddress(const deCONZ::Address &a, const deCONZ::Address &b);
 
 extern const quint64 macPrefixMask;
 
@@ -1577,7 +1577,6 @@ public:
     void handleTuyaClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleZclAttributeReportIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleZclConfigureReportingResponseIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
-    void sendZclDefaultResponse(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame, quint8 status);
     void taskToLocalData(const TaskItem &task);
     void handleZclAttributeReportIndicationXiaomiSpecial(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void queuePollNode(RestNodeBase *node);
@@ -2059,7 +2058,8 @@ public:
     // general
     ApiConfig config;
     QTime queryTime;
-    deCONZ::ApsController *apsCtrl;
+    ApsControllerWrapper apsCtrlWrapper;
+    deCONZ::ApsController *apsCtrl = nullptr;
     uint groupTaskNodeIter; // Iterates through nodes array
     QElapsedTimer idleTimer;
     int idleTotalCounter; // sys timer

--- a/firmware_update.cpp
+++ b/firmware_update.cpp
@@ -30,10 +30,14 @@
  */
 void DeRestPluginPrivate::initFirmwareUpdate()
 {
+    if (!apsCtrl)
+    {
+        return;
+    }
+
     fwProcess = nullptr;
     fwUpdateState = FW_Idle;
 
-    Q_ASSERT(apsCtrl);
     apsCtrl->setParameter(deCONZ::ParamFirmwareUpdateActive, deCONZ::FirmwareUpdateIdle);
 
     fwUpdateStartedByUser = false;
@@ -306,7 +310,6 @@ void DeRestPluginPrivate::firmwareUpdateTimerFired()
  */
 void DeRestPluginPrivate::queryFirmwareVersion()
 {
-    Q_ASSERT(apsCtrl);
     if (!apsCtrl)
     {
         return;

--- a/ias_ace.cpp
+++ b/ias_ace.cpp
@@ -95,11 +95,6 @@ void DeRestPluginPrivate::handleIasAceClusterIndication(const deCONZ::ApsDataInd
     else if (zclFrame.commandId() == CMD_GET_ZONE_STATUS)
     {
     }
-
-    if (!(zclFrame.frameControl() & deCONZ::ZclFCDisableDefaultResponse))
-    {
-        sendZclDefaultResponse(ind, zclFrame, deCONZ::ZclSuccessStatus);
-    }
 }
 
 void DeRestPluginPrivate::sendArmResponse(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame, quint8 armMode)
@@ -152,7 +147,7 @@ void DeRestPluginPrivate::sendArmResponse(const deCONZ::ApsDataIndication &ind, 
         outZclFrame.writeToStream(stream);
     }
 
-    if (apsCtrl && apsCtrl->apsdeDataRequest(req) != deCONZ::Success)
+    if (apsCtrlWrapper.apsdeDataRequest(req) != deCONZ::Success)
     {
         DBG_Printf(DBG_INFO_L2, "[IAS ACE] - Failed to send IAS ACE arm reponse.\n");
     }

--- a/ias_zone.cpp
+++ b/ias_zone.cpp
@@ -416,12 +416,6 @@ void DeRestPluginPrivate::handleIasZoneClusterIndication(const deCONZ::ApsDataIn
 
         checkIasEnrollmentStatus(sensor);
     }
-
-    // Allow clearing the alarm bit for Develco devices
-    if (!(zclFrame.frameControl() & deCONZ::ZclFCDisableDefaultResponse))
-    {
-        sendZclDefaultResponse(ind, zclFrame, deCONZ::ZclSuccessStatus);
-    }
 }
 
 /*! Processes the received IAS zone status value.
@@ -567,7 +561,7 @@ bool DeRestPluginPrivate::sendIasZoneEnrollResponse(Sensor *sensor)
 
     DBG_Printf(DBG_IAS, "[IAS ZONE] - 0x%016llX Send Zone Enroll Response, zcl.seq: %u\n", sensor->address().ext(), outZclFrame.sequenceNumber());
 
-    if (apsCtrl && apsCtrl->apsdeDataRequest(req) != deCONZ::Success)
+    if (apsCtrlWrapper.apsdeDataRequest(req) != deCONZ::Success)
     {
         DBG_Printf(DBG_IAS, "[IAS ZONE] - 0x%016llX Failed sending Zone Enroll Response\n", sensor->address().ext());
         return false;
@@ -618,7 +612,7 @@ bool DeRestPluginPrivate::sendIasZoneEnrollResponse(const deCONZ::ApsDataIndicat
 
     DBG_Printf(DBG_IAS, "[IAS ZONE] - 0x%016llX Send Zone Enroll Response, zcl.seq: %u\n", ind.srcAddress().ext(), zclFrame.sequenceNumber());
 
-    if (apsCtrl && apsCtrl->apsdeDataRequest(req) != deCONZ::Success)
+    if (apsCtrlWrapper.apsdeDataRequest(req) != deCONZ::Success)
     {
         DBG_Printf(DBG_IAS, "[IAS ZONE] - 0x%016llX Failed sending Zone Enroll Response\n", ind.srcAddress().ext());
         return false;

--- a/poll_control.cpp
+++ b/poll_control.cpp
@@ -172,7 +172,7 @@ bool DeRestPluginPrivate::checkPollControlClusterTask(Sensor *sensor)
              outZclFrame.writeToStream(stream);
          }
 
-         if (apsCtrl && apsCtrl->apsdeDataRequest(apsReq) == deCONZ::Success)
+         if (apsCtrlWrapper.apsdeDataRequest(apsReq) == deCONZ::Success)
          {
              item->setValue(item->toNumber() & ~R_PENDING_SET_LONG_POLL_INTERVAL);
              return true;

--- a/reset_device.cpp
+++ b/reset_device.cpp
@@ -89,7 +89,7 @@ void DeRestPluginPrivate::checkResetState()
                 //                    flags |= 0x80; // rejoin
                 stream << flags; // flags
 
-                if (apsCtrl->apsdeDataRequest(req) == deCONZ::Success)
+                if (apsCtrlWrapper.apsdeDataRequest(req) == deCONZ::Success)
                 {
                     resetDeviceApsRequestId = req.id();
                     resetDeviceState = ResetWaitConfirm;
@@ -153,7 +153,7 @@ void DeRestPluginPrivate::checkResetState()
                 //                    flags |= 0x80; // rejoin
                 stream << flags; // flags
 
-                if (apsCtrl->apsdeDataRequest(req) == deCONZ::Success)
+                if (apsCtrlWrapper.apsdeDataRequest(req) == deCONZ::Success)
                 {
                     resetDeviceApsRequestId = req.id();
                     resetDeviceState = ResetWaitConfirm;

--- a/thermostat_ui_configuration.cpp
+++ b/thermostat_ui_configuration.cpp
@@ -117,11 +117,6 @@ void DeRestPluginPrivate::handleThermostatUiConfigurationClusterIndication(const
             queSaveDb(DB_SENSORS, DB_SHORT_SAVE_DELAY);
         }
     }
-
-    if (!(zclFrame.frameControl() & deCONZ::ZclFCDisableDefaultResponse))
-    {
-        sendZclDefaultResponse(ind, zclFrame, deCONZ::ZclSuccessStatus);
-    }
 }
 
 /*! Write Attribute on thermostat ui configuration cluster.

--- a/time.cpp
+++ b/time.cpp
@@ -212,11 +212,10 @@ void DeRestPluginPrivate::sendTimeClusterResponse(const deCONZ::ApsDataIndicatio
         outZclFrame.writeToStream(stream);
     }
 
-    if (apsCtrl && apsCtrl->apsdeDataRequest(req) != deCONZ::Success)
+    if (apsCtrlWrapper.apsdeDataRequest(req) != deCONZ::Success)
     {
         DBG_Printf(DBG_INFO, "Time failed to send reponse\n");
     }
-
 }
 
 /*! Get all available timezone identifiers.

--- a/tuya.cpp
+++ b/tuya.cpp
@@ -123,12 +123,6 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
         // 0x01 : TUYA_REPORTING > Used to inform of changes in its state.
         // 0x02 : TUYA_QUERY > Send after receiving a 0x00 command.
         
-        // Send default response, it seem at least 0x01 and 0x02 need defaut response
-        if ((zclFrame.commandId() == TUYA_REPORTING || zclFrame.commandId() == TUYA_QUERY)&& !(zclFrame.frameControl() & deCONZ::ZclFCDisableDefaultResponse))
-        {
-            sendZclDefaultResponse(ind, zclFrame, deCONZ::ZclSuccessStatus);
-        }
-
         if (zclFrame.payload().size() < 7)
         {
             DBG_Printf(DBG_INFO, "Tuya : Payload too short\n");

--- a/upnp.cpp
+++ b/upnp.cpp
@@ -48,7 +48,11 @@ void DeRestPluginPrivate::initUpnpDiscovery()
 /*! Replaces description_in.xml template with dynamic content. */
 void DeRestPluginPrivate::initDescriptionXml()
 {
-    deCONZ::ApsController *apsCtrl = deCONZ::ApsController::instance();
+    if (!apsCtrl)
+    {
+        return;
+    }
+
     QString serverRoot = apsCtrl->getParameter(deCONZ::ParamHttpRoot);
 
     if (!serverRoot.isEmpty())

--- a/utils/utils.cpp
+++ b/utils/utils.cpp
@@ -8,6 +8,7 @@
  *
  */
 
+#include <deconz/aps.h>
 #include <deconz/dbg_trace.h>
 #include "utils.h"
 #include "resource.h"
@@ -210,4 +211,31 @@ RestData verifyRestData(const ResourceItemDescriptor &rid, const QVariant &val)
     {
         return data;
     }
+}
+
+/*! Compare addresses where either NWK or MAC address might not be known.
+    \returns true if both adresses have same MAC address (strong guaranty).
+    \returns true if at least one of the addresses doesn't have MAC but the NWK addresses are equal.
+    \returns false otherwise.
+*/
+bool isSameAddress(const deCONZ::Address &a, const deCONZ::Address &b)
+{
+    if (a.hasExt() && b.hasExt())
+    {
+        // nested if statement, so the NWK check won't be made if both MAC addresses are known
+        if (a.ext() != b.ext())
+        {
+             return false;
+        }
+    }
+    else  if (a.hasNwk() && b.hasNwk())
+    {
+       if (a.nwk() != b.nwk())
+       {
+            return false;
+       }
+    }
+    else { return false; }
+
+    return true;
 }

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -16,6 +16,10 @@
 #include <array>
 #include "resource.h"
 
+namespace deCONZ {
+    class Address;
+}
+
 struct KeyMap {
     QLatin1String key;
     };
@@ -49,6 +53,7 @@ bool startsWith(QLatin1String str, QLatin1String needle);
 int indexOf(QLatin1String haystack, QLatin1String needle);
 bool contains(QLatin1String haystack, QLatin1String needle);
 RestData verifyRestData(const ResourceItemDescriptor &rid, const QVariant &val);
+bool isSameAddress(const deCONZ::Address &a, const deCONZ::Address &b);
 
 template <typename K, typename Cont>
 decltype(auto) matchKeyValue(const K &key, const Cont &cont)

--- a/xiaomi.cpp
+++ b/xiaomi.cpp
@@ -1,5 +1,6 @@
 #include "de_web_plugin.h"
 #include "de_web_plugin_private.h"
+#include "utils/utils.h"
 
 /*! Handle manufacturer specific Xiaomi ZCL attribute report commands to basic cluster.
  */

--- a/xmas.cpp
+++ b/xmas.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "de_web_plugin_private.h"
+#include "utils/utils.h"
 
 #define TUYA_COMMAND_SET 0x00
 


### PR DESCRIPTION
This PR adds automatic handling of ZCL Default Response to also catch cases where we currently miss sending the response.

The magic happens by observing outgoing APS requests if they contain a specific ZCL response and automatically send the ZCL Default Response at the end of the APS indication processing. For this C++ RAII is used with an extra ZclDefaultResponder object which sends the response in its destructor.

* All outgoing APS requests use `ApsControllerWrapper` instead of plain `ApsController`.
* All manual sending of ZCL Default Responses was removed.
* Moved `isSameAddress()`into `utils.h`.
* Removed `sendZclDefaultResponse()` from plugin.