### PR TITLE
Fix: Correct cluster for innr SP120 `state/on`

### DIFF
--- a/devices/innr/sp_120.json
+++ b/devices/innr/sp_120.json
@@ -52,7 +52,7 @@
           "refresh.interval": 60,
           "parse": {
             "at": "0x0000",
-            "cl": "0x0008",
+            "cl": "0x0006",
             "ep": 1,
             "eval": "Item.val = Attr.val",
             "fn": "zcl"


### PR DESCRIPTION
Required cluster is 0x0006 instead of 0x0008.