### PR TITLE
Add initial support for ZC-W1 (_tz3000_i8jfiezr)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ deCONZ beta releases are scheduled roughly once per week. After 2–3 betas a st
 Current Beta: **v2.12.6-beta**  
 Current Stable: **v2.12.6**
 
-Next Beta: **v2.13.0-beta**
+Next Beta: **v2.13.0-beta**  
 Next Stable: **v2.13.x** expected in October.
 
 Installation

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -120,6 +120,7 @@ const quint64 silabs10MacPrefix   = 0x8471270000000000ULL;
 const quint64 embertecMacPrefix   = 0x848e960000000000ULL;
 const quint64 YooksmartMacPrefix  = 0x84fd270000000000ULL;
 const quint64 silabsMacPrefix     = 0x90fd9f0000000000ULL;
+const quint64 telinkMacPrefix     = 0xa4c1380000000000ULL;
 const quint64 zhejiangMacPrefix   = 0xb0ce180000000000ULL;
 const quint64 silabs7MacPrefix    = 0xbc33ac0000000000ULL;
 const quint64 dlinkMacPrefix      = 0xc4e90a0000000000ULL;
@@ -413,6 +414,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_NONE, "RH3052", emberMacPrefix }, // Tuyatec temperature sensor
     { VENDOR_NONE, "RH3052", konkeMacPrefix }, // Tuyatec/Lupus temperature sensor
     { VENDOR_EMBER, "TS0201", silabs3MacPrefix }, // Tuya/Blitzwolf temperature and humidity sensor
+    { VENDOR_TUYA, "TS0201", telinkMacPrefix }, // Tuya ZC-W1 temperature sensor
     { VENDOR_NONE, "TS0204", silabs3MacPrefix }, // Tuya gas sensor
     { VENDOR_NONE, "TS0205", silabs3MacPrefix }, // Tuya smoke sensor
     { VENDOR_NONE, "TS0121", silabs3MacPrefix }, // Tuya/Blitzwolf smart plug

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -507,6 +507,7 @@ extern const quint64 silabs7MacPrefix;
 extern const quint64 silabs8MacPrefix;
 extern const quint64 silabs9MacPrefix;
 extern const quint64 silabs10MacPrefix;
+extern const quint64 telinkMacPrefix;
 extern const quint64 instaMacPrefix;
 extern const quint64 boschMacPrefix;
 extern const quint64 jennicMacPrefix;


### PR DESCRIPTION
- Product name: ZC-W1
- Manufacturer: _tz3000_i8jfiezr
- Model identifier: TS0201
Nothing special, see https://github.com/dresden-elektronik/deconz-rest-plugin/issues/5292