### PR TITLE
DDF for Aqara E1 roller shade (lumi.curtain.acn002)

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -2578,10 +2578,6 @@ void DeRestPluginPrivate::checkLightBindingsForAttributeReporting(LightNode *lig
         }
         else if (lightNode->manufacturerCode() == VENDOR_XIAOMI)
         {
-            if (lightNode->modelId().startsWith(QLatin1String("lumi.curtain.acn002")))
-            {
-                return;
-            }
         }
         else if (lightNode->manufacturerCode() == VENDOR_STELPRO)
         {

--- a/database.cpp
+++ b/database.cpp
@@ -3997,10 +3997,6 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             }
             item = sensor.addItem(DataTypeUInt8, RStateBattery);
             item->setValue(100);
-            if (sensor.modelId().startsWith(QLatin1String("lumi.curtain.acn002")))
-            {
-                sensor.addItem(DataTypeBool, RStateCharging);
-            }
         }
         else if (sensor.type() == QLatin1String("CLIPDaylightOffset"))
         {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -286,7 +286,6 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_XIAOMI, "lumi.plug", xiaomiMacPrefix }, // Xiaomi smart plugs (router)
     { VENDOR_XIAOMI, "lumi.switch.b1naus01", xiaomiMacPrefix }, // Xiaomi Aqara ZB3.0 Smart Wall Switch Single Rocker WS-USC03
     // { VENDOR_XIAOMI, "lumi.curtain", jennicMacPrefix}, // Xiaomi curtain controller (router) - exposed only as light
-    { VENDOR_XIAOMI, "lumi.curtain.acn002", lumiMacPrefix}, // Xiaomi roller shade driver E1
     { VENDOR_XIAOMI, "lumi.curtain.hagl04", xiaomiMacPrefix}, // Xiaomi B1 curtain controller
     { VENDOR_XIAOMI, "lumi.remote.cagl01", xiaomiMacPrefix },  // Xiaomi Aqara T1 Cube MFKZQ11LM
     { VENDOR_XIAOMI, "lumi.sensor_magnet.agl02", xiaomiMacPrefix}, // Xiaomi Aqara T1 open/close sensor MCCGQ12LM
