### PR TITLE
Remove obsolete ZDP code

### DIFF
--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1548,7 +1548,6 @@ public:
     bool sendTuyaCommand(const deCONZ::ApsDataIndication &ind, qint8 commandId, const QByteArray &data);
     void handleCommissioningClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     bool sendTuyaRequestThermostatSetWeeklySchedule(TaskItem &taskRef, quint8 weekdays, const QString &transitions, qint8 Dp_identifier);
-    void handleZdpIndication(const deCONZ::ApsDataIndication &ind);
     bool handleMgmtBindRspConfirm(const deCONZ::ApsDataConfirm &conf);
     void handleDeviceAnnceIndication(const deCONZ::ApsDataIndication &ind);
     void handleNodeDescriptorResponseIndication(const deCONZ::ApsDataIndication &ind);


### PR DESCRIPTION
All the `handleZdpIndication()` function did is handled by other parts of the code, like PollManager. The removal gets rid of an extra loop through all light nodes.

FLS-NB specific code to set the sensor reachable is handled by `updateSensorNode()` and friends.