### PR TITLE
Add sensitivity and selftest for Xiaomi smoke and gas sensor

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -4002,6 +4002,13 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             {
                 sensor.removeItem(RConfigBattery);
             }
+            
+            if (sensor.modelId() == QLatin1String("lumi.sensor_smoke") ||
+                sensor.modelId() == QLatin1String("lumi.sensor_natgas"))
+            {
+                sensor.addItem(DataTypeBool, RConfigSelfTest)->setValue(false);
+                item = sensor.addItem(DataTypeUInt8, RConfigSensitivity);
+            }
         }
         else if (sensor.modelId().startsWith(QLatin1String("tagv4"))) // SmartThings Arrival sensor
         {
@@ -4093,7 +4100,15 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             ResourceItem *item = sensor.item(RConfigEnrolled);
             if (item)
             {
-                item->setValue(IAS_STATE_INIT); // reset at startup
+                if (sensor.modelId() == QLatin1String("lumi.sensor_smoke") ||
+                    sensor.modelId() == QLatin1String("lumi.sensor_natgas"))
+                {
+                    item->setValue(IAS_STATE_ENROLLED); // Doesn't support proper enrollment, so device is not kept unnecessarily busy
+                }
+                else
+                {
+                    item->setValue(IAS_STATE_INIT); // reset at startup
+                }
             }
         }
 

--- a/database.cpp
+++ b/database.cpp
@@ -4031,7 +4031,9 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             {
                 // no support for some IAS Zone flags
             }
-            else if (sensor.modelId() == QLatin1String("Keyfob-ZB3.0"))
+            else if (sensor.modelId() == QLatin1String("Keyfob-ZB3.0") ||
+                     sensor.modelId() == QLatin1String("lumi.sensor_smoke") ||
+                     sensor.modelId() == QLatin1String("lumi.sensor_natgas"))
             {
                 sensor.addItem(DataTypeBool, RStateLowBattery)->setValue(false);
             }

--- a/de_web.pro
+++ b/de_web.pro
@@ -152,6 +152,7 @@ HEADERS  = bindings.h \
            tuya.h \
            utils/utils.h \
            websocket_server.h \
+           xiaomi.h \
            zdp/zdp_handlers.h
 
 SOURCES  = air_quality.cpp \

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -7635,7 +7635,9 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
         {
             // no support for some IAS flags
         }
-        else if (modelId == QLatin1String("Keyfob-ZB3.0"))
+        else if (modelId == QLatin1String("Keyfob-ZB3.0") ||
+                 modelId == QLatin1String("lumi.sensor_smoke") ||
+                 modelId == QLatin1String("lumi.sensor_natgas"))
         {
             sensorNode.addItem(DataTypeBool, RStateLowBattery)->setValue(false);
         }

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -302,6 +302,7 @@ using namespace deCONZ::literals;
 #define WRITE_TIME             (1 << 20)
 #define READ_THERMOSTAT_SCHEDULE (1 << 21)
 #define WRITE_DEVICEMODE       (1 << 22)
+#define READ_SENSITIVITY       (1 << 23)
 
 #define READ_MODEL_ID_INTERVAL   (60 * 60) // s
 #define READ_SWBUILD_ID_INTERVAL (60 * 60) // s
@@ -1323,6 +1324,7 @@ public Q_SLOTS:
     void simpleRestartAppTimerFired();
     void pushSensorInfoToCore(Sensor *sensor);
     void pollNextDevice();
+    void xiaomiSelfTestTimerFired();
 
     // database
 #if DECONZ_LIB_VERSION >= 0x010E00
@@ -1461,8 +1463,8 @@ public:
     bool processZclAttributes(Sensor *sensorNode);
     bool readBindingTable(RestNodeBase *node, quint8 startIndex);
     bool getGroupIdentifiers(RestNodeBase *node, quint8 endpoint, quint8 startIndex);
-    bool readAttributes(RestNodeBase *restNode, quint8 endpoint, uint16_t clusterId, const std::vector<uint16_t> &attributes, uint16_t manufacturerCode = 0);
-    bool writeAttribute(RestNodeBase *restNode, quint8 endpoint, uint16_t clusterId, const deCONZ::ZclAttribute &attribute, uint16_t manufacturerCode = 0);
+    bool readAttributes(RestNodeBase *restNode, quint8 endpoint, uint16_t clusterId, const std::vector<uint16_t> &attributes, uint16_t manufacturerCode = 0, bool force = false);
+    bool writeAttribute(RestNodeBase *restNode, quint8 endpoint, uint16_t clusterId, const deCONZ::ZclAttribute &attribute, uint16_t manufacturerCode = 0, bool force = false);
     bool readSceneAttributes(LightNode *lightNode, uint16_t groupId, uint8_t sceneId);
     bool readGroupMembership(LightNode *lightNode, const std::vector<uint16_t> &groups);
     void foundGroupMembership(LightNode *lightNode, uint16_t groupId);
@@ -2105,6 +2107,7 @@ public:
     QUdpSocket *udpSock;
     QUdpSocket *udpSockOut;
     uint8_t haEndpoint;
+    QTimer *xiaomiSelfTestTimer;
 
     // events
     EventEmitter *eventEmitter = nullptr;

