### PR TITLE
Fix Ikea Styrbar lockup of top/bottom buttons short press after long press side buttons

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -5054,9 +5054,13 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                         }
                     }
                 }
-                else if (ind.clusterId() == ONOFF_CLUSTER_ID && sensor->modelId() == QLatin1String("Remote Control N2") && sensor->previousCommandId == 0x09)
+                else if (ind.clusterId() == ONOFF_CLUSTER_ID && sensor->previousCommandId == 0x09 && sensor->modelId() == QLatin1String("Remote Control N2"))
                 {
+                    // for left and right buttons long press, the Ikea Styrbar sends:
+                    // 0x09 -> ON -> 0x07 -> 0x08 -> 0x09
+                    // disable to not trigger 1002 and 2002 button events
                     ok = false;
+                    sensor->previousCommandId = 0xFF;
                 }
                 else if (ind.clusterId() == LEVEL_CLUSTER_ID && zclFrame.commandId() == 0x04 && // move to level (with on/off)
                          sensor->modelId().startsWith(QLatin1String("Z3-1BRL"))) // Lutron Aurora Friends-of-Hue dimmer


### PR DESCRIPTION
When holding the side buttons for a few seconds, the 1002 and 2002 events won't be triggered anymore.
This happened since we filter out the OnOff cluster commands during long press which are send by the side and the top and bottom buttons.

This PR resets the remembered state making the 1002 and 2002 button events for top and bottom buttons work again.

Note: The long press for for the side buttons works, but only starts after pressing them for more than 4 seconds.