### PR TITLE
Add DDF for Phoscon Kobold

### DIFF
--- a/button_maps.json
+++ b/button_maps.json
@@ -211,6 +211,28 @@
                 [1, "0x01", "SCENES", "RECALL_SCENE", "4", "S_BUTTON_6", "S_BUTTON_ACTION_SHORT_RELEASED", "Recall scene 4"]
             ]
         },
+        "deKoboldMap": {
+            "vendor": "dresden elektronik",
+            "modelids": ["Kobold"],
+            "doc": "Kobold",
+            "buttons": [
+                {"S_BUTTON_1": "Button 1"}
+            ],
+            "map": [
+                [1, "0x02", "ONOFF", "ON", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],
+                [1, "0x02", "ONOFF", "OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "Off"],
+                [1, "0x02", "LEVEL_CONTROL", "MOVE", "0", "S_BUTTON_1", "S_BUTTON_ACTION_HOLD", "Dimm up"],
+                [1, "0x02", "LEVEL_CONTROL", "MOVE", "1", "S_BUTTON_1", "S_BUTTON_ACTION_HOLD", "Dimm down"],
+                [1, "0x02", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "1", "S_BUTTON_1", "S_BUTTON_ACTION_LONG_RELEASED", "Dimm stop"],
+                [1, "0x02", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_LONG_RELEASED", "Dimm stop"],
+                [2, "0x02", "ONOFF", "ON", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],
+                [2, "0x02", "ONOFF", "OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "Off"],
+                [2, "0x02", "LEVEL_CONTROL", "MOVE", "0", "S_BUTTON_1", "S_BUTTON_ACTION_HOLD", "Dimm up"],
+                [2, "0x02", "LEVEL_CONTROL", "MOVE", "1", "S_BUTTON_1", "S_BUTTON_ACTION_HOLD", "Dimm down"],
+                [2, "0x02", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "1", "S_BUTTON_1", "S_BUTTON_ACTION_LONG_RELEASED", "Dimm stop"],
+                [2, "0x02", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_LONG_RELEASED", "Dimm stop"]
+            ]
+        },
         "instaRemoteMap": {
             "vendor": "GIRA / JUNG",
             "doc":"Switches and remotes",

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4674,7 +4674,8 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
     sensor->previousSequenceNumber = zclFrame.sequenceNumber();
 
     if ((ind.dstAddressMode() == deCONZ::ApsGroupAddress && ind.dstAddress().group() != 0) &&
-       (sensor->modelId() != QLatin1String("Pocket remote"))) // Need to prevent this device use group feature, just without avoiding the RConfigGroup creation.
+       sensor->modelId() != QLatin1String("Pocket remote") && // Need to prevent this device use group feature, just without avoiding the RConfigGroup creation.
+       !(ind.srcEndpoint() == 2 && sensor->modelId() == QLatin1String("Kobold"))) // managed via REST API and "auto" config.group, check src.endpoint:2 to skip modelId check
     {
         ResourceItem *item = sensor->addItem(DataTypeString, RConfigGroup);
 

--- a/device.cpp
+++ b/device.cpp
@@ -1911,7 +1911,7 @@ const deCONZ::Node *Device::node() const
 
 bool Device::managed() const
 {
-    return devManaged > 0 && d->managed && d->flags.hasDdf;
+    return d->managed && d->flags.hasDdf;
 }
 
 void Device::setManaged(bool managed)

--- a/device.cpp
+++ b/device.cpp
@@ -778,12 +778,6 @@ void DEV_IdleStateHandler(Device *device, const Event &event)
         DBG_Printf(DBG_DEV, "DEV (NOT reachable) Idle event %s/0x%016llX/%s\n", event.resource(), event.deviceKey(), event.what());
     }
 
-    if (!DEV_TestManaged())
-    {
-        d->setState(DEV_DeadStateHandler);
-        return;
-    }
-
     DEV_CheckItemChanges(device, event);
 
     // process parallel states

--- a/devices/dresden_elektronik/kobold.json
+++ b/devices/dresden_elektronik/kobold.json
@@ -1,0 +1,183 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "dresden elektronik",
+  "modelid": "Kobold",
+  "product": "Kobold",
+  "sleeper": false,
+  "supportsMgmtBind": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_DIMMABLE_LIGHT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert",
+          "default": "none"
+        },
+        {
+          "name": "state/bri",
+          "refresh.interval": 5,
+          "read": {
+            "at": "0x0000",
+            "cl": "0x0008",
+            "ep": 1,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0000",
+            "cl": "0x0008",
+            "ep": 1,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl"
+          }
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 5,
+          "read": {
+            "at": "0x0000",
+            "cl": "0x0006",
+            "ep": 1,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0000",
+            "cl": "0x0006",
+            "ep": 1,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl"
+          }
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_SWITCH",
+      "fingerprint": { "profile": "0x0104", "device": "0x0104", "endpoint": "0x02", "out": ["0x0006", "0x0008"] },
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x02",
+        "0x0006"
+      ],
+      "buttons": {
+        "1": {"name": "Push"}
+      },
+      "buttonevents": {
+        "1001": {"action": "HOLD", "button": 1},
+        "1002": {"action": "SHORT_RELEASE", "button": 1},
+        "1003": {"action": "LONG_RELEASE", "button": 1}
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/group",
+          "default": "auto"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/buttonevent",
+          "awake": true
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0006",
+      "report": [
+          {"at": "0x0000", "dt": "0x10", "min": 65535, "max": 65535 }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0008",
+      "report": [
+          {"at": "0x0000", "dt": "0x20", "min": 65535, "max": 65535, "change": "0x01" }
+      ]
+    },
+    {
+      "bind": "groupcast",
+      "src.ep": 2,
+      "cl": "0x0006",
+      "config.group": 0
+    },
+    {
+      "bind": "groupcast",
+      "src.ep": 2,
+      "cl": "0x0008",
+      "config.group": 0
+    }
+  ]
+}

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1700,7 +1700,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                         updated = true;
                         checkSensorBindingsForClientClusters(sensor);
 
-                        if (device && device->managed() && data.string != item->toString())
+                        if (device && device->managed())
                         {
                             // if the device has groupcast bindings check for reconfiguration
                             enqueueEvent(Event(RDevices, REventDDFReload, 0, sensor->address().ext()));


### PR DESCRIPTION
New Dimmer Switch which can be configured to control lights or groups directly.
The DDF makes use of the new groupcast bindings and group configuration capabilities.

Via REST API the `config.group`can be set to control a specific Zigbee group (on/off and dimming).

![image](https://user-images.githubusercontent.com/383386/145314599-6567776e-5b8a-4944-9e34-c9d3d496280c.png)