--- a/ias_zone.cpp
+++ b/ias_zone.cpp
@@ -322,6 +322,10 @@ void DeRestPluginPrivate::handleIasZoneClusterIndication(const deCONZ::ApsDataIn
                     
                     QString sens = QString("%1").arg(attr.numericValue().u64, 16, 16, QLatin1Char('0')).at(3);
                     quint8 sensitivity = sens.toUInt(&ok);
+                    
+                    if      (sensitivity == 1) { sensitivity = 2; }
+                    else if (sensitivity == 2) { sensitivity = 1; }
+                    else if (sensitivity == 3) { sensitivity = 0; }
 
                     ResourceItem *item = nullptr;
                     item = sensor->item(RConfigSensitivity);

--- a/resource.cpp
+++ b/resource.cpp
@@ -189,6 +189,7 @@ const char *RConfigHumiMinThreshold = "config/humidityminthreshold";
 const char *RConfigReachable = "config/reachable";
 const char *RConfigSchedule = "config/schedule";
 const char *RConfigScheduleOn = "config/schedule_on";
+const char *RConfigSelfTest = "config/selftest";
 const char *RConfigSensitivity = "config/sensitivity";
 const char *RConfigSensitivityMax = "config/sensitivitymax";
 const char *RConfigSetValve = "config/setvalve";
@@ -391,6 +392,7 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, QVariant::Bool, RConfigReachable));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, QVariant::String, RConfigSchedule));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, QVariant::Bool, RConfigScheduleOn));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, QVariant::Bool, RConfigSelfTest));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, QVariant::Double, RConfigSensitivity));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, QVariant::Double, RConfigSensitivityMax));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeInt8, QVariant::Double, RConfigSunriseOffset, -120, 120));

--- a/resource.h
+++ b/resource.h
@@ -196,6 +196,7 @@ extern const char *RConfigVolume;
 extern const char *RConfigReachable;
 extern const char *RConfigSchedule;
 extern const char *RConfigScheduleOn;
+extern const char *RConfigSelfTest;
 extern const char *RConfigSensitivity;
 extern const char *RConfigSensitivityMax;
 extern const char *RConfigSetValve;

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -39,6 +39,12 @@ struct KeyValMapInt
     quint16 value = 0;
 };
 
+struct KeyValMapUint8Uint32
+{
+    quint8 key = 0;
+    quint32 value = 0;
+};
+
 struct KeyValMapTuyaSingle
 {
     QLatin1String key;
@@ -69,6 +75,7 @@ inline bool isValid(const KeyValMapTuyaSingle &entry) { return entry.key.size() 
 constexpr KeyMap invalidValue(KeyMap) { return KeyMap{QLatin1String("")}; }
 constexpr KeyValMap invalidValue(KeyValMap) { return KeyValMap{QLatin1String(""), 0 }; }
 constexpr KeyValMapInt invalidValue(KeyValMapInt) { return KeyValMapInt{ 0, 0 }; }
+constexpr KeyValMapUint8Uint32 invalidValue(KeyValMapUint8Uint32) { return KeyValMapUint8Uint32{ 0, 0 }; }
 constexpr KeyValMapTuyaSingle invalidValue(KeyValMapTuyaSingle) { return KeyValMapTuyaSingle{QLatin1String(""), {0} }; }
 
 template <typename K, typename Cont, typename V = typename Cont::value_type>

--- a/xiaomi.h
+++ b/xiaomi.h
@@ -7,5 +7,9 @@
 #define XIAOMI_ATTRID_SPECIAL_REPORT      0x00F7
 #define XIAOMI_ATTRID_MOTION_SENSITIVITY  0x010C
 #define XIAOMI_ATTRID_MULTICLICK_MODE     0x0125
+#define XIAOMI_ATTRID_HONEYWELL_CONFIG    0xFFF0
+#define XIAOMI_ATTRID_SMOKE_SENSITIVITY   0xFFF1
+
+extern const std::array<KeyValMapUint8Uint32, 3> RConfigXiaomiHoneywellSensitivityValues;
 
 #endif // XIAOMI_H

--- a/xiaomi.h
+++ b/xiaomi.h
@@ -1,6 +1,8 @@
 #ifndef XIAOMI_H
 #define XIAOMI_H
 
+#include "utils/utils.h"
+
 #define XIAOMI_CLUSTER_ID                 0xFCC0
 
 #define XIAOMI_ATTRID_DEVICE_MODE         0x0009

--- a/zdp/zdp_handlers.cpp
+++ b/zdp/zdp_handlers.cpp
@@ -176,7 +176,15 @@ void DeRestPluginPrivate::handleDeviceAnnceIndication(const deCONZ::ApsDataIndic
 
             if (item)
             {
-                item->setValue(IAS_STATE_INIT);
+                if (si->modelId() == QLatin1String("lumi.sensor_smoke") ||
+                    si->modelId() == QLatin1String("lumi.sensor_natgas"))
+                {
+                    item->setValue(IAS_STATE_ENROLLED); // Doesn't support proper enrollment, so device is not kept unnecessarily busy
+                }
+                else
+                {
+                    item->setValue(IAS_STATE_INIT); // reset at startup
+                }
             }
 
             if (si->modelId().startsWith(QLatin1String("lumi")) && si->type() == QLatin1String("ZHASwitch"))


### PR DESCRIPTION
See #5210.

This PR adds `RConfigSensitivity` and `RConfigSelfTest` to the Honeywell smoke and gas sensors.

The selftest will be a hit and miss for the smoke sensor, as it doesn't give any kind of response or updates any attribute value (battery powered). As it also mac polls just every 15 secs (instead of the usual 7.5, a quite remarkable deviation), delivery of the command cannot be ensured. The gas sensor reacts instantly (mains powered). For the value to return to `false` after issuing a selftest, a 3 seconds timer is used.

Sensitivity can be handled better. For the smoke sensor, the command is retried every 10 secs until the corresponding attribute holding the sensitivity value is successfully read. The same scale for the allowed values and the meaning is applied as for the Hue motion sensor (0 - low, 1 - medium, 2 - high).

Additionally, the tamper state is removed, as both devices do not support it anyway. They have also been excluded from the IAS enrollment process, as they do not comply with the zigbee specs in this regard, so the devices do not get hammered with unnecessary requests (will be marked as enrolled).