### PR TITLE
Add support for Legrand  ZGP kinetic switch (Self-e)

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1599,30 +1599,30 @@ void DeRestPluginPrivate::gpProcessButtonEvent(const deCONZ::GpDataIndication &i
     }
     else if (sensor->modelId() == QLatin1String("LEGRANDZGPTOGGLESWITCH"))
     {
-        if (btn == GpCommandIdToggle)
+        if (btn == deCONZ::GpCommandIdToggle)
         {
             btn = S_BUTTON_1 + S_BUTTON_ACTION_SHORT_RELEASED;
         }
-        else //Will be GpCommandIdOff
+        else //Will be deCONZ::GpCommandIdOff
         {
             btn = S_BUTTON_1 + S_BUTTON_ACTION_DOUBLE_PRESS;
         }
     }
     else if sensor->modelId() == QLatin1String("LEGRANDZGPSCENESWITCH"))
     {
-        if (btn == GpCommandIdScene4)
+        if (btn == deCONZ::GpCommandIdScene4)
         {
             btn = S_BUTTON_1 + S_BUTTON_ACTION_SHORT_RELEASED;
         }
-        else if (btn == GpCommandIdScene5)
+        else if (btn == deCONZ::GpCommandIdScene5)
         {
             btn = S_BUTTON_2 + S_BUTTON_ACTION_SHORT_RELEASED;
         }
-        else if (btn == GpCommandIdScene6)
+        else if (btn == deCONZ::GpCommandIdScene6)
         {
             btn = S_BUTTON_3 + S_BUTTON_ACTION_SHORT_RELEASED;
         }
-        else //Will be GpCommandIdScene7
+        else //Will be deCONZ::GpCommandIdScene7
         {
             btn = S_BUTTON_4 + S_BUTTON_ACTION_SHORT_RELEASED;
         }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1885,7 +1885,7 @@ void DeRestPluginPrivate::gpDataIndication(const deCONZ::GpDataIndication &ind)
                 // 0x20 GpCommandIdOff
                 // 0x22 GpCommandIdToggle
 
-                sensorNode.setModelId("ZGPSWITCH");
+                sensorNode.setModelId("LEGRANDZGPSWITCH");
                 sensorNode.setManufacturer("Legrand");
                 sensorNode.setSwVersion("1.0");
             }
@@ -1921,7 +1921,7 @@ void DeRestPluginPrivate::gpDataIndication(const deCONZ::GpDataIndication &ind)
                 {
                     sensorNode.setName(QString("FoH Switch %2").arg(sensorNode.id()));
                 }
