### PR TITLE
Use `isSameAddress()` for address comparison

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -224,26 +224,12 @@ void DeRestPluginPrivate::handleMgmtBindRspIndication(const deCONZ::ApsDataIndic
         std::vector<BindingTableReader>::iterator i = bindingTableReaders.begin();
         std::vector<BindingTableReader>::iterator end = bindingTableReaders.end();
 
-        if (ind.srcAddress().hasExt())
+        for (; i != end; ++i)
         {
-            for (; i != end; ++i)
+            if (isSameAddress(ind.srcAddress(), i->apsReq.dstAddress()))
             {
-                if (i->apsReq.dstAddress().ext() == ind.srcAddress().ext())
-                {
-                    btReader = &(*i);
-                    break;
-                }
-            }
-        }
-        else if (ind.srcAddress().hasNwk())
-        {
-            for (; i != end; ++i)
-            {
-                if (i->apsReq.dstAddress().nwk() == ind.srcAddress().nwk())
-                {
-                    btReader = &(*i);
-                    break;
-                }
+                btReader = &(*i);
+                break;
             }
         }
     }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1308,8 +1308,7 @@ void DeRestPluginPrivate::apsdeDataConfirm(const deCONZ::ApsDataConfirm &conf)
 
         if (conf.dstAddressMode() == deCONZ::ApsNwkAddress &&
             task.req.dstAddressMode() == deCONZ::ApsNwkAddress &&
-            conf.dstAddress().hasNwk() && task.req.dstAddress().hasNwk() &&
-            conf.dstAddress().nwk() != task.req.dstAddress().nwk())
+            !isSameAddress(conf.dstAddress(), task.req.dstAddress()))
         {
             DBG_Printf(DBG_INFO, "warn APSDE-DATA.confirm: 0x%02X nwk mismatch\n", conf.id());
             //continue;
@@ -11910,13 +11909,7 @@ void DeRestPluginPrivate::handleZclAttributeReportIndication(const deCONZ::ApsDa
                 continue;
             }
 
-            if      (ind.srcAddress().hasExt() && sensor.address().hasExt() &&
-                     ind.srcAddress().ext() == sensor.address().ext())
-            { }
-            else if (ind.srcAddress().hasNwk() && sensor.address().hasNwk() &&
-                     ind.srcAddress().nwk() == sensor.address().nwk())
-            { }
-            else
+            if (!isSameAddress(ind.srcAddress(), sensor.address()))
             {
                 continue;
             }
@@ -12015,8 +12008,7 @@ void DeRestPluginPrivate::storeRecoverOnOffBri(LightNode *lightNode)
 
     for (; i != end; ++i)
     {
-        if (i->address.hasNwk() && lightNode->address().hasNwk() &&
-            i->address.nwk() == lightNode->address().nwk())
+        if (isSameAddress(i->address, lightNode->address()))
         {
             // update entry
             i->onOff = onOff ? onOff->toBool() : false;
@@ -13951,8 +13943,7 @@ void DeRestPluginPrivate::handleOnOffClusterIndication(const deCONZ::ApsDataIndi
                 continue;
             }
 
-            if ((s.address().hasExt() && s.address().ext() == ind.srcAddress().ext()) ||
-                (s.address().hasNwk() && s.address().nwk() == ind.srcAddress().nwk()))
+            if (isSameAddress(s.address(), ind.srcAddress()))
             {
                 if (!s.type().endsWith(QLatin1String("Presence")))
                 {

--- a/poll_manager.cpp
+++ b/poll_manager.cpp
@@ -163,16 +163,9 @@ void PollManager::apsdeDataConfirm(const deCONZ::ApsDataConfirm &conf)
         return;
     }
 
-    if (dstAddr.hasExt() && conf.dstAddress().hasExt()
-        && dstAddr.ext() != conf.dstAddress().ext())
+    if (!isSameAddress(dstAddr, conf.dstAddress()))
     {
-
-    }
-
-    else if (dstAddr.hasNwk() && conf.dstAddress().hasNwk()
-        && dstAddr.nwk() != conf.dstAddress().nwk())
-    {
-
+        return;
     }
 
     DBG_Printf(DBG_INFO_L2, "Poll APS confirm %u status: 0x%02X\n", conf.id(), conf.status());

--- a/poll_manager.cpp
+++ b/poll_manager.cpp
@@ -10,6 +10,7 @@
 
 #include "poll_manager.h"
 #include "de_web_plugin_private.h"
+#include "utils/utils.h"
 
 /*! Constructor.
  */

--- a/reset_device.cpp
+++ b/reset_device.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "de_web_plugin_private.h"
+#include "utils/utils.h"
 
 #define CHECK_RESET_DEVICES 3000
 #define WAIT_CONFIRM 2000

--- a/reset_device.cpp
+++ b/reset_device.cpp
@@ -231,9 +231,7 @@ void DeRestPluginPrivate::handleMgmtLeaveRspIndication(const deCONZ::ApsDataIndi
 
             for (i = nodes.begin(); i != end; ++i)
             {
-
-                if ((ind.srcAddress().hasExt() && i->address().ext() == ind.srcAddress().ext()) ||
-                    (ind.srcAddress().hasNwk() && i->address().nwk() == ind.srcAddress().nwk()))
+                if (isSameAddress(ind.srcAddress(), i->address()))
                 {
                    i->setResetRetryCount(0);
                    if (i->state() == LightNode::StateDeleted)
@@ -248,8 +246,7 @@ void DeRestPluginPrivate::handleMgmtLeaveRspIndication(const deCONZ::ApsDataIndi
 
             for (s = sensors.begin(); s != send; ++s)
             {
-                if ((ind.srcAddress().hasExt() && s->address().ext() == ind.srcAddress().ext()) ||
-                    (ind.srcAddress().hasNwk() && s->address().nwk() == ind.srcAddress().nwk()))
+                if (isSameAddress(ind.srcAddress(), s->address()))
                 {
                    s->setResetRetryCount(0);
                    s->item(RConfigReachable)->setValue(false);

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -3109,8 +3109,7 @@ void DeRestPluginPrivate::handleIndicationSearchSensors(const deCONZ::ApsDataInd
         return;
     }
 
-    if ((ind.srcAddress().hasExt() && ind.srcAddress().ext() == fastProbeAddr.ext()) ||
-        (fastProbeAddr.hasExt() && ind.srcAddress().hasNwk() && ind.srcAddress().nwk() == fastProbeAddr.nwk()))
+    if (isSameAddress(ind.srcAddress(), fastProbeAddr))
     {
         DBG_Printf(DBG_INFO, "FP indication 0x%04X / 0x%04X (0x%016llX / 0x%04X)\n", ind.profileId(), ind.clusterId(), ind.srcAddress().ext(), ind.srcAddress().nwk());
         DBG_Printf(DBG_INFO, "                      ...     (0x%016llX / 0x%04X)\n", fastProbeAddr.ext(), fastProbeAddr.nwk());
@@ -3213,16 +3212,7 @@ void DeRestPluginPrivate::handleIndicationSearchSensors(const deCONZ::ApsDataInd
             return;
         }
 
-        if (!fastProbeAddr.hasExt())
-        {
-            return;
-        }
-
-        if (ind.srcAddress().hasExt() && fastProbeAddr.ext() != ind.srcAddress().ext())
-        {
-            return;
-        }
-        else if (ind.srcAddress().hasNwk() && fastProbeAddr.nwk() != ind.srcAddress().nwk())
+        if (!isSameAddress(ind.srcAddress(), fastProbeAddr))
         {
             return;
         }
@@ -3310,13 +3300,7 @@ void DeRestPluginPrivate::handleIndicationSearchSensors(const deCONZ::ApsDataInd
 
         for (; i != end; ++i)
         {
-            if (ind.srcAddress().hasExt() && i->address.ext() == ind.srcAddress().ext())
-            {
-                sc = &*i;
-                break;
-            }
-
-            if (ind.srcAddress().hasNwk() && i->address.nwk() == ind.srcAddress().nwk())
+            if (isSameAddress(ind.srcAddress(), i->address))
             {
                 sc = &*i;
                 break;
@@ -3374,20 +3358,15 @@ void DeRestPluginPrivate::handleIndicationSearchSensors(const deCONZ::ApsDataInd
                 {
                     // ignore
                 }
-                else*/ if (node->address().hasExt() && ind.srcAddress().hasExt() &&
-                    ind.srcAddress().ext() == node->address().ext())
+                else*/
+                
+                if (isSameAddress(node->address(), ind.srcAddress()))
                 {
                     indAddress = node->address();
                     macCapabilities = node->macCapabilities();
                     break;
                 }
-                else if (node->address().hasNwk() && ind.srcAddress().hasNwk() &&
-                    ind.srcAddress().nwk() == node->address().nwk())
-                {
-                    indAddress = node->address();
-                    macCapabilities = node->macCapabilities();
-                    break;
-                }
+                
                 i++;
             }
         }

--- a/utils/utils.cpp
+++ b/utils/utils.cpp
@@ -227,15 +227,15 @@ bool isSameAddress(const deCONZ::Address &a, const deCONZ::Address &b)
         // nested if statement, so the NWK check won't be made if both MAC addresses are known
         if (a.ext() != b.ext())
         {
-             return false;
+            return false;
         }
     }
-    else  if (a.hasNwk() && b.hasNwk())
+    else if (a.hasNwk() && b.hasNwk())
     {
-       if (a.nwk() != b.nwk())
-       {
+        if (a.nwk() != b.nwk())
+        {
             return false;
-       }
+        }
     }
     else { return false; }
 


### PR DESCRIPTION
This PR is intended to make use of `isSameAddress()` more often when address comparisons are required and thereby save some lines of code.

There's further places where `ext()` and its existance is checked exclusively, but I'm not sure if it's appreciated to change those as well (would probably result in a slight processing overhead).