### PR TITLE
Fix: Make Xiaomi WRS-R02 switch configuration more robust

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -3916,9 +3916,9 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 //item->setValue(0);
             }
 
-            if (sensor.modelId().endsWith(QLatin1String("86opcn01")))
+            if (sensor.modelId().endsWith(QLatin1String("86opcn01")) || sensor.modelId() == QLatin1String("lumi.remote.b28ac1"))
             {
-                // Aqara Opple switches need to be configured to send proper button events
+                // Aqara switches need to be configured to send proper button events
                 item = sensor.addItem(DataTypeUInt16, RConfigPending);
                 item->setValue(item->toNumber() | R_PENDING_MODE);
             }

--- a/zdp/zdp_handlers.cpp
+++ b/zdp/zdp_handlers.cpp
@@ -177,6 +177,17 @@ void DeRestPluginPrivate::handleDeviceAnnceIndication(const deCONZ::ApsDataIndic
             {
                 item->setValue(IAS_STATE_INIT);
             }
+
+            if (si->modelId().startsWith(QLatin1String("lumi")) && si->type() == QLatin1String("ZHASwitch"))
+            {
+                item = si->item(RConfigPending); // holds switch configuration requirement
+
+                if (item)
+                {
+                    item->setValue(item->toNumber() | R_PENDING_MODE); // Ensure the device Xiaomi device operation mode is marked for writing when the device is reset AND
+                                                                       // a ZHASwitch resource already exists which is not marked as deleted.
+                }
+            }
             
             checkSensorGroup(&*si);
             checkSensorBindingsForAttributeReporting(&*si);

--- a/zdp/zdp_handlers.cpp
+++ b/zdp/zdp_handlers.cpp
@@ -184,7 +184,7 @@ void DeRestPluginPrivate::handleDeviceAnnceIndication(const deCONZ::ApsDataIndic
 
                 if (item)
                 {
-                    item->setValue(item->toNumber() | R_PENDING_MODE); // Ensure the device Xiaomi device operation mode is marked for writing when the device is reset AND
+                    item->setValue(item->toNumber() | R_PENDING_MODE); // Ensure the Xiaomi device operation mode is marked for writing when the device is reset AND
                                                                        // a ZHASwitch resource already exists which is not marked as deleted.
                 }
             }


### PR DESCRIPTION
As there's always one more place to whitelist, the device now adds `RConfigPending` after restart to allow switch configuration.

Additionally, to make the configuration procedure more robust, `RConfigPending` is now set to require configuration upon device announcement (currently applicable for Opples and WRS-R02). This ensures the Xiaomi device operation mode is marked for writing when the device is reset AND a ZHASwitch resource already exists which is not marked as deleted. Without it, the device does not get configured if reset more than once while deconz is running.