### PR TITLE
Add custom Node Descriptor response handling

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1193,6 +1193,12 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
     {
         switch (ind.clusterId())
         {
+        case ZDP_NODE_DESCRIPTOR_CLID:
+        {
+            ZDP_HandleNodeDescriptorRequest(ind, apsCtrl);
+        }
+            break;
+
         case ZDP_NODE_DESCRIPTOR_RSP_CLID:
         {
             // Safeguard to issue a 2nd active endpoint request in case the first one got MIA

--- a/utils/utils.cpp
+++ b/utils/utils.cpp
@@ -9,7 +9,9 @@
  */
 
 #include <deconz/aps.h>
+#include <deconz/aps_controller.h>
 #include <deconz/dbg_trace.h>
+#include <deconz/node.h>
 #include "utils.h"
 #include "resource.h"
 
@@ -238,4 +240,26 @@ bool isSameAddress(const deCONZ::Address &a, const deCONZ::Address &b)
     else { return false; }
 
     return true;
+}
+
+const deCONZ::Node *getCoreNode(quint64 extAddress, deCONZ::ApsController *apsCtrl)
+{
+    DBG_Assert(apsCtrl);
+
+    if (apsCtrl && extAddress != 0)
+    {
+        int i = 0;
+        const deCONZ::Node *node = nullptr;
+
+        while (apsCtrl->getNode(i, &node) == 0)
+        {
+            if (node->address().ext() == extAddress)
+            {
+                return node;
+            }
+            i++;
+        }
+    }
+
+    return nullptr;
 }

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -18,6 +18,8 @@
 
 namespace deCONZ {
     class Address;
+    class ApsController;
+    class Node;
 }
 
 struct KeyMap
@@ -81,5 +83,7 @@ decltype(auto) matchKeyValue(const K &key, const Cont &cont)
 
     return ret;
 }
+
+const deCONZ::Node *getCoreNode(quint64 extAddress, deCONZ::ApsController *apsCtrl);
 
 #endif // UTILS_H

--- a/zdp/zdp_handlers.h
+++ b/zdp/zdp_handlers.h
@@ -12,4 +12,11 @@
 #define ZDP_HANDLERS_H
 
 
+namespace deCONZ {
+    class ApsController;
+    class ApsDataIndication;
+}
+
+void ZDP_HandleNodeDescriptorRequest(const deCONZ::ApsDataIndication &ind, deCONZ::ApsController *apsCtrl);
+
 #endif // ZDP_HANDLERS_H


### PR DESCRIPTION
With next firmware version and deCONZ v2.12.2-beta, Node Descriptor requests are forwarded to the application.

The handler allows to customize the response for specific devices.