### PR TITLE
Fix alarm system GET response to include armmask without 'A'

### DIFF
--- a/rest_alarmsystems.cpp
+++ b/rest_alarmsystems.cpp
@@ -146,7 +146,7 @@ static QVariantMap alarmSystemToMap(const AlarmSystem *alarmSys)
         {
             QVariantMap dev;
 
-            if ((entry.flags & (AS_ENTRY_FLAG_ARMED_AWAY | AS_ENTRY_FLAG_ARMED_AWAY | AS_ENTRY_FLAG_ARMED_AWAY)) != 0)
+            if ((entry.flags & (AS_ENTRY_FLAG_ARMED_AWAY | AS_ENTRY_FLAG_ARMED_STAY | AS_ENTRY_FLAG_ARMED_NIGHT)) != 0)
             {
                 dev[paramArmMask] = QLatin1String(entry.armMask);
             }


### PR DESCRIPTION
The device `armmask` in the PUT request is correctly stored and used.
However, REST API GET always returned "none" if no 'A' is part of the `armmask`.