### PR TITLE
DEV enqueue missing state/lastupdated event to fix rule handling

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1177,6 +1177,7 @@ void DeRestPluginPrivate::apsdeDataIndicationDevice(const deCONZ::ApsDataIndicat
                     if (lastUpdated)
                     {
                         lastUpdated->setValue(item->lastSet());
+                        enqueueEvent(Event(r->prefix(), lastUpdated->descriptor().suffix, idItem->toString(), device->key()));
                     }
                 }
             }


### PR DESCRIPTION
Noticeable for example in the Hue Dimmer DDF which stopped processing of rules on button events.