-                else if (sensorNode.Manufacturer() == QLatin1String("Legrand"))
+                else if (sensorNode.manufacturer() == QLatin1String("Legrand"))
                 {
                     sensorNode.setName(QString("Self-e switch %2").arg(sensorNode.id()));
                 }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1470,6 +1470,7 @@ void DeRestPluginPrivate::gpProcessButtonEvent(const deCONZ::GpDataIndication &i
     sensor->rx();
 
     quint32 btn = ind.gpdCommandId();
+
     if (sensor->modelId() == QLatin1String("FOHSWITCH"))
     {
         // Map the command to the mapped button and action.
@@ -1649,6 +1650,9 @@ int DeRestPluginPrivate::taskCountForAddress(const deCONZ::Address &address)
  */
 void DeRestPluginPrivate::gpDataIndication(const deCONZ::GpDataIndication &ind)
 {
+    // display some information
+    DBG_Printf(DBG_ZGP, "ZGP  : gpdsrcid %u , command 0x%02X , Payload %s\n", ind.gpdSrcId(), ind.gpdCommandId(), qPrintable(ind.payload().toHex()));
+    
     switch (ind.gpdCommandId())
     {
     case deCONZ::GpCommandIdScene0:
@@ -1867,6 +1871,23 @@ void DeRestPluginPrivate::gpDataIndication(const deCONZ::GpDataIndication &ind)
                 sensorNode.setModelId("FOHSWITCH");
                 sensorNode.setManufacturer("PhilipsFoH");
                 sensorNode.setSwVersion("PTM216Z");
+            }
+            else if (gpdDeviceId == GpDeviceIdGenericSwitch && options.byte == 0xC5 && extOptions.byte == 0xF2 && ind.payload().size() == 31)
+            {
+                //For the 1 button switch (0 677 23L or ZLGP17):
+                //Button 1: Device commissioning : options.byte 0xC5 , extOptions.byte 0xF2 , gpdsrcid 5345230 , command 0x02 , Payload 02c5f20164366c366d12f5587972fd1dae3dee65ff1de0f001000004022220
+
+                //For the 2 buttons switch (0 677 24L or ZLGP18):
+                //Button 1: Device commissioning : options.byte 0xC5 , extOptions.byte 0xF2 , gpdsrcid 5375258 , command 0x02 , Payload 02c5f29ddf38cc0baaa63c6d8c31176a7d50892a7f84e35f00000004022220
+                //Button 2: Device commissioning : options.byte 0xC5 , extOptions.byte 0xF2 , gpdsrcid 5375259 , command 0x02 , Payload 02c5f2361cf5a1f812cebb4744edfec5d591f07fe3e2935800000004022220
+                
+                // It use as command
+                // 0x20 GpCommandIdOff
+                // 0x22 GpCommandIdToggle
+
+                sensorNode.setModelId("ZGPSWITCH");
+                sensorNode.setManufacturer("Legrand");
+                sensorNode.setSwVersion("1.0");
             }
             else
             {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1921,6 +1921,10 @@ void DeRestPluginPrivate::gpDataIndication(const deCONZ::GpDataIndication &ind)
                 {
                     sensorNode.setName(QString("FoH Switch %2").arg(sensorNode.id()));
                 }
+                else if (sensorNode.Manufacturer() == QLatin1String("Legrand"))
+                {
+                    sensorNode.setName(QString("Self-e switch %2").arg(sensorNode.id()));
+                }
                 else
                 {
                     sensorNode.setName(QString("Hue Tap %2").arg(sensorNode.id()));

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1597,6 +1597,36 @@ void DeRestPluginPrivate::gpProcessButtonEvent(const deCONZ::GpDataIndication &i
             btn = btnMapped + S_BUTTON_ACTION_LONG_RELEASED;
         }
     }
+    else if (sensor->modelId() == QLatin1String("LEGRANDZGPTOGGLESWITCH"))
+    {
+        if (btn == GpCommandIdToggle)
+        {
+            btn = S_BUTTON_1 + S_BUTTON_ACTION_SHORT_RELEASED;
+        }
+        else //Will be GpCommandIdOff
+        {
+            btn = S_BUTTON_1 + S_BUTTON_ACTION_DOUBLE_PRESS;
+        }
+    }
+    else if sensor->modelId() == QLatin1String("LEGRANDZGPSCENESWITCH"))
+    {
+        if (btn == GpCommandIdScene4)
+        {
+            btn = S_BUTTON_1 + S_BUTTON_ACTION_SHORT_RELEASED;
+        }
+        else if (btn == GpCommandIdScene5)
+        {
+            btn = S_BUTTON_2 + S_BUTTON_ACTION_SHORT_RELEASED;
+        }
+        else if (btn == GpCommandIdScene6)
+        {
+            btn = S_BUTTON_3 + S_BUTTON_ACTION_SHORT_RELEASED;
+        }
+        else //Will be GpCommandIdScene7
+        {
+            btn = S_BUTTON_4 + S_BUTTON_ACTION_SHORT_RELEASED;
+        }
+    }
 
     updateSensorEtag(sensor);
     sensor->updateStateTimestamp();

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1820,6 +1820,9 @@ void DeRestPluginPrivate::gpDataIndication(const deCONZ::GpDataIndication &ind)
             {
                 return;
             }
+            
+            // display some information
+            DBG_Printf(DBG_ZGP, "Device commissioning : options.byte 0x%02X , extOptions.byte 0x%02X , gpdsrcid %u , command 0x%02X , Payload %s\n", options.byte, extOptions.byte, ind.gpdSrcId(), gpdDeviceId, qPrintable(ind.payload().toHex()));
 
             // create new sensor
             Sensor sensorNode;

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1608,7 +1608,7 @@ void DeRestPluginPrivate::gpProcessButtonEvent(const deCONZ::GpDataIndication &i
             btn = S_BUTTON_1 + S_BUTTON_ACTION_DOUBLE_PRESS;
         }
     }
-    else if sensor->modelId() == QLatin1String("LEGRANDZGPSCENESWITCH"))
+    else if (sensor->modelId() == QLatin1String("LEGRANDZGPSCENESWITCH"))
     {
         if (btn == deCONZ::GpCommandIdScene4)
         {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1936,7 +1936,8 @@ void DeRestPluginPrivate::gpDataIndication(const deCONZ::GpDataIndication &ind)
                 {
                     sensorNode.setName(QString("FoH Switch %2").arg(sensorNode.id()));
                 }
-                else if (sensorNode.modelId() == QLatin1String("LEGRANDZGPSWITCH"))
+                else if (sensorNode.modelId() == QLatin1String("LEGRANDZGPTOGGLESWITCH") ||
+                         sensorNode.modelId() == QLatin1String("LEGRANDZGPSCENESWITCH"))
                 {
                     sensorNode.setName(QString("Self-e switch %2").arg(sensorNode.id()));
                 }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1826,7 +1826,7 @@ void DeRestPluginPrivate::gpDataIndication(const deCONZ::GpDataIndication &ind)
             }
             
             // display some information
-            DBG_Printf(DBG_ZGP, "Device commissioning : options.byte 0x%02X, extOptions.byte 0x%02X\n", options.byte, extOptions.byte);
+            DBG_Printf(DBG_ZGP, "Device commissioning : device type 0x%02X, options.byte 0x%02X, extOptions.byte 0x%02X\n", gpdDeviceId, options.byte, extOptions.byte);
 
             // create new sensor
             Sensor sensorNode;
@@ -1875,17 +1875,32 @@ void DeRestPluginPrivate::gpDataIndication(const deCONZ::GpDataIndication &ind)
             else if (gpdDeviceId == GpDeviceIdOnOffSwitch && options.byte == 0xC5 && extOptions.byte == 0xF2 && ind.payload().size() == 31)
             {
                 //For the 1 button switch (0 677 23L or ZLGP17):
-                //Button 1: Device commissioning : options.byte 0xC5 , extOptions.byte 0xF2 , gpdsrcid 5345230 , command 0x02 , Payload 02c5f20164366c366d12f5587972fd1dae3dee65ff1de0f001000004022220
+                //Button 1: Device commissioning : options.byte 0xC5 , extOptions.byte 0xF2 , gpdsrcid 5345230 , gpdDeviceId 0x02 , Payload 02c5f20164366c366d12f5587972fd1dae3dee65ff1de0f001000004022220
 
                 //For the 2 buttons switch (0 677 24L or ZLGP18):
-                //Button 1: Device commissioning : options.byte 0xC5 , extOptions.byte 0xF2 , gpdsrcid 5375258 , command 0x02 , Payload 02c5f29ddf38cc0baaa63c6d8c31176a7d50892a7f84e35f00000004022220
-                //Button 2: Device commissioning : options.byte 0xC5 , extOptions.byte 0xF2 , gpdsrcid 5375259 , command 0x02 , Payload 02c5f2361cf5a1f812cebb4744edfec5d591f07fe3e2935800000004022220
+                //Button 1: Device commissioning : options.byte 0xC5 , extOptions.byte 0xF2 , gpdsrcid 5375258 , gpdDeviceId 0x02 , Payload 02c5f29ddf38cc0baaa63c6d8c31176a7d50892a7f84e35f00000004022220
+                //Button 2: Device commissioning : options.byte 0xC5 , extOptions.byte 0xF2 , gpdsrcid 5375259 , gpdDeviceId 0x02 , Payload 02c5f2361cf5a1f812cebb4744edfec5d591f07fe3e2935800000004022220
                 
-                // It use as command
+                // they use as command
                 // 0x20 GpCommandIdOff
                 // 0x22 GpCommandIdToggle
 
-                sensorNode.setModelId("LEGRANDZGPSWITCH");
+                sensorNode.setModelId("LEGRANDZGPTOGGLESWITCH");
+                sensorNode.setManufacturer("Legrand");
+                sensorNode.setSwVersion("1.0");
+            }
+            else if (gpdDeviceId == 0xfe && options.byte == 0xC5 && extOptions.byte == 0xF2 && ind.payload().size() == 37) //0xfe is for scene switch ?
+            {
+                //For the 4 buttons switch (0 677 55L or ZLGP15):
+                //          Device commissioning : options.byte 0xC5 , extOptions.byte 0xF2 , gpdsrcid 5350418 , gpdDeviceId 0x02 , Payload fec5f20aed654eac2b62be20be25648b591e5097033fbf640000000408141516171c1d1e1f
+                
+                // they use as command
+                // 0x14 GpCommandIdScene4
+                // 0x15 GpCommandIdScene5
+                // 0x16 GpCommandIdScene6
+                // 0x17 GpCommandIdScene7
+
+                sensorNode.setModelId("LEGRANDZGPSCENESWITCH");
                 sensorNode.setManufacturer("Legrand");
                 sensorNode.setSwVersion("1.0");
             }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1651,7 +1651,7 @@ int DeRestPluginPrivate::taskCountForAddress(const deCONZ::Address &address)
 void DeRestPluginPrivate::gpDataIndication(const deCONZ::GpDataIndication &ind)
 {
     // display some information
-    DBG_Printf(DBG_ZGP, "ZGP  : gpdsrcid %u , command 0x%02X , Payload %s\n", ind.gpdSrcId(), ind.gpdCommandId(), qPrintable(ind.payload().toHex()));
+    DBG_Printf(DBG_ZGP, "Incoming ZGP Frame: gpdsrcid %u, command 0x%02X, Payload %s\n", ind.gpdSrcId(), ind.gpdCommandId(), qPrintable(ind.payload().toHex()));
     
     switch (ind.gpdCommandId())
     {
@@ -1826,7 +1826,7 @@ void DeRestPluginPrivate::gpDataIndication(const deCONZ::GpDataIndication &ind)
             }
             
             // display some information
-            DBG_Printf(DBG_ZGP, "Device commissioning : options.byte 0x%02X , extOptions.byte 0x%02X , gpdsrcid %u , command 0x%02X , Payload %s\n", options.byte, extOptions.byte, ind.gpdSrcId(), gpdDeviceId, qPrintable(ind.payload().toHex()));
+            DBG_Printf(DBG_ZGP, "Device commissioning : options.byte 0x%02X, extOptions.byte 0x%02X\n", options.byte, extOptions.byte);
 
             // create new sensor
             Sensor sensorNode;

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1872,7 +1872,7 @@ void DeRestPluginPrivate::gpDataIndication(const deCONZ::GpDataIndication &ind)
                 sensorNode.setManufacturer("PhilipsFoH");
                 sensorNode.setSwVersion("PTM216Z");
             }
-            else if (gpdDeviceId == GpDeviceIdGenericSwitch && options.byte == 0xC5 && extOptions.byte == 0xF2 && ind.payload().size() == 31)
+            else if (gpdDeviceId == GpDeviceIdOnOffSwitch && options.byte == 0xC5 && extOptions.byte == 0xF2 && ind.payload().size() == 31)
             {
                 //For the 1 button switch (0 677 23L or ZLGP17):
                 //Button 1: Device commissioning : options.byte 0xC5 , extOptions.byte 0xF2 , gpdsrcid 5345230 , command 0x02 , Payload 02c5f20164366c366d12f5587972fd1dae3dee65ff1de0f001000004022220

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1921,7 +1921,7 @@ void DeRestPluginPrivate::gpDataIndication(const deCONZ::GpDataIndication &ind)
                 {
                     sensorNode.setName(QString("FoH Switch %2").arg(sensorNode.id()));
                 }
-                else if (sensorNode.manufacturer() == QLatin1String("Legrand"))
+                else if (sensorNode.modelId() == QLatin1String("LEGRANDZGPSWITCH"))
                 {
                     sensorNode.setName(QString("Self-e switch %2").arg(sensorNode.id()));
                 }


### PR DESCRIPTION
Tested devices are the 1, 2 gangs Toggle switch  and the scene one.
see > https://forum.phoscon.de/t/legrand-self-e-batteryless-switches-zlgp1x/95


- the 1 button switch (0 677 23L or ZLGP17)
- the 2 buttons switch (0 677 24L or ZLGP18)
- the 4 buttons switch (0 677 55L or ZLGP15)

(Just need to add a L at previous reference)

```

{
    "config": {
        "on": true
    },
    "ep": 242,
    "etag": "4a1be5089a93990eb183cecac8dc1e65",
    "lastseen": "2021-07-12T15:22Z",
    "manufacturername": "Legrand",
    "modelid": "LEGRANDZGPSWITCH",
    "name": "Self-e switch 4",
    "state": {
        "buttonevent": 224,
        "lastupdated": "2021-07-12T15:22:53.464"
    },
    "type": "ZGPSwitch",
    "uniqueid": "00:00:00:00:00:52:05:1b-f2"
}
```