### PR TITLE
Fix DDF matching modelId constant strings

### DIFF
--- a/device_descriptions.cpp
+++ b/device_descriptions.cpp
@@ -485,10 +485,11 @@ const DeviceDescription &DeviceDescriptions::get(const Resource *resource) const
     Q_D(const DeviceDescriptions);
 
     const auto modelId = resource->item(RAttrModelId)->toString();
+    const auto modelIdConstant = stringToConstant(modelId);
 
-    const auto i = std::find_if(d->descriptions.begin(), d->descriptions.end(), [&modelId](const DeviceDescription &ddf)
+    const auto i = std::find_if(d->descriptions.begin(), d->descriptions.end(), [&modelId, &modelIdConstant](const DeviceDescription &ddf)
     {
-        return ddf.modelIds.contains(modelId);
+        return ddf.modelIds.contains(modelId) || (modelId != modelIdConstant && ddf.modelIds.contains(modelIdConstant));
     });
 
     if (i != d->descriptions.end())


### PR DESCRIPTION
Than the DDF is loaded from .local location prior to `constants.json` the matching fails.

https://github.com/dresden-elektronik/deconz-rest-plugin/issues/5828