### PR TITLE
Add Initial support for CASA.ia Temperature probe CTHS-317-ET

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2996,6 +2996,8 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId() == QLatin1String("4in1-Sensor-ZB3.0") ||
         sensor->modelId() == QLatin1String("DoorWindow-Sensor-ZB3.0") ||
         sensor->modelId() == QLatin1String("Keyfob-ZB3.0") ||
+        // Casa.IA
+        sensor->modelId().startsWith(QLatin1String("CTHS317ET")) ||
         // Sercomm
         sensor->modelId().startsWith(QLatin1String("SZ-")) ||
         sensor->modelId().startsWith(QLatin1String("GZ-")) ||

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -104,6 +104,7 @@ const quint64 ikea2MacPrefix      = 0x14b4570000000000ULL;
 const quint64 profaluxMacPrefix   = 0x20918a0000000000ULL;
 const quint64 stMacPrefix         = 0x24fd5b0000000000ULL;
 const quint64 samjinMacPrefix     = 0x286d970000000000ULL;
+const quint64 casaiaPrefix        = 0x3c6a2c0000000000ULL;
 const quint64 sinopeMacPrefix     = 0x500b910000000000ULL;
 const quint64 lumiMacPrefix       = 0x54ef440000000000ULL;
 const quint64 silabs6MacPrefix    = 0x588e810000000000ULL;
@@ -433,6 +434,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_NONE, "0yu2xgi", silabs5MacPrefix }, // Tuya siren
     { VENDOR_EMBER, "TS0601", silabs9MacPrefix }, // Tuya siren
     { VENDOR_EMBER, "TS0222", silabs9MacPrefix }, // TYZB01 light sensor
+    { VENDOR_OWON, "CTHS317ET", casaiaPrefix }, // CASA.ia Temperature probe CTHS-317-ET
     { VENDOR_NONE, "eaxp72v", ikea2MacPrefix }, // Tuya TRV Wesmartify Thermostat Essentials Premium
     { VENDOR_NONE, "88teujp", silabs8MacPrefix }, // SEA802-Zigbee
     { VENDOR_NONE, "uhszj9s", silabs8MacPrefix }, // HiHome WZB-TRVL

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -501,6 +501,7 @@ extern const quint64 silabs8MacPrefix;
 extern const quint64 silabs9MacPrefix;
 extern const quint64 silabs10MacPrefix;
 extern const quint64 instaMacPrefix;
+extern const quint64 casaiaPrefix;
 extern const quint64 boschMacPrefix;
 extern const quint64 jennicMacPrefix;
 extern const quint64 lutronMacPrefix;


### PR DESCRIPTION
Nothing special.
- Product name: Temperature Probe CTHS-317-ET
- Manufacturer: CASAIA
- Model identifier: CTHS317ET

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/5138