### PR TITLE
Prevent unnecessary polling for ZNCZ04LM

### DIFF
--- a/devices/xiaomi/xiaomi_zncz04lm_smart_plug.json
+++ b/devices/xiaomi/xiaomi_zncz04lm_smart_plug.json
@@ -62,8 +62,7 @@
           "default": "none"
         },
         {
-          "name": "state/on",
-          "refresh.interval": 5
+          "name": "state/on"
         },
         {
           "name": "state/reachable"
@@ -144,6 +143,9 @@
             "eval": "Item.val = Math.round(Attr.val);",
             "fn": "xiaomi:special",
             "idx": "0x97"
+          },
+          "read": {
+            "fn": "none"
           }
         },
         {
@@ -151,7 +153,7 @@
         },
         {
           "name": "state/power",
-          "refresh.interval": 300,
+          "refresh.interval": 10,
           "read": {
             "at": "0x0055",
             "cl": "0x000C",
@@ -172,6 +174,9 @@
             "eval": "Item.val = Math.round(Attr.val / 10);",
             "fn": "xiaomi:special",
             "idx": "0x96"
+          },
+          "read": {
+            "fn": "none"
           }
         }
       ]
@@ -245,7 +250,7 @@
         },
         {
           "name": "state/consumption",
-          "refresh.interval": 30,
+          "refresh.interval": 300,
           "read": {
             "at": "0x0055",
             "cl": "0x000C",


### PR DESCRIPTION
Default behavior to poll voltage and consumption as defined in `state/voltage` and `state/current` shall be prevented, as otherwise the wrong clusters are polled.