### PR TITLE
Enable APS ACKs for ZCL Default Response

### DIFF
--- a/aps_controller_wrapper.cpp
+++ b/aps_controller_wrapper.cpp
@@ -31,7 +31,7 @@ static bool ZCL_SendDefaultResponse(deCONZ::ApsController *apsCtrl, const deCONZ
     apsReq.setProfileId(ind.profileId());
     apsReq.setRadius(0);
     apsReq.setClusterId(ind.clusterId());
-    //apsReq.setTxOptions(deCONZ::ApsTxAcknowledgedTransmission);
+    apsReq.setTxOptions(deCONZ::ApsTxAcknowledgedTransmission);
 
     deCONZ::ZclFrame outZclFrame;
     outZclFrame.setSequenceNumber(zclFrame.sequenceNumber());


### PR DESCRIPTION
For end devices it can happen that the APS request is enqueued in the firmware but never sent, in which case the APS confirm ends with a timout status code (0xF0).

It looks like a timing issue, where the plugin doesn't push the APS request fast enough, and the end device MAC data polls too fast for a response. Or when the end device's initial request required an APS ACK from the coordinator.

This can be seen for Samjin Motion sensor, where not a single ZCL Default Response made it to the device. I suspect a few other devices could be affected as well.

The fix is simple, with APS ACK enabled the firmware will just retry to send the response if it doesn't work on the first attempt.
This is more heavy, but given that the ZCL Default Response is kind of important in order to keep devices alive, worth it.

![image](https://user-images.githubusercontent.com/383386/127897709-229dae11-f220-45fb-87ad-22d75163c48a.png)

The sniffer screenshot shows the applied fix, after the marked packed.