### PR TITLE
Don't send ZCL Default Response to answer one

### DIFF
--- a/aps_controller_wrapper.cpp
+++ b/aps_controller_wrapper.cpp
@@ -71,6 +71,11 @@ static bool ZCL_SendDefaultResponse(deCONZ::ApsController *apsCtrl, const deCONZ
 //! Returns true if \p zclFrame requires a ZCL Default Response.
 static bool ZCL_NeedDefaultResponse(const deCONZ::ApsDataIndication &ind, const deCONZ::ZclFrame &zclFrame)
 {
+    if (zclFrame.isDefaultResponse())
+    {
+        return false;
+    }
+
     if (ind.dstAddressMode() == deCONZ::ApsNwkAddress) // only respond to unicast
     {
         if (!(zclFrame.frameControl() & deCONZ::ZclFCDisableDefaultResponse))


### PR DESCRIPTION
When a device sends a ZCL Default Response to the coordinator, it shouldn't send one back.