### PR TITLE
Add support for Mueller-Licht Tint remote 404049

### DIFF
--- a/button_maps.json
+++ b/button_maps.json
@@ -1300,7 +1300,7 @@
         "tintMap": {
             "vendor": "Tint",
             "doc": "Remote",
-            "modelids": ["ZBT-Remote-ALL-RGBW"],
+            "modelids": ["ZBT-Remote-ALL-RGBW", "tint-Remote-white"],
             "map": [
                 [1, "0x01", "ONOFF", "OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "Off"],
                 [1, "0x01", "ONOFF", "ON", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],

--- a/database.cpp
+++ b/database.cpp
@@ -3375,7 +3375,8 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             {
                 sensor.addItem(DataTypeUInt16, RStateEventDuration);
             }
-            else if (sensor.modelId().startsWith(QLatin1String("ZBT-Remote-ALL-RGBW")))
+            else if (sensor.modelId().startsWith(QLatin1String("ZBT-Remote-ALL-RGBW")) ||
+                     sensor.modelId().startsWith(QLatin1String("tint-Remote-white")))
             {
                 sensor.addItem(DataTypeUInt16, RStateX);
                 sensor.addItem(DataTypeUInt16, RStateY);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -510,6 +510,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_PHILIO, "PST03A-v2.2.5", emberMacPrefix }, // Philio pst03-a
     { VENDOR_EMBERTEC, "BQZ10-AU", embertecMacPrefix }, // Embertec smart plug
     { VENDOR_MUELLER, "ZBT-Remote-ALL-RGBW", jennicMacPrefix }, // Tint remote control
+    { VENDOR_MUELLER, "tint-Remote-white", jennicMacPrefix }, // Tint remote control
     { VENDOR_PLUGWISE_BV, "160-01", emberMacPrefix }, // Plugwise smart plug
     { VENDOR_NIKO_NV, "Smart plug Zigbee PE", silabs9MacPrefix }, // Niko Smart Plug 552-80699
     { VENDOR_ATMEL, "Bell", dishMacPrefix }, // Sage doorbell sensor
@@ -4800,7 +4801,8 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
             Event e(RSensors, REventValidGroup, sensor->id());
             enqueueEvent(e);
         }
-        else if (sensor->modelId().startsWith(QLatin1String("ZBT-Remote-ALL-RGBW")))
+        else if (sensor->modelId().startsWith(QLatin1String("ZBT-Remote-ALL-RGBW")) ||
+                 sensor->modelId().startsWith(QLatin1String("tint-Remote-white")))
         {
             bool changed = true;
             if (gids.length() != 3)
@@ -4996,7 +4998,9 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                     stream >> dataType;
                     stream >> pl3;
 
-                    if (ind.clusterId() == BASIC_CLUSTER_ID && sensor->modelId().startsWith(QLatin1String("ZBT-Remote-ALL-RGBW")))
+                    if (ind.clusterId() == BASIC_CLUSTER_ID &&
+                       (sensor->modelId().startsWith(QLatin1String("ZBT-Remote-ALL-RGBW")) ||
+                        sensor->modelId().startsWith(QLatin1String("tint-Remote-white"))))
                     {
                         ok = attrId == 0x4005 && dataType == deCONZ::Zcl8BitUint && buttonMap.zclParam0 == pl3;
                     }
@@ -5193,7 +5197,8 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                 }
                 else if (ind.clusterId() == COLOR_CLUSTER_ID &&
                          zclFrame.commandId() == 0x07 && zclFrame.payload().size() >= 4 && // Move to Color
-                         sensor->modelId().startsWith(QLatin1String("ZBT-Remote-ALL-RGBW")))
+                         (sensor->modelId().startsWith(QLatin1String("ZBT-Remote-ALL-RGBW")) ||
+                          sensor->modelId().startsWith(QLatin1String("tint-Remote-white"))))
                 {
                     quint16 x;
                     quint16 y;
@@ -5272,7 +5277,8 @@ void DeRestPluginPrivate::checkSensorButtonEvent(Sensor *sensor, const deCONZ::A
                 }
                 else if (ind.clusterId() == COLOR_CLUSTER_ID &&
                          zclFrame.commandId() == 0x0a && zclFrame.payload().size() >= 2 && // Move to Color Temperature
-                         sensor->modelId().startsWith(QLatin1String("ZBT-Remote-ALL-RGBW")))
+                         (sensor->modelId().startsWith(QLatin1String("ZBT-Remote-ALL-RGBW")) ||
+                          sensor->modelId().startsWith(QLatin1String("tint-Remote-white"))))
                 {
                     quint16 ct;
                     QDataStream stream(zclFrame.payload());
@@ -7255,7 +7261,8 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             clusterId = VENDOR_CLUSTER_ID;
             sensorNode.addItem(DataTypeUInt16, RStateEventDuration);
         }
-        else if (modelId.startsWith(QLatin1String("ZBT-Remote-ALL-RGBW")))
+        else if (modelId.startsWith(QLatin1String("ZBT-Remote-ALL-RGBW")) ||
+                 modelId.startsWith(QLatin1String("tint-Remote-white")))
         {
             sensorNode.addItem(DataTypeUInt16, RStateX);
             sensorNode.addItem(DataTypeUInt16, RStateY);


### PR DESCRIPTION
This adds support for the Müller-Licht Tint remote control 404049 as requested in #5841.