### PR TITLE
Fix : Add power measurement for Blitzwolf BW-SHP15

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2949,6 +2949,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId().startsWith(QLatin1String("TS0044")) ||
         sensor->modelId().startsWith(QLatin1String("TS0222")) || // TYZB01 light sensor 
         sensor->modelId().startsWith(QLatin1String("TS004F")) || // 4 Gang Tuya ZigBee Wireless 12 Scene Switch
+        sensor->modelId().startsWith(QLatin1String("TS011F")) || // Plugs
         // Tuyatec
         sensor->modelId().startsWith(QLatin1String("RH3040")) ||
         sensor->modelId().startsWith(QLatin1String("RH3001")) ||

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -438,6 +438,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_EMBER, "TS0601", silabs9MacPrefix }, // Tuya siren
     { VENDOR_EMBER, "TS0222", silabs9MacPrefix }, // TYZB01 light sensor
     { VENDOR_NONE, "eaxp72v", ikea2MacPrefix }, // Tuya TRV Wesmartify Thermostat Essentials Premium
+    { VENDOR_EMBER, "TS011F", YooksmartMacPrefix }, // Tuya Plug Blitzwolf BW-SHP15
     { VENDOR_NONE, "88teujp", silabs8MacPrefix }, // SEA802-Zigbee
     { VENDOR_NONE, "uhszj9s", silabs8MacPrefix }, // HiHome WZB-TRVL
     { VENDOR_NONE, "fvq6avy", silabs7MacPrefix }, // Revolt NX-4911-675 Thermostat
@@ -3552,9 +3553,10 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
 
                     if (ia->id() == 0x0001 && lightNode->modelId() == QLatin1String("TS011F")) // Application version
                     {
-                        // For Lidl plugs (TS011F) date code is empty, use this attribute instead.
+                        // For some Tuya plugs (TS011F) date code is empty, use this attribute instead.
                         // _TZ3000_1obwwnmq    3x plug
                         // _TZ3000_kdi2o9m6    1x plug
+                        // _TZ3000_mraovvmm
                         const auto str = QString::number(static_cast<int>(ia->numericValue().u8));
                         ResourceItem *item = lightNode->item(RAttrSwVersion);
 

--- a/poll_manager.cpp
+++ b/poll_manager.cpp
@@ -440,7 +440,7 @@ void PollManager::pollTimerFired()
         if (item && (item->toString().isEmpty() ||
              (item->lastSet().secsTo(now) > READ_SWBUILD_ID_INTERVAL))) // dynamic
         {
-            if (lightNode->manufacturerCode() == VENDOR_EMBER && lightNode->modelId() == QLatin1String("TS011F")) // LIDL plugs
+            if (lightNode->manufacturerCode() == VENDOR_EMBER && lightNode->modelId() == QLatin1String("TS011F")) // Tuya plugs
             {
                 if (item->toString().isEmpty())
                 {


### PR DESCRIPTION
Nothing special, perhaps can make some conflitct with lidl devices ? I m using a general code for all TS011F model id.
See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/5162