### PR TITLE
Correct switch configuration code for Opple/WRS-R02

### DIFF
--- a/xiaomi.cpp
+++ b/xiaomi.cpp
@@ -694,30 +694,25 @@ void DeRestPluginPrivate::handleZclAttributeReportIndicationXiaomiSpecial(const 
     
     item = r->item(RAttrModelId);
 
-    if (item && item->toString().endsWith(QLatin1String("86opcn01")))
+    if (item && (item->toString().endsWith(QLatin1String("86opcn01")) || item->toString() == QLatin1String("lumi.remote.b28ac1")))
     {
         auto *item2 = r->item(RConfigPending);
         
-        if (item && (item->toString().endsWith(QLatin1String("86opcn01")) || item->toString() == QLatin1String("lumi.remote.b28ac1")))
+        if (item2 && (item2->toNumber() & R_PENDING_MODE))
         {
-            auto *item2 = r->item(RConfigPending);
-            
-            if (item2 && (item2->toNumber() & R_PENDING_MODE))
-            {
-                // Aqara switches need to be configured to send proper button events
-                // send the magic word
-                DBG_Printf(DBG_INFO, "Write Aqara switch 0x%016llX mode attribute 0x0009 = 1\n", ind.srcAddress().ext());
-                deCONZ::ZclAttribute attr(0x0009, deCONZ::Zcl8BitUint, QLatin1String("mode"), deCONZ::ZclReadWrite, false);
-                attr.setValue(static_cast<quint64>(1));
-                writeAttribute(restNodePending, 0x01, XIAOMI_CLUSTER_ID, attr, VENDOR_XIAOMI);
+            // Aqara switches need to be configured to send proper button events
+            // send the magic word
+            DBG_Printf(DBG_INFO, "Write Aqara switch 0x%016llX mode attribute 0x0009 = 1\n", ind.srcAddress().ext());
+            deCONZ::ZclAttribute attr(0x0009, deCONZ::Zcl8BitUint, QLatin1String("mode"), deCONZ::ZclReadWrite, false);
+            attr.setValue(static_cast<quint64>(1));
+            writeAttribute(restNodePending, 0x01, XIAOMI_CLUSTER_ID, attr, VENDOR_XIAOMI);
 
-                DBG_Printf(DBG_INFO, "Write Aqara switch 0x%016llX multiclick mode attribute 0x0125 = 2\n", ind.srcAddress().ext());
-                deCONZ::ZclAttribute attr2(0x0125, deCONZ::Zcl8BitUint, QLatin1String("multiclick mode"), deCONZ::ZclReadWrite, false);
-                attr2.setValue(static_cast<quint64>(2));
-                writeAttribute(restNodePending, 0x01, XIAOMI_CLUSTER_ID, attr2, VENDOR_XIAOMI);
+            DBG_Printf(DBG_INFO, "Write Aqara switch 0x%016llX multiclick mode attribute 0x0125 = 2\n", ind.srcAddress().ext());
+            deCONZ::ZclAttribute attr2(0x0125, deCONZ::Zcl8BitUint, QLatin1String("multiclick mode"), deCONZ::ZclReadWrite, false);
+            attr2.setValue(static_cast<quint64>(2));
+            writeAttribute(restNodePending, 0x01, XIAOMI_CLUSTER_ID, attr2, VENDOR_XIAOMI);
 
-                item2->setValue(item2->toNumber() & ~R_PENDING_MODE);
-            }
+            item2->setValue(item2->toNumber() & ~R_PENDING_MODE);
         }
     }
 


### PR DESCRIPTION
Due to some missed lines of code (which should have been deleted), the mechanism did exclusively work for Opple switches but not for the WRS-R02 (in case initial configuration fails). This also resolves the corresponding compiler warning.