### PR TITLE
Do not use `durationDue` for Philips and Develco motion sensors

### DIFF
--- a/occupancy_sensing.cpp
+++ b/occupancy_sensing.cpp
@@ -86,22 +86,28 @@ void DeRestPluginPrivate::handleOccupancySensingClusterIndication(const deCONZ::
                 enqueueEvent(Event(RSensors, RStatePresence, sensor->id(), item));
                 stateUpdated = true;
 
-                const NodeValue &val = sensor->getZclValue(OCCUPANCY_SENSING_CLUSTER_ID, OCCUPIED_STATE);
-
-                // prepare to automatically set presence to false
-                if (item->toBool())
+                // The checked sensors support reporting occupancy = false
+                if (!sensor->modelId().startsWith(QLatin1String("MOSZB-1")) && !sensor->modelId().startsWith(QLatin1String("SML00")))
                 {
-                    if (val.maxInterval > 0 && updateType == NodeValue::UpdateByZclReport)
+                    const NodeValue &val = sensor->getZclValue(OCCUPANCY_SENSING_CLUSTER_ID, OCCUPIED_STATE);
+
+                    // prepare to automatically set presence to false
+                    if (item->toBool())
                     {
-                        // prevent setting presence back to false, when report.maxInterval > config.duration
-                        sensor->durationDue = item->lastSet().addSecs(val.maxInterval);
-                    }
-                    else
-                    {
-                        ResourceItem *item2 = sensor->item(RConfigDuration);
-                        if (item2 && item2->toNumber() > 0)
+                        if (val.maxInterval > 0 && updateType == NodeValue::UpdateByZclReport)
                         {
-                            sensor->durationDue = item->lastSet().addSecs(item2->toNumber());
+                            // prevent setting presence back to false, when report.maxInterval > config.duration
+                            // Add 3 seconds grace time for late reports
+                            sensor->durationDue = item->lastSet().addSecs(val.maxInterval + 3);
+                        }
+                        else
+                        {
+                            ResourceItem *item2 = sensor->item(RConfigDuration);
+                            if (item2 && item2->toNumber() > 0)
+                            {
+                                // If occupied state is not reportable, add duration seconds after a occupied = true to automatically set to false
+                                sensor->durationDue = item->lastSet().addSecs(item2->toNumber());
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Philips SML00X and Develco MOSZB-1XX motion sensors get `RConfigDelay` exposed which represents the occupied to unoccupied delay setting of the device. If no further motion is detected, they report occupied state `false` amongst regular attribute reporting intervals.

As the `durationDue` mechanism is used for those sensors as well, certain unwanted behavior can occur in rare cases, leading to a swift change in presence (`true` to `false` to `true`) rather than a constant `true`. This e.g. can happen, if the attribute report to prevent the automatic change from presence `true` to `false` is processed a second too late.

This PR omits usage of the `durationDue` feature for both motion sensors and additionally adds a 3 seconds grace time for late attribute reports from other motion sensors using the occupancy sensing cluster.