### PR TITLE
Fast FIX: reverse fire state on Woox smoke sensor

### DIFF
--- a/tuya.cpp
+++ b/tuya.cpp
@@ -1272,7 +1272,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                     case 0x0401: // Preset for Moes or Alamr for Woox
                         if (productId == "Tuya_OTH R7049 Smoke Alarm")
                         {
-                            bool fire = (data == 0) ? false : true;
+                            bool fire = (data == 0) ? true : false;
                             ResourceItem *item = sensorNode->item(RStateFire);
 
                             if (item && item->toBool() != fire)


### PR DESCRIPTION
See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/4693

Sorry.