### PR TITLE
Initial support for Legrand Wireless Smart Dimmer with Netatmo WNRL63

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2904,6 +2904,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId() == QLatin1String("Teleruptor") || //Legrand teleruptor
         sensor->modelId() == QLatin1String("Contactor") || //Legrand Contactor
         sensor->modelId() == QLatin1String("Pocket remote") || //Legrand wireless remote 4 scene
+        sensor->modelId() == QLatin1String("Remote dimmer switch") || //Wireless Smart Dimmer with Netatmo WNRL63
         // Adeo
         sensor->modelId() == QLatin1String("LDSENK10") || // ADEO Animal compatible motion sensor (Leroy Merlin)
         // Philio
@@ -3203,6 +3204,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
                 sensor->modelId() == QLatin1String("Shutters central remote switch") ||
                 sensor->modelId() == QLatin1String("Double gangs remote switch") ||
                 sensor->modelId() == QLatin1String("Pocket remote") ||
+                sensor->modelId() == QLatin1String("Remote dimmer switch") ||
                 sensor->modelId() == QLatin1String("Remote toggle switch") )
             {
                 //Those device don't support report attribute
@@ -3233,6 +3235,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
                      sensor->modelId() == QLatin1String("Shutters central remote switch") ||
                      sensor->modelId() == QLatin1String("Double gangs remote switch") ||
                      sensor->modelId() == QLatin1String("Pocket remote") ||
+                     sensor->modelId() == QLatin1String("Remote dimmer switch") ||
                      sensor->modelId().startsWith(QLatin1String("ZHMS101")) ||
                      sensor->modelId().startsWith(QLatin1String("3AFE14010402000D")) || //konke presence sensor
                      sensor->modelId().startsWith(QLatin1String("3AFE28010402000D")) || //konke presence sensor
@@ -3691,6 +3694,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
     }
     // LEGRAND Remote switch, simple and double
     else if (sensor->modelId() == QLatin1String("Remote switch") ||
+             sensor->modelId() == QLatin1String("Remote dimmer switch") ||
              sensor->modelId() == QLatin1String("Double gangs remote switch"))
     {
         clusters.push_back(ONOFF_CLUSTER_ID);

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -4014,9 +4014,10 @@ void DeRestPluginPrivate::checkSensorGroup(Sensor *sensor)
          sensor->modelId() == QLatin1String("Double gangs remote switch") ||
 	     sensor->modelId() == QLatin1String("Shutters central remote switch") ||
          sensor->modelId() == QLatin1String("Remote toggle switch") ||
+         sensor->modelId() == QLatin1String("Remote dimmer switch") ||
          sensor->modelId() == QLatin1String("Remote motion sensor"))
     {
-        //Make group but without uniqueid
+        //Make group but without uniqueid, Legrand Stuff, don't have group cluster
     }
     else if (sensor->modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
              sensor->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote

--- a/button_maps.json
+++ b/button_maps.json
@@ -1066,7 +1066,7 @@
         "legrandSwitchRemote": {
             "vendor": "Legrand",
             "doc": "Remote switch",
-            "modelids": ["Remote switch"],
+            "modelids": ["Remote switch", "Remote dimmer switch"],
             "map": [
                 [1, "0x01", "ONOFF", "TOGGLE", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "Toggle"],
                 [1, "0x01", "ONOFF", "ON", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],

--- a/database.cpp
+++ b/database.cpp
@@ -3202,7 +3202,6 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 clusterId = clusterId ? clusterId : ONOFF_CLUSTER_ID;
                 if (sensor.modelId().startsWith(QLatin1String("RDM00")) ||
                     sensor.modelId().startsWith(QLatin1String("Pocket remote")) ||
-                    sensor.modelId().startsWith(QLatin1String("Remote dimmer switch")) ||
                     sensor.modelId().startsWith(QLatin1String("SYMFONISK")))
                 {
                     // blacklisted

--- a/database.cpp
+++ b/database.cpp
@@ -3202,6 +3202,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 clusterId = clusterId ? clusterId : ONOFF_CLUSTER_ID;
                 if (sensor.modelId().startsWith(QLatin1String("RDM00")) ||
                     sensor.modelId().startsWith(QLatin1String("Pocket remote")) ||
+                    sensor.modelId().startsWith(QLatin1String("Remote dimmer switch")) ||
                     sensor.modelId().startsWith(QLatin1String("SYMFONISK")))
                 {
                     // blacklisted

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -402,6 +402,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_LEGRAND, "Teleruptor", legrandMacPrefix }, // Legrand Teleruptor
     { VENDOR_LEGRAND, "Contactor", legrandMacPrefix }, // Legrand Contactor
     { VENDOR_LEGRAND, "Pocket remote", legrandMacPrefix }, // Legrand wireless 4 x scene remote
+    { VENDOR_LEGRAND, "Remote dimmer switch", legrandMacPrefix }, // Legrand Wireless Smart Dimmer with Netatmo WNRL63
     { VENDOR_NETVOX, "Z809AE3R", netvoxMacPrefix }, // Netvox smartplug
     { VENDOR_LDS, "ZB-ONOFFPlug-D0005", silabs2MacPrefix }, // Samsung SmartPlug 2019 (7A-PL-Z-J3)
     { VENDOR_LDS, "ZBT-DIMSwitch", silabs2MacPrefix }, // Linkind 1 key Remote Control / ZS23000178
@@ -4234,6 +4235,7 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
              sensor->modelId() == QLatin1String("Double gangs remote switch") || //Legrand micro module
              sensor->modelId() == QLatin1String("Shutters central remote switch") || // legrand shutter switch
              sensor->modelId() == QLatin1String("Remote motion sensor") || // legrand motion sensor
+             sensor->modelId() == QLatin1String("Remote dimmer switch") || // legrand motion sensor
              sensor->modelId() == QLatin1String("Remote toggle switch")) // legrand switch simple and double
     {
         checkReporting = true;
@@ -7799,6 +7801,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                 if (sensorNode.modelId() == QLatin1String("Remote switch") ||
                     sensorNode.modelId() == QLatin1String("Shutters central remote switch") ||
                     sensorNode.modelId() == QLatin1String("Pocket remote") ||
+                    sensorNode.modelId() == QLatin1String("Remote dimmer switch") ||
                     sensorNode.modelId() == QLatin1String("Double gangs remote switch") )
                 {
                     //Ask for battery but only every day max
@@ -15316,6 +15319,7 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
                  sensor->modelId() == QLatin1String("Remote toggle switch") || // Legrand switch module
                  sensor->modelId() == QLatin1String("Remote motion sensor") || // Legrand motion sensor
                  sensor->modelId() == QLatin1String("Pocket remote") || // Legrand remote scene x 4
+                 sensor->modelId() == QLatin1String("Remote dimmer switch") || // Legrand Wireless Smart Dimmer with Netatmo WNRL63
                  sensor->modelId() == QLatin1String("ZBT-CCTSwitch-D0001") || // LDS Remote
                  sensor->modelId() == QLatin1String("ZBT-DIMController-D0800") || // Mueller-Licht tint dimmer
                  sensor->modelId() == QLatin1String("Shutters central remote switch")) // Legrand shutter switch

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4235,13 +4235,13 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
              sensor->modelId() == QLatin1String("Double gangs remote switch") || //Legrand micro module
              sensor->modelId() == QLatin1String("Shutters central remote switch") || // legrand shutter switch
              sensor->modelId() == QLatin1String("Remote motion sensor") || // legrand motion sensor
-             sensor->modelId() == QLatin1String("Remote dimmer switch") || // legrand motion sensor
              sensor->modelId() == QLatin1String("Remote toggle switch")) // legrand switch simple and double
     {
         checkReporting = true;
         checkClientCluster = true;
     }
-    else if (sensor->modelId() == QLatin1String("Pocket remote")) // legrand 4x scene remote
+    else if (sensor->modelId() == QLatin1String("Pocket remote") ||  // legrand 4x scene remote
+             sensor->modelId() == QLatin1String("Remote dimmer switch")) // legrand 4x scene remote
     {
         checkReporting = true;
     }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4235,13 +4235,13 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
              sensor->modelId() == QLatin1String("Double gangs remote switch") || //Legrand micro module
              sensor->modelId() == QLatin1String("Shutters central remote switch") || // legrand shutter switch
              sensor->modelId() == QLatin1String("Remote motion sensor") || // legrand motion sensor
+             sensor->modelId() == QLatin1String("Remote dimmer switch") || // Legrand remote dimmer
              sensor->modelId() == QLatin1String("Remote toggle switch")) // legrand switch simple and double
     {
         checkReporting = true;
         checkClientCluster = true;
     }
-    else if (sensor->modelId() == QLatin1String("Pocket remote") ||  // legrand 4x scene remote
-             sensor->modelId() == QLatin1String("Remote dimmer switch")) // legrand 4x scene remote
+    else if (sensor->modelId() == QLatin1String("Pocket remote"))  // legrand 4x scene remote
     {
         checkReporting = true;
     }

--- a/power_configuration.cpp
+++ b/power_configuration.cpp
@@ -161,6 +161,7 @@ void DeRestPluginPrivate::handlePowerConfigurationClusterIndication(const deCONZ
                     sensor.modelId() == QLatin1String("Shutters central remote switch") || // Legrand switch module
                     sensor.modelId() == QLatin1String("Remote toggle switch") || // Legrand shutter switch
                     sensor.modelId() == QLatin1String("Remote motion sensor") || // Legrand motion sensor
+                    sensor.modelId() == QLatin1String("Remote dimmer switch") || // Legrand Wireless Smart Dimmer with Netatmo WNRL63
                     sensor.modelId() == QLatin1String("lumi.sensor_magnet.agl02") || // Xiaomi Aqara T1 open/close sensor MCCGQ12LM
                     sensor.modelId() == QLatin1String("lumi.flood.agl02") ||         // Xiaomi Aqara T1 water leak sensor SJCGQ12LM
                     sensor.modelId() == QLatin1String("lumi.motion.agl04") ||        // Xiaomi Aqara RTCGQ13LM high precision motion sensor


### PR DESCRIPTION
- Product name: Wireless Smart Dimmer with Netatmo
- Manufacturer: Legrand
- Model identifier: Remote Dimmer Switch
See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/5343