### PR TITLE
Fix update sensor config/group via REST-API

### DIFF
--- a/resource.cpp
+++ b/resource.cpp
@@ -1469,3 +1469,25 @@ QLatin1String R_DataTypeToString(ApiDataType type)
 
     return QLatin1String("unknown");
 }
+
+/*! Returns true if \p str contains a valid list of group identifiers.
+
+    Valid values are:
+      ""          empty
+      "45"        single group
+      "343,123"   two groups
+ */
+bool isValidRConfigGroup(const QString &str)
+{
+    int result = 0;
+    const QStringList groupList = str.split(',', SKIP_EMPTY_PARTS);
+
+    for (const auto &groupId : groupList)
+    {
+        bool ok = false;
+        auto gid = groupId.toUInt(&ok, 0);
+        if (ok && gid <= UINT16_MAX) { result++; }
+    }
+
+    return result == groupList.size();
+}

--- a/resource.h
+++ b/resource.h
@@ -588,6 +588,8 @@ bool R_SetValueEventOnSet(Resource *r, const char *suffix, const V &val, Resourc
     return result;
 }
 
+bool isValidRConfigGroup(const QString &str);
+
 uint8_t DDF_GetSubDeviceOrder(const QString &type);
 QLatin1String R_DataTypeToString(ApiDataType type);
 inline bool isValid(Resource::Handle hnd) { return hnd.hash != 0 && hnd.index < UINT16_MAX && hnd.type != 0; }

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1678,8 +1678,12 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                 }
                 else if (rid.suffix == RConfigGroup) // String
                 {
-                    checkSensorBindingsForClientClusters(sensor);
-                    continue;
+                    data.valid = isValidRConfigGroup(data.string);
+                    if (data.valid)
+                    {
+                        updated = true;
+                        checkSensorBindingsForClientClusters(sensor);
+                    }
                 }
                 else if (QString(rid.suffix).startsWith("config/ubisys_j1_")) // Unsigned integer
                 {

--- a/utils/utils.cpp
+++ b/utils/utils.cpp
@@ -173,6 +173,11 @@ RestData verifyRestData(const ResourceItemDescriptor &rid, const QVariant &val)
                 data.valid = true;
                 return data;
             }
+            else if (rid.suffix == RConfigGroup)
+            {
+                data.valid = true; // empty string allowed
+                return data;
+            }
             else
             {
                 return data;


### PR DESCRIPTION
Config group is uses to specify the group id(s) used in group bindings.
This affects switches like Ubisys C4/S1/S2 where the group list is configured via REST-API.

Regression from: babe2ac60b4ad698f7b486ef929138b21075f3ec