### PR TITLE
Added DDF for Sengled E12-N1E

### DIFF
--- a/devices/sengled/E12-N1E.json
+++ b/devices/sengled/E12-N1E.json
@@ -5,7 +5,7 @@
   "vendor": "sengled",
   "product": "E12-N1E",
   "sleeper": false,
-  "status": "Gold",
+  "status": "Bronze",
   "subdevices": [
     {
       "type": "$TYPE_COLOR_DIMMABLE_LIGHT",

--- a/devices/sengled/E12-N1E.json
+++ b/devices/sengled/E12-N1E.json
@@ -1,0 +1,164 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "sengled",
+  "modelid": "E12-N1E",
+  "vendor": "sengled",
+  "product": "E12-N1E",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_COLOR_DIMMABLE_LIGHT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert",
+          "description": "The currently active alert effect.",
+          "default": "none"
+        },
+        {
+          "name": "state/bri",
+          "description": "The current brightness.",
+          "refresh.interval": 5
+        },
+        {
+          "name": "state/colormode",
+          "description": "The currently active color mode."
+        },
+        {
+          "name": "state/ct",
+          "description": "The current Mired color temperature of the light. Where Mired is 1000000 / color temperature (in kelvins).",
+          "refresh.interval": 5
+        },
+        {
+          "name": "state/effect",
+          "description": "The currently active effect.",
+          "default": "none"
+        },
+        {
+          "name": "state/hue",
+          "description": "The current color hue."
+        },
+        {
+          "name": "state/on",
+          "description": "True when device is on; false when off.",
+          "refresh.interval": 5
+        },
+        {
+          "name": "state/reachable"
+        },
+        {
+          "name": "state/sat",
+          "description": "The current color saturation.",
+          "refresh.interval": 5
+        },
+        {
+          "name": "state/x",
+          "description": "The current color x coordinate.",
+          "refresh.interval": 5
+        },
+        {
+          "name": "state/y",
+          "description": "The current color y coordinate."
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0006",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 300
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0008",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x20",
+          "min": 1,
+          "max": 300,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0300",
+      "report": [
+        {
+          "at": "0x0007",
+          "dt": "0x21",
+          "min": 154,
+          "max": 500,
+          "change": "0x00000001"
+        },
+        {
+          "at": "0x0003",
+          "dt": "0x21",
+          "min": 1,
+          "max": 300,
+          "change": "0x0000000A"
+        },
+        {
+          "at": "0x0004",
+          "dt": "0x21",
+          "min": 1,
+          "max": 300,
+          "change": "0x0000000A"
+        },
+        {
+          "at": "0x0008",
+          "dt": "0x30",
+          "min": 1,
+          "max": 300
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Previously color temperature support for this device was broken; added state/ct in DDF to allow this property to be properly picked up by api clients. Has been tested.

I believe this addresses #4833 and possibly #5590 