### PR TITLE
Improve IAS Zone enrollment

### DIFF
--- a/zdp/zdp_handlers.cpp
+++ b/zdp/zdp_handlers.cpp
@@ -169,6 +169,14 @@ void DeRestPluginPrivate::handleDeviceAnnceIndication(const deCONZ::ApsDataIndic
                 Event e(si->prefix(), RConfigReachable, si->id(), item);
                 enqueueEvent(e);
             }
+            
+            item = si->item(RConfigEnrolled); // holds per device IAS state variable
+
+            if (item)
+            {
+                item->setValue(IAS_STATE_INIT);
+            }
+            
             checkSensorGroup(&*si);
             checkSensorBindingsForAttributeReporting(&*si);
             checkSensorBindingsForClientClusters(&*si);


### PR DESCRIPTION
When a device is or was previously paired and either gets reset or at least sends a device announce, the IAS zone enrollment check is not triggered as the corresponding sensor has already the configuration item `enrolled` set to 1 (enrolled). Consequently, if is not checked if that is really accurate.

This PR sets the resource item to the value initializing the enrollment check upon device announcement.