### PR TITLE
DDF add ubisys S2

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2898,7 +2898,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         // ubisys
         sensor->modelId().startsWith(QLatin1String("D1")) ||
         sensor->modelId().startsWith(QLatin1String("S1")) ||
-        sensor->modelId().startsWith(QLatin1String("S2")) ||
+        sensor->modelId().startsWith(QLatin1String("S2-R")) ||
         // IKEA
         sensor->modelId().startsWith(QLatin1String("TRADFRI")) ||
         sensor->modelId().startsWith(QLatin1String("Remote Control N2")) || // STYRBAR
@@ -3941,7 +3941,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
         }
         sensor->setMgmtBindSupported(true);
     }
-    else if (sensor->modelId().startsWith(QLatin1String("S2")))
+    else if (sensor->modelId().startsWith(QLatin1String("S2-R")))
     {
         clusters.push_back(ONOFF_CLUSTER_ID);
         clusters.push_back(LEVEL_CLUSTER_ID);
@@ -4445,13 +4445,12 @@ void DeRestPluginPrivate::processUbisysBinding(Sensor *sensor, const Binding &bn
             if       (bnd.srcEndpoint == 0x02) { pos = 0; }
             else if  (bnd.srcEndpoint == 0x03) { pos = 1; } // S1-R only
         }
-        else if (sensor->modelId().startsWith(QLatin1String("S2")))
+        else if (sensor->modelId().startsWith(QLatin1String("S2-R")))
         {
             DBG_Assert(sensor->fingerPrint().endpoint == 0x03);
 
             if       (bnd.srcEndpoint == 0x03) { pos = 0; }
             else if  (bnd.srcEndpoint == 0x04) { pos = 1; }
-
         }
         else
         {

--- a/button_maps.json
+++ b/button_maps.json
@@ -787,7 +787,7 @@
         "ubisysS2Map": {
             "vendor": "Ubisys",
             "doc": "Power switch S2",
-            "modelids": ["S2"],
+            "modelids": ["S2 (5502)", "S2", "S2-R"],
             "map": [
                 [1, "0x03", "ONOFF", "TOGGLE", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "Toggle"],
                 [1, "0x03", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_HOLD", "Move up (with on/off)"],

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -294,7 +294,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_UBISYS, "D1", ubisysMacPrefix },
     { VENDOR_UBISYS, "J1", ubisysMacPrefix },
     { VENDOR_UBISYS, "S1", ubisysMacPrefix },
-    { VENDOR_UBISYS, "S2", ubisysMacPrefix },
+    { VENDOR_UBISYS, "S2-R", ubisysMacPrefix },
     { VENDOR_NONE, "Z716A", netvoxMacPrefix },
     // { VENDOR_OSRAM_STACK, "Plug", osramMacPrefix }, // OSRAM plug - exposed only as light
     { VENDOR_OSRAM, "Lightify Switch Mini", emberMacPrefix }, // Osram 3 button remote
@@ -1222,6 +1222,7 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
 
     if ((ind.profileId() == HA_PROFILE_ID) || (ind.profileId() == ZLL_PROFILE_ID))
     {
+        const bool devManaged = device && device->managed();
         {
             QDataStream stream(ind.asdu());
             stream.setByteOrder(QDataStream::LittleEndian);
@@ -1260,11 +1261,11 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
             break;
 
         case METERING_CLUSTER_ID:
-            if (!DEV_TestStrict()) { handleSimpleMeteringClusterIndication(ind, zclFrame); }
+            if (!DEV_TestStrict() && !devManaged) { handleSimpleMeteringClusterIndication(ind, zclFrame); }
             break;
 
         case ELECTRICAL_MEASUREMENT_CLUSTER_ID:
-            if (!DEV_TestStrict()) { handleElectricalMeasurementClusterIndication(ind, zclFrame); }
+            if (!DEV_TestStrict() && !devManaged) { handleElectricalMeasurementClusterIndication(ind, zclFrame); }
             break;
 
         case IAS_ZONE_CLUSTER_ID:
@@ -1300,7 +1301,7 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
             break;
 
         case WINDOW_COVERING_CLUSTER_ID:
-            if (!DEV_TestStrict()) { handleWindowCoveringClusterIndication(ind, zclFrame); }
+            if (!DEV_TestStrict() && !devManaged) { handleWindowCoveringClusterIndication(ind, zclFrame); }
             break;
 
         case TUYA_CLUSTER_ID:
@@ -6517,7 +6518,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                         if ((modelId.startsWith(QLatin1String("D1")) && i->endpoint() == 0x02) ||
                             (modelId.startsWith(QLatin1String("J1")) && i->endpoint() == 0x02) ||
                             (modelId.startsWith(QLatin1String("S1")) && i->endpoint() == 0x02) ||
-                            (modelId.startsWith(QLatin1String("S2")) && i->endpoint() == 0x03))
+                            (modelId.startsWith(QLatin1String("S2-R")) && i->endpoint() == 0x03))
                         {
                             // Combine multiple switch endpoints into a single ZHASwitch resource
                             fpSwitch.outClusters.push_back(ci->id());
@@ -10770,7 +10771,7 @@ bool DeRestPluginPrivate::processZclAttributes(Sensor *sensorNode)
         // whitelist by Model ID
         if (sensorNode->modelId().startsWith(QLatin1String("FLS-NB")) ||
             sensorNode->modelId().startsWith(QLatin1String("D1")) || sensorNode->modelId().startsWith(QLatin1String("S1")) ||
-            sensorNode->modelId().startsWith(QLatin1String("S2")) || sensorNode->manufacturer().startsWith(QLatin1String("BEGA")))
+            sensorNode->modelId().startsWith(QLatin1String("S2-R")) || sensorNode->manufacturer().startsWith(QLatin1String("BEGA")))
         {
             ok = true;
         }

--- a/devices/ubisys/s2_5502.json
+++ b/devices/ubisys/s2_5502.json
@@ -1,0 +1,422 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "ubisys",
+  "modelid": "S2 (5502)",
+  "product": "S2 (5502)",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_ON_OFF_OUTPUT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert",
+          "default": "none"
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 305
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_ON_OFF_OUTPUT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x02"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert",
+          "default": "none"
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 305
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_SWITCH",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x03",
+        "0x0006"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0001",
+        "endpoint": "0x03",
+        "in": [
+          "0x0000",
+          "0x0003"
+        ],
+        "out": [
+          "0x0005",
+          "0x0006",
+          "0x0008"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/group",
+          "default": "auto,auto"
+        },
+        {
+          "name": "config/mode"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/buttonevent"
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_POWER_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x05",
+        "0x0b04"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0501",
+        "endpoint": "0x05",
+        "in": [
+          "0x0000",
+          "0x0B04"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/current",
+          "refresh.interval": 30,
+          "read": {
+            "at": "0x0508",
+            "cl": "0x0b04",
+            "ep": 5,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0508",
+            "cl": "0x0b04",
+            "ep": 5,
+            "eval": "if (Attr.val != 65535) { Item.val = Attr.val; }"
+          }
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/power",
+          "refresh.interval": 30,
+          "read": {
+            "at": "0x050b",
+            "cl": "0x0b04",
+            "ep": 5,
+            "fn": "zcl"
+          }
+        },
+        {
+          "name": "state/voltage",
+          "refresh.interval": 30,
+          "read": {
+            "at": "0x0505",
+            "cl": "0x0b04",
+            "ep": 5,
+            "fn": "zcl"
+          }
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_CONSUMPTION_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x05",
+        "0x0702"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0501",
+        "endpoint": "0x05",
+        "in": [
+          "0x0000",
+          "0x0702"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/consumption",
+          "refresh.interval": 30,
+          "read": {
+            "at": "0x0000",
+            "cl": "0x0702",
+            "ep": 5,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0000",
+            "cl": "0x0702",
+            "ep": 5,
+            "eval": "Item.val = Attr.val"
+          }
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/power",
+          "refresh.interval": 305,
+          "read": {
+            "at": "0x0400",
+            "cl": "0x0702",
+            "ep": 5,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0400",
+            "cl": "0x0702",
+            "ep": 5,
+            "eval": "Item.val = Attr.val"
+          }
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0006",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 300
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 2,
+      "cl": "0x0006",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 300
+        }
+      ]
+    },
+    {
+      "bind": "groupcast",
+      "config.group": 0,
+      "src.ep": 3,
+      "cl": "0x0006"
+    },
+    {
+      "bind": "groupcast",
+      "config.group": 0,
+      "src.ep": 3,
+      "cl": "0x0008"
+    },
+    {
+      "bind": "groupcast",
+      "config.group": 1,
+      "src.ep": 4,
+      "cl": "0x0006"
+    },
+    {
+      "bind": "groupcast",
+      "config.group": 1,
+      "src.ep": 4,
+      "cl": "0x0008"
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 5,
+      "cl": "0x0702",
+      "report": [
+        {
+          "at": "0x0400",
+          "dt": "0x2A",
+          "min": 1,
+          "max": 300
+        }
+      ]
+    }
+  ]
+}

--- a/electrical_measurement.cpp
+++ b/electrical_measurement.cpp
@@ -208,7 +208,7 @@ void DeRestPluginPrivate::handleElectricalMeasurementClusterIndication(const deC
                         modelId == QLatin1String("PoP") ||                                        // Apex Smart Plug
                         modelId == QLatin1String("TS011F") ||                                     // Tuya plugs
                         modelId.startsWith(QLatin1String("S1")) ||                                // Ubisys S1/S1-R
-                        modelId.startsWith(QLatin1String("S2")) ||                                // Ubisys S2/S2-R
+                        modelId.startsWith(QLatin1String("S2-R")) ||                              // Ubisys S2-R
                         modelId.startsWith(QLatin1String("J1")) ||                                // Ubisys J1/J1-R
                         modelId.startsWith(QLatin1String("D1")))                                  // Ubisys D1/D1-R
                     {


### PR DESCRIPTION
The DDF replaces most part of the C++ implementation.
The S2 was broken since a few releases due code changes.

Note that the Electrical Measurement cluster doesn't support reporting, and Simple Metering cluster only for attribute 0x0400. The rest gets polled.

Like the C4 the `button_maps.json` was broken due incomplete modelid in combination with startsWith() check.