### PR TITLE
DDF add ubisys S1

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2897,7 +2897,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId() == QLatin1String("easyCodeTouch_v1") ||
         // ubisys
         sensor->modelId().startsWith(QLatin1String("D1")) ||
-        sensor->modelId().startsWith(QLatin1String("S1")) ||
+        sensor->modelId().startsWith(QLatin1String("S1-R")) ||
         sensor->modelId().startsWith(QLatin1String("S2")) ||
         // IKEA
         sensor->modelId().startsWith(QLatin1String("TRADFRI")) ||
@@ -3930,7 +3930,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForClientClusters(Sensor *sensor)
         srcEndpoints.push_back(0x03);
         sensor->setMgmtBindSupported(true);
     }
-    else if (sensor->modelId().startsWith(QLatin1String("S1")))
+    else if (sensor->modelId().startsWith(QLatin1String("S1-R")))
     {
         clusters.push_back(ONOFF_CLUSTER_ID);
         clusters.push_back(LEVEL_CLUSTER_ID);
@@ -4438,7 +4438,7 @@ void DeRestPluginPrivate::processUbisysBinding(Sensor *sensor, const Binding &bn
             else if  (bnd.srcEndpoint == 0x03) { pos = 1; }
 
         }
-        else if (sensor->modelId().startsWith(QLatin1String("S1")))
+        else if (sensor->modelId().startsWith(QLatin1String("S1-R")))
         {
             DBG_Assert(sensor->fingerPrint().endpoint == 0x02);
 

--- a/button_maps.json
+++ b/button_maps.json
@@ -740,10 +740,22 @@
                 [1, "0x01", "DOOR_LOCK", "ATTRIBUTE_REPORT", "3", "S_BUTTON_1", "S_BUTTON_ACTION_DROP", "Drop"]
             ]
         },
+        "ubisysS1Map": {
+            "vendor": "Ubisys",
+            "doc": "Universal power switch S1 (5501)",
+            "modelids": ["S1 (5501)"],
+            "map": [
+                [1, "0x02", "ONOFF", "TOGGLE", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "Toggle"],
+                [1, "0x02", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_HOLD", "Move up (with on/off)"],
+                [1, "0x02", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ (with on/off)"],
+                [1, "0x02", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "1", "S_BUTTON_1", "S_BUTTON_ACTION_HOLD", "Move down (with on/off)"],
+                [1, "0x02", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "1", "S_BUTTON_1", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ (with on/off)"]                
+            ]
+        },
         "ubisysD1Map": {
             "vendor": "Ubisys",
-            "doc": "Universal dimmer D1 and power switch S1",
-            "modelids": ["D1", "S1"],
+            "doc": "Universal dimmer D1 and power switch S1-R",
+            "modelids": ["D1", "S1-R", "S1"],
             "map": [
                 [1, "0x02", "ONOFF", "TOGGLE", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "Toggle"],
                 [1, "0x02", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_HOLD", "Move up (with on/off)"],

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1426,7 +1426,7 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
                         sensorNode = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), 0x01);
                     }
                     else if (sensorNode->modelId().startsWith(QLatin1String("D1")) || // ubisys
-                             sensorNode->modelId().startsWith(QLatin1String("S1")))   // ubisys
+                             sensorNode->modelId().startsWith(QLatin1String("S1-R")))   // ubisys
                     {
                         sensorNode = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), 0x02);
                     }
