### PR TITLE
DDF group bindings and group allocation

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -5980,32 +5980,6 @@ void DeRestPluginPrivate::checkConsistency()
     {
         gwProxyPort = 0;
     }
-
-    {
-        std::vector<Group>::iterator i = groups.begin();
-        std::vector<Group>::iterator end = groups.end();
-
-        for (; i != end; ++i)
-        {
-            for (size_t j = 0; j < i->m_deviceMemberships.size(); j++)
-            {
-                const QString &sid = i->m_deviceMemberships[j];
-                Sensor *sensor = getSensorNodeForId(sid);
-
-                if (!sensor || sensor->deletedState() != Sensor::StateNormal)
-                {
-                    // sensor isn't available anymore
-                    DBG_Printf(DBG_INFO, "remove sensor %s from group 0x%04X\n", qPrintable(sid), i->address());
-                    i->m_deviceMemberships[j] = i->m_deviceMemberships.back();
-                    i->m_deviceMemberships.pop_back();
-                }
-                else
-                {
-                    j++;
-                }
-            }
-        }
-    }
 }
 
 /*! Timer handler for storing persistent data.

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -17678,6 +17678,122 @@ Resource *DEV_AddResource(const LightNode &lightNode)
     return &l;
 }
 
+/*!  Called by init DDF to allocate new groups for config.group = "auto [,auto, ...]".
+
+     For each "auto" entry in the comma seperated group list a new \c Group is allocated
+     and assigned to the device via device membership and group.uniqueid.
+
+     The group.uniqueid is generated based on the position in the config.group list:
+
+     "auto":            00:11:22:33:44:55:66:77
+
+     "auto,auto":       00:11:22:33:44:55:66:77
+                        00:11:22:33:44:55:66:77-1
+
+     "auto,auto,auto":  00:11:22:33:44:55:66:77
+                        00:11:22:33:44:55:66:77-1
+                        00:11:22:33:44:55:66:77-2
+
+     Where 00:11:22:33:44:55:66:77 is the MAC address of the device.
+     Note: The first group has no "-0" suffix, to be backward compatible with old code.
+ */
+void DEV_AllocateGroup(const Device *device, Resource *rsub, ResourceItem *item)
+{
+    assert(device);
+    assert(rsub);
+    assert(item);
+    assert(item->descriptor().suffix == RConfigGroup);
+
+    if (!device || !rsub || !item || item->descriptor().suffix != RConfigGroup)
+    {
+        return;
+    }
+
+    if (isValidRConfigGroup(item->toString()))
+    {
+        return;
+    }
+
+    const auto &rId = rsub->item(RAttrId)->toString();
+    auto &groups = plugin->groups;
+    auto ls = item->toString().split(',', SKIP_EMPTY_PARTS);
+
+    int allocated = 0;
+    for (int i = 0; i < ls.size(); i++)
+    {
+        if (ls[i] == QLatin1String("auto"))
+        {
+            QString gUniqueId = device->item(RAttrUniqueId)->toString();
+            if (ls.size() > 1)
+            {
+                gUniqueId += "-" + QString::number(i);
+            }
+
+            auto g = groups.begin();
+            const auto gend = groups.end();
+
+            for (; g != gend; ++g)
+            {
+                if (g->address() == 0 || g->state() != Group::StateNormal)
+                {
+                    continue;
+                }
+
+                const ResourceItem *uid = g->item(RAttrUniqueId);
+
+                if (uid && uid->toString() == gUniqueId)
+                {
+                    ls[i] = g->id(); // device group already exists, grab group id
+                    g->addDeviceMembership(rId);
+                    allocated++;
+                    break;
+                }
+            }
+
+            if (g == gend)
+            {
+                for (quint16 gid = 20000 ; gid < 25000; gid++)
+                {
+                    const auto match = std::find_if(groups.cbegin(), groups.cend(), [gid](const Group &x) { return x.address() == gid; });
+
+                    if (match == groups.cend())
+                    {
+                        Group group;
+
+                        group.setAddress(gid);
+                        group.addItem(DataTypeString, RAttrUniqueId)->setValue(gUniqueId);
+                        group.addDeviceMembership(rId);
+                        group.setName(rsub->item(RAttrName)->toString() + " " + QString::number(i));
+                        ls[i] = group.id();
+
+                        groups.push_back(group);
+                        plugin->updateGroupEtag(&groups.back());
+                        plugin->queSaveDb(DB_GROUPS, DB_SHORT_SAVE_DELAY);
+                        allocated++;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    if (allocated > 0)
+    {
+        item->setValue(ls.join(','));
+        DB_StoreSubDeviceItem(rsub, item);
+
+        if (rsub->prefix() == RSensors)
+        {
+            Sensor *s = static_cast<Sensor*>(rsub);
+            if (s)
+            {
+                s->setNeedSaveDatabase(true);
+                plugin->queSaveDb(DB_SENSORS, DB_SHORT_SAVE_DELAY);
+            }
+        }
+    }
+}
+
 /*! Returns deCONZ core node for a given \p extAddress.
  */
 const deCONZ::Node *DEV_GetCoreNode(uint64_t extAddress)

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -706,7 +706,6 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
     haEndpoint = 0;
     gwGroupSendDelay = deCONZ::appArgumentNumeric("--group-delay", GROUP_SEND_DELAY);
     supportColorModeXyForGroups = true;
-    groupDeviceMembershipChecked = false;
     gwLinkButton = false;
     gwWebSocketNotifyAll = true;
     gwdisablePermitJoinAutoOff = false;

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1796,7 +1796,6 @@ public:
     bool gwRunFromShellScript;
     QString gwRunMode;
     bool gwDeleteUnknownRules;
-    bool groupDeviceMembershipChecked;
     QVariantMap gwUserParameter;
     std::vector<QString> gwUserParameterToDelete;
     deCONZ::Address gwDeviceAddress;

--- a/device.cpp
+++ b/device.cpp
@@ -29,6 +29,10 @@
 #define STATE_LEVEL_BINDING  StateLevel1
 #define STATE_LEVEL_POLL     StateLevel2
 
+#define MGMT_BIND_SUPPORT_UNKNOWN -1
+#define MGMT_BIND_SUPPORTED        1
+#define MGMT_BIND_NOT_SUPPORTED    0
+
 typedef void (*DeviceStateHandler)(Device *, const Event &);
 
 /*! Device state machine description can be found in the wiki:
@@ -43,8 +47,10 @@ void DEV_SimpleDescriptorStateHandler(Device *device, const Event &event);
 void DEV_BasicClusterStateHandler(Device *device, const Event &event);
 void DEV_GetDeviceDescriptionHandler(Device *device, const Event &event);
 void DEV_BindingHandler(Device *device, const Event &event);
+void DEV_BindingTableReadHandler(Device *device, const Event &event);
 void DEV_BindingTableVerifyHandler(Device *device, const Event &event);
-void DEV_CreatebindingHandler(Device *device, const Event &event);
+void DEV_BindingCreateHandler(Device *device, const Event &event);
+void DEV_BindingRemoveHandler(Device *device, const Event &event);
 void DEV_ReadReportConfigurationHandler(Device *device, const Event &event);
 void DEV_ReadNextReportConfigurationHandler(Device *device, const Event &event);
 void DEV_ConfigureReportingHandler(Device *device, const Event &event);
@@ -98,7 +104,8 @@ struct BindingContext
     size_t bindingCheckRound = 0;
     size_t bindingIter = 0;
     size_t reportIter = 0;
-    bool mgmtBindSupported = false;
+    int mgmtBindSupported = MGMT_BIND_SUPPORT_UNKNOWN;
+    uint8_t mgmtBindStartIndex = 0;
     std::vector<BindingTracker> bindingTrackers;
     std::vector<DDF_Binding> bindings;
     std::vector<ReportTracker> reportTrackers;
@@ -798,23 +805,34 @@ void DEV_BindingHandler(Device *device, const Event &event)
     if (event.what() == REventStateEnter)
     {
         DBG_Printf(DBG_DEV, "DEV Binding enter %s/0x%016llX\n", event.resource(), event.deviceKey());
+
+        if (!d->node->isRouter())
+        {
+            // most end devices support it, however disable for now until further testing
+            d->binding.mgmtBindSupported = MGMT_BIND_NOT_SUPPORTED;
+        }
     }
-    else if (event.what() == REventPoll || event.what() == REventAwake)
+    else if (event.what() == REventPoll || event.what() == REventAwake || event.what() == REventBindingTick)
     {
-        DBG_Printf(DBG_DEV, "DEV Binding verify bindings %s/0x%016llX\n", event.resource(), event.deviceKey());
         d->binding.bindingIter = 0;
-        d->setState(DEV_BindingTableVerifyHandler, STATE_LEVEL_BINDING);
-        DEV_EnqueueEvent(device, REventBindingTick);
+        if (d->binding.mgmtBindSupported == MGMT_BIND_NOT_SUPPORTED)
+        {
+            d->setState(DEV_BindingTableVerifyHandler, STATE_LEVEL_BINDING);
+        }
+        else
+        {
+            d->setState(DEV_BindingTableReadHandler, STATE_LEVEL_BINDING);
+        }
     }
     else if (event.what() == REventBindingTable)
     {
         if (event.num() == deCONZ::ZdpSuccess)
         {
-            d->binding.mgmtBindSupported = true;
+            d->binding.mgmtBindSupported = MGMT_BIND_SUPPORTED;
         }
         else if (event.num() == deCONZ::ZdpNotSupported)
         {
-            d->binding.mgmtBindSupported = false;
+            d->binding.mgmtBindSupported = MGMT_BIND_NOT_SUPPORTED;
         }
     }
 }
@@ -834,25 +852,125 @@ deCONZ::Binding DEV_ToCoreBinding(const DDF_Binding &bnd, quint64 srcAddress)
     return {};
 }
 
+void DEV_BindingTableReadHandler(Device *device, const Event &event)
+{
+    DevicePrivate *d = device->d;
+
+    if (event.what() == REventStateEnter)
+    {
+        DBG_Printf(DBG_DEV, "DEV Binding read bindings %s/0x%016llX\n", event.resource(), event.deviceKey());
+        d->binding.mgmtBindStartIndex = 0;
+        DEV_EnqueueEvent(device, REventBindingTick);
+    }
+    else if (event.what() == REventBindingTick)
+    {
+        d->zdpResult = ZDP_MgmtBindReq(d->binding.mgmtBindStartIndex, d->node->address(), d->apsCtrl);
+
+        if (d->zdpResult.isEnqueued)
+        {
+            d->startStateTimer(MaxConfirmTimeout, STATE_LEVEL_BINDING);
+        }
+        else
+        {
+            d->setState(DEV_BindingHandler, STATE_LEVEL_BINDING);
+        }
+    }
+    else if (event.what() == REventStateLeave)
+    {
+        d->stopStateTimer(STATE_LEVEL_BINDING);
+    }
+    else if (event.what() == REventApsConfirm)
+    {
+        if (d->zdpResult.apsReqId == EventApsConfirmId(event))
+        {
+            if (EventApsConfirmStatus(event) == deCONZ::ApsSuccessStatus)
+            {
+                d->stopStateTimer(STATE_LEVEL_BINDING);
+                d->startStateTimer(d->maxResponseTime, STATE_LEVEL_BINDING);
+            }
+            else
+            {
+                d->setState(DEV_BindingHandler, STATE_LEVEL_BINDING);
+            }
+        }
+    }
+    else if (event.what() == REventZdpMgmtBindResponse)
+    {
+        uint8_t buf[128];
+        if (event.hasData() && event.dataSize() >= 5 && event.dataSize() < sizeof(buf))
+        {
+            if (event.getData(buf, event.dataSize()))
+            {
+                const uint8_t seq = buf[0];
+                const uint8_t status = buf[1];
+                const uint8_t size = buf[2];
+                const uint8_t index = buf[3];
+                const uint8_t count = buf[4];
+
+                if (seq != d->zdpResult.zdpSeq)
+                {
+                    return;
+                }
+
+                if (status == deCONZ::ZdpSuccess)
+                {
+                    d->stopStateTimer(STATE_LEVEL_BINDING);
+
+                    d->binding.mgmtBindSupported = MGMT_BIND_SUPPORTED;
+
+                    if (size > index + count)
+                    {
+                        d->binding.mgmtBindStartIndex = index + count;
+                        DEV_EnqueueEvent(device, REventBindingTick); // process next
+                    }
+                    else
+                    {
+                        d->binding.bindingIter = 0;
+                        d->setState(DEV_BindingTableVerifyHandler, STATE_LEVEL_BINDING);
+                    }
+                }
+                else
+                {
+                    if (status == deCONZ::ZdpNotSupported)
+                    {
+                        d->binding.mgmtBindSupported = MGMT_BIND_NOT_SUPPORTED;
+                    }
+                    d->setState(DEV_BindingHandler, STATE_LEVEL_BINDING);
+                }
+            }
+        }
+    }
+    else if (event.what() == REventStateTimeout)
+    {
+        DBG_Printf(DBG_DEV, "ZDP read binding table timeout: 0x%016llX\n", device->key());
+        d->setState(DEV_BindingHandler, STATE_LEVEL_BINDING);
+    }
+}
+
 void DEV_BindingTableVerifyHandler(Device *device, const Event &event)
 {
     DevicePrivate *d = device->d;
 
-    if (event.what() != REventBindingTick)
+    if (event.what() == REventStateEnter)
+    {
+        DBG_Printf(DBG_DEV, "DEV Binding verify bindings %s/0x%016llX\n", event.resource(), event.deviceKey());
+        DEV_EnqueueEvent(device, REventBindingTick);
+    }
+    else if (event.what() != REventBindingTick)
     {
 
     }
     else if (d->binding.bindingIter >= d->binding.bindings.size())
     {
         d->binding.bindingCheckRound++;
-        d->setState(DEV_BindingIdleHandler, STATE_LEVEL_BINDING);
+        d->setState(DEV_BindingRemoveHandler, STATE_LEVEL_BINDING);
     }
     else
     {
         auto &ddfBinding = d->binding.bindings[d->binding.bindingIter];
         auto &tracker = d->binding.bindingTrackers[d->binding.bindingIter];
 
-        if (ddfBinding.dstExtAddress == 0)
+        if (ddfBinding.dstExtAddress == 0 && ddfBinding.isUnicastBinding)
         {
             ddfBinding.dstExtAddress = d->apsCtrl->getParameter(deCONZ::ParamMacAddress);
             DBG_Assert(ddfBinding.dstExtAddress != 0);
@@ -863,8 +981,43 @@ void DEV_BindingTableVerifyHandler(Device *device, const Event &event)
                 return;
             }
         }
+        else if (ddfBinding.isGroupBinding)
+        {
+            bool ok = false;
 
-        const auto bindingTable = device->node()->bindingTable();
+            // update destination group based on RConfigGroup
+            for (const auto &sub : device->subDevices())
+            {
+                ResourceItem *configGroup = sub->item(RConfigGroup);
+                if (!configGroup)
+                {
+                    continue;
+                }
+
+                const auto ls = configGroup->toString().split(',', SKIP_EMPTY_PARTS);
+                if (ddfBinding.configGroup >= ls.size())
+                {
+                    ddfBinding.dstGroup = 0; // clear
+                    break;
+                }
+
+                uint group = ls[ddfBinding.configGroup].toUShort(&ok, 0);
+                if (ok && group != 0)
+                {
+                    ddfBinding.dstGroup = group;
+                }
+                break;
+            }
+
+            if (!ok)
+            {
+                d->binding.bindingIter++; // process next
+                DEV_EnqueueEvent(device, REventBindingTick);
+                return;
+            }
+        }
+
+        const auto &bindingTable = device->node()->bindingTable();
         const auto bnd = DEV_ToCoreBinding(ddfBinding, d->deviceKey);
 
         const auto i = std::find(bindingTable.const_begin(), bindingTable.const_end(), bnd);
@@ -903,12 +1056,17 @@ void DEV_BindingTableVerifyHandler(Device *device, const Event &event)
 
         if (needBind)
         {
-            d->setState(DEV_CreatebindingHandler, STATE_LEVEL_BINDING);
+            d->setState(DEV_BindingCreateHandler, STATE_LEVEL_BINDING);
         }
-        else
+        else if (i->dstAddressMode() == deCONZ::ApsExtAddress)
         {
             d->binding.reportIter = 0;
             d->setState(DEV_ReadReportConfigurationHandler, STATE_LEVEL_BINDING);
+        }
+        else if (i->dstAddressMode() == deCONZ::ApsGroupAddress)
+        {
+            d->binding.bindingIter++; // process next
+            DEV_EnqueueEvent(device, REventBindingTick);
         }
     }
 }
@@ -919,10 +1077,9 @@ static void DEV_ProcessNextBinding(Device *device)
 
     d->binding.bindingIter++;
     d->setState(DEV_BindingTableVerifyHandler, STATE_LEVEL_BINDING);
-    DEV_EnqueueEvent(device, REventBindingTick);
 }
 
-void DEV_CreatebindingHandler(Device *device, const Event &event)
+void DEV_BindingCreateHandler(Device *device, const Event &event)
 {
     DevicePrivate *d = device->d;
 
@@ -972,8 +1129,7 @@ void DEV_CreatebindingHandler(Device *device, const Event &event)
             {
                 BindingTracker &tracker = d->binding.bindingTrackers[d->binding.bindingIter];
                 tracker.tBound = deCONZ::steadyTimeRef();
-                d->binding.reportIter = 0;
-                d->setState(DEV_ReadReportConfigurationHandler, STATE_LEVEL_BINDING);
+                d->setState(DEV_BindingTableVerifyHandler, STATE_LEVEL_BINDING);
             }
             else
             {
@@ -984,6 +1140,96 @@ void DEV_CreatebindingHandler(Device *device, const Event &event)
     else if (event.what() == REventStateTimeout)
     {
         DBG_Printf(DBG_DEV, "ZDP create binding timeout: 0x%016llX\n", device->key());
+        d->setState(DEV_BindingHandler, STATE_LEVEL_BINDING);
+    }
+}
+
+void DEV_BindingRemoveHandler(Device *device, const Event &event)
+{
+    DevicePrivate *d = device->d;
+
+    if (event.what() == REventStateEnter)
+    {
+        const auto &bindingTable = device->node()->bindingTable();
+        auto i = bindingTable.const_begin();
+        auto end = bindingTable.const_end();
+
+        for (; i != end; ++i)
+        {
+            if (i->dstAddressMode() == deCONZ::ApsGroupAddress)
+            {
+                bool hasDdfBinding = false;
+                bool hasDdfGroup = false;
+
+                for (const auto &ddfBinding : d->binding.bindings)
+                {
+                    if (ddfBinding.isGroupBinding &&
+                        i->clusterId() == ddfBinding.clusterId &&
+                        i->srcEndpoint() == ddfBinding.srcEndpoint)
+                    {
+                        hasDdfBinding = true;
+                        if (i->dstAddress().group() == ddfBinding.dstGroup)
+                        {
+                            hasDdfGroup = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (hasDdfBinding && !hasDdfGroup)
+                {
+                    break;
+                }
+            }
+        }
+
+        if (i == bindingTable.const_end())
+        {
+            d->setState(DEV_BindingIdleHandler, STATE_LEVEL_BINDING);
+            return;
+        }
+
+        d->zdpResult = ZDP_UnbindReq(*i, d->apsCtrl);
+
+        if (d->zdpResult.isEnqueued)
+        {
+            d->startStateTimer(MaxConfirmTimeout, STATE_LEVEL_BINDING);
+        }
+        else
+        {
+            d->setState(DEV_BindingHandler, STATE_LEVEL_BINDING);
+        }
+    }
+    else if (event.what() == REventStateLeave)
+    {
+        d->stopStateTimer(STATE_LEVEL_BINDING);
+    }
+    else if (event.what() == REventApsConfirm)
+    {
+        if (d->zdpResult.apsReqId == EventApsConfirmId(event))
+        {
+            if (EventApsConfirmStatus(event) == deCONZ::ApsSuccessStatus)
+            {
+                d->stopStateTimer(STATE_LEVEL_BINDING);
+                d->startStateTimer(d->maxResponseTime, STATE_LEVEL_BINDING);
+            }
+            else
+            {
+                d->setState(DEV_BindingHandler, STATE_LEVEL_BINDING);
+            }
+        }
+    }
+    else if (event.what() == REventZdpResponse)
+    {
+        if (EventZdpResponseSequenceNumber(event) == d->zdpResult.zdpSeq)
+        {
+            d->setState(DEV_BindingHandler, STATE_LEVEL_BINDING);
+            DEV_EnqueueEvent(device, REventBindingTick);
+        }
+    }
+    else if (event.what() == REventStateTimeout)
+    {
+        DBG_Printf(DBG_DEV, "ZDP remove binding timeout: 0x%016llX\n", device->key());
         d->setState(DEV_BindingHandler, STATE_LEVEL_BINDING);
     }
 }
@@ -1697,6 +1943,7 @@ void Device::handleEvent(const Event &event, DEV_StateLevel level)
     else if (event.what() == REventDDFReload)
     {
         d->setState(DEV_InitStateHandler);
+        d->binding.bindingCheckRound = 0;
         d->startStateTimer(50, StateLevel0);
     }
     else if (d->state[level])
@@ -1826,7 +2073,7 @@ bool isSame(const DDF_Binding &a, const DDF_Binding &b)
     return a.clusterId == b.clusterId &&
            a.srcEndpoint == b.srcEndpoint &&
            (
-            (a.isGroupBinding && b.isGroupBinding && a.dstGroup == b.dstGroup) ||
+            (a.isGroupBinding && b.isGroupBinding && a.configGroup == b.configGroup) ||
             (a.isUnicastBinding && b.isUnicastBinding && a.dstExtAddress == b.dstExtAddress)
            );
 }
@@ -1866,7 +2113,7 @@ void Device::addBinding(const DDF_Binding &bnd)
         d->binding.bindings.push_back(bnd);
         d->binding.bindingTrackers.push_back(tracker);
         Q_ASSERT(d->binding.bindings.size() == d->binding.bindingTrackers.size());
-        if (bnd.dstEndpoint == 0)
+        if (bnd.dstEndpoint == 0 && bnd.isUnicastBinding)
         {
             d->binding.bindings.back().dstEndpoint = 0x01; // todo query coordinator endpoint
         }

--- a/device_compat.cpp
+++ b/device_compat.cpp
@@ -19,13 +19,14 @@
 int getFreeSensorId();
 int getFreeLightId();
 
+#define READ_GROUPS            (1 << 5) // from web_plugin_private.h
+
 /*! Overloads to add specific resources in higher layer.
     Since Device class doesn't know anything about web plugin or testing code,
     this is a free standing function which needs to be implemented in the higher layer.
 */
 Resource *DEV_AddResource(const Sensor &sensor);
 Resource *DEV_AddResource(const LightNode &lightNode);
-
 
 /*! V1 compatibility function to create SensorNodes based on sub-device description.
  */
@@ -116,7 +117,7 @@ static Resource *DEV_InitLightNodeFromDescription(Device *device, const DeviceDe
 
     lightNode.item(RAttrType)->setValue(DeviceDescriptions::instance()->constantToString(sub.type));
     lightNode.setUniqueId(uniqueId);
-    lightNode.setNode(const_cast<deCONZ::Node*>(device->node()));
+    lightNode.enableRead(READ_GROUPS);
 
     auto dbItem = std::make_unique<DB_LegacyItem>();
     dbItem->uniqueId = lightNode.item(RAttrUniqueId)->toCString();

--- a/device_ddf_init.cpp
+++ b/device_ddf_init.cpp
@@ -15,6 +15,8 @@
 #include "database.h"
 #include "utils/utils.h"
 
+void DEV_AllocateGroup(const Device *device, Resource *rsub, ResourceItem *item);
+
 static QString uniqueIdFromTemplate(const QStringList &templ, const quint64 extAddress)
 {
     bool ok = false;
@@ -172,6 +174,15 @@ bool DEV_InitDeviceFromDescription(Device *device, const DeviceDescription &ddf)
                     stateChange.setChangeTimeoutMs(1000 * 60 * 60);
                     rsub->addStateChange(stateChange);
                 }
+            }
+
+            if (item->descriptor().suffix == RConfigGroup)
+            {
+                if (item->toString().isEmpty() && !ddfItem.defaultValue.isNull())
+                {
+                    item->setValue(ddfItem.defaultValue.toString());
+                }
+                DEV_AllocateGroup(device, rsub, item);
             }
 
 //            if (item->descriptor().suffix == RConfigCheckin)

--- a/device_descriptions.cpp
+++ b/device_descriptions.cpp
@@ -1294,9 +1294,12 @@ static DDF_Binding DDF_ParseBinding(const QJsonObject &obj)
     {
         result.isUnicastBinding = 1;
     }
+    else if (type == QLatin1String("groupcast"))
+    {
+        result.isGroupBinding = 1;
+    }
     else
     {
-        // TODO group cast
         return {};
     }
 
@@ -1332,6 +1335,20 @@ static DDF_Binding DDF_ParseBinding(const QJsonObject &obj)
     else
     {
         result.dstEndpoint = 0;
+    }
+
+    if (result.isGroupBinding && obj.contains(QLatin1String("config.group")))
+    {
+        const auto configGroup = obj.value(QLatin1String("config.group")).toInt(-1);
+        if (configGroup < 0 || configGroup >= 255)
+        {
+            return {};
+        }
+        result.configGroup = configGroup;
+    }
+    else
+    {
+        result.configGroup = 0;
     }
 
     const auto report = obj.value(QLatin1String("report"));

--- a/device_descriptions.h
+++ b/device_descriptions.h
@@ -54,6 +54,7 @@ public:
     quint16 clusterId;
     quint8 srcEndpoint;
     quint8 dstEndpoint;
+    quint8 configGroup;
     struct
     {
         unsigned int isGroupBinding : 1;

--- a/devices/generic/items/config_group_item.json
+++ b/devices/generic/items/config_group_item.json
@@ -1,0 +1,8 @@
+{
+	"schema": "resourceitem1.schema.json",
+	"id": "config/group",
+	"datatype": "String",
+	"access": "RW",
+	"public": true,
+	"description": "comma seperated list of groups which a device controls."
+}

--- a/event.h
+++ b/event.h
@@ -28,6 +28,7 @@ public:
     DeviceKey deviceKey() const { return m_deviceKey; }
     void setDeviceKey(DeviceKey key) { m_deviceKey = key; }
     bool hasData() const;
+    quint16 dataSize() const { return m_dataSize; }
     bool getData(void *dst, size_t size) const;
 
 private:
@@ -62,6 +63,11 @@ Event EventWithData(const char *resource, const char *what, const D &data, Devic
 {
     static_assert (std::is_trivially_copyable<D>::value, "data needs to be trivially copyable");
     return Event(resource, what, &data, sizeof(data), deviceKey);
+}
+
+inline Event EventWithData(const char *resource, const char *what, const void *data, size_t size, DeviceKey deviceKey)
+{
+    return Event(resource, what, data, size, deviceKey);
 }
 
 //! Unpacks APS confirm id.

--- a/resource.cpp
+++ b/resource.cpp
@@ -50,6 +50,7 @@ const char *REventTick = "event/tick";
 const char *REventTimerFired = "event/timerfired";
 const char *REventZclResponse = "event/zcl.response";
 const char *REventZclReadReportConfigResponse = "event/zcl.read.report.config.response";
+const char *REventZdpMgmtBindResponse = "event/zdp.mgmt.bind.response";
 const char *REventZdpResponse = "event/zdp.response";
 
 const char *RInvalidSuffix = "invalid/suffix";

--- a/resource.h
+++ b/resource.h
@@ -78,6 +78,7 @@ extern const char *REventTick;
 extern const char *REventTimerFired;
 extern const char *REventZclResponse;
 extern const char *REventZclReadReportConfigResponse;
+extern const char *REventZdpMgmtBindResponse;
 extern const char *REventZdpResponse;
 
 // resouce suffixes: state/buttonevent, config/on, ...

--- a/rest_devices.cpp
+++ b/rest_devices.cpp
@@ -591,7 +591,11 @@ bool ddfSerializeV1(JsonDoc &doc, const DeviceDescription &ddf, char *buf, size_
             JsonObject binding = bindings.createNestedObject();
 
             if      (bnd.isUnicastBinding) { binding["bind"] = "unicast"; }
-            else if (bnd.isGroupBinding)   { binding["bind"] = "groupcast"; }
+            else if (bnd.isGroupBinding)
+            {
+                binding["bind"] = "groupcast";
+                binding["config.group"] = bnd.configGroup;
+            }
 
             binding["src.ep"] = bnd.srcEndpoint;
 

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -14,6 +14,7 @@
 #include <QUrlQuery>
 #include <QVariantMap>
 #include <QtCore/qmath.h>
+#include "database.h"
 #include "de_web_plugin.h"
 #include "de_web_plugin_private.h"
 #include "json.h"
@@ -652,6 +653,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
     TaskItem task;
     QString id = req.path[3];
     Sensor *sensor = id.length() < MIN_UNIQUEID_LENGTH ? getSensorNodeForId(id) : getSensorNodeForUniqueId(id);
+    Device *device = sensor->parentResource() ? static_cast<Device*>(sensor->parentResource()) : nullptr;
     bool ok;
     bool updated;
     bool save = false;
@@ -1697,6 +1699,12 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                     {
                         updated = true;
                         checkSensorBindingsForClientClusters(sensor);
+
+                        if (device && device->managed() && data.string != item->toString())
+                        {
+                            // if the device has groupcast bindings check for reconfiguration
+                            enqueueEvent(Event(RDevices, REventDDFReload, 0, sensor->address().ext()));
+                        }
                     }
                 }
                 else if (QString(rid.suffix).startsWith("config/ubisys_j1_")) // Unsigned integer
@@ -1796,6 +1804,11 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                         rsp.list.append(rspItem);
                         Event e(RSensors, rid.suffix, id, item);
                         enqueueEvent(e);
+
+                        if (device && device->managed())
+                        {
+                            DB_StoreSubDeviceItem(sensor, item);
+                        }
                     }
 
                     save = true;

--- a/zdp/zdp.h
+++ b/zdp/zdp.h
@@ -60,6 +60,8 @@ ZDP_Result ZDP_NodeDescriptorReq(const deCONZ::Address &addr, deCONZ::ApsControl
 ZDP_Result ZDP_ActiveEndpointsReq(const deCONZ::Address &addr, deCONZ::ApsController *apsCtrl);
 ZDP_Result ZDP_SimpleDescriptorReq(const deCONZ::Address &addr, uint8_t endpoint, deCONZ::ApsController *apsCtrl);
 ZDP_Result ZDP_BindReq(const deCONZ::Binding &bnd, deCONZ::ApsController *apsCtrl);
+ZDP_Result ZDP_UnbindReq(const deCONZ::Binding &bnd, deCONZ::ApsController *apsCtrl);
+ZDP_Result ZDP_MgmtBindReq(uint8_t startIndex, const deCONZ::Address &addr, deCONZ::ApsController *apsCtrl);
 uint8_t ZDP_NextSequenceNumber();
 
 #endif // ZDP_H


### PR DESCRIPTION
### Group allocation

For each "auto" entry in the comma separated group list a new `Group` is allocated and assigned to the device via device membership and  `group.uniqueid`.

The `group.uniqueid` is generated based on the position in the `config.group` list:

```
     "auto":            00:11:22:33:44:55:66:77

     "auto,auto":       00:11:22:33:44:55:66:77
                        00:11:22:33:44:55:66:77-1

     "auto,auto,auto":  00:11:22:33:44:55:66:77
                        00:11:22:33:44:55:66:77-1
                        00:11:22:33:44:55:66:77-2
```

Where 00:11:22:33:44:55:66:77 is the MAC address of the device.
Note: The first group has no "-0" suffix, to be backward compatible with old code.

### Dynamic group bindings

Requires deCONZ v2.13.3.
The group bindings specified in the DDF refer to the `RConfigGroup` group list and can be changed via REST-API. 
The Device binding state machine takes care of creation, reconfiguration and removal of group bindings.

Example: Allocation of one group with index 0, auto will be replaced with the allocated group id.

```
{
  "items": [
        {
          "name": "config/group",
          "default": "auto"
        }
  ]
}
```

```
  "bindings": [
    {
      "bind": "groupcast",
      "src.ep": 2,
      "cl": "0x0006",
      "config.group": 0
    },
    {
      "bind": "groupcast",
      "src.ep": 2,
      "cl": "0x0008",
      "config.group": 0
    }
  ]
```

The  `"config.group": 0`   is the index in the `config.group` list.


If `config.group` is changed via REST API, all bindings will be automatically updated by the Device binding state machine.