### PR TITLE
Fix ZDP requests to devices with changed NWK addressing

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -15175,7 +15175,7 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
         {
             DBG_Printf(DBG_INFO, "[1] get node descriptor for 0x%016llx\n", sc->address.ext());
 
-            if (ZDP_NodeDescriptorReq(sc->address.nwk(), apsCtrl))
+            if (ZDP_NodeDescriptorReq(sc->address, apsCtrl))
             {
                 queryTime = queryTime.addSecs(5);
                 sc->timeout.restart();
@@ -15190,7 +15190,7 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
         {
             DBG_Printf(DBG_INFO, "[2] get active endpoints for 0x%016llx\n", sc->address.ext());
 
-            if (ZDP_ActiveEndpointsReq(sc->address.nwk(), apsCtrl))
+            if (ZDP_ActiveEndpointsReq(sc->address, apsCtrl))
             {
                 queryTime = queryTime.addSecs(5);
                 sc->timeout.restart();
@@ -15220,7 +15220,7 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
                 {
                     DBG_Printf(DBG_INFO, "[3] get simple descriptor 0x%02X for 0x%016llx\n", ep, sc->address.ext());
 
-                    if (ZDP_SimpleDescriptorReq(sc->address.nwk(), ep, apsCtrl))
+                    if (ZDP_SimpleDescriptorReq(sc->address, ep, apsCtrl))
                     {
                         queryTime = queryTime.addSecs(1);
                         sc->timeout.restart();

--- a/device.cpp
+++ b/device.cpp
@@ -298,7 +298,7 @@ void DEV_NodeDescriptorStateHandler(Device *device, const Event &event)
         }
         else
         {
-            d->zdpResult = ZDP_NodeDescriptorReq(device->item(RAttrNwkAddress)->toNumber(), d->apsCtrl);
+            d->zdpResult = ZDP_NodeDescriptorReq(d->node->address(), d->apsCtrl);
             if (d->zdpResult.isEnqueued)
             {
                 d->startStateTimer(MaxConfirmTimeout, StateLevel0);
@@ -359,7 +359,7 @@ void DEV_ActiveEndpointsStateHandler(Device *device, const Event &event)
         }
         else
         {
-            d->zdpResult = ZDP_ActiveEndpointsReq(device->item(RAttrNwkAddress)->toNumber(), d->apsCtrl);
+            d->zdpResult = ZDP_ActiveEndpointsReq(d->node->address(), d->apsCtrl);
             if (d->zdpResult.isEnqueued)
             {
                 d->startStateTimer(MaxConfirmTimeout, StateLevel0);
@@ -432,7 +432,7 @@ void DEV_SimpleDescriptorStateHandler(Device *device, const Event &event)
         }
         else
         {
-            d->zdpResult = ZDP_SimpleDescriptorReq(device->item(RAttrNwkAddress)->toNumber(), needFetchEp, d->apsCtrl);
+            d->zdpResult = ZDP_SimpleDescriptorReq(d->node->address(), needFetchEp, d->apsCtrl);
             if (d->zdpResult.isEnqueued)
             {
                 d->startStateTimer(MaxConfirmTimeout, StateLevel0);

--- a/zdp/zdp.cpp
+++ b/zdp/zdp.cpp
@@ -17,20 +17,26 @@
 
 static uint8_t zdpSeq;
 
-ZDP_Result ZDP_NodeDescriptorReq(quint16 nwkAddress, deCONZ::ApsController *apsCtrl)
+ZDP_Result ZDP_NodeDescriptorReq(const deCONZ::Address &addr, deCONZ::ApsController *apsCtrl)
 {
     Q_ASSERT(apsCtrl);
 
-    DBG_Printf(DBG_INFO, "ZDP get node descriptor for 0x%04X\n", nwkAddress);
-    deCONZ::ApsDataRequest apsReq;
+    DBG_Printf(DBG_INFO, "ZDP get node descriptor for 0x%04X\n", addr.nwk());
     ZDP_Result result;
+
+    if (!addr.hasExt() || !addr.hasNwk())
+    {
+        return result;
+    }
+
+    deCONZ::ApsDataRequest apsReq;
 
     result.apsReqId = apsReq.id();
     result.zdpSeq = zdpSeq++;
 
     // ZDP Header
-    apsReq.dstAddress().setNwk(nwkAddress);
-    apsReq.setDstAddressMode(deCONZ::ApsNwkAddress);
+    apsReq.dstAddress() = addr;
+    apsReq.setDstAddressMode(deCONZ::ApsExtAddress);
     apsReq.setDstEndpoint(ZDO_ENDPOINT);
     apsReq.setSrcEndpoint(ZDO_ENDPOINT);
     apsReq.setProfileId(ZDP_PROFILE_ID);
@@ -42,7 +48,7 @@ ZDP_Result ZDP_NodeDescriptorReq(quint16 nwkAddress, deCONZ::ApsController *apsC
     stream.setByteOrder(QDataStream::LittleEndian);
 
     stream << result.zdpSeq;
-    stream << nwkAddress;
+    stream << addr.nwk();
 
     if (apsCtrl->apsdeDataRequest(apsReq) == deCONZ::Success)
     {
@@ -53,20 +59,26 @@ ZDP_Result ZDP_NodeDescriptorReq(quint16 nwkAddress, deCONZ::ApsController *apsC
     return result;
 }
 
-ZDP_Result ZDP_ActiveEndpointsReq(uint16_t nwkAddress, deCONZ::ApsController *apsCtrl)
+ZDP_Result ZDP_ActiveEndpointsReq(const deCONZ::Address &addr, deCONZ::ApsController *apsCtrl)
 {
     Q_ASSERT(apsCtrl);
 
-    DBG_Printf(DBG_INFO, "ZDP get active endpoints for 0x%04X\n", nwkAddress);
-    deCONZ::ApsDataRequest apsReq;
+    DBG_Printf(DBG_INFO, "ZDP get active endpoints for 0x%04X\n", addr.nwk());
     ZDP_Result result;
+
+    if (!addr.hasExt() || !addr.hasNwk())
+    {
+        return result;
+    }
+
+    deCONZ::ApsDataRequest apsReq;
 
     result.apsReqId = apsReq.id();
     result.zdpSeq = zdpSeq++;
 
     // ZDP Header
-    apsReq.dstAddress().setNwk(nwkAddress);
-    apsReq.setDstAddressMode(deCONZ::ApsNwkAddress);
+    apsReq.dstAddress() = addr;
+    apsReq.setDstAddressMode(deCONZ::ApsExtAddress);
     apsReq.setDstEndpoint(ZDO_ENDPOINT);
     apsReq.setSrcEndpoint(ZDO_ENDPOINT);
     apsReq.setProfileId(ZDP_PROFILE_ID);
@@ -78,7 +90,7 @@ ZDP_Result ZDP_ActiveEndpointsReq(uint16_t nwkAddress, deCONZ::ApsController *ap
     stream.setByteOrder(QDataStream::LittleEndian);
 
     stream << result.zdpSeq;
-    stream << nwkAddress;
+    stream << addr.nwk();
 
     if (apsCtrl->apsdeDataRequest(apsReq) == deCONZ::Success)
     {
@@ -89,20 +101,26 @@ ZDP_Result ZDP_ActiveEndpointsReq(uint16_t nwkAddress, deCONZ::ApsController *ap
     return result;
 }
 
-ZDP_Result ZDP_SimpleDescriptorReq(uint16_t nwkAddress, quint8 endpoint, deCONZ::ApsController *apsCtrl)
+ZDP_Result ZDP_SimpleDescriptorReq(const deCONZ::Address &addr, quint8 endpoint, deCONZ::ApsController *apsCtrl)
 {
     Q_ASSERT(apsCtrl);
 
-    DBG_Printf(DBG_INFO, "ZDP get simple descriptor 0x%02X for 0x%04X\n", endpoint, nwkAddress);
-    deCONZ::ApsDataRequest apsReq;
+    DBG_Printf(DBG_INFO, "ZDP get simple descriptor 0x%02X for 0x%04X\n", endpoint, addr.nwk());
     ZDP_Result result;
+
+    if (!addr.hasExt() || !addr.hasNwk())
+    {
+        return result;
+    }
+
+    deCONZ::ApsDataRequest apsReq;
 
     result.apsReqId = apsReq.id();
     result.zdpSeq = zdpSeq++;
 
     // ZDP Header
-    apsReq.dstAddress().setNwk(nwkAddress);
-    apsReq.setDstAddressMode(deCONZ::ApsNwkAddress);
+    apsReq.dstAddress() = addr;
+    apsReq.setDstAddressMode(deCONZ::ApsExtAddress);
     apsReq.setDstEndpoint(ZDO_ENDPOINT);
     apsReq.setSrcEndpoint(ZDO_ENDPOINT);
     apsReq.setProfileId(ZDP_PROFILE_ID);
@@ -114,7 +132,7 @@ ZDP_Result ZDP_SimpleDescriptorReq(uint16_t nwkAddress, quint8 endpoint, deCONZ:
     stream.setByteOrder(QDataStream::LittleEndian);
 
     stream << result.zdpSeq;
-    stream << nwkAddress;
+    stream << addr.nwk();
     stream << endpoint;
 
     if (apsCtrl->apsdeDataRequest(apsReq) == deCONZ::Success)

--- a/zdp/zdp.h
+++ b/zdp/zdp.h
@@ -15,6 +15,7 @@
 
 namespace deCONZ
 {
+    class Address;
     class ApsController;
     class Binding;
 }
@@ -55,9 +56,9 @@ struct ZDP_Result
     }
 };
 
-ZDP_Result ZDP_NodeDescriptorReq(uint16_t nwkAddress, deCONZ::ApsController *apsCtrl);
-ZDP_Result ZDP_ActiveEndpointsReq(uint16_t nwkAddress, deCONZ::ApsController *apsCtrl);
-ZDP_Result ZDP_SimpleDescriptorReq(uint16_t nwkAddress, uint8_t endpoint, deCONZ::ApsController *apsCtrl);
+ZDP_Result ZDP_NodeDescriptorReq(const deCONZ::Address &addr, deCONZ::ApsController *apsCtrl);
+ZDP_Result ZDP_ActiveEndpointsReq(const deCONZ::Address &addr, deCONZ::ApsController *apsCtrl);
+ZDP_Result ZDP_SimpleDescriptorReq(const deCONZ::Address &addr, uint8_t endpoint, deCONZ::ApsController *apsCtrl);
 ZDP_Result ZDP_BindReq(const deCONZ::Binding &bnd, deCONZ::ApsController *apsCtrl);
 uint8_t ZDP_NextSequenceNumber();
 


### PR DESCRIPTION
Seen with the Hue motion sensor, the NWK address can change. This is detected in the core but it needs the MAC address in the APS request to switch to the new NWK address.