### PR TITLE
Trigger manufacturer name read and consider it while selecting DDF

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -2617,7 +2617,7 @@ static int sqliteLoadLightNodeCallback(void *user, int ncols, char **colval , ch
             }
             else if (strcmp(colname[i], "modelid") == 0)
             {
-                if (!val.isEmpty() && 0 != val.compare(QLatin1String("Unknown"), Qt::CaseInsensitive))
+                if (!val.isEmpty())
                 {
                     lightNode->setModelId(val);
                     lightNode->item(RAttrModelId)->setValue(val);
@@ -2627,7 +2627,7 @@ static int sqliteLoadLightNodeCallback(void *user, int ncols, char **colval , ch
             }
             else if (strcmp(colname[i], "manufacturername") == 0)
             {
-                if (!val.isEmpty() && 0 != val.compare(QLatin1String("Unknown"), Qt::CaseInsensitive))
+                if (!val.isEmpty())
                 {
                     lightNode->setManufacturerName(val);
                     lightNode->clearRead(READ_VENDOR_NAME);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -16709,7 +16709,7 @@ void DeRestPlugin::idleTimerFired()
 
                 if (!sensorNode->mustRead(READ_VENDOR_NAME) &&
                    (sensorNode->manufacturer().isEmpty() ||
-                    sensorNode->manufacturer() == QLatin1String("unknown")))
+                    sensorNode->manufacturer() == QLatin1String("Unknown")))
                 {
                     sensorNode->setLastRead(READ_VENDOR_NAME, d->idleTotalCounter);
                     sensorNode->setNextReadTime(READ_VENDOR_NAME, d->queryTime);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -10659,7 +10659,7 @@ bool DeRestPluginPrivate::processZclAttributes(LightNode *lightNode)
 
     if (lightNode->mustRead(READ_VENDOR_NAME) && tNow > lightNode->nextReadTime(READ_VENDOR_NAME))
     {
-        if (!lightNode->manufacturer().isEmpty() && lightNode->manufacturer() != QLatin1String("Unknown"))
+        if (!lightNode->manufacturer().isEmpty())
         {
             lightNode->clearRead(READ_VENDOR_NAME);
             processed++;
@@ -16484,7 +16484,7 @@ void DeRestPlugin::idleTimerFired()
                             d->queSaveDb(DB_LIGHTS, DB_SHORT_SAVE_DELAY);
                         }
 
-                        if ((lightNode->manufacturer().isEmpty() || lightNode->manufacturer() == QLatin1String("Unknown")) && lightNode->manufacturer() != l.manufacturer())
+                        if (lightNode->manufacturer().isEmpty() && !l.manufacturer().isEmpty())
                         {
                             lightNode->setManufacturerName(l.manufacturer());
                             lightNode->setNeedSaveDatabase(true);
@@ -16562,7 +16562,7 @@ void DeRestPlugin::idleTimerFired()
                     }
                 }
 
-                if (lightNode->manufacturer().isEmpty() || (lightNode->manufacturer() == QLatin1String("Unknown")))
+                if (lightNode->manufacturer().isEmpty())
                 {
                     lightNode->setLastRead(READ_VENDOR_NAME, d->idleTotalCounter);
                     lightNode->enableRead(READ_VENDOR_NAME);
@@ -16707,9 +16707,7 @@ void DeRestPlugin::idleTimerFired()
                     break;
                 }
 
-                if (!sensorNode->mustRead(READ_VENDOR_NAME) &&
-                   (sensorNode->manufacturer().isEmpty() ||
-                    sensorNode->manufacturer() == QLatin1String("Unknown")))
+                if (!sensorNode->mustRead(READ_VENDOR_NAME) && sensorNode->manufacturer().isEmpty())
                 {
                     sensorNode->setLastRead(READ_VENDOR_NAME, d->idleTotalCounter);
                     sensorNode->setNextReadTime(READ_VENDOR_NAME, d->queryTime);

--- a/device.cpp
+++ b/device.cpp
@@ -527,7 +527,7 @@ bool DEV_FillItemFromSubdevices(Device *device, const char *itemSuffix, const st
         if (sitem && sitem->lastSet().isValid())
         {
             // copy from sub-device into device
-            if (ditem->setValue(sitem->toVariant()))
+            if (sitem->toVariant() != QLatin1String("Unknown") && ditem->setValue(sitem->toVariant()))
             {
                 return true;
             }

--- a/device.cpp
+++ b/device.cpp
@@ -527,7 +527,7 @@ bool DEV_FillItemFromSubdevices(Device *device, const char *itemSuffix, const st
         if (sitem && sitem->lastSet().isValid())
         {
             // copy from sub-device into device
-            if (sitem->toVariant() != QLatin1String("Unknown") && ditem->setValue(sitem->toVariant()))
+            if (ditem->setValue(sitem->toVariant()))
             {
                 return true;
             }

--- a/device_ddf_init.cpp
+++ b/device_ddf_init.cpp
@@ -218,7 +218,7 @@ bool DEV_InitBaseDescriptionForDevice(Device *device, DeviceDescription &ddf)
     ddf.manufacturerNames.push_back(device->item(RAttrManufacturerName)->toString());
     ddf.modelIds.push_back(device->item(RAttrModelId)->toString());
 
-    if (ddf.manufacturerNames.last().isEmpty() || ddf.manufacturerNames.last() == QLatin1String("Unknown") || ddf.modelIds.isEmpty() || ddf.modelIds.front().isEmpty())
+    if (ddf.manufacturerNames.last().isEmpty() || ddf.modelIds.isEmpty() || ddf.modelIds.front().isEmpty())
     {
         return false;
     }

--- a/device_descriptions.cpp
+++ b/device_descriptions.cpp
@@ -487,10 +487,11 @@ const DeviceDescription &DeviceDescriptions::get(const Resource *resource) const
 
     const auto modelId = resource->item(RAttrModelId)->toString();
     const auto manufacturer = resource->item(RAttrManufacturerName)->toString();
+    const auto manufacturerConstant = stringToConstant(manufacturer);
 
-    const auto i = std::find_if(d->descriptions.begin(), d->descriptions.end(), [&modelId, &manufacturer](const DeviceDescription &ddf)
+    const auto i = std::find_if(d->descriptions.begin(), d->descriptions.end(), [&modelId, &manufacturer, &manufacturerConstant](const DeviceDescription &ddf)
     {
-        return ddf.modelIds.contains(modelId) && ddf.manufacturerNames.contains(manufacturer);
+        return (ddf.modelIds.contains(modelId) && (ddf.manufacturerNames.contains(manufacturer) || ddf.manufacturerNames.contains(manufacturerConstant)));
     });
 
     if (i != d->descriptions.end())

--- a/device_descriptions.cpp
+++ b/device_descriptions.cpp
@@ -481,14 +481,16 @@ const DeviceDescription &DeviceDescriptions::get(const Resource *resource) const
 {
     Q_ASSERT(resource);
     Q_ASSERT(resource->item(RAttrModelId));
+    Q_ASSERT(resource->item(RAttrManufacturerName));
 
     Q_D(const DeviceDescriptions);
 
     const auto modelId = resource->item(RAttrModelId)->toString();
+    const auto manufacturer = resource->item(RAttrManufacturerName)->toString();
 
-    const auto i = std::find_if(d->descriptions.begin(), d->descriptions.end(), [&modelId](const DeviceDescription &ddf)
+    const auto i = std::find_if(d->descriptions.begin(), d->descriptions.end(), [&modelId, &manufacturer](const DeviceDescription &ddf)
     {
-        return ddf.modelIds.contains(modelId);
+        return ddf.modelIds.contains(modelId) && ddf.manufacturerNames.contains(manufacturer);
     });
 
     if (i != d->descriptions.end())

--- a/light_node.cpp
+++ b/light_node.cpp
@@ -40,8 +40,6 @@ LightNode::LightNode() :
     addItem(DataTypeString, RAttrUniqueId);
     addItem(DataTypeTime, RAttrLastAnnounced);
     addItem(DataTypeTime, RAttrLastSeen);
-
-    setManufacturerName(QLatin1String("Unknown"));
 }
 
 /*! Returns the LightNode state.
@@ -82,7 +80,7 @@ void LightNode::setManufacturerCode(uint16_t code)
     {
         m_manufacturerCode = code;
 
-        if (!manufacturer().isEmpty() && (manufacturer() != QLatin1String("Unknown")))
+        if (!manufacturer().isEmpty())
         {
             return;
         }
@@ -110,12 +108,12 @@ void LightNode::setManufacturerCode(uint16_t code)
         case VENDOR_SCHLAGE: name = QLatin1String("Schlage"); break;
         case VENDOR_DEVELCO: name = QLatin1String("Develco Products A/S"); break;
         case VENDOR_NETVOX:   name = QLatin1String("netvox"); break;
-        default:
-            name = QLatin1String("Unknown");
-            break;
         }
 
-        setManufacturerName(name);
+        if (!manufacturer().isEmpty())
+        {
+            setManufacturerName(name);
+        }
     }
 }
 

--- a/poll_manager.cpp
+++ b/poll_manager.cpp
@@ -425,9 +425,7 @@ void PollManager::pollTimerFired()
     else if (suffix == RAttrModelId)
     {
         item = r->item(RAttrModelId);
-        if (item && (item->toString().isEmpty() || item->toString() == QLatin1String("unknown") ||
-             (item->lastSet().secsTo(now) > READ_MODEL_ID_INTERVAL && item->toString().startsWith("FLS-A")) // dynamic model ids
-            ))
+        if (item && (item->toString().isEmpty() || (item->lastSet().secsTo(now) > READ_MODEL_ID_INTERVAL && item->toString().startsWith("FLS-A")))) // dynamic model ids
         {
             clusterId = BASIC_CLUSTER_ID;
             //attributes.push_back(0x0004); // manufacturer

--- a/tuya.cpp
+++ b/tuya.cpp
@@ -502,7 +502,7 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                             }
 
                             //Find model id if missing (modelId().isEmpty ?) and complete it
-                            if (lightNode->modelId().isNull() || lightNode->modelId() == QLatin1String("Unknown") || lightNode->manufacturer() == QLatin1String("Unknown"))
+                            if (lightNode->modelId().isNull() || lightNode->manufacturer().isNull())
                             {
                                 DBG_Printf(DBG_INFO, "Tuya debug 10 : Updating model ID\n");
                                 if (!lightNode2->modelId().isNull())


### PR DESCRIPTION
See the linked issue for further info.

- Ensure that the model ID **and** the manufacturer name are now queried if the values are not yet known.
- The respective DDF match is now executed on both attributes instead of just the model ID.
- Additionally, neither the manufacturer name nor the model ID is set to "Unknown" if not queried and respective checks have been removed.

The DDF match might be extended in future to e.g. take a device firmware into account.

Additionally, this includes the successor of #5829 to fix matching the manufacturer name agains constants.