### PR TITLE
Fix TRADFRI remote control arrow buttons hold/long release events

### DIFF
--- a/basic.cpp
+++ b/basic.cpp
@@ -79,9 +79,22 @@ void DeRestPluginPrivate::sendBasicClusterResponse(const deCONZ::ApsDataIndicati
                 break;
 
             case 0x0001: // Application Version
+            {
                 stream << code;
                 stream << (quint8) deCONZ::Zcl8BitUint;
-                stream << (quint8) 0x00;
+
+                Sensor *sensor = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), ind.srcEndpoint());
+                if (sensor && sensor->modelId() == QLatin1String("TRADFRI remote control"))
+                {
+                    // Since firmware version 2.3.014 when the large middle button is pressed the remote reads this attribute.
+                    // If it isn't 17 as reported by earlier remote firmware, the left/right buttons don't send hold and long press commands anymore.
+                    stream << quint8(17);
+                }
+                else
+                {
+                    stream << quint8(0x00);
+                }
+            }
                 break;
 
             case 0x0002: // Stack Version


### PR DESCRIPTION
When pressing the middle button for more than 5 seconds the remote reads the Application Version attribute. If the coordinator doesn't respond with value 17 as indicated in earlier remote firmware versions, the arrow buttons don't send hold/long release commands anymore.

This is a followup PR for https://github.com/dresden-elektronik/deconz-rest-plugin/pull/4951