### PR TITLE
Fix Tuya TRV reporting temperature value (MOES TRV HY368 TS0601)

### DIFF
--- a/tuya.cpp
+++ b/tuya.cpp
@@ -195,7 +195,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
 
             QString transitions;
             
-            Scheduledatalength = zclFrame.payload().size() - 6;
+            quint8 Scheduledatalength = zclFrame.payload().size() - 6;
             quint8 blocklength = 0;
             quint8 values_to_read = 0;
 

--- a/tuya.cpp
+++ b/tuya.cpp
@@ -273,7 +273,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
             }
             
             //Sanitary check
-            if (Scheduledatalength < (part * blocklength * values_to_read)
+            if (Scheduledatalength < (part * blocklength * values_to_read))
             {
                 DBG_Printf(DBG_INFO, "Tuya : Schedule data error\n");
                 return;


### PR DESCRIPTION
Prevent some TRV use the min temperature command as temperature command
See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/5394

Correct issue on schedule command.