### PR TITLE
Fix DDF Javascript numeric value convesion for Attr.val

### DIFF
--- a/device_js/device_js_wrappers.cpp
+++ b/device_js/device_js_wrappers.cpp
@@ -154,16 +154,24 @@ QVariant JsZclAttribute::value() const
     case deCONZ::Zcl56BitBitMap:
     case deCONZ::Zcl56BitData:
     case deCONZ::Zcl56BitUint:
+        return QVariant::fromValue(quint64(attr->numericValue().u64));
+
     case deCONZ::Zcl64BitBitMap:
     case deCONZ::Zcl64BitUint:
     case deCONZ::Zcl64BitData:
     case deCONZ::ZclIeeeAddress:
-        return QString::number(attr->numericValue().u64);
+        return QString::number(quint64(attr->numericValue().u64));
 
+    case deCONZ::Zcl8BitInt:
+    case deCONZ::Zcl16BitInt:
+    case deCONZ::Zcl24BitInt:
+    case deCONZ::Zcl32BitInt:
     case deCONZ::Zcl48BitInt:
     case deCONZ::Zcl56BitInt:
+        return QVariant::fromValue(qint64(attr->numericValue().s64));
+
     case deCONZ::Zcl64BitInt:
-        return QString::number(attr->numericValue().s64);
+        return QString::number(qint64(attr->numericValue().u64));
 
     case deCONZ::ZclSingleFloat:
         return attr->numericValue().real;


### PR DESCRIPTION
For some data types a string instead of numeric was returned. If the expression was evaluated weird results appeared, e.g:
`"5" + 1 = "51"`

This fixes DDF state/humidity values.