### PR TITLE
Fix ZDP manufacturer specific array size

### DIFF
--- a/zdp/zdp_handlers.cpp
+++ b/zdp/zdp_handlers.cpp
@@ -267,7 +267,7 @@ struct MapMfCode
     quint16 serverMask;
 };
 
-static const std::array<MapMfCode, 3> mapMfCode = {
+static const std::array<MapMfCode, 2> mapMfCode = {
     {
         { 0x04cf8c0000000000ULL, 0x115F, 0x0040}, // Xiaomi
         { 0x54ef440000000000ULL, 0x115F, 0x0040}  // Xiaomi
@@ -331,6 +331,7 @@ void ZDP_HandleNodeDescriptorRequest(const deCONZ::ApsDataIndication &ind, deCON
     }
 
     auto i = std::find_if(mapMfCode.cbegin(), mapMfCode.cend(), [&ind](const auto &entry) {
+        Q_ASSERT(entry.macPrefix != 0); // array size larger than given entries
         return (ind.srcAddress().ext() & entry.macPrefix) == entry.macPrefix;
     });
 


### PR DESCRIPTION
The default `std::array` initialization sets every unspecified member to 0, resulting in `std::find_if`  returning the last entry.

* Fix the array size
* Add check to catch this error in future