### PR TITLE
Don't reset Sonoff SNZB-03 presence

### DIFF
--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -3013,7 +3013,10 @@ void DeRestPluginPrivate::checkSensorStateTimerFired()
         {
             QDateTime now = QDateTime::currentDateTime();
 
-            if (sensor->modelId() == QLatin1String("TY0202")) // Lidl/SILVERCREST motion sensor
+
+            const std::array<QLatin1String, 5> iasZoneOffSensors = {QLatin1String("TY0202"), QLatin1String("MS01"), QLatin1String("MSO1"), QLatin1String("ms01") ,QLatin1String("66666")};
+            const auto resetByIasZone = std::find(iasZoneOffSensors.cbegin(), iasZoneOffSensors.cend(), sensor->modelId()) != iasZoneOffSensors.cend();
+            if (resetByIasZone)
             {
                 continue; // will be only reset via IAS Zone status
             }

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -3011,17 +3011,7 @@ void DeRestPluginPrivate::checkSensorStateTimerFired()
 
         if (sensor->durationDue.isValid())
         {
-            QDateTime now = QDateTime::currentDateTime();
-
-
-            const std::array<QLatin1String, 5> iasZoneOffSensors = {QLatin1String("TY0202"), QLatin1String("MS01"), QLatin1String("MSO1"), QLatin1String("ms01") ,QLatin1String("66666")};
-            const auto resetByIasZone = std::find(iasZoneOffSensors.cbegin(), iasZoneOffSensors.cend(), sensor->modelId()) != iasZoneOffSensors.cend();
-            if (resetByIasZone)
-            {
-                continue; // will be only reset via IAS Zone status
-            }
-
-            if (sensor->durationDue <= now)
+            if (sensor->durationDue <= QDateTime::currentDateTime())
             {
                 // automatically set presence to false, if not triggered in config.duration
                 ResourceItem *item = sensor->item(RStatePresence);


### PR DESCRIPTION
Attempt to determine whether an IAS Zone motion sensor sends restore reports and only queue presence reset if it does not. 