### PR TITLE
Prevent DDF devices to poll too fast in idle mode

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -17881,6 +17881,17 @@ const deCONZ::Node *DEV_GetCoreNode(uint64_t extAddress)
     return nullptr;
 }
 
+/* Returns number of APS requests currently in the queue. */
+int DEV_ApsQueueSize()
+{
+#if DECONZ_LIB_VERSION >= 0x011103
+    deCONZ::ApsController *ctrl = deCONZ::ApsController::instance();
+    return ctrl->apsQueueSize();
+#else
+    return 1;
+#endif
+}
+
 void DeRestPluginPrivate::pollSwUpdateStateTimerFired()
 {
     if (gwSwUpdateState != swUpdateState.transferring &&

--- a/device_tick.cpp
+++ b/device_tick.cpp
@@ -19,6 +19,8 @@
 #define TICK_INTERVAL_JOIN 500
 #define TICK_INTERVAL_IDLE 1000
 
+extern int DEV_ApsQueueSize();
+
 struct JoinDevice
 {
     DeviceKey deviceKey;
@@ -156,7 +158,10 @@ static void DT_StateIdle(DeviceTickPrivate *d, const Event &event)
     {
         if (event.what() == REventStateTimeout)
         {
-            DT_PollNextIdleDevice(d);
+            if (DEV_ApsQueueSize() < 4)
+            {
+                DT_PollNextIdleDevice(d);
+            }
             DT_StartTimer(d, TICK_INTERVAL_IDLE);
         }
         else if (event.what() == REventStateEnter)


### PR DESCRIPTION
This is only a rough workaround which will be replaced by a more precise method later. The problem is in a network with lots of DDF devices the APS queue can be stressed too fast, since the DeviceTick triggers polling without waiting if the previous polling device is already finished.