@@ -2433,7 +2432,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
     }
     if (node->nodeDescriptor().manufacturerCode() == VENDOR_KEEN_HOME || // Keen Home Vent
         node->nodeDescriptor().manufacturerCode() == VENDOR_JENNIC || // Xiaomi lumi.ctrl_neutral1, lumi.ctrl_neutral2
-        node->nodeDescriptor().manufacturerCode() == VENDOR_XIAOMI || // Xiaomi lumi.curtain.hagl04, lumi.curtain.acn002
+        node->nodeDescriptor().manufacturerCode() == VENDOR_XIAOMI || // Xiaomi lumi.curtain.hagl04
         node->nodeDescriptor().manufacturerCode() == VENDOR_EMBER || // atsmart Z6-03 switch + Heiman plug + Tuya stuff
         (!node->nodeDescriptor().isNull() && node->nodeDescriptor().manufacturerCode() == VENDOR_NONE) || // Climax Siren
         node->nodeDescriptor().manufacturerCode() == VENDOR_DEVELCO || // Develco Smoke sensor with siren
@@ -4085,20 +4084,27 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
             }
             else if (ic->id() == ANALOG_OUTPUT_CLUSTER_ID && (event.clusterId() == ANALOG_OUTPUT_CLUSTER_ID))
             {
-                if (!(lightNode->modelId().startsWith(QLatin1String("lumi.curtain"))))
+                if (!lightNode->modelId().startsWith(QLatin1String("lumi.curtain")))
                 {
                     continue; // ignore except for lumi.curtain
                 }
 
-                std::vector<deCONZ::ZclAttribute>::const_iterator ia = ic->attributes().begin();
-                std::vector<deCONZ::ZclAttribute>::const_iterator enda = ic->attributes().end();
+                auto ia = ic->attributes().cbegin();
+                const auto enda = ic->attributes().cend();
+
                 for (;ia != enda; ++ia)
                 {
                     if (ia->id() == 0x0055) // Present Value
                     {
+                        if (ia->numericValue().real < 0.0f || ia->numericValue().real > 100.0f)
+                        {
+                            // invalid value range
+                            break;
+                        }
+
                         lightNode->setZclValue(updateType, event.endpoint(), event.clusterId(), ia->id(), ia->numericValue());
 
-                        quint8 lift = 100 - ia->numericValue().real;
+                        int lift = 100 - int(ia->numericValue().real);
                         bool open = lift < 100;
                         if (lightNode->setValue(RStateLift, lift))
                         {

--- a/device_ddf_init.cpp
+++ b/device_ddf_init.cpp
@@ -179,6 +179,16 @@ bool DEV_InitDeviceFromDescription(Device *device, const DeviceDescription &ddf)
                 }
             }
 
+            // DDF enforce sub device "type" (enables overwriting the type from C++ code)
+            if (item->descriptor().suffix == RAttrType)
+            {
+                const QString type = DeviceDescriptions::instance()->constantToString(sub.type);
+                if (type != item->toString() && !type.startsWith('$'))
+                {
+                    item->setValue(type);
+                }
+            }
+
             if (item->descriptor().suffix == RConfigGroup)
             {
                 if (item->toString().isEmpty() && !ddfItem.defaultValue.isNull())

--- a/devices/xiaomi/aq_curtain_acn002.json
+++ b/devices/xiaomi/aq_curtain_acn002.json
@@ -1,0 +1,159 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "$MF_LUMI",
+  "modelid": "lumi.curtain.acn002",
+  "vendor": "Aqara",
+  "product": "Roller Shade Driver E1",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_WINDOW_COVERING_DEVICE",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0006", "eval": "Item.val = Attr.val"},
+          "read": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0006"},
+          "refresh.interval": 84000
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert"
+        },
+        {
+          "deprecated": "2022-03-01",
+          "name": "state/bri",
+          "parse": {"fn": "zcl", "cl": "0x000D", "at": "0x0055", "ep": 1, "eval": "if (Attr.val >= 0 && Attr.val <= 100) {Item.val = 254 * (100 - Attr.val) / 100;}"},
+          "read": {"fn": "none"}
+        },
+        {
+          "name": "state/lift",
+          "parse": {"fn": "zcl", "cl": "0x000D", "at": "0x0055", "ep": 1, "eval": "if (Attr.val >= 0 && Attr.val <= 100) {Item.val = 100 - Attr.val;}"},
+          "read": {"fn": "zcl", "cl": "0x000D", "at": "0x0055", "ep": 1},
+          "refresh.interval": 300
+        },
+        {
+          "deprecated": "2022-03-01",
+          "name": "state/on",
+          "parse": {"fn": "zcl", "cl": "0x000D", "at": "0x0055", "ep": 1, "eval": "if (Attr.val >= 0 && Attr.val <= 100) {Item.val = (254 * (100 - Attr.val) / 100) > 0;}"},
+          "read": {"fn": "none"}
+        },
+        {
+          "name": "state/open",
+          "parse": {"fn": "zcl", "cl": "0x000D", "at": "0x0055", "ep": 1, "eval": "if (Attr.val >= 0 && Attr.val <= 100) {Item.val = (100 - Attr.val) < 100;}"},
+          "read": {"fn": "none"}
+        },
+        {
+          "name": "state/reachable"
+        },
+        {
+          "name": "state/speed",
+          "parse": {"fn": "zcl", "cl": "0xFCC0", "at": "0x0408", "ep": 1, "mf": "0x115F", "eval": "Item.val = Attr.val;"},
+          "read": {"fn": "zcl", "cl": "0xFCC0", "at": "0x0408", "ep": 1, "mf": "0x115F"},
+          "refresh.interval": 3600
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_BATTERY_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0xfcc0"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0100",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0xFCC0"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0006", "eval": "Item.val = Attr.val"},
+          "read": {"fn": "none"}
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "config/temperature",
+          "parse": {"fn": "xiaomi:special", "ep": 1, "at": "0x00f7", "idx": "0x03", "eval": "Item.val = Attr.val * 100;"},
+          "read": {"fn": "none"}
+        },
+        {
+          "name": "state/battery",
+          "parse": {"fn": "xiaomi:special", "ep": 1, "at": "0x00f7", "idx": "0x65", "eval": "Item.val = Attr.val;"},
+          "read": {"fn": "none"}
+        },
+        {
+          "name": "state/charging",
+          "parse": {"fn": "xiaomi:special", "ep": 1, "at": "0x00f7", "idx": "0x69", "eval": "Item.val = Attr.val == 1;"},
+          "public": false
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    }
+  ]
+}

