### PR TITLE
Add Initial support for Tuya covering _TZE200_iossyxra

### DIFF
--- a/general.xml
+++ b/general.xml
@@ -1842,6 +1842,7 @@ by the Poll Control Cluster Client.</description>
 				<value name="Off" value="0"></value>
 				<value name="On" value="1"></value>
 			</attribute>
+            <attribute id="0xf003" name="Calibration time (tenth of a second)" type="u16" default="0x0000" required="m" access="rw"></attribute>
         </attribute-set>
         <command id="0x00" dir="recv" name="Up / Open" required="m"></command>
         <command id="0x01" dir="recv" name="Down / Close" required="m"></command>

--- a/product_match.cpp
+++ b/product_match.cpp
@@ -80,6 +80,7 @@ static const ProductMap products[] =
     {"_TZE200_fdtjuw7u", "TS0601", "Yushun", "Tuya_COVD YS-MT750"},
     {"_TZE200_bqcqqjpb", "TS0601", "Yushun", "Tuya_COVD YS-MT750"},
     {"_TZE200_nueqqe6k", "TS0601", "Zemismart", "Tuya_COVD M515EGB"},
+    {"_TZE200_iossyxra", "TS0601", "Zemismart", "Tuya_COVD Roller Shade"},
 
     // Tuya covering not using tuya cluster but need reversing
     {"_TZ3000_egq7y6pr", "TS130F", "Lonsonho", "11830304 Switch"},


### PR DESCRIPTION
- Product name: Zemismart Battery Roller Shade
- Manufacturer: _TZE200_iossyxra
- Model identifier: TS0601

Warning the support is partial, still need a tuya command for calibration.
See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/5191

Edit:
Have added in the xml a new tuya command for calibration.