### PR TITLE
Add EventEmitter class to decouple enqueueEvent() from plugin

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -4141,8 +4141,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                         item = sensor.item(RConfigGroup);
                         if (item && !item->toString().isEmpty() && item->toString() != QLatin1String("0"))
                         {
-                            Event e(RSensors, REventValidGroup, sensor.id());
-                            d->enqueueEvent(e);
+                            enqueueEvent(Event(RSensors, REventValidGroup, sensor.id()));
                         }
                     }
                 }

--- a/de_web.pro
+++ b/de_web.pro
@@ -116,6 +116,7 @@ HEADERS  = bindings.h \
            de_web_plugin_private.h \
            de_web_widget.h \
            event.h \
+           event_emitter.h \
            fan_control.h \
            gateway.h \
            gateway_scanner.h \
@@ -163,6 +164,7 @@ SOURCES  = air_quality.cpp \
            de_otau.cpp \
            electrical_measurement.cpp \
            event.cpp \
+           event_emitter.cpp \
            event_queue.cpp \
            fan_control.cpp \
            firmware_update.cpp \

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -603,7 +603,8 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
     databaseTimer = new QTimer(this);
     databaseTimer->setSingleShot(true);
 
-    initEventQueue();
+    eventEmitter = new EventEmitter(this);
+    connect(eventEmitter, &EventEmitter::eventNotify, this, &DeRestPluginPrivate::handleEvent);
     initResourceDescriptors();
 
     connect(databaseTimer, SIGNAL(timeout()),
@@ -900,6 +901,7 @@ DeRestPluginPrivate::~DeRestPluginPrivate()
         inetDiscoveryManager->deleteLater();
         inetDiscoveryManager = 0;
     }
+    eventEmitter = nullptr;
 }
 
 DeRestPluginPrivate *DeRestPluginPrivate::instance()
@@ -15982,7 +15984,7 @@ void DeRestPlugin::idleTimerFired()
     if (localTime)
     {
         localTime->setValue(QDateTime::currentDateTime());
-        d->enqueueEvent(Event(RConfig, RConfigLocalTime, 0));
+        enqueueEvent(Event(RConfig, RConfigLocalTime, 0));
     }
 
     if (d->idleLastActivity < IDLE_USER_LIMIT)

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -25,7 +25,7 @@
 #include "aps_controller_wrapper.h"
 #include "resource.h"
 #include "daylight.h"
-#include "event.h"
+#include "event_emitter.h"
 #include "green_power.h"
 #include "resource.h"
 #include "rest_node_base.h"
@@ -1374,9 +1374,7 @@ public Q_SLOTS:
     void checkSensorStateTimerFired();
 
     // events
-    void initEventQueue();
-    void eventQueueTimerFired();
-    void enqueueEvent(const Event &event);
+    void handleEvent(const Event &e);
 
     // firmware update
     void initFirmwareUpdate();
@@ -2101,8 +2099,7 @@ public:
     uint8_t haEndpoint;
 
     // events
-    QTimer *eventTimer;
-    std::deque<Event> eventQueue;
+    EventEmitter *eventEmitter = nullptr;
 
     // bindings
     size_t verifyRuleIter;

--- a/event_emitter.cpp
+++ b/event_emitter.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ */
+
+#include <QTimer>
+#include <QElapsedTimer>
+#include "event_emitter.h"
+
+static EventEmitter *instance_ = nullptr;
+
+EventEmitter::EventEmitter(QObject *parent) :
+    QObject(parent)
+{
+    m_queue.reserve(64);
+
+    m_timer = new QTimer(this);
+    m_timer->setSingleShot(true);
+    m_timer->setInterval(1);
+    connect(m_timer, &QTimer::timeout, this, &EventEmitter::timerFired);
+
+    Q_ASSERT(instance_ == nullptr);
+    instance_ = this;
+}
+
+void EventEmitter::enqueueEvent(const Event &event)
+{
+    m_queue.push_back(event);
+
+    if (!m_timer->isActive())
+    {
+        m_timer->start();
+    }
+}
+
+EventEmitter::~EventEmitter()
+{
+    instance_ = nullptr;
+}
+
+void EventEmitter::timerFired()
+{
+    QElapsedTimer t;
+    t.start();
+    while (m_pos < m_queue.size() && t.elapsed() < 10)
+    {
+        emit eventNotify(m_queue[m_pos]);
+        m_pos++;
+        if (m_pos == m_queue.size())
+        {
+            m_queue.clear();
+            m_pos = 0;
+        }
+    }
+
+    if (!m_queue.empty())
+    {
+        m_timer->start();
+    }
+}
+
+/*! Puts an event into the queue.
+    \param event - the event
+ */
+void enqueueEvent(const Event &event)
+{
+    if (instance_)
+    {
+        instance_->enqueueEvent(event);
+    }
+}

--- a/event_emitter.h
+++ b/event_emitter.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ */
+
+#ifndef EVENT_EMITTER_H
+#define EVENT_EMITTER_H
+
+#include <QObject>
+#include <vector>
+#include "event.h"
+
+class QTimer;
+
+void enqueueEvent(const Event &event);
+
+class EventEmitter : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit EventEmitter(QObject *parent = nullptr);
+    void enqueueEvent(const Event &event);
+    ~EventEmitter();
+
+public Q_SLOTS:
+    void timerFired();
+
+Q_SIGNALS:
+    void eventNotify(const Event&);
+
+private:
+    size_t m_pos = 0;
+    QTimer *m_timer = nullptr;
+    std::vector<Event> m_queue;
+};
+
+#endif // EVENT_EMITTER_H

--- a/event_queue.cpp
+++ b/event_queue.cpp
@@ -1,25 +1,9 @@
-#include <QVariantMap>
 #include "de_web_plugin_private.h"
-#include "json.h"
-
-/*! Inits the event queue.
- */
-void DeRestPluginPrivate::initEventQueue()
-{
-    eventTimer = new QTimer(this);
-    eventTimer->setSingleShot(true);
-    eventTimer->setInterval(1);
-    connect(eventTimer, SIGNAL(timeout()), this, SLOT(eventQueueTimerFired()));
-}
 
 /*! Handles one event and fires again if more are in the queue.
  */
-void DeRestPluginPrivate::eventQueueTimerFired()
+void DeRestPluginPrivate::handleEvent(const Event &e)
 {
-    DBG_Assert(!eventQueue.empty());
-
-    Event &e = eventQueue.front();
-
     if (e.resource() == RSensors)
     {
         handleSensorEvent(e);
@@ -34,29 +18,4 @@ void DeRestPluginPrivate::eventQueueTimerFired()
     }
 
     handleRuleEvent(e);
-
-    eventQueue.pop_front();
-
-    if (!eventQueue.empty())
-    {
-        eventTimer->start();
-    }
-}
-
-/*! Puts an event into the queue.
-    \param event - the event
- */
-void DeRestPluginPrivate::enqueueEvent(const Event &event)
-{
-    if (DBG_IsEnabled(DBG_INFO_L2) && event.what() && event.resource())
-    {
-        DBG_Printf(DBG_INFO_L2, "enqueue event %s for %s/%s\n", event.what(), event.resource(), qPrintable(event.id()));
-    }
-
-    eventQueue.push_back(event);
-
-    if (!eventTimer->isActive())
-    {
-        eventTimer->start();
-    }
 }

--- a/light_node.cpp
+++ b/light_node.cpp
@@ -271,7 +271,7 @@ uint8_t LightNode::colorLoopSpeed() const
  */
 void LightNode::didSetValue(ResourceItem *i)
 {
-    plugin->enqueueEvent(Event(RLights, i->descriptor().suffix, id(), i));
+    enqueueEvent(Event(RLights, i->descriptor().suffix, id(), i));
     plugin->updateLightEtag(this);
     setNeedSaveDatabase(true);
     plugin->saveDatabaseItems |= DB_LIGHTS;

--- a/poll_control.cpp
+++ b/poll_control.cpp
@@ -53,7 +53,7 @@ static void handleCheckinCommand(DeRestPluginPrivate *plugin, const deCONZ::ApsD
         {
             item->setIsPublic(false);
             item->setValue(now);
-            plugin->enqueueEvent(Event(r->prefix(), item->descriptor().suffix, r->toString(RAttrId), item));
+            enqueueEvent(Event(r->prefix(), item->descriptor().suffix, r->toString(RAttrId), item));
         }
     }
 

--- a/rest_devices.cpp
+++ b/rest_devices.cpp
@@ -73,7 +73,7 @@ bool deleteSensor(Sensor *sensor, DeRestPluginPrivate *plugin)
         sensor->setNeedSaveDatabase(true);
         sensor->setResetRetryCount(10);
 
-        plugin->enqueueEvent(Event(sensor->prefix(), REventDeleted, sensor->id()));
+        enqueueEvent(Event(sensor->prefix(), REventDeleted, sensor->id()));
         return true;
     }
 
@@ -106,7 +106,7 @@ bool deleteLight(LightNode *lightNode, DeRestPluginPrivate *plugin)
             }
         }
 
-        plugin->enqueueEvent(Event(lightNode->prefix(), REventDeleted, lightNode->id()));
+        enqueueEvent(Event(lightNode->prefix(), REventDeleted, lightNode->id()));
         return true;
     }
 

--- a/rest_groups.cpp
+++ b/rest_groups.cpp
@@ -2785,7 +2785,7 @@ static void recallSceneCheckGroupChanges(DeRestPluginPrivate *d, Group *group, S
         if (item && item->toBool() != ls->on())
         {
             item->setValue(ls->on());
-            d->enqueueEvent(Event(RLights, RStateOn, lightNode->id(), item));
+            enqueueEvent(Event(RLights, RStateOn, lightNode->id(), item));
             changed = true;
             groupOnChanged = true;
         }
@@ -2794,7 +2794,7 @@ static void recallSceneCheckGroupChanges(DeRestPluginPrivate *d, Group *group, S
         if (item && ls->bri() != item->toNumber())
         {
             item->setValue(ls->bri());
-            d->enqueueEvent(Event(RLights, RStateBri, lightNode->id(), item));
+            enqueueEvent(Event(RLights, RStateBri, lightNode->id(), item));
             changed = true;
             groupBriChanged = true;
         }
@@ -2805,7 +2805,7 @@ static void recallSceneCheckGroupChanges(DeRestPluginPrivate *d, Group *group, S
             if (ls->colorMode() != item->toString())
             {
                 item->setValue(ls->colorMode());
-                d->enqueueEvent(Event(RLights, RStateColorMode, lightNode->id()));
+                enqueueEvent(Event(RLights, RStateColorMode, lightNode->id()));
                 changed = true;
                 groupColorModeChanged = true;
             }
@@ -2816,14 +2816,14 @@ static void recallSceneCheckGroupChanges(DeRestPluginPrivate *d, Group *group, S
                 if (item && ls->x() != item->toNumber())
                 {
                     item->setValue(ls->x());
-                    d->enqueueEvent(Event(RLights, RStateX, lightNode->id(), item));
+                    enqueueEvent(Event(RLights, RStateX, lightNode->id(), item));
                     changed = true;
                 }
                 item = lightNode->item(RStateY);
                 if (item && ls->y() != item->toNumber())
                 {
                     item->setValue(ls->y());
-                    d->enqueueEvent(Event(RLights, RStateY, lightNode->id(), item));
+                    enqueueEvent(Event(RLights, RStateY, lightNode->id(), item));
                     changed = true;
                 }
             }
@@ -2833,7 +2833,7 @@ static void recallSceneCheckGroupChanges(DeRestPluginPrivate *d, Group *group, S
                 if (item && ls->colorTemperature() != item->toNumber())
                 {
                     item->setValue(ls->colorTemperature());
-                    d->enqueueEvent(Event(RLights, RStateCt, lightNode->id(), item));
+                    enqueueEvent(Event(RLights, RStateCt, lightNode->id(), item));
                     changed = true;
                     groupCtChanged = true;
                 }
@@ -2844,7 +2844,7 @@ static void recallSceneCheckGroupChanges(DeRestPluginPrivate *d, Group *group, S
                 if (item && ls->enhancedHue() != item->toNumber())
                 {
                     item->setValue(ls->enhancedHue());
-                    d->enqueueEvent(Event(RLights, RStateHue, lightNode->id(), item));
+                    enqueueEvent(Event(RLights, RStateHue, lightNode->id(), item));
                     changed = true;
                     groupHueSatChanged = true;
                 }
@@ -2853,7 +2853,7 @@ static void recallSceneCheckGroupChanges(DeRestPluginPrivate *d, Group *group, S
                 if (item && ls->saturation() != item->toNumber())
                 {
                     item->setValue(ls->saturation());
-                    d->enqueueEvent(Event(RLights, RStateSat, lightNode->id(), item));
+                    enqueueEvent(Event(RLights, RStateSat, lightNode->id(), item));
                     changed = true;
                     groupHueSatChanged = true;
                 }


### PR DESCRIPTION
For now with a global `enqueueEvent()` free function, to not change hundret's lines of code. In future we can make this cleaner and get rid of the globals.

One timer call handles multiple events, if the total processing time is below 10 ms. This is done because one timer activation might take +-10 ms until called by Qt (borrowed from Device code).

The event queue uses `std::vector` instead `std::queue`, which is several times faster.