### PR TITLE
Correct consumption values for innr SP120 smart plug

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2114,8 +2114,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         rq3.attributeId = 0x0508; // RMS Current
         rq3.minInterval = 1;
         rq3.maxInterval = 300;
-        if (modelId == QLatin1String("SP 120") ||                  // innr
-            modelId == QLatin1String("PoP") ||                     // Apex Smart Plug
+        if (modelId == QLatin1String("PoP") ||                     // Apex Smart Plug
             modelId == QLatin1String("DoubleSocket50AU") ||        // Aurora
             modelId.startsWith(QLatin1String("SPLZB-1")) ||        // Develco smart plug
             modelId == QLatin1String("Smart16ARelay51AU") ||       // Aurora (Develco) smart plug

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -329,7 +329,6 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_LUTRON, "Z3-1BRL", lutronMacPrefix }, // Lutron Aurora Friends-of-Hue dimmer
     { VENDOR_KEEN_HOME , "SV01-", celMacPrefix}, // Keen Home Vent
     { VENDOR_KEEN_HOME , "SV02-", celMacPrefix}, // Keen Home Vent
-    { VENDOR_INNR, "SP 120", jennicMacPrefix}, // innr smart plug
     { VENDOR_JENNIC, "VMS_ADUROLIGHT", jennicMacPrefix }, // Trust motion sensor ZPIR-8000
     { VENDOR_JENNIC, "CSW_ADUROLIGHT", jennicMacPrefix }, // Trust contact sensor ZMST-808
     { VENDOR_JENNIC, "ZYCT-202", jennicMacPrefix }, // Trust remote control ZYCT-202 (older model)
@@ -7502,8 +7501,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             {
                 item = sensorNode.addItem(DataTypeUInt64, RStateConsumption);
             }
-            if ((modelId != QLatin1String("SP 120")) &&
-                (modelId != QLatin1String("ZB-ONOFFPlug-D0005")) &&
+            if ((modelId != QLatin1String("ZB-ONOFFPlug-D0005")) &&
                 (modelId != QLatin1String("TS0121")) &&
                 (!modelId.startsWith(QLatin1String("BQZ10-AU"))) &&
                 (!modelId.startsWith(QLatin1String("ROB_200"))) &&

--- a/devices/innr/sp_120.json
+++ b/devices/innr/sp_120.json
@@ -2,9 +2,10 @@
   "schema": "devcap1.schema.json",
   "manufacturername": "innr",
   "modelid": "SP 120",
+  "vendor": "innr",
   "product": "SP 120",
   "sleeper": false,
-  "status": "Silver",
+  "status": "Gold",
   "path": "/devices/innr/sp_120.json",
   "subdevices": [
     {
@@ -43,20 +44,10 @@
           "name": "attr/uniqueid"
         },
         {
-          "name": "state/alert",
-          "description": "The currently active alert effect.",
-          "default": "none"
+          "name": "state/alert"
         },
         {
-          "name": "state/on",
-          "refresh.interval": 60,
-          "parse": {
-            "at": "0x0000",
-            "cl": "0x0006",
-            "ep": 1,
-            "eval": "Item.val = Attr.val",
-            "fn": "zcl"
-          }
+          "name": "state/on"
         },
         {
           "name": "state/reachable"
@@ -107,7 +98,12 @@
         },
         {
           "name": "state/consumption",
-          "refresh.interval": 300
+          "parse": {
+            "at": "0x0000",
+            "cl": "0x0702",
+            "ep": 1,
+            "eval": "Item.val = Attr.val * 10;"
+          }
         },
         {
           "name": "state/lastupdated"
@@ -157,19 +153,16 @@
           "name": "config/reachable"
         },
         {
-          "name": "state/current",
-          "refresh.interval": 300
+          "name": "state/current"
         },
         {
           "name": "state/lastupdated"
         },
         {
-          "name": "state/power",
-          "refresh.interval": 300
+          "name": "state/power"
         },
         {
-          "name": "state/voltage",
-          "refresh.interval": 300
+          "name": "state/voltage"
         }
       ]
     }
@@ -184,7 +177,7 @@
           "at": "0x0000",
           "dt": "0x10",
           "min": 1,
-          "max": 1800
+          "max": 300
         }
       ]
     },
@@ -211,22 +204,22 @@
           "at": "0x0505",
           "dt": "0x21",
           "min": 1,
-          "max": 500,
-          "change": "0x00000003"
+          "max": 300,
+          "change": "0x00000001"
         },
         {
           "at": "0x0508",
           "dt": "0x21",
           "min": 1,
           "max": 300,
-          "change": "0x0000000F"
+          "change": "0x00000064"
         },
         {
           "at": "0x050B",
           "dt": "0x29",
           "min": 1,
           "max": 300,
-          "change": "0x00000003"
+          "change": "0x00000001"
         }
       ]
     }

--- a/electrical_measurement.cpp
+++ b/electrical_measurement.cpp
@@ -193,8 +193,7 @@ void DeRestPluginPrivate::handleElectricalMeasurementClusterIndication(const deC
 
                 if (item && current != 65535)
                 {
-                    if (modelId == QLatin1String("SP 120") ||                                     // innr
-                        modelId.startsWith(QLatin1String("outlet")) ||                            // Samsung SmartThings IM6001-OTP/IM6001-OTP01
+                    if (modelId.startsWith(QLatin1String("outlet")) ||                            // Samsung SmartThings IM6001-OTP/IM6001-OTP01
                         modelId == QLatin1String("DoubleSocket50AU") ||                           // Aurora
                         modelId.startsWith(QLatin1String("SPLZB-1")) ||                           // Develco smart plug
                         modelId == QLatin1String("Smart16ARelay51AU") ||                          // Aurora (Develco) smart plug

--- a/simple_metering.cpp
+++ b/simple_metering.cpp
@@ -94,8 +94,7 @@ void DeRestPluginPrivate::handleSimpleMeteringClusterIndication(const deCONZ::Ap
                     consumption = static_cast<quint64>(round((double)consumption / 10.0)); // 0.1 Wh -> Wh
                     DDF_AnnoteZclParse(sensor, item, ind.srcEndpoint(), ind.clusterId(), attrId, "Item.val = Math.round(Attr.val / 10)");
                 }
-                else if (modelId == QLatin1String("SP 120") ||                    // innr
-                         modelId == QLatin1String("Plug-230V-ZB3.0") ||           // Immax
+                else if (modelId == QLatin1String("Plug-230V-ZB3.0") ||           // Immax
                          modelId == QLatin1String("Smart plug Zigbee PE") ||      // Niko Smart Plug 552-80699
                          modelId == QLatin1String("TS011F") ||                    // Tuya / Blitzwolf 
                          modelId == QLatin1String("TS0121"))                      // Tuya / Blitzwolf


### PR DESCRIPTION
Consumption values calculated by DDF must be multiplied by 10.

Additionally:
- Reporting intervals and reportable changes have been amended according to legacy code
- DDF status has been set to gold
- Legacy code has been removed