### PR TITLE
Fix Aqara WXKG11LM 2018 remote button handling

### DIFF
--- a/button_maps.json
+++ b/button_maps.json
@@ -577,7 +577,7 @@
                 [1, "0x01", "MULTISTATE_INPUT", "ATTRIBUTE_REPORT", "255", "S_BUTTON_1", "S_BUTTON_ACTION_LONG_RELEASED", "Long released"]
             ]
         },
-        "xiaomiSwitchB1acn01Map": {
+        "xiaomiSwitchB28ac1Map": {
             "vendor": "Xiaomi",
             "doc": "WRS-R02 Aqara wireless remote switch H1 (Double Rocker)",
             "modelids": ["lumi.remote.b28ac1"],


### PR DESCRIPTION
Regression from v2.12.2-beta. Due the duplicated JSON key "xiaomiSwitchB1acn01Map", only the last one was properly  loaded.

Related PR: https://github.com/dresden-elektronik/deconz-rest-plugin/pull/5067

Issue: https://github.com/dresden-elektronik/deconz-rest-plugin/issues/5117