### PR TITLE
Enable Gold status DDF files by default

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -3183,7 +3183,6 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
         quint8 endpoint = sensor.fingerPrint().endpoint;
         DBG_Printf(DBG_INFO_L2, "DB found sensor %s %s\n", qPrintable(sensor.name()), qPrintable(sensor.id()));
 
-        if (DEV_TestManaged())
         {
             const auto ddf = d->deviceDescriptions->get(&sensor);
             if (ddf.isValid())
@@ -3194,7 +3193,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 {
                     DBG_Printf(DBG_INFO, "DB legacy loading sensor %s %s, later handled by DDF %s\n", qPrintable(sensor.name()), qPrintable(sensor.id()), qPrintable(ddf.product));
                 }
-                else
+                else if (DEV_TestManaged() || d->deviceDescriptions->enabledStatusFilter().contains(ddf.status))
                 {
                     DBG_Printf(DBG_INFO, "DB skip loading sensor %s %s, handled by DDF %s\n", qPrintable(sensor.name()), qPrintable(sensor.id()), qPrintable(ddf.product));
                     return 0;

--- a/device_descriptions.h
+++ b/device_descriptions.h
@@ -232,6 +232,8 @@ class DeviceDescriptions : public QObject
 public:
     explicit DeviceDescriptions(QObject *parent = nullptr);
     ~DeviceDescriptions();
+    void setEnabledStatusFilter(const QStringList &filter);
+    const QStringList &enabledStatusFilter() const;
     const DeviceDescription &get(const Resource *resource) const;
     void put(const DeviceDescription &ddf);
     const DeviceDescription &load(const QString &path);

--- a/devices/dresden_elektronik/fls_pp3.json
+++ b/devices/dresden_elektronik/fls_pp3.json
@@ -4,7 +4,7 @@
   "modelid": ["FLS-PP3", "FLS-PP3 White"],
   "product": "FLS-PP lp",
   "sleeper": false,
-  "status": "Gold",
+  "status": "Silver",
   "subdevices": [
     {
       "type": "$TYPE_EXTENDED_COLOR_LIGHT",

--- a/devices/immax/07048L_smart_plug.json
+++ b/devices/immax/07048L_smart_plug.json
@@ -5,7 +5,7 @@
   "vendor": "Immax Neo",
   "product": "07048L",
   "sleeper": false,
-  "status": "Gold",
+  "status": "Silver",
   "subdevices": [
     {
       "type": "$TYPE_SMART_PLUG",

--- a/devices/innr/sp_120.json
+++ b/devices/innr/sp_120.json
@@ -4,7 +4,7 @@
   "modelid": "SP 120",
   "product": "SP 120",
   "sleeper": false,
-  "status": "Bronze",
+  "status": "Silver",
   "path": "/devices/innr/sp_120.json",
   "subdevices": [
     {

--- a/devices/philips/rwl02_dimmer_switch.json
+++ b/devices/philips/rwl02_dimmer_switch.json
@@ -5,7 +5,7 @@
     "manufacturername": "$MF_PHILIPS",
     "modelid": ["RWL021", "RWL021"],
     "product": "Dimmer Switch 1. Gen EU/US",
-    "status": "Gold",
+    "status": "Silver",
     "sleeper": true,
     "md:known_issues": [ ],
     "subdevices": [

--- a/devices/philips/sml001_motion_sensor.json
+++ b/devices/philips/sml001_motion_sensor.json
@@ -5,7 +5,7 @@
     "manufacturername": "$MF_PHILIPS",
     "modelid": "SML001",
     "product": "Motion Sensor 1. Gen (SML001)",
-    "status": "Gold",
+    "status": "Silver",
     "sleeper": false,
     "md:known_issues": [ ],
     "subdevices": [

--- a/devices/xiaomi/xiaomi_mccgq14lm_openclose_sensor.json
+++ b/devices/xiaomi/xiaomi_mccgq14lm_openclose_sensor.json
@@ -5,7 +5,7 @@
   "vendor": "Xiaomi Aqara",
   "product": "Open/close sensor MCCGQ14LM",
   "sleeper": true,
-  "status": "Gold",
+  "status": "Silver",
   "subdevices": [
     {
       "type": "$TYPE_OPEN_CLOSE_SENSOR",

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -3274,6 +3274,12 @@ void DeRestPluginPrivate::handleIndicationSearchSensors(const deCONZ::ApsDataInd
         return;
     }
 
+    Device *device = DEV_GetDevice(m_devices, ind.srcAddress().ext());
+    if (device && device->managed())
+    {
+        return;
+    }
+
     if (isSameAddress(ind.srcAddress(), fastProbeAddr))
     {
         DBG_Printf(DBG_INFO, "FP indication 0x%04X / 0x%04X (0x%016llX / 0x%04X)\n", ind.profileId(), ind.clusterId(), ind.srcAddress().ext(), ind.srcAddress().nwk());

--- a/ui/device_widget.h
+++ b/ui/device_widget.h
@@ -43,6 +43,7 @@ private Q_SLOTS:
     void enablePermitJoin();
     void disablePermitJoin();
     void enableDDFHandlingChanged();
+    void reloadTimerFired();
 
 private:
     Ui::DeviceWidget *ui;

--- a/ui/device_widget.ui
+++ b/ui/device_widget.ui
@@ -53,7 +53,7 @@
        <item>
         <widget class="QLabel" name="label_5">
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Important:&lt;/span&gt; The following test modes for Device Description Files (DDF) are not suitable for production networks.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Important:&lt;/span&gt; The &amp;quot;Hybrid&amp;quot; and &amp;quot;Strict&amp;quot; modes for Device Description Files (DDF) are for developers and not suitable for production networks.&lt;/p&gt;&lt;p&gt;For production networks only use &amp;quot;Basic&amp;quot; mode with &amp;quot;Gold&amp;quot; status.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
@@ -79,13 +79,19 @@
        <item>
         <widget class="QGroupBox" name="groupBox">
          <property name="title">
-          <string>DDF handling</string>
+          <string>DDF mode</string>
+         </property>
+         <property name="flat">
+          <bool>false</bool>
+         </property>
+         <property name="checkable">
+          <bool>false</bool>
          </property>
          <layout class="QFormLayout" name="formLayout">
           <item row="0" column="0">
-           <widget class="QRadioButton" name="ddfDisabledRadioButton">
+           <widget class="QRadioButton" name="ddfFilteredRadioButton">
             <property name="text">
-             <string>Disabled</string>
+             <string>Basic</string>
             </property>
             <property name="checked">
              <bool>true</bool>
@@ -95,18 +101,21 @@
           <item row="0" column="1">
            <widget class="QLabel" name="label_7">
             <property name="text">
-             <string>Don't use DDF files.</string>
+             <string>Legacy code and DDF with status:</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
+          <item row="2" column="0">
            <widget class="QRadioButton" name="ddfNormalRadioButton">
             <property name="text">
-             <string>Normal</string>
+             <string>Hybrid</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="2" column="1">
            <widget class="QLabel" name="label_4">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Join and process devices via DDF if available. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -119,14 +128,14 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="3" column="0">
            <widget class="QRadioButton" name="ddfStrictRadioButton">
             <property name="text">
              <string>Strict</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="3" column="1">
            <widget class="QLabel" name="label_6">
             <property name="text">
              <string>Disables legacy code for joining and processing.</string>
@@ -134,6 +143,69 @@
             <property name="wordWrap">
              <bool>true</bool>
             </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QGroupBox" name="ddfFilterGroupBox">
+            <property name="title">
+             <string/>
+            </property>
+            <layout class="QFormLayout" name="formLayout_2">
+             <item row="0" column="0">
+              <widget class="QCheckBox" name="ddfFilterBronzeCheckBox">
+               <property name="text">
+                <string>Bronze</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QCheckBox" name="ddfFilterSilverCheckBox">
+               <property name="text">
+                <string>Silver</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QLabel" name="label_8">
+               <property name="text">
+                <string>Untested and potentially incomplete.</string>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QLabel" name="label_9">
+               <property name="text">
+                <string>Tested but potentially incomplete.</string>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QCheckBox" name="ddfFilterGoldCheckBox">
+               <property name="text">
+                <string>Gold</string>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QLabel" name="label_10">
+               <property name="text">
+                <string>Safe to use for production networks.</string>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
          </layout>


### PR DESCRIPTION
The "Disabled" DDF mode is replaced by "Basic" mode in which only DDF files with enabled status are loaded.

The default is Gold, but Bronze and Silver can also be enabled. *This setting is persistent.* "Strict" and "Hybrid" (formerly Normal) modes are *not* persistent and revert to Basic mode after each deCONZ start to prevent user errors.

When the modes are changed in Control panel, all Devices with DDF will be reloaded, one per second, to reflect the changes without restarting deCONZ.

![image](https://user-images.githubusercontent.com/383386/145312012-c99f7eb1-0adc-4507-af3e-1ced10fedf99.png)

To prevent any surprises all Gold status DDF files are set to Silver for now. This is done so that they are not enabled by default. After more testing these can be set to Gold again.