--- a/light_node.cpp
+++ b/light_node.cpp
@@ -528,12 +528,6 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
                 // DEV_ID_Z30_ONOFF_PLUGIN_UNIT
                 deviceId = DEV_ID_HA_WINDOW_COVERING_DEVICE;
             }
-            else if (isWindowCovering && manufacturerCode() == VENDOR_XIAOMI && deviceId == DEV_ID_HA_ONOFF_LIGHT) // lumi.curtain.acn002, but modelId hasn't yet been read.
-            {
-                deviceId = DEV_ID_HA_WINDOW_COVERING_DEVICE; // Fix wrong device type.
-                addItem(DataTypeString, RStateAlert); // Supports Identify.
-                addItem(DataTypeUInt8, RStateSpeed); // Motor speed setting.
-            }
 
             switch (deviceId)
             {

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1541,7 +1541,8 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
     quint8 targetSpeed = 0;
 
     // Check parameters.
-    for (QVariantMap::const_iterator p = map.begin(); p != map.end(); p++)
+    const auto mapEnd = map.cend();
+    for (auto p = map.cbegin(); p != mapEnd; ++p)
     {
         bool paramOk = false;
         bool valueOk = false;

--- a/xiaomi.cpp
+++ b/xiaomi.cpp
@@ -687,7 +687,7 @@ void DeRestPluginPrivate::handleZclAttributeReportIndicationXiaomiSpecial(const 
 
                 item->setValue(quint8(bat));
                 enqueueEvent(Event(RSensors, RConfigBattery, sensor.id(), item));
-                q_ptr->nodeUpdated(sensor.address().ext(), QLatin1String(item->descriptor().suffix), QString::number(bat));
+                emit q_ptr->nodeUpdated(sensor.address().ext(), QLatin1String(item->descriptor().suffix), QString::number(bat));
 
                 if (item->lastSet() == item->lastChanged())
                 {
@@ -703,7 +703,7 @@ void DeRestPluginPrivate::handleZclAttributeReportIndicationXiaomiSpecial(const 
             {
                 item->setValue(charging == 1);
                 enqueueEvent(Event(RSensors, RStateCharging, sensor.id(), item));
-                q_ptr->nodeUpdated(sensor.address().ext(), QLatin1String(item->descriptor().suffix), QString::number(charging));
+                emit q_ptr->nodeUpdated(sensor.address().ext(), QLatin1String(item->descriptor().suffix), QString::number(charging));
                 sensor.updateStateTimestamp();
                 if (item->lastSet() == item->lastChanged())
                 {


### PR DESCRIPTION
Followup for the C++ implementation in PR https://github.com/dresden-elektronik/deconz-rest-plugin/pull/5619 , Issue https://github.com/dresden-elektronik/deconz-rest-plugin/issues/5330

The PR replaces a few hard coded parts in C++ with DDF mechanics.

The ZHABattery `config.temperature` value is way off, and reports 37°C in my setup :) perhaps we should ditch it?

Starting with this PR the sub resource "type" attribute will overwrite the one given by the C++ implementation, like here "Dimmable light" is replaces with "Window covering", this might be handy for other devices as well.
