### PR TITLE
Enable websocket server to listen on IP specified via `--http-listen` command line parameter

### DIFF
--- a/websocket_server.cpp
+++ b/websocket_server.cpp
@@ -10,9 +10,8 @@
 
 #ifdef USE_WEBSOCKETS
 
-#include "de_web_plugin.h"
-#include "de_web_plugin_private.h"
 #include "deconz/dbg_trace.h"
+#include "deconz/util.h"
 #include "websocket_server.h"
 
 /*! Constructor.

--- a/websocket_server.cpp
+++ b/websocket_server.cpp
@@ -29,13 +29,13 @@ WebSocketServer::WebSocketServer(QObject *parent, quint16 port) :
     }
 
     QHostAddress address;
-    if (deCONZ::appArgumentString("--http-listen", 0).isEmpty()) // Tie websocket server to specified IP, if any
+    if (deCONZ::appArgumentString("--http-listen", QString()).isEmpty()) // Tie websocket server to specified IP, if any
     {
         address = QHostAddress::AnyIPv4;
     }
     else
     {
-        address = deCONZ::appArgumentString("--http-listen", 0);
+        address = deCONZ::appArgumentString("--http-listen", QString());
     }
 
     while (!srv->listen(address, ports[p]))


### PR DESCRIPTION
The websocket server can now be bound to the IP address specified via command line, similar to the regular webserver. If the parameter is not provided or the IP is invalid/not found, it will default back to listen on any IP.

The example below has the webserver running on port 8080 and the websocket server on port 8888. This change is already running in my production environment 😉 

![grafik](https://user-images.githubusercontent.com/4005212/130856604-afa1a90b-e232-4b4a-ac70-fea087804de3.png)