@@ -6516,7 +6516,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     {
                         if ((modelId.startsWith(QLatin1String("D1")) && i->endpoint() == 0x02) ||
                             (modelId.startsWith(QLatin1String("J1")) && i->endpoint() == 0x02) ||
-                            (modelId.startsWith(QLatin1String("S1")) && i->endpoint() == 0x02) ||
+                            (modelId.startsWith(QLatin1String("S1-R")) && i->endpoint() == 0x02) ||
                             (modelId.startsWith(QLatin1String("S2")) && i->endpoint() == 0x03))
                         {
                             // Combine multiple switch endpoints into a single ZHASwitch resource
@@ -10769,7 +10769,7 @@ bool DeRestPluginPrivate::processZclAttributes(Sensor *sensorNode)
         // only read binding table of chosen sensors
         // whitelist by Model ID
         if (sensorNode->modelId().startsWith(QLatin1String("FLS-NB")) ||
-            sensorNode->modelId().startsWith(QLatin1String("D1")) || sensorNode->modelId().startsWith(QLatin1String("S1")) ||
+            sensorNode->modelId().startsWith(QLatin1String("D1")) || sensorNode->modelId().startsWith(QLatin1String("S1-R")) ||
             sensorNode->modelId().startsWith(QLatin1String("S2")) || sensorNode->manufacturer().startsWith(QLatin1String("BEGA")))
         {
             ok = true;
@@ -17954,7 +17954,7 @@ void DeRestPluginPrivate::pushSensorInfoToCore(Sensor *sensor)
 
     if (sensor->modelId().startsWith(QLatin1String("FLS-NB")))
     { } // use name from light
-    else if (sensor->modelId().startsWith(QLatin1String("D1")) || sensor->modelId().startsWith(QLatin1String("S1")) ||
+    else if (sensor->modelId().startsWith(QLatin1String("D1")) || sensor->modelId().startsWith(QLatin1String("S1-R")) ||
              sensor->modelId().startsWith(QLatin1String("S2")) ||sensor->modelId().startsWith(QLatin1String("lumi.ctrl_")))
     { } // use name from light
     else if (sensor->type() == QLatin1String("ZHAConsumption") || sensor->type() == QLatin1String("ZHAPower"))

--- a/devices/ubisys/s1_5501.json
+++ b/devices/ubisys/s1_5501.json
@@ -1,0 +1,348 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "ubisys",
+  "modelid": "S1 (5501)",
+  "product": "S1 (5501)",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_ON_OFF_PLUGIN_UNIT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert",
+          "default": "none"
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 305
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_SWITCH",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x02",
+        "0x0006"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0001",
+        "endpoint": "0x02",
+        "in": [
+          "0x0000"
+        ],
+        "out": [
+          "0x0005",
+          "0x0006",
+          "0x0008"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/group",
+          "default": "auto"
+        },
+        {
+          "name": "config/mode"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/buttonevent"
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_POWER_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x03",
+        "0x0b04"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0501",
+        "endpoint": "0x03",
+        "in": [
+          "0x0000",
+          "0x0B04"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/current",
+          "refresh.interval": 30,
+          "read": {
+            "at": "0x0508",
+            "cl": "0x0b04",
+            "ep": 3,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0508",
+            "cl": "0x0b04",
+            "ep": 3,
+            "eval": "if (Attr.val != 65535) { Item.val = Attr.val; }"
+          }
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/power",
+          "refresh.interval": 30,
+          "read": {
+            "at": "0x050b",
+            "cl": "0x0b04",
+            "ep": 3,
+            "fn": "zcl"
+          }
+        },
+        {
+          "name": "state/voltage",
+          "refresh.interval": 30,
+          "read": {
+            "at": "0x0505",
+            "cl": "0x0b04",
+            "ep": 3,
+            "fn": "zcl"
+          }
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_CONSUMPTION_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x03",
+        "0x0702"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0501",
+        "endpoint": "0x03",
+        "in": [
+          "0x0000",
+          "0x0702"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/consumption",
+          "refresh.interval": 30,
+          "read": {
+            "at": "0x0000",
+            "cl": "0x0702",
+            "ep": 3,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0000",
+            "cl": "0x0702",
+            "ep": 3,
+            "eval": "Item.val = Attr.val"
+          }
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/power",
+          "refresh.interval": 305,
+          "read": {
+            "at": "0x0400",
+            "cl": "0x0702",
+            "ep": 3,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0400",
+            "cl": "0x0702",
+            "ep": 3,
+            "eval": "Item.val = Attr.val"
+          }
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0006",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 300
+        }
+      ]
+    },
+    {
+      "bind": "groupcast",
+      "config.group": 0,
+      "src.ep": 2,
+      "cl": "0x0006"
+    },
+    {
+      "bind": "groupcast",
+      "config.group": 0,
+      "src.ep": 2,
+      "cl": "0x0008"
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 3,
+      "cl": "0x0702",
+      "report": [
+        {
+          "at": "0x0400",
+          "dt": "0x2A",
+          "min": 1,
+          "max": 300
+        }
+      ]
+    }
+  ]
+}

--- a/electrical_measurement.cpp
+++ b/electrical_measurement.cpp
@@ -207,7 +207,7 @@ void DeRestPluginPrivate::handleElectricalMeasurementClusterIndication(const deC
                         modelId == QLatin1String("SMRZB-1") ||                                    // Develco smart cable
                         modelId == QLatin1String("PoP") ||                                        // Apex Smart Plug
                         modelId == QLatin1String("TS011F") ||                                     // Tuya plugs
-                        modelId.startsWith(QLatin1String("S1")) ||                                // Ubisys S1/S1-R
+                        modelId.startsWith(QLatin1String("S1-R")) ||                              // Ubisys S1-R
                         modelId.startsWith(QLatin1String("S2")) ||                                // Ubisys S2/S2-R
                         modelId.startsWith(QLatin1String("J1")) ||                                // Ubisys J1/J1-R
                         modelId.startsWith(QLatin1String("D1")))                                  // Ubisys D1/D1-R


### PR DESCRIPTION
The ubisys S1 wasn't working for a few releases due some other code changes.
The DDF replaces most of the C++ implementation.

Note for the ubisys S1-R a separate DDF needs to be created, except if it is equal... needs to be tested.