### PR TITLE
Enable alarm systems in rules; return alarm systems in full config request

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -6009,7 +6009,7 @@ bool DB_LoadSecret(DB_Secret &secret)
         return false;
     }
 
-    return true;
+    return !secret.secret.empty();
 }
 
 static bool initSecretsTable()

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -17445,6 +17445,10 @@ Resource *DeRestPluginPrivate::getResource(const char *resource, const QString &
     {
         return &config;
     }
+    else if (resource == RAlarmSystems)
+    {
+        return AS_GetAlarmSystem(id.toUInt(), *alarmSystems);
+    }
 
     return 0;
 }

--- a/ias_ace.cpp
+++ b/ias_ace.cpp
@@ -105,6 +105,18 @@ QLatin1String IAS_PanelStatusToString(quint8 panelStatus)
     return QLatin1String("");
 }
 
+int IAS_PanelStatusFromString(const QString &panelStatus)
+{
+    const auto i = std::find(IAS_PanelStates.cbegin(), IAS_PanelStates.cend(), panelStatus);
+
+    if (i != IAS_PanelStates.cend())
+    {
+        return std::distance(IAS_PanelStates.cbegin(), i);
+    }
+
+    return -1;
+}
+
 static quint8 handleArmCommand(AlarmSystem *alarmSys, quint8 armMode, const QString &pinCode, quint64 srcAddress)
 {
     if (!alarmSys || armMode > IAS_ACE_ARM_MODE_ARM_ALL_ZONES)

--- a/ias_ace.h
+++ b/ias_ace.h
@@ -46,6 +46,7 @@ class AlarmSystems;
 class ApsControllerWrapper;
 
 QLatin1String IAS_PanelStatusToString(quint8 panelStatus);
+int IAS_PanelStatusFromString(const QString &panelStatus);
 void IAS_IasAceClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame, AlarmSystems *alarmSystems, ApsControllerWrapper &apsCtrlWrapper);
 
 #endif // IAS_ACE_H

--- a/rest_alarmsystems.cpp
+++ b/rest_alarmsystems.cpp
@@ -239,6 +239,18 @@ int AS_handleAlarmSystemsApi(const ApiRequest &req, ApiResponse &rsp, AlarmSyste
     return REQ_NOT_HANDLED;
 }
 
+QVariantMap AS_AlarmSystemsToMap(const AlarmSystems &alarmSystems)
+{
+    QVariantMap result;
+
+    for (const AlarmSystem *alarmSys : alarmSystems.alarmSystems)
+    {
+        result[QString::number(alarmSys->id())] = alarmSystemToMap(alarmSys);
+    }
+
+    return result;
+}
+
 static int getAllAlarmSystems(const ApiRequest &, ApiResponse &rsp, const AlarmSystems &alarmSystems)
 {
     rsp.httpStatus = HttpStatusOk;
@@ -249,11 +261,7 @@ static int getAllAlarmSystems(const ApiRequest &, ApiResponse &rsp, const AlarmS
         return REQ_READY_SEND;
     }
 
-    for (const AlarmSystem *alarmSys : alarmSystems.alarmSystems)
-    {
-        QVariantMap map = alarmSystemToMap(alarmSys);
-        rsp.map[QString::number(alarmSys->id())] = map;
-    }
+    rsp.map = AS_AlarmSystemsToMap(alarmSystems);
 
     return REQ_READY_SEND;
 }

--- a/rest_alarmsystems.h
+++ b/rest_alarmsystems.h
@@ -11,6 +11,8 @@
 #ifndef REST_ALARMSYSTEMS_H
 #define REST_ALARMSYSTEMS_H
 
+#include <QVariant>
+
 class ApiRequest;
 class ApiResponse;
 class EventEmitter;
@@ -23,5 +25,6 @@ class AlarmSystems;
             REQ_NOT_HANDLED
  */
 int AS_handleAlarmSystemsApi(const ApiRequest &req, ApiResponse &rsp, AlarmSystems &alarmSystems, EventEmitter *eventEmitter);
+QVariantMap AS_AlarmSystemsToMap(const AlarmSystems &alarmSystems);
 
 #endif // REST_ALARMSYSTEMS_H

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -18,6 +18,7 @@
 #include <QVariantMap>
 #include <QNetworkInterface>
 #include <QProcessEnvironment>
