### PR TITLE
DDF add Ubisys C4

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -3700,7 +3700,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
     }
 
     std::vector<quint8> srcEndpoints;
-    QStringList gids = item->toString().split(',', QString::SkipEmptyParts);
+    QStringList gids = item->toString().split(',', SKIP_EMPTY_PARTS);
 
     //quint8 srcEndpoint = sensor->fingerPrint().endpoint;
     std::vector<quint16> clusters;
@@ -4022,9 +4022,8 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
     bool ret = false;
     for (int j = 0; j < (int)srcEndpoints.size() && j < gids.size(); j++)
     {
-        QString gid = gids[j];
         quint8 srcEndpoint = srcEndpoints[j];
-        Group *group = getGroupForId(gid);
+        Group *group = getGroupForId(gids[j]);
 
         if (!group)
         {
@@ -4474,7 +4473,7 @@ void DeRestPluginPrivate::processUbisysBinding(Sensor *sensor, const Binding &bn
 
         // remove group bindings which aren't configured via 'config.group'
         QString dstGroup = QString::number(bnd.dstAddress.group);
-        QStringList gids = item->toString().split(',');
+        QStringList gids = item->toString().split(',', SKIP_EMPTY_PARTS);
 
         if (!gids.contains(dstGroup) || (pos == -1) || (gids.size() < (pos + 1)) || gids[pos] != dstGroup)
         {

--- a/button_maps.json
+++ b/button_maps.json
@@ -743,7 +743,7 @@
         "ubisysC4Map": {
             "vendor": "Ubisys",
             "doc": "Control unit C4",
-            "modelids": ["C4"],
+            "modelids": ["C4 (5504)", "C4"],
             "map": [
                 [1, "0x01", "ONOFF", "TOGGLE", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "Toggle"],
                 [1, "0x01", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_HOLD", "Move up (with on/off)"],

--- a/database.cpp
+++ b/database.cpp
@@ -4278,31 +4278,6 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             {
                 item->setValue(supportedModes.first());
             }
-
-//            QStringList gids;
-//            item = sensor.addItem(DataTypeString, RConfigGroup);
-//            if (!item->toString().isEmpty())
-//            {
-//                gids = item->toString().split(',');
-//            }
-
-//            int n = 0;
-//            if      (sensor.modelId().startsWith(QLatin1String("D1"))) { n = 2; }
-//            else if (sensor.modelId().startsWith(QLatin1String("S1-R"))) { n = 2; }
-//            else if (sensor.modelId().startsWith(QLatin1String("S1"))) { n = 1; }
-//            else if (sensor.modelId().startsWith(QLatin1String("S2"))) { n = 2; }
-//            else if (sensor.modelId().startsWith(QLatin1String("C4"))) { n = 4; }
-
-//            while (gids.size() < n)
-//            {
-//                gids.append("-1"); // not configured, TODO extract from BIND rules if available
-//            }
-
-//            QString out = gids.join(',');
-//            if (item->toString() != out)
-//            {
-//                item->setValue(out);
-//            }
         }
 
         if (extAddr != 0)

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -10445,10 +10445,9 @@ Group *DeRestPluginPrivate::getGroupForName(const QString &name)
  */
 Group *DeRestPluginPrivate::getGroupForId(const QString &id)
 {
-    DBG_Assert(id.isEmpty() == false);
-    if (id.isEmpty())
+    if (id.isEmpty() || !id.front().isDigit())
     {
-        return 0;
+        return nullptr;
     }
 
     // check valid 16-bit group id 0..0xFFFF
@@ -10457,25 +10456,22 @@ Group *DeRestPluginPrivate::getGroupForId(const QString &id)
     if (!ok || (gid > 0xFFFFUL))
     {
         DBG_Printf(DBG_INFO, "Get group for id error: invalid group id %s\n", qPrintable(id));
-        return 0;
+        return nullptr;
     }
     if (gid == 0)
     {
         gid = gwGroup0;
     }
 
-    std::vector<Group>::iterator i = groups.begin();
-    std::vector<Group>::iterator end = groups.end();
-
-    for (; i != end; ++i)
+    for (auto &group : groups)
     {
-        if (i->address() == gid)
+        if (group.address() == gid)
         {
-            return &(*i);
+            return &group;
         }
     }
 
-    return 0;
+    return nullptr;
 }
 
 /*! Delete a group of a switch from database permanently.

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -291,7 +291,6 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_XIAOMI, "lumi.motion.agl04", lumiMacPrefix}, // Xiaomi Aqara RTCGQ13LM high precision motion sensor
     { VENDOR_XIAOMI, "lumi.flood.agl02", xiaomiMacPrefix}, // Xiaomi Aqara T1 water leak sensor SJCGQ12LM
     { VENDOR_XIAOMI, "lumi.switch.n0agl1", lumiMacPrefix}, // Xiaomi Aqara Single Switch Module T1 (With Neutral)
-    { VENDOR_UBISYS, "C4", ubisysMacPrefix },
     { VENDOR_UBISYS, "D1", ubisysMacPrefix },
     { VENDOR_UBISYS, "J1", ubisysMacPrefix },
     { VENDOR_UBISYS, "S1", ubisysMacPrefix },
@@ -6512,7 +6511,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     {
                         if ((modelId.startsWith(QLatin1String("D1")) && i->endpoint() == 0x02) ||
                             (modelId.startsWith(QLatin1String("J1")) && i->endpoint() == 0x02) ||
-                            (modelId.startsWith(QLatin1String("C4")) && i->endpoint() == 0x01) ||
                             (modelId.startsWith(QLatin1String("S1")) && i->endpoint() == 0x02) ||
                             (modelId.startsWith(QLatin1String("S2")) && i->endpoint() == 0x03))
                         {
@@ -9987,36 +9985,6 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                             updateSensorEtag(&*i);
                         }
                     }
-                    else if (event.clusterId() == UBISYS_DEVICE_SETUP_CLUSTER_ID && event.endpoint() == 0xE8 &&
-                            existDevicesWithVendorCodeForMacPrefix(event.node()->address(), VENDOR_UBISYS)) // ubisys device management
-                    {
-//                        bool updated = false;
-                        for (;ia != enda; ++ia)
-                        {
-                            if (std::find(event.attributeIds().begin(),
-                                          event.attributeIds().end(),
-                                          ia->id()) == event.attributeIds().end())
-                            {
-                                continue;
-                            }
-
-                            if (ia->id() == 0x0000 && ia->dataType() == deCONZ::ZclArray) // Input configurations
-                            {
-                                QByteArray arr = ia->toVariant().toByteArray();
-                                qDebug() << arr.toHex();
-                            }
-                            else if (ia->id() == 0x0001 && ia->dataType() == deCONZ::ZclArray) // Input actions
-                            {
-                                QByteArray arr = ia->toVariant().toByteArray();
-                                qDebug() << arr.toHex();
-                            }
-
-                            if (i->modelId().startsWith(QLatin1String("C4")))
-                            {
-                                processUbisysC4Configuration(&*i);
-                            }
-                        }
-                    }
                     else if (event.clusterId() == VENDOR_CLUSTER_ID && i->modelId() == QLatin1String("de_spect"))
                     {
                         bool updated = false;
@@ -10796,8 +10764,7 @@ bool DeRestPluginPrivate::processZclAttributes(Sensor *sensorNode)
         // whitelist by Model ID
         if (sensorNode->modelId().startsWith(QLatin1String("FLS-NB")) ||
             sensorNode->modelId().startsWith(QLatin1String("D1")) || sensorNode->modelId().startsWith(QLatin1String("S1")) ||
-            sensorNode->modelId().startsWith(QLatin1String("S2")) || sensorNode->manufacturer().startsWith(QLatin1String("BEGA")) ||
-            sensorNode->modelId().startsWith(QLatin1String("C4")))
+            sensorNode->modelId().startsWith(QLatin1String("S2")) || sensorNode->manufacturer().startsWith(QLatin1String("BEGA")))
         {
             ok = true;
         }

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1317,7 +1317,6 @@ public Q_SLOTS:
     void checkOldSensorGroups(Sensor *sensor);
     void deleteGroupsWithDeviceMembership(const QString &id);
     void processUbisysBinding(Sensor *sensor, const Binding &bnd);
-    void processUbisysC4Configuration(Sensor *sensor);
     void bindingTimerFired();
     void bindingToRuleTimerFired();
     void bindingTableReaderTimerFired();

--- a/device_ddf_init.cpp
+++ b/device_ddf_init.cpp
@@ -84,7 +84,7 @@ static ResourceItem *DEV_InitDeviceDescriptionItem(const DeviceDescription::Item
     }
     else if (ddfItem.defaultValue.isValid())
     {
-        if (!item->lastSet().isValid())
+        if (ddfItem.isStatic || !item->lastSet().isValid())
         {
             item->setValue(ddfItem.defaultValue);
         }

--- a/device_ddf_init.cpp
+++ b/device_ddf_init.cpp
@@ -84,7 +84,10 @@ static ResourceItem *DEV_InitDeviceDescriptionItem(const DeviceDescription::Item
     }
     else if (ddfItem.defaultValue.isValid())
     {
-        item->setValue(ddfItem.defaultValue);
+        if (!item->lastSet().isValid())
+        {
+            item->setValue(ddfItem.defaultValue);
+        }
     }
 
     assert(ddfItem.handle != DeviceDescription::Item::InvalidItemHandle);

--- a/devices/ubisys/c4_5504.json
+++ b/devices/ubisys/c4_5504.json
@@ -48,7 +48,10 @@
           "name": "attr/name"
         },
         {
-          "name": "attr/swversion"
+          "name": "attr/swversion",
+          "parse": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x4000", "eval": "Item.val = Attr.val"},
+          "read": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x4000"},
+          "refresh.interval": 180
         },
         {
           "name": "attr/type"

--- a/devices/ubisys/c4_5504.json
+++ b/devices/ubisys/c4_5504.json
@@ -1,0 +1,131 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "ubisys",
+  "modelid": "C4 (5504)",
+  "product": "C4 (5504)",
+  "sleeper": false,
+  "status": "Silver",
+  "path": "/devices/ubisys/c4_5504.json",
+  "subdevices": [
+    {
+      "type": "$TYPE_SWITCH",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0006"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0001",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000"
+        ],
+        "out": [
+          "0x0005",
+          "0x0006",
+          "0x0008"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/group",
+          "default": "auto,auto,auto,auto"
+        },
+        {
+          "name": "config/mode"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/buttonevent"
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "groupcast",
+      "src.ep": 1,
+      "cl": "0x0006",
+      "config.group": 0
+    },
+    {
+      "bind": "groupcast",
+      "src.ep": 1,
+      "cl": "0x0008",
+      "config.group": 0
+    },
+    {
+      "bind": "groupcast",
+      "src.ep": 2,
+      "cl": "0x0006",
+      "config.group": 1
+    },
+    {
+      "bind": "groupcast",
+      "src.ep": 2,
+      "cl": "0x0008",
+      "config.group": 1
+    },
+    {
+      "bind": "groupcast",
+      "src.ep": 3,
+      "cl": "0x0006",
+      "config.group": 2
+    },
+    {
+      "bind": "groupcast",
+      "src.ep": 3,
+      "cl": "0x0008",
+      "config.group": 2
+    },
+    {
+      "bind": "groupcast",
+      "src.ep": 4,
+      "cl": "0x0006",
+      "config.group": 3
+    },
+    {
+      "bind": "groupcast",
+      "src.ep": 4,
+      "cl": "0x0008",
+      "config.group": 3
+    }
+  ]
+}

--- a/devices/ubisys/c4_5504.json
+++ b/devices/ubisys/c4_5504.json
@@ -4,8 +4,7 @@
   "modelid": "C4 (5504)",
   "product": "C4 (5504)",
   "sleeper": false,
-  "status": "Silver",
-  "path": "/devices/ubisys/c4_5504.json",
+  "status": "Gold",
   "subdevices": [
     {
       "type": "$TYPE_SWITCH",

--- a/resource.cpp
+++ b/resource.cpp
@@ -1477,6 +1477,7 @@ QLatin1String R_DataTypeToString(ApiDataType type)
       ""          empty
       "45"        single group
       "343,123"   two groups
+      "1,null,null,null"  4 groups but only first set
  */
 bool isValidRConfigGroup(const QString &str)
 {
@@ -1488,6 +1489,7 @@ bool isValidRConfigGroup(const QString &str)
         bool ok = false;
         auto gid = groupId.toUInt(&ok, 0);
         if (ok && gid <= UINT16_MAX) { result++; }
+        else if (!ok && groupId == QLatin1String("null")) { result++; }
     }
 
     return result == groupList.size();

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1698,7 +1698,6 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                     if (data.valid)
                     {
                         updated = true;
-                        checkSensorBindingsForClientClusters(sensor);
 
                         if (device && device->managed())
                         {
@@ -2795,6 +2794,11 @@ void DeRestPluginPrivate::handleSensorEvent(const Event &e)
         ResourceItem *item = sensor->item(e.what());
         if (item && item->isPublic())
         {
+            if (e.what() == RConfigGroup)
+            {
+                checkSensorBindingsForClientClusters(sensor);
+            }
+
             if (!(item->needPushSet() || item->needPushChange()))
             {
                 return; // already pushed


### PR DESCRIPTION
The C4 is currently broken for various reasons. The DDF is meant to replace the C++ implementation while being backward compatible. Group binding and reconfiguration of these works as for Kobold with the "auto" `config.group` support for all 4 endpoints.

Initially with the DDF the C4 wil create 4 device groups and binds to them so that x002 button events are received right away.
The controlled groups can be reconfigured via REST API or within the Phoscon App switch details view. It might take a minute or two until the changes are applied.

**TODO**

* ~~Check the C++ implementation of `processUbisysC4Configuration()` it looks incomplete, is it even needed?~~
   https://github.com/dresden-elektronik/deconz-rest-plugin/blob/master/bindings.cpp#L4496
* ~~Remove C++ code for C4~~

The PR seems good to go, luckily could remove some unholy C++ stuff.

Tested with C4 firmware versions:

10F2-7B09-0000-0004-0107015E-ubisys-C4.ota
10F2-7B09-0000-0004-0192020D-spo-fmi4.ota1 &rarr; this version needs to be loaded before the next one!
10F2-7B29-0000-0004-01930221-spo-fmi4.ota

Final note the firmware now also supports a nice Sw Version attribute, Date Code is still 20170531-DE-FB1.