### PR TITLE
Add button events for ROBB Smarrt wireless remotes

### DIFF
--- a/button_maps.json
+++ b/button_maps.json
@@ -1047,7 +1047,7 @@
         "sunricherMap": {
             "vendor": "Sunricher",
             "doc": "Wireless switches from Sunricher, Namron, SLC and EcoDim",
-            "modelids": ["ED-10010", "ED-10011", "ED-10012", "ED-10013", "ED-10014", "ED-10015", "ZG2833K8_EU05", "ZG2835", "4512700", "4512701", "4512702", "4512703", "4512705", "4512714", "4512719", "4512720", "4512721", "4512722", "4512729", "S57003", "ROB_200-008"],
+            "modelids": ["ED-10010", "ED-10011", "ED-10012", "ED-10013", "ED-10014", "ED-10015", "ZG2833K8_EU05", "ZG2835", "4512700", "4512701", "4512702", "4512703", "4512705", "4512714", "4512719", "4512720", "4512721", "4512722", "4512729", "S57003", "ROB_200-008", "ROB_200-009-0", "ROB_200-008-0", "ROB_200-007-0"],
             "map": [
                 [1, "0x01", "ONOFF", "ON", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],
                 [1, "0x01", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_HOLD", "Move up (with on/off)"],


### PR DESCRIPTION
https://www.robbshop.nl/robb-smarrt-draadloze-schakelaar-wit-2knops-zigbee
https://www.robbshop.nl/robb-smarrt-draadloze-schakelaar-wit-4knops-zigbee
https://www.robbshop.nl/robb-smarrt-draadloze-schakelaar-wit-8knops-zigbee

These are rebranded Sunricher remotes. Tested with the 2-button version.

https://github.com/dresden-elektronik/deconz-rest-plugin/pull/5000 already added the 8-button version (as `ROB_200-008`), but mine apparently has a trailing `-0`, which according to the website the other versions should also. Seeing the screenshots in https://github.com/dresden-elektronik/deconz-rest-plugin/issues/4601 that's probably another revision.