### PR TITLE
Fix: Warning for Develco siren SIRZB-110 via REST API

### DIFF
--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -2216,7 +2216,7 @@ int DeRestPluginPrivate::setWarningDeviceState(const ApiRequest &req, ApiRespons
             }
             else if (taskRef.lightNode->modelId() == QLatin1String("SIRZB-110"))    // Doesn't support strobe
             {
-                task.options = 0x13;    // Warning mode 1 (burglar), no Strobe, Very high sound
+                task.options = 0xC1;    // Warning mode 1 (burglar), no Strobe, Very high sound, Develco uses inversed bit order
             }
             task.duration = 1;
         }
@@ -2230,7 +2230,7 @@ int DeRestPluginPrivate::setWarningDeviceState(const ApiRequest &req, ApiRespons
             }
             else if (taskRef.lightNode->modelId() == QLatin1String("SIRZB-110"))    // Doesn't support strobe
             {
-                task.options = 0x13;    // Warning mode 1 (burglar), no Strobe, Very high sound
+                task.options = 0xC1;    // Warning mode 1 (burglar), no Strobe, Very high sound, Develco uses inversed bit order
             }
             task.duration = onTime > 0 ? onTime : 300;
         }


### PR DESCRIPTION
Develco concatenates the subfields differently. Instead of mode (4 bits), strobe (2 bits) and level (2 bits), it must be level (2 bits), strobe (2 bits) and mode (4 bits).

So:
"Standard": b00010011 -> 0x13 -> 19
Develco: b11000001 -> 0xC1 -> 193