### PR TITLE
Removal of unused rxCounter() functions and calls

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1168,7 +1168,6 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
             if (sensorNode)
             {
                 sensorNode->rx();
-                sensorNode->incrementRxCounter();
                 ResourceItem *item = sensorNode->item(RConfigReachable);
                 if (item && !item->toBool())
                 {
@@ -3932,17 +3931,6 @@ void DeRestPluginPrivate::checkSensorNodeReachable(Sensor *sensor, const deCONZ:
             //checkSensorBindingsForAttributeReporting(sensor);
 
             updated = true;
-/*
-            if (event &&
-                (event->event() == deCONZ::NodeEvent::UpdatedClusterDataZclRead ||
-                 event->event() == deCONZ::NodeEvent::UpdatedClusterDataZclReport))
-            {
-            }
-            else if (sensor->rxCounter() == 0)
-            {
-                reachable = false; // wait till received something from sensor
-            }
-*/
         }
         if (sensor->type() == QLatin1String("ZHATime") && !sensor->mustRead(READ_TIME))
         {
@@ -7918,7 +7906,6 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
             event.event() == deCONZ::NodeEvent::UpdatedClusterDataZclRead)
         {
             i->rx();
-            i->incrementRxCounter();
         }
 
         checkSensorNodeReachable(&*i, &event);
@@ -13994,7 +13981,6 @@ void DeRestPluginPrivate::handleOnOffClusterIndication(const deCONZ::ApsDataIndi
                     checkSensorNodeReachable(&s);
                 }
 
-                s.incrementRxCounter();
                 item = s.item(RStatePresence);
                 if (item)
                 {

--- a/ias_zone.cpp
+++ b/ias_zone.cpp
@@ -178,7 +178,6 @@ void DeRestPluginPrivate::handleIasZoneClusterIndication(const deCONZ::ApsDataIn
     }
 
     sensor->rx(); // mark rx here so that Read Attributes will work early on
-    sensor->incrementRxCounter();
 
     ResourceItem *itemIasState = sensor->item(RConfigEnrolled);
     ResourceItem *itemPending = sensor->item(RConfigPending);

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -151,8 +151,7 @@ Sensor::Sensor() :
     Resource(RSensors),
     m_deletedstate(Sensor::StateNormal),
     m_mode(ModeTwoGroups),
-    m_resetRetryCount(0),
-    m_rxCounter(0)
+    m_resetRetryCount(0)
 {
     QDateTime now = QDateTime::currentDateTime();
     lastStatePush = now;
@@ -302,20 +301,7 @@ void Sensor::updateStateTimestamp()
     if (i)
     {
         i->setValue(QDateTime::currentDateTimeUtc());
-        m_rxCounter++;
     }
-}
-
-/*! Increments the number of received commands during this session. */
-void Sensor::incrementRxCounter()
-{
-    m_rxCounter++;
-}
-
-/*! Returns number of received commands during this session. */
-int Sensor::rxCounter() const
-{
-    return m_rxCounter;
 }
 
 /*! Returns the sensor manufacturer.

--- a/sensor.h
+++ b/sensor.h
@@ -123,8 +123,6 @@ public:
     uint8_t zdpResetSeq() const;
     void setZdpResetSeq(uint8_t zdpResetSeq);
     void updateStateTimestamp();
-    void incrementRxCounter();
-    int rxCounter() const;
 
     QString stateToString();
     QString configToString();
@@ -150,7 +148,6 @@ private:
     uint8_t m_resetRetryCount;
     uint8_t m_zdpResetSeq;
     ButtonMapRef m_buttonMapRef{};
-    int m_rxCounter;
 };
 
 #endif // SENSOR_H


### PR DESCRIPTION
`incrementRxCounter()` and `rxCounter()` do not seem to be used anymore in the plugin, hence the removal.