### PR TITLE
Fix sending of negative values for thermostats

### DIFF
--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1540,7 +1540,7 @@ public:
     bool addTaskThermostatGetSchedule(TaskItem &task);
     bool addTaskThermostatSetWeeklySchedule(TaskItem &task, quint8 weekdays, const QString &transitions);
     void updateThermostatSchedule(Sensor *sensor, quint8 newWeekdays, QString &transitions);
-    bool addTaskThermostatReadWriteAttribute(TaskItem &task, uint8_t readOrWriteCmd, uint16_t mfrCode, uint16_t attrId, uint8_t attrType, uint32_t attrValue);
+    bool addTaskThermostatReadWriteAttribute(TaskItem &task, uint8_t readOrWriteCmd, uint16_t mfrCode, uint16_t attrId, uint8_t attrType, int attrValue);
     bool addTaskThermostatWriteAttributeList(TaskItem &task, uint16_t mfrCode, QMap<quint16, quint32> &AttributeList );
     bool addTaskControlModeCmd(TaskItem &task, uint8_t cmdId, int8_t mode);
     bool addTaskSyncTime(Sensor *sensor);

--- a/thermostat.cpp
+++ b/thermostat.cpp
@@ -1282,7 +1282,7 @@ void DeRestPluginPrivate::addTaskThermostatGetScheduleTimer()
    \return true - on success
            false - on error
  */
-bool DeRestPluginPrivate::addTaskThermostatReadWriteAttribute(TaskItem &task, uint8_t readOrWriteCmd, uint16_t mfrCode, uint16_t attrId, uint8_t attrType, uint32_t attrValue)
+bool DeRestPluginPrivate::addTaskThermostatReadWriteAttribute(TaskItem &task, uint8_t readOrWriteCmd, uint16_t mfrCode, uint16_t attrId, uint8_t attrType, int attrValue)
 {
     if (readOrWriteCmd != deCONZ::ZclReadAttributesId && readOrWriteCmd != deCONZ::ZclWriteAttributesId)
     {


### PR DESCRIPTION
For thermostats, negative values were never send due to an inappropriate data type in the respective function. E.g. negative offsets for devices supporting it were always send as 0.