+#include "rest_alarmsystems.h"
 #include "daylight.h"
 #include "de_web_plugin.h"
 #include "de_web_plugin_private.h"
@@ -1252,9 +1253,8 @@ int DeRestPluginPrivate::getFullState(const ApiRequest &req, ApiResponse &rsp)
         }
     }
 
-    // scenes
-    {
-    }
+    // alarm systems
+    rsp.map[QLatin1String("alarmsystems")] = AS_AlarmSystemsToMap(*alarmSystems);
 
     configToMap(req, configMap);
 

--- a/rest_rules.cpp
+++ b/rest_rules.cpp
@@ -71,8 +71,8 @@ int DeRestPluginPrivate::getAllRules(const ApiRequest &req, ApiResponse &rsp)
     Q_UNUSED(req)
     rsp.httpStatus = HttpStatusOk;
 
-    std::vector<Rule>::const_iterator i = rules.begin();
-    std::vector<Rule>::const_iterator end = rules.end();
+    auto i = rules.cbegin();
+    const auto end = rules.cend();
 
     for (; i != end; ++i)
     {
@@ -84,8 +84,8 @@ int DeRestPluginPrivate::getAllRules(const ApiRequest &req, ApiResponse &rsp)
 
         QVariantMap rule;
 
-        std::vector<RuleCondition>::const_iterator c = i->conditions().begin();
-        std::vector<RuleCondition>::const_iterator cend = i->conditions().end();
+        auto c = i->conditions().cbegin();
+        const auto cend = i->conditions().cend();
 
         QVariantList conditions;
 
@@ -101,8 +101,8 @@ int DeRestPluginPrivate::getAllRules(const ApiRequest &req, ApiResponse &rsp)
             conditions.append(condition);
         }
 
-        std::vector<RuleAction>::const_iterator a = i->actions().begin();
-        std::vector<RuleAction>::const_iterator aend = i->actions().end();
+        auto a = i->actions().cbegin();
+        const auto aend = i->actions().cend();
 
         QVariantList actions;
 
@@ -166,8 +166,8 @@ bool DeRestPluginPrivate::ruleToMap(const Rule *rule, QVariantMap &map)
         return false;
     }
 
-    std::vector<RuleCondition>::const_iterator c = rule->conditions().begin();
-    std::vector<RuleCondition>::const_iterator c_end = rule->conditions().end();
+    auto c = rule->conditions().cbegin();
+    const auto c_end = rule->conditions().cend();
 
     QVariantList conditions;
 
@@ -183,8 +183,8 @@ bool DeRestPluginPrivate::ruleToMap(const Rule *rule, QVariantMap &map)
         conditions.append(condition);
     }
 
-    std::vector<RuleAction>::const_iterator a = rule->actions().begin();
-    std::vector<RuleAction>::const_iterator a_end = rule->actions().end();
+    auto a = rule->actions().cbegin();
+    const auto a_end = rule->actions().cend();
 
     QVariantList actions;
 
@@ -199,8 +199,8 @@ bool DeRestPluginPrivate::ruleToMap(const Rule *rule, QVariantMap &map)
         QVariant body = Json::parse(a->body(), ok);
         QVariantMap bodymap = body.toMap();
 
-        QVariantMap::const_iterator b = bodymap.begin();
-        QVariantMap::const_iterator b_end = bodymap.end();
+        auto b = bodymap.cbegin();
+        const auto b_end = bodymap.cend();
 
         QVariantMap resultmap;
 
@@ -212,9 +212,6 @@ bool DeRestPluginPrivate::ruleToMap(const Rule *rule, QVariantMap &map)
         action["body"] = resultmap;
         actions.append(action);
     }
-
-    map["actions"] = actions;
-    map["conditions"] = conditions;
 
     map["actions"] = actions;
     map["conditions"] = conditions;
@@ -264,8 +261,8 @@ int DeRestPluginPrivate::getRule(const ApiRequest &req, ApiResponse &rsp)
         return REQ_READY_SEND;
     }
 
-    std::vector<RuleCondition>::const_iterator c = rule->conditions().begin();
-    std::vector<RuleCondition>::const_iterator c_end = rule->conditions().end();
+    auto c = rule->conditions().cbegin();
+    const auto c_end = rule->conditions().cend();
 
     QVariantList conditions;
 
@@ -281,8 +278,8 @@ int DeRestPluginPrivate::getRule(const ApiRequest &req, ApiResponse &rsp)
         conditions.append(condition);
     }
 
-    std::vector<RuleAction>::const_iterator a = rule->actions().begin();
-    std::vector<RuleAction>::const_iterator a_end = rule->actions().end();
+    auto a = rule->actions().cbegin();
+    const auto a_end = rule->actions().cend();
 
     QVariantList actions;
 
@@ -297,8 +294,8 @@ int DeRestPluginPrivate::getRule(const ApiRequest &req, ApiResponse &rsp)
         QVariant body = Json::parse(a->body(), ok);
         QVariantMap bodymap = body.toMap();
 
-        QVariantMap::const_iterator b = bodymap.begin();
-        QVariantMap::const_iterator b_end = bodymap.end();
+        auto b = bodymap.cbegin();
+        const auto b_end = bodymap.cend();
 
         QVariantMap resultmap;
 
@@ -455,8 +452,8 @@ int DeRestPluginPrivate::createRule(const ApiRequest &req, ApiResponse &rsp)
 
             do {
                 ok = true;
-                std::vector<Rule>::const_iterator i = rules.begin();
-                std::vector<Rule>::const_iterator end = rules.end();
+                auto i = rules.cbegin();
+                const auto end = rules.cend();
 
                 for (; i != end; ++i)
                 {
@@ -483,8 +480,8 @@ int DeRestPluginPrivate::createRule(const ApiRequest &req, ApiResponse &rsp)
             if (checkActions(actionsList, rsp))
             {
                 std::vector<RuleAction> actions;
-                QVariantList::const_iterator ai = actionsList.begin();
-                QVariantList::const_iterator aend = actionsList.end();
+                auto ai = actionsList.cbegin();
+                const auto aend = actionsList.cend();
 
                 for (; ai != aend; ++ai)
                 {
@@ -508,8 +505,8 @@ int DeRestPluginPrivate::createRule(const ApiRequest &req, ApiResponse &rsp)
             if (checkConditions(conditionsList, rsp))
             {
                 std::vector<RuleCondition> conditions;
-                QVariantList::const_iterator ci = conditionsList.begin();
-                QVariantList::const_iterator cend = conditionsList.end();
+                auto ci = conditionsList.cbegin();
+                const auto cend = conditionsList.cend();
 
                 for (; ci != cend; ++ci)
                 {
@@ -598,8 +595,8 @@ int DeRestPluginPrivate::updateRule(const ApiRequest &req, ApiResponse &rsp)
     userActivity();
 
     //check invalid parameter
-    QVariantMap::const_iterator pi = map.begin();
-    QVariantMap::const_iterator pend = map.end();
+    auto pi = map.cbegin();
+    const auto pend = map.cend();
 
     for (; pi != pend; ++pi)
     {
@@ -747,8 +744,8 @@ int DeRestPluginPrivate::updateRule(const ApiRequest &req, ApiResponse &rsp)
         if (checkActions(actionsList,rsp))
         {
             std::vector<RuleAction> actions;
-            QVariantList::const_iterator ai = actionsList.begin();
-            QVariantList::const_iterator aend = actionsList.end();
+            auto ai = actionsList.cbegin();
+            const auto aend = actionsList.cend();
 
             for (; ai != aend; ++ai)
             {
@@ -780,8 +777,8 @@ int DeRestPluginPrivate::updateRule(const ApiRequest &req, ApiResponse &rsp)
         if (checkConditions(conditionsList, rsp))
         {
             std::vector<RuleCondition> conditions;
-            QVariantList::const_iterator ci = conditionsList.begin();
-            QVariantList::const_iterator cend = conditionsList.end();
+            auto ci = conditionsList.cbegin();
+            const auto cend = conditionsList.cend();
 
             for (; ci != cend; ++ci)
             {
@@ -830,8 +827,8 @@ int DeRestPluginPrivate::updateRule(const ApiRequest &req, ApiResponse &rsp)
  */
 bool DeRestPluginPrivate::checkActions(QVariantList actionsList, ApiResponse &rsp)
 {
-    QVariantList::const_iterator ai = actionsList.begin();
-    QVariantList::const_iterator aend = actionsList.end();
+    auto ai = actionsList.cbegin();
+    const auto aend = actionsList.cend();
 
     for (; ai != aend; ++ai)
     {
@@ -903,9 +900,8 @@ bool DeRestPluginPrivate::checkActions(QVariantList actionsList, ApiResponse &rs
  */
 bool DeRestPluginPrivate::checkConditions(QVariantList conditionsList, ApiResponse &rsp)
 {
-    // check condition parameters
-    QVariantList::const_iterator ci = conditionsList.begin();
-    QVariantList::const_iterator cend = conditionsList.end();
+    auto ci = conditionsList.cbegin();
+    const auto cend = conditionsList.cend();
 
     for (; ci != cend; ++ci)
     {
@@ -998,8 +994,8 @@ void DeRestPluginPrivate::queueCheckRuleBindings(const Rule &rule)
 
     {   // search in conditions for binding srcAddress and srcEndpoint
 
-        std::vector<RuleCondition>::const_iterator i = rule.conditions().begin();
-        std::vector<RuleCondition>::const_iterator end = rule.conditions().end();
+        auto i = rule.conditions().cbegin();
+        const auto end = rule.conditions().cend();
 
         for (; i != end; ++i)
         {
@@ -1094,8 +1090,8 @@ void DeRestPluginPrivate::queueCheckRuleBindings(const Rule &rule)
     DBG_Printf(DBG_INFO, "verify Rule %s: %s\n", qPrintable(rule.id()), qPrintable(rule.name()));
 
     { // search in actions for binding dstAddress, dstEndpoint and clusterId
-        std::vector<RuleAction>::const_iterator i = rule.actions().begin();
-        std::vector<RuleAction>::const_iterator end = rule.actions().end();
+        auto i = rule.actions().begin();
+        const auto end = rule.actions().end();
 
         for (; i != end; ++i)
         {
@@ -1228,8 +1224,8 @@ bool DeRestPluginPrivate::evaluateRule(Rule &rule, const Event &e, Resource *eRe
         }
     }
 
-    std::vector<RuleCondition>::const_iterator c = rule.conditions().begin();
-    std::vector<RuleCondition>::const_iterator cend = rule.conditions().end();
+    auto c = rule.conditions().cbegin();
+    const auto cend = rule.conditions().cend();
 
     for (; c != cend; ++c)
     {
@@ -1556,8 +1552,8 @@ void DeRestPluginPrivate::triggerRule(Rule &rule)
     DBG_Printf(DBG_INFO, "trigger rule %s - %s\n", qPrintable(rule.id()), qPrintable(rule.name()));
 
     bool triggered = false;
-    std::vector<RuleAction>::const_iterator ai = rule.actions().begin();
-    std::vector<RuleAction>::const_iterator aend = rule.actions().end();
+    auto ai = rule.actions().cbegin();
+    const auto aend = rule.actions().cend();
 
     for (; ai != aend; ++ai)
     {

--- a/rule.cpp
+++ b/rule.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2017-2021 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -8,6 +8,7 @@
  *
  */
 
+#include "ias_ace.h"
 #include "rule.h"
 
 static int _ruleHandle = 1;
@@ -402,18 +403,19 @@ RuleCondition::RuleCondition(const QVariantMap &map)
     m_value = map["value"];
 
     // cache id
-    if (m_address.startsWith(QLatin1String("/sensors")) ||
-        m_address.startsWith(QLatin1String("/groups")) ||
-        m_address.startsWith(QLatin1String("/lights"))) // /sensors/<id>/state/buttonevent, ...
+    if (m_address.startsWith(QLatin1String(RSensors)) ||
+        m_address.startsWith(QLatin1String(RGroups)) ||
+        m_address.startsWith(QLatin1String(RLights)) ||
+        m_address.startsWith(QLatin1String(RAlarmSystems))) // /sensors/<id>/state/buttonevent, ...
     {
-        QStringList addrList = m_address.split('/', QString::SkipEmptyParts);
+        QStringList addrList = m_address.split('/', SKIP_EMPTY_PARTS);
         if (addrList.size() > 1)
         {
             m_id = addrList[1];
         }
     }
 
-    if (m_address.startsWith(QLatin1String("/sensors")))
+    if (m_address.startsWith(QLatin1String(RSensors)))
     {
         m_prefix = RSensors;
         if (m_address.endsWith(QLatin1String("/illuminance")))
@@ -421,17 +423,23 @@ RuleCondition::RuleCondition(const QVariantMap &map)
             m_address.replace(QLatin1String("/illuminance"), QLatin1String("/lux"));
         }
     }
-    else if (m_address.startsWith(QLatin1String("/config")))
+    else if (m_address.startsWith(QLatin1String(RConfig)))
     {
         m_prefix = RConfig;
     }
-    else if (m_address.startsWith(QLatin1String("/groups")))
+    else if (m_address.startsWith(QLatin1String(RGroups)))
     {
         m_prefix = RGroups;
     }
-    else if (m_address.startsWith(QLatin1String("/lights")))
+    else if (m_address.startsWith(QLatin1String(RLights)))
     {
         m_prefix = RLights;
+    }
+    else if (m_address.startsWith(QLatin1String(RAlarmSystems)))
+    {
+        m_prefix = RAlarmSystems;
+
+
     }
 
     ResourceItemDescriptor rid;
@@ -538,11 +546,23 @@ RuleCondition::RuleCondition(const QVariantMap &map)
         }
         else if (m_op == OpEqual || m_op == OpNotEqual || m_op == OpGreaterThan || m_op == OpLowerThan)
         {
-            int num = str.toInt(&ok);
-            if (ok)
+            if (rid.suffix == RStateArmState)
             {
-                m_value = static_cast<double>(num);
-            } else { m_op = OpUnknown; } // mark invalid
+                // transform from string to number
+                int num = IAS_PanelStatusFromString(str);
+                if (num >= 0)
+                {
+                    m_num = num;
+                } else { m_op = OpUnknown; } // mark invalid
+            }
+            else
+            {
+                int num = str.toInt(&ok);
+                if (ok)
+                {
+                    m_value = static_cast<double>(num);
+                } else { m_op = OpUnknown; } // mark invalid
+            }
         }
     }
 

--- a/rule.cpp
+++ b/rule.cpp
@@ -206,8 +206,8 @@ int Rule::handle() const
 QString Rule::actionsToString(const std::vector<RuleAction> &actions)
 {
     QString jsonString = QLatin1String("[");
-    std::vector<RuleAction>::const_iterator i = actions.begin();
-    std::vector<RuleAction>::const_iterator i_end = actions.end();
+    auto i = actions.cbegin();
+    const auto i_end = actions.cend();
 
     for (; i != i_end; ++i)
     {
@@ -229,8 +229,8 @@ QString Rule::conditionsToString(const std::vector<RuleCondition> &conditions)
 {
     QVariantList ls;
 
-    std::vector<RuleCondition>::const_iterator i = conditions.begin();
-    std::vector<RuleCondition>::const_iterator iend = conditions.end();
+    auto i = conditions.cbegin();
+    const auto iend = conditions.cend();
 
     for (; i != iend; ++i)
     {
@@ -261,8 +261,8 @@ std::vector<RuleAction> Rule::jsonToActions(const QString &json)
         return actions;
     }
 
-    QVariantList::const_iterator i = var.begin();
-    QVariantList::const_iterator end = var.end();
+    auto i = var.cbegin();
+    const auto end = var.cend();
 
     for (; i != end; ++i)
     {
@@ -291,8 +291,8 @@ std::vector<RuleCondition> Rule::jsonToConditions(const QString &json)
         return conditions;
     }
 
-    QVariantList::const_iterator i = var.begin();
-    QVariantList::const_iterator end = var.end();
+    auto i = var.cbegin();
+    const auto end = var.cend();
 
     for (; i != end; ++i)
     {


### PR DESCRIPTION
- With this PR alarm systems can be used as a trigger in rules via `state/armstate`.
- Further alarm systems can be armed and disarmed by rules, e.g. arm at a certain time.
- All alarm systems are returned in the `GET /api/<apikey>` full config response.

Example to turn a light on when the alarm system gets `armed_away`:

```json
{
    "actions": [
        {
            "address": "/lights/15/state",
            "body": {
                "bri": 255,
                "on": true
            },
            "method": "PUT"
        }
    ],
    "conditions": [
        {
            "address": "/alarmsystems/1/state/armstate",
            "operator": "dx"
        },
        {
            "address": "/alarmsystems/1/state/armstate",
            "operator": "eq",
            "value": "armed_away"
        }
    ],
    "name": "Armed away"
}
```