### PR TITLE
Securely generate network key when resetting adapters

### DIFF
--- a/backup.cpp
+++ b/backup.cpp
@@ -17,6 +17,7 @@
 #include <deconz.h>
 #include "backup.h"
 #include "json.h"
+#include "crypto/random.h"
 
 #define EXT_PROCESS_TIMEOUT 10000
 
@@ -524,9 +525,10 @@ bool BAK_ResetConfiguration(deCONZ::ApsController *apsCtrl, bool resetGW, bool d
 
     if (resetGW)
     {
-        qsrand(QDateTime::currentMSecsSinceEpoch());
+        uint16_t panId;
+        CRYPTO_RandomBytes((unsigned char*)&panId, sizeof(panId));
+
         uint8_t deviceType = deCONZ::Coordinator;
-        uint16_t panId = qrand();
         quint64 apsUseExtPanId = 0x0000000000000000;
         uint16_t nwkAddress = 0x0000;
         //uint32_t channelMask = 33554432; // 25
@@ -540,13 +542,8 @@ bool BAK_ResetConfiguration(deCONZ::ApsController *apsCtrl, bool resetGW, bool d
             return false;
         }
 
-        QByteArray nwkKey1 = QByteArray::number(qrand(), 16);
-        QByteArray nwkKey2 = QByteArray::number(qrand(), 16);
-        QByteArray nwkKey3 = QByteArray::number(qrand(), 16);
-        QByteArray nwkKey4 = QByteArray::number(qrand(), 16);
-
-        QByteArray nwkKey = nwkKey1.append(nwkKey2).append(nwkKey3).append(nwkKey4);
-        nwkKey.resize(16);
+        QByteArray nwkKey(16, '\x00');
+        CRYPTO_RandomBytes((unsigned char*)nwkKey.data(), nwkKey.size());
 
         QByteArray tcLinkKey = QByteArray::fromHex("5a6967426565416c6c69616e63653039");
         uint8_t nwkUpdateId = 1;

--- a/crypto/random.cpp
+++ b/crypto/random.cpp
@@ -84,7 +84,7 @@ private:
 void fallbackRandom(unsigned char *buf, unsigned int size)
 {
    std::random_device rd;
-   std::uniform_int_distribution<int> dist(1, 255); //range is 1-255
+   std::uniform_int_distribution<int> dist(0, 255); //range is 0-255
 
    for (unsigned i = 0; i < size; i++)
    {

--- a/crypto/random.cpp
+++ b/crypto/random.cpp
@@ -84,12 +84,11 @@ private:
 void fallbackRandom(unsigned char *buf, unsigned int size)
 {
    std::random_device rd;
-   std::mt19937 mt(rd());
    std::uniform_int_distribution<int> dist(1, 255); //range is 1-255
 
    for (unsigned i = 0; i < size; i++)
    {
-       buf[i] = dist(mt) & 0xFF;
+       buf[i] = dist(rd) & 0xFF;
    }
 }
 


### PR DESCRIPTION
`qrand()` is not suitable for generating the network key when factory resetting an adapter.

The first call to `qrand()` sets the public PAN ID. This leaks enough RNG state to make bruteforcing the full state feasible from a single captured packet and thus allows the network key to be easily computed.

Unoptimized PoC: https://github.com/puddly/deconz-network-key-leak-poc

---

I can't figure out how to test this branch with the deCONZ Docker image so while the code compiles, I'm not certain of its correctness.  Feel free to close this PR and re-implement it yourself, the changes are pretty minor.
