### PR TITLE
Fix : Reverse side for Yoolax covering

### DIFF
--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1693,7 +1693,6 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
             R_GetProductId(taskRef.lightNode) == QLatin1String("Zigbee curtain switch") ||
             R_GetProductId(taskRef.lightNode) == QLatin1String("Tuya_COVD YS-MT750") ||
             R_GetProductId(taskRef.lightNode) == QLatin1String("Tuya_COVD DS82") ||
-            taskRef.lightNode->modelId() == QLatin1String("D10110") ||
             taskRef.lightNode->modelId() == QLatin1String("Motor Controller"))
         {
             targetLiftZigBee = 100 - targetLift;


### PR DESCRIPTION
Problem in direction between API request and Zigbee return.
See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/4257#issuecomment-855281308