### PR TITLE
DDF for OWON THS317-ET Multisensor (temp probe support)

### DIFF
--- a/ddf_for_OWON_THS317-ET
+++ b/ddf_for_OWON_THS317-ET
@@ -1,0 +1,114 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "OWON",
+  "modelid": "THS317-ET",
+  "product": "THS317-ET",
+  "sleeper": true,
+  "status": "Bronze",
+  "path": "/devices/ths317-et.json",
+  "subdevices": [
+    {
+      "type": "$TYPE_TEMPERATURE_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x03",
+        "0x0402"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/offset",
+          "default": 0
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+            "name": "config/battery",
+            "parse": {"cl": "0x0001", "at": "0x0021", "eval": "Item.val = Attr.val"},
+            "awake": true
+        },
+        {
+          "name": "state/lastupdated"
+        },
+          {
+          "name": "state/temperature",
+          "awake": true,
+          "read": {
+            "at": "0x0000",
+            "cl": "0x0402",
+            "ep": 3,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0000",
+            "cl": "0x0402",
+            "ep": 3,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl"
+          }
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 3,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0020",
+          "dt": "0x21",
+          "min": 300,
+          "max": 3000,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 3,
+      "cl": "0x0402",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x29",
+          "min": 60,
+          "max": 600,
+          "change": "0x00000014"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This is a DDF I created for this sensor with the help of @Smanar and @Mimiix. It actually works pretty well for reading the temperature cluster, the battery and the sw version, but this sensor is supposed to report humidity and is also a PIR sensor.
As you can see on the screenshots provided in issue #5738 it probably lack some cluster for these other features to be supported by deCONZ so if someone have a sniffer and this device, feel free to contribute to make other commands usable.
As requested the DDF has been set up to Bronze status.