### PR TITLE
Fix DDf bindings wrong address mode data type on old GCC

### DIFF
--- a/zdp/zdp.cpp
+++ b/zdp/zdp.cpp
@@ -151,7 +151,7 @@ ZDP_Result ZDP_BindReq(const deCONZ::Binding &bnd, deCONZ::ApsController *apsCtr
     stream << bnd.srcAddress();
     stream << bnd.srcEndpoint();
     stream << bnd.clusterId();
-    stream << bnd.dstAddressMode();
+    stream << static_cast<uint8_t>(bnd.dstAddressMode());
 
     if (bnd.dstAddressMode() == deCONZ::ApsGroupAddress)
     {


### PR DESCRIPTION
GCC 7 doesn't treat the u8 enum properly and presents it as 32-bit integer. Which scrambles the binding request.