### PR TITLE
DDF fix loading light group membership and events

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -2648,8 +2648,8 @@ static int sqliteLoadLightNodeCallback(void *user, int ncols, char **colval , ch
         lightNode->setName(name);
     }
 
-    QStringList::const_iterator gi = groupIds.begin();
-    QStringList::const_iterator gend = groupIds.end();
+    auto gi = groupIds.cbegin();
+    const auto gend = groupIds.cend();
 
     for (; gi != gend; ++gi)
     {
@@ -2662,8 +2662,8 @@ static int sqliteLoadLightNodeCallback(void *user, int ncols, char **colval , ch
         }
 
         // already known?
-        std::vector<GroupInfo>::const_iterator k = lightNode->groups().begin();
-        std::vector<GroupInfo>::const_iterator kend = lightNode->groups().end();
+        auto k = lightNode->groups().cbegin();
+        const auto kend = lightNode->groups().cend();
 
         for (; k != kend; ++k)
         {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1117,17 +1117,13 @@ void DeRestPluginPrivate::apsdeDataIndicationDevice(const deCONZ::ApsDataIndicat
                 }
 
                 const bool push = item->pushOnSet() || (item->pushOnChange() && item->lastChanged() == item->lastSet());
-                if (idItem && push)
+                if (idItem)
                 {
                     enqueueEvent(Event(r->prefix(), item->descriptor().suffix, idItem->toString(), device->key()));
-                    if (item->lastChanged() == item->lastSet())
+                    if (push && item->lastChanged() == item->lastSet())
                     {
                         DB_StoreSubDeviceItem(r, item);
                     }
-                }
-                else if (idItem)
-                {
-                    device->handleEvent(Event(r->prefix(), item->descriptor().suffix, idItem->toString(), device->key()));
                 }
 
                 if (item->descriptor().suffix[0] == 's') // state/*

--- a/device_compat.cpp
+++ b/device_compat.cpp
@@ -146,6 +146,34 @@ static Resource *DEV_InitLightNodeFromDescription(Device *device, const DeviceDe
         }
     }
 
+    {
+        dbItem->column = "groups";
+        if (DB_LoadLegacyLightValue(dbItem.get()))
+        {
+            const auto groupList = QString(static_cast<QLatin1String>(dbItem->value)).split(',', SKIP_EMPTY_PARTS);
+
+            for (const auto &g : groupList)
+            {
+                bool ok = false;
+                uint gid = g.toUShort(&ok, 0);
+                if (!ok) { continue; }
+
+                auto i = std::find_if(lightNode.groups().cbegin(), lightNode.groups().cend(), [gid](const auto &group)
+                {
+                    return gid == group.id;
+                });
+
+                if (i == lightNode.groups().cend())
+                {
+                    GroupInfo groupInfo;
+                    groupInfo.id = gid;
+                    groupInfo.state = GroupInfo::StateInGroup;
+                    lightNode.groups().push_back(groupInfo);
+                }
+            }
+        }
+    }
+
     // remove some items which need to be specified via DDF
     lightNode.removeItem(RStateOn);
     lightNode.removeItem(RStateBri);

--- a/rest_groups.cpp
+++ b/rest_groups.cpp
@@ -3396,7 +3396,6 @@ void DeRestPluginPrivate::handleGroupEvent(const Event &e)
     {
         return;
     }
-    const QDateTime now = QDateTime::currentDateTime();
 
     if (e.what() == REventCheckGroupAnyOn)
     {


### PR DESCRIPTION
- Lights with a DDF didn't load groups after startup.
- After "parse" always emit events for sub resources, not only on push. This fixes group `any_on` / `all_on`.