### PR TITLE
Enforce skipping legacy code while in strict mode for numerous clusters

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -8129,9 +8129,9 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                     }
                 }
             }
-            if (!DEV_TestStrict())
+            else if (*ci == TIME_CLUSTER_ID)
             {
-                else if (*ci == TIME_CLUSTER_ID)
+                if (!DEV_TestStrict())
                 {
                     if (sensorNode.modelId() == QLatin1String("Thermostat")) // eCozy
                     {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1198,16 +1198,19 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
             break;
 
         case ONOFF_CLUSTER_ID:
-            handleOnOffClusterIndication(ind, zclFrame);
-            handleClusterIndicationGateways(ind, zclFrame);
+            if (!DEV_TestStrict())
+            {
+                handleOnOffClusterIndication(ind, zclFrame);
+                handleClusterIndicationGateways(ind, zclFrame);
+            }
             break;
 
         case METERING_CLUSTER_ID:
-            handleSimpleMeteringClusterIndication(ind, zclFrame);
+            if (!DEV_TestStrict()) { handleSimpleMeteringClusterIndication(ind, zclFrame); }
             break;
 
         case ELECTRICAL_MEASUREMENT_CLUSTER_ID:
-            handleElectricalMeasurementClusterIndication(ind, zclFrame);
+            if (!DEV_TestStrict()) { handleElectricalMeasurementClusterIndication(ind, zclFrame); }
             break;
 
         case IAS_ZONE_CLUSTER_ID:
@@ -1231,7 +1234,7 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
             break;
 
         case POWER_CONFIGURATION_CLUSTER_ID:
-            handlePowerConfigurationClusterIndication(ind, zclFrame);
+            if (!DEV_TestStrict()) { handlePowerConfigurationClusterIndication(ind, zclFrame); }
             break;
 
         case XAL_CLUSTER_ID:
@@ -1243,7 +1246,7 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
             break;
 
         case WINDOW_COVERING_CLUSTER_ID:
-            handleWindowCoveringClusterIndication(ind, zclFrame);
+            if (!DEV_TestStrict()) { handleWindowCoveringClusterIndication(ind, zclFrame); }
             break;
 
         case TUYA_CLUSTER_ID:
@@ -1252,11 +1255,11 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
             break;
 
         case THERMOSTAT_CLUSTER_ID:
-            handleThermostatClusterIndication(ind, zclFrame);
+            if (!DEV_TestStrict()) { handleThermostatClusterIndication(ind, zclFrame); }
             break;
 
         case BASIC_CLUSTER_ID:
-            handleBasicClusterIndication(ind, zclFrame);
+            if (!DEV_TestStrict()) { handleBasicClusterIndication(ind, zclFrame); }
             break;
 
         case APPLIANCE_EVENTS_AND_ALERTS_CLUSTER_ID:
@@ -1264,11 +1267,11 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
             break;
 
         case THERMOSTAT_UI_CONFIGURATION_CLUSTER_ID:
-            handleThermostatUiConfigurationClusterIndication(ind, zclFrame);
+            if (!DEV_TestStrict()) { handleThermostatUiConfigurationClusterIndication(ind, zclFrame); }
             break;
 
         case DIAGNOSTICS_CLUSTER_ID:
-            handleDiagnosticsClusterIndication(ind, zclFrame);
+            if (!DEV_TestStrict()) { handleDiagnosticsClusterIndication(ind, zclFrame); }
             break;
 
         case IDENTIFY_CLUSTER_ID:
@@ -1277,7 +1280,7 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
 
         case DEVELCO_AIR_QUALITY_CLUSTER_ID: // Develco specific -> VOC Management
         case BOSCH_AIR_QUALITY_CLUSTER_ID: // Bosch Air quality sensor
-            handleAirQualityClusterIndication(ind, zclFrame);
+            if (!DEV_TestStrict()) { handleAirQualityClusterIndication(ind, zclFrame); }
             break;
 
         case POLL_CONTROL_CLUSTER_ID:
@@ -1297,11 +1300,11 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
             break;
 
         case XIAOMI_CLUSTER_ID:
-            handleXiaomiLumiClusterIndication(ind, zclFrame);
+            if (!DEV_TestStrict()) { handleXiaomiLumiClusterIndication(ind, zclFrame); }
             break;
 
         case OCCUPANCY_SENSING_CLUSTER_ID:
-            handleOccupancySensingClusterIndication(ind, zclFrame);
+            if (!DEV_TestStrict()) { handleOccupancySensingClusterIndication(ind, zclFrame); }
             break;
 
         default:

--- a/electrical_measurement.cpp
+++ b/electrical_measurement.cpp
@@ -14,11 +14,6 @@
  */
 void DeRestPluginPrivate::handleElectricalMeasurementClusterIndication(const deCONZ::ApsDataIndication &ind, const deCONZ::ZclFrame &zclFrame)
 {
-    if (DEV_TestStrict())
-    {
-        return;
-    }
-
     if (zclFrame.isDefaultResponse())
     {
         return;

--- a/ias_zone.cpp
+++ b/ias_zone.cpp
@@ -318,9 +318,12 @@ void DeRestPluginPrivate::handleIasZoneClusterIndication(const deCONZ::ApsDataIn
 
                 case IAS_ZONE_STATUS:
                 {
-                    const quint16 zoneStatus = attr.numericValue().u16;   // might be reported or received via CMD_STATUS_CHANGE_NOTIFICATION
+                    if (!DEV_TestStrict())
+                    {
+                        const quint16 zoneStatus = attr.numericValue().u16;   // might be reported or received via CMD_STATUS_CHANGE_NOTIFICATION
 
-                    processIasZoneStatus(sensor, zoneStatus, updateType);
+                        processIasZoneStatus(sensor, zoneStatus, updateType);
+                    }
 
                 }
                     break;
@@ -376,18 +379,21 @@ void DeRestPluginPrivate::handleIasZoneClusterIndication(const deCONZ::ApsDataIn
     // Read ZCL Cluster Command Response
     if (isClusterCmd && zclFrame.commandId() == CMD_STATUS_CHANGE_NOTIFICATION)
     {
-        quint16 zoneStatus;
-        quint8 extendedStatus;
-        quint8 zoneId;
-        quint16 delay;
-        stream >> zoneStatus;
-        stream >> extendedStatus; // reserved, set to 0
-        stream >> zoneId;
-        stream >> delay;
-        DBG_Assert(stream.status() == QDataStream::Ok);
-        DBG_Printf(DBG_IAS, "[IAS ZONE] - 0x%016llX Status Change, status: 0x%04X, zoneId: %u, delay: %u\n", sensor->address().ext(), zoneStatus, zoneId, delay);
+        if (!DEV_TestStrict())
+        {
+            quint16 zoneStatus;
+            quint8 extendedStatus;
+            quint8 zoneId;
+            quint16 delay;
+            stream >> zoneStatus;
+            stream >> extendedStatus; // reserved, set to 0
+            stream >> zoneId;
+            stream >> delay;
+            DBG_Assert(stream.status() == QDataStream::Ok);
+            DBG_Printf(DBG_IAS, "[IAS ZONE] - 0x%016llX Status Change, status: 0x%04X, zoneId: %u, delay: %u\n", sensor->address().ext(), zoneStatus, zoneId, delay);
 
-        processIasZoneStatus(sensor, zoneStatus, NodeValue::UpdateByZclReport);
+            processIasZoneStatus(sensor, zoneStatus, NodeValue::UpdateByZclReport);
+        }
         
         checkIasEnrollmentStatus(sensor);
     }


### PR DESCRIPTION
In order to better test created DDFs and the associated new code processing, using strict mode will disable legacy data processing for numerous clusters.