### PR TITLE
Fix Xiaomi WXKG11LM regression bug for ZHASwitch resource creation

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -6227,7 +6227,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     {
                         fpSwitch.inClusters.push_back(ci->id());
                     }
-                    else if (modelId == QLatin1String("lumi.sensor_switch.aq3"))
+                    else if (modelId == QLatin1String("lumi.sensor_switch.aq3") || modelId == QLatin1String("lumi.remote.b1acn01"))
                     {
                         fpSwitch.inClusters.push_back(ci->id());
                     }


### PR DESCRIPTION
This fix should allow the device to be paired again.