### PR TITLE
Omit exposure of certain resource items for Aqara Single Switch Module T1 (with neutral)

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -3471,6 +3471,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     (!sensor.modelId().startsWith(QLatin1String("lumi.plug.ma"))) &&
                     (sensor.modelId() != QLatin1String("Plug-230V-ZB3.0")) &&
                     (sensor.modelId() != QLatin1String("lumi.switch.b1naus01")) &&
+                    (sensor.modelId() != QLatin1String("lumi.switch.n0agl1")) &&
                     (sensor.modelId() != QLatin1String("Connected socket outlet")) &&
                     (!sensor.modelId().startsWith(QLatin1String("SPW35Z"))))
                 {
@@ -3888,6 +3889,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 sensor.modelId() != QLatin1String("lumi.curtain") &&
                 sensor.modelId() != QLatin1String("lumi.sensor_natgas") &&
                 sensor.modelId() != QLatin1String("lumi.switch.b1naus01") &&
+                sensor.modelId() != QLatin1String("lumi.switch.n0agl1") &&
                 !sensor.modelId().startsWith(QLatin1String("lumi.relay.c")) &&
                 !sensor.type().endsWith(QLatin1String("Battery")))
             {

--- a/database.cpp
+++ b/database.cpp
@@ -3924,6 +3924,11 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 item = sensor.addItem(DataTypeUInt16, RConfigPending);
                 item->setValue(item->toNumber() | R_PENDING_MODE);
             }
+            
+            if (sensor.modelId() == QLatin1String("lumi.switch.n0agl1"))
+            {
+                sensor.removeItem(RConfigBattery);
+            }
         }
         else if (sensor.modelId().startsWith(QLatin1String("tagv4"))) // SmartThings Arrival sensor
         {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -7355,7 +7355,13 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
     else if (modelId.startsWith(QLatin1String("lumi")))
     {
         sensorNode.setManufacturer("LUMI");
-        if (!sensorNode.node()->nodeDescriptor().receiverOnWhenIdle() && sensorNode.modelId() != QLatin1String("lumi.sensor_natgas") &&
+        if (!sensorNode.modelId().startsWith(QLatin1String("lumi.ctrl_")) &&
+            !sensorNode.modelId().startsWith(QLatin1String("lumi.plug")) &&
+            !sensorNode.modelId().startsWith(QLatin1String("lumi.relay.c")) &&
+            sensorNode.modelId() != QLatin1String("lumi.curtain") &&
+            sensorNode.modelId() != QLatin1String("lumi.sensor_natgas") &&
+            sensorNode.modelId() != QLatin1String("lumi.switch.b1naus01") &&
+            sensorNode.modelId() != QLatin1String("lumi.switch.n0agl1") &&
             !sensorNode.type().endsWith(QLatin1String("Battery")))
         {
             sensorNode.addItem(DataTypeUInt8, RConfigBattery);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6862,6 +6862,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                 (!modelId.startsWith(QLatin1String("lumi.plug.ma"))) &&
                 (modelId != QLatin1String("Plug-230V-ZB3.0")) &&
                 (modelId != QLatin1String("lumi.switch.b1naus01")) &&
+                (modelId != QLatin1String("lumi.switch.n0agl1")) &&
                 (modelId != QLatin1String("Connected socket outlet")) &&
                 (!modelId.startsWith(QLatin1String("SPW35Z"))))
             {
@@ -7354,12 +7355,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
     else if (modelId.startsWith(QLatin1String("lumi")))
     {
         sensorNode.setManufacturer("LUMI");
-        if (!sensorNode.modelId().startsWith(QLatin1String("lumi.ctrl_")) &&
-            !sensorNode.modelId().startsWith(QLatin1String("lumi.plug")) &&
-            !sensorNode.modelId().startsWith(QLatin1String("lumi.relay.c")) &&
-            sensorNode.modelId() != QLatin1String("lumi.curtain") &&
-            sensorNode.modelId() != QLatin1String("lumi.sensor_natgas") &&
-            sensorNode.modelId() != QLatin1String("lumi.switch.b1naus01") &&
+        if (!sensorNode.node()->nodeDescriptor().receiverOnWhenIdle() && sensorNode.modelId() != QLatin1String("lumi.sensor_natgas") &&
             !sensorNode.type().endsWith(QLatin1String("Battery")))
         {
             sensorNode.addItem(DataTypeUInt8, RConfigBattery);


### PR DESCRIPTION
Do not expose RConfigBattery (mains powered) and RStatePower (for consumption sensor)