### PR TITLE
Blacklist invalid announced color cluster of iluminize 511.012

### DIFF
--- a/light_node.cpp
+++ b/light_node.cpp
@@ -367,7 +367,7 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
                 {
                     if ((manufacturerCode() == VENDOR_NONE && deviceId == DEV_ID_ZLL_DIMMABLE_LIGHT) ||
                         (manufacturerCode() == VENDOR_NONE && deviceId == DEV_ID_LEVEL_CONTROL_SWITCH) ||
-                        (manufacturer() == QLatin1String("iluminize") && deviceId == DEV_ID_HA_DIMMABLE_LIGHT))
+                        (manufacturer() == QLatin1String("iluminize") && modelId() == QLatin1String("511.012")))
                     {
                         // GLEDOPTO GL-C-009 advertises non-functional color cluster
                         // ORVIBO T10D1ZW in-wall dimmer does the same

--- a/light_node.cpp
+++ b/light_node.cpp
@@ -366,10 +366,12 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
                 else if (i->id() == COLOR_CLUSTER_ID)
                 {
                     if ((manufacturerCode() == VENDOR_NONE && deviceId == DEV_ID_ZLL_DIMMABLE_LIGHT) ||
-                        (manufacturerCode() == VENDOR_NONE && deviceId == DEV_ID_LEVEL_CONTROL_SWITCH))
+                        (manufacturerCode() == VENDOR_NONE && deviceId == DEV_ID_LEVEL_CONTROL_SWITCH) ||
+                        (manufacturer() == QLatin1String("iluminize") && deviceId == DEV_ID_HA_DIMMABLE_LIGHT))
                     {
                         // GLEDOPTO GL-C-009 advertises non-functional color cluster
                         // ORVIBO T10D1ZW in-wall dimmer does the same
+                        // iluminize 511.012 even
                     }
                     else
                     {


### PR DESCRIPTION
According to https://github.com/dresden-elektronik/deconz-rest-plugin/issues/5651 this pull request adds an exception for iluminize 511.012 not to add the indicated 0x0300 color cluster since it's a dimmable light only.

Was compiled for docker usage and successfully tested.

REST API w/ connected Home Assistant and HomeKit is working well again for that device.