### PR TITLE
DDF support Tuya manufacturer specific cluster

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1323,7 +1323,7 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
 
         case TUYA_CLUSTER_ID:
             // Tuya manfacture cluster:
-            handleTuyaClusterIndication(ind, zclFrame);
+            handleTuyaClusterIndication(ind, zclFrame, device);
             break;
 
         case THERMOSTAT_CLUSTER_ID:

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1600,7 +1600,7 @@ public:
     void handleBasicClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void sendBasicClusterResponse(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handlePhilipsClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame, Device *device);
-    void handleTuyaClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
+    void handleTuyaClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame, Device *device);
     void handleZclAttributeReportIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleZclConfigureReportingResponseIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void taskToLocalData(const TaskItem &task);

--- a/device_access_fn.cpp
+++ b/device_access_fn.cpp
@@ -15,6 +15,97 @@
 #include "resource.h"
 #include "zcl/zcl.h"
 
+/*
+    Documentation for manufacturer specific Tuya cluster (0xEF00)
+
+        https://developer.tuya.com/en/docs/iot-device-dev/tuya-zigbee-universal-docking-access-standard?id=K9ik6zvofpzql
+
+    Tuya ZCL insights
+
+        https://github.com/TuyaInc/tuya_zigbee_sdk/blob/master/silicon_labs_zigbee/include/zigbee_attr.h
+
+    Basic cluster (0x0000)
+    -------------
+
+    0x0001 Application version:: 0b 01 00 0001 = 1.0.1 ie 0x41 for 1.0.1
+
+    0x0004 Manufacturer name:  XXX…XXX (16 bytes in length, consisting of an 8-byte prefix and an 8-byte PID)
+                               0-7 bytes: _ TZE600_
+                               8-16 bytes: PID (created and provided by the product manager in the platform or self-service)
+
+    Tuya cluster (0xEF00)
+    ---------------------
+
+    https://developer.tuya.com/en/docs/iot-device-dev/tuya-zigbee-universal-docking-access-standard?id=K9ik6zvofpzql
+
+    Zigbee generic docking is suitable for scenarios where the Zigbee standard protocol is not supported or not very suitable.
+
+    ZDP Simple Descriptor Device Id (0x0051)
+
+    Frame control for outgoing commands:
+
+        deCONZ::ZclFCClusterCommand
+        deCONZ::ZclFCDirectionClientToServer
+        deCONZ::ZclFCDisableDefaultResponse
+
+    DP data format
+    --------------
+
+    DPID  U8        Datapoint serial number
+    Type  U8        Datatype in value
+
+          Name  Id   Length
+          ------------------------------
+          raw     0x00
+          bool    0x01
+          value   0x02
+          string  0x03
+          enum    0x04
+          bitmap  0x05
+
+    Length U16      Length of Value
+    Value  1/2/4/N  The value as big endian
+
+
+    ZCL Payload of comamnds
+    -----------------------
+
+    Example MoesGo switch TY_DATA_REPORT
+
+    00 4c        sequence number
+    02           DPID
+    02           Type: Value
+    00 04        Length: 4
+    00 00 00 15
+
+*/
+#define TUYA_CLUSTER_ID 0xEF00
+
+enum TuyaCommandId : unsigned char
+{
+    TY_DATA_REQUEST              = 0x00,
+    TY_DATA_RESPONSE             = 0x01,
+    TY_DATA_REPORT               = 0x02,
+    TY_DATA_QUERY                = 0x03,
+    TUYA_MCU_VERSION_REQ         = 0x10,
+    TUYA_MCU_VERSION_RSP         = 0x11,
+    TUYA_MCU_OTA_NOTIFY          = 0x12,
+    TUYA_MCU_OTA_BLOCK_DATA_REQ  = 0x13,
+    TUYA_MCU_OTA_BLOCK_DATA_RSP  = 0x14,
+    TUYA_MCU_OTA_RESULT          = 0x15,
+    TUYA_MCU_SYNC_TIME           = 0x24
+};
+
+enum TuyaDataType : unsigned char
+{
+    TuyaDataTypeRaw              = 0x00,
+    TuyaDataTypeBool             = 0x01,
+    TuyaDataTypeValue            = 0x02,
+    TuyaDataTypeString           = 0x03,
+    TuyaDataTypeEnum             = 0x04,
+    TuyaDataTypeBitmap           = 0x05
+};
+
 enum DA_Constants
 {
     BroadcastEndpoint = 255, //! Accept incoming commands from any endpoint.
@@ -480,6 +571,394 @@ bool parseZclAttribute(Resource *r, ResourceItem *item, const deCONZ::ApsDataInd
             result = true;
         }
     }
+
+    return result;
+}
+
+/*! A generic function to parse Tuya private cluster values from response/report commands.
+    The item->parseParameters() is expected to be an object (given in the device description file).
+
+    {"fn": "tuya", "dpid": datapointId, "eval": expression}
+
+    - datapointId: 1-255 the datapoint identifier (DPID) to extract
+    - expression: Javascript expression to transform the raw value
+
+    Example: { "parse": {"fn": "tuya", "dpid:" 1, "eval": "Attr.val + R.item('config/offset').val" } }
+ */
+bool parseTuyaData(Resource *r, ResourceItem *item, const deCONZ::ApsDataIndication &ind, const deCONZ::ZclFrame &zclFrame, const QVariant &parseParameters)
+{
+    bool result = false;
+
+    if (ind.clusterId() != TUYA_CLUSTER_ID || !(zclFrame.commandId() == TY_DATA_REPORT || zclFrame.commandId() ==  TY_DATA_RESPONSE))
+    {
+        return result;
+    }
+
+    if (!item->parseFunction()) // init on first call
+    {
+        const auto map = parseParameters.toMap();
+        if (map.isEmpty())
+        {
+            return result;
+        }
+
+        if (!map.contains(QLatin1String("dpid")) || !map.contains(QLatin1String("eval")))
+        {
+            return result;
+        }
+
+        bool ok = false;
+        ZCL_Param param{};
+        param.attributes[0] = variantToUint(map.value(QLatin1String("dpid")), 255, &ok);
+        if (!ok)
+        {
+            return result;
+        }
+        param.valid = 1;
+        param.endpoint = ind.srcEndpoint();
+        param.clusterId = ind.clusterId();
+        param.attributeCount = 1;
+
+        item->setParseFunction(parseTuyaData);
+        item->setZclProperties(param);
+    }
+
+    quint16 seq;
+    quint8 dpid;
+    quint8 dataType;
+    quint16 dataLength;
+    quint8 zclDataType = 0;
+    const auto &zclParam = item->zclParam();
+
+    QDataStream stream(zclFrame.payload());
+    stream.setByteOrder(QDataStream::BigEndian); // tuya is big endian!
+
+    stream >> seq;
+
+    while (!stream.atEnd()) // a message can contain multiple datapoints
+    {
+        stream >> dpid;
+        stream >> dataType;
+        stream >> dataLength;
+
+        if (stream.status() != QDataStream::Ok)
+        {
+            return result;
+        }
+
+        deCONZ::NumericUnion num{0};
+
+        switch (dataType)
+        {
+        case TuyaDataTypeRaw:
+        case TuyaDataTypeString:
+            return result; // TODO implement?
+
+        case TuyaDataTypeBool:
+        { stream >> num.u8; zclDataType = deCONZ::ZclBoolean; }
+            break;
+
+        case TuyaDataTypeEnum:
+        { stream >> num.u8; zclDataType = deCONZ::Zcl8BitEnum; }
+            break;
+
+        case TuyaDataTypeValue: // docs aren't clear, assume signed
+        {  stream >> num.s32; zclDataType = deCONZ::Zcl32BitInt; }
+            break;
+
+        case TuyaDataTypeBitmap:
+        {
+            switch (dataLength)
+            {
+            case 1: { stream >> num.u8;  zclDataType = deCONZ::Zcl8BitBitMap; } break;
+            case 2: { stream >> num.u16; zclDataType = deCONZ::Zcl16BitBitMap; } break;
+            case 4: { stream >> num.u32; zclDataType = deCONZ::Zcl32BitBitMap; } break;
+            }
+        }
+            break;
+
+        default:
+            return result; // unkown datatype
+        }
+
+        if (dpid == zclParam.attributes[0])
+        {
+            // map datapoint into ZCL attribute
+            deCONZ::ZclAttribute attr(dpid, zclDataType, QLatin1String(""), deCONZ::ZclReadWrite, true);
+            attr.setNumericValue(num);
+
+            if (evalZclAttribute(r, item, ind, zclFrame, attr, parseParameters))
+            {
+                item->setLastZclReport(deCONZ::steadyTimeRef().ref);
+                result = true;
+            }
+        }
+
+        const char *rt = zclFrame.commandId() == TY_DATA_REPORT ? "REPORT" : "RESPONSE";
+
+        DBG_Printf(DBG_INFO, "TY_DATA_%s: seq %u, dpid: 0x%02X, type: 0x%02X, length: %u, val: %d\n",
+                   rt, seq, dpid, dataType, dataLength, num.s32);
+    }
+
+    return result;
+}
+
+/*! A generic function to trigger Tuya device reporting all datapoints.
+    Important: This function should be attached to only one item!
+    The item->readParameters() is expected to be an object (given in the device description file).
+
+    { "fn": "tuya"}
+
+    Example: { "read": {"fn": "tuya"} }
+ */
+static DA_ReadResult readTuyaAllData(const Resource *r, const ResourceItem *item, deCONZ::ApsController *apsCtrl, const QVariant &readParameters)
+{
+    Q_UNUSED(item)
+    Q_UNUSED(readParameters);
+
+    DA_ReadResult result{};
+
+    // Workaround: dont't query too quickly, reports will only be send a few seconds after receiving the query command.
+    // The device report timer resets on each received query.
+    // Not the ideal solution since this is global across all devices but should do the trick for now.
+    static deCONZ::SteadyTimeRef lastReadGlobal{};
+
+    auto now = deCONZ::steadyTimeRef();
+    if (now - lastReadGlobal < deCONZ::TimeSeconds{15})
+    {
+        return result;
+    }
+
+    lastReadGlobal = now;
+
+    auto *rTop = r->parentResource() ? r->parentResource() : r;
+
+    const auto *extAddr = rTop->item(RAttrExtAddress);
+    const auto *nwkAddr = rTop->item(RAttrNwkAddress);
+
+    if (!extAddr || !nwkAddr)
+    {
+        return result;
+    }
+
+    deCONZ::ApsDataRequest req;
+    deCONZ::ZclFrame zclFrame;
+
+    req.setDstEndpoint(1); // TODO is this always 1? if not search simple descriptor for Tuya cluster
+    req.setTxOptions(deCONZ::ApsTxAcknowledgedTransmission);
+    req.setDstAddressMode(deCONZ::ApsNwkAddress);
+    req.dstAddress().setNwk(nwkAddr->toNumber());
+    req.dstAddress().setExt(extAddr->toNumber());
+    req.setClusterId(TUYA_CLUSTER_ID);
+    req.setProfileId(HA_PROFILE_ID);
+    req.setSrcEndpoint(1); // TODO
+
+    zclFrame.setSequenceNumber(zclNextSequenceNumber());
+    zclFrame.setCommandId(TY_DATA_QUERY);
+
+    zclFrame.setFrameControl(deCONZ::ZclFCClusterCommand |
+                             deCONZ::ZclFCDirectionClientToServer |
+                             deCONZ::ZclFCDisableDefaultResponse);
+
+    // no payload
+
+    { // ZCL frame
+        QDataStream stream(&req.asdu(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+        zclFrame.writeToStream(stream);
+    }
+
+    result.isEnqueued = apsCtrl->apsdeDataRequest(req) == deCONZ::Success;
+    result.apsReqId = req.id();
+    result.sequenceNumber = zclFrame.sequenceNumber();
+
+    return result;
+}
+
+/*! A generic function to write Tuya data.
+    The \p writeParameters is expected to contain one object (given in the device description file).
+
+    { "fn": "tuya", "dpid": datapointId, "dt": dataType, "eval": expression }
+
+    - datapointId: number
+    - dataType: string hex value
+
+          bool           0x10
+          s32 value      0x2b
+          enum           0x30
+          8-bit bitmap   0x18
+          16-bit bitmap  0x19
+          32-bit bitmap  0x1b
+
+    - expression: to transform the item value
+
+    Example: "write": {"fn":"tuya", "dpid": 1,  "dt": "0x10", "eval": "Item.val == 1"}
+ */
+bool writeTuyaData(const Resource *r, const ResourceItem *item, deCONZ::ApsController *apsCtrl, const QVariant &writeParameters)
+{
+    Q_ASSERT(r);
+    Q_ASSERT(item);
+    Q_ASSERT(apsCtrl);
+
+    bool result = false;
+    const auto rParent = r->parentResource() ? r->parentResource() : r;
+    const auto *extAddr = rParent->item(RAttrExtAddress);
+    const auto *nwkAddr = rParent->item(RAttrNwkAddress);
+
+    if (!extAddr || !nwkAddr)
+    {
+        return result;
+    }
+
+    const auto map = writeParameters.toMap();
+
+    if (!map.contains(QLatin1String("dpid")) || !map.contains(QLatin1String("dt")) || !map.contains(QLatin1String("eval")))
+    {
+        return result;
+    }
+
+    bool ok = false;
+
+    const auto dpid = variantToUint(map.value(QLatin1String("dpid")), 255, &ok);
+    if (!ok)
+    {
+        return result;
+    }
+    const auto dataType = variantToUint(map.value("dt"), UINT8_MAX, &ok);
+    switch (dataType)
+    {
+    case deCONZ::ZclBoolean:
+    case deCONZ::Zcl32BitInt:
+    case deCONZ::Zcl8BitEnum:
+    case deCONZ::Zcl8BitBitMap:
+    case deCONZ::Zcl16BitBitMap:
+    case deCONZ::Zcl32BitBitMap:
+        break;
+
+    default:
+        return result; // unsupported datatype
+    }
+
+    const auto expr = map.value("eval").toString();
+
+    if (!ok || expr.isEmpty())
+    {
+        return result;
+    }
+
+    DBG_Printf(DBG_INFO, "writeTuyaData, dpid: 0x%02X, type: 0x%02X, expr: %s\n",
+               dpid & 0xFF, dataType & 0xFF, qPrintable(expr));
+
+    deCONZ::ApsDataRequest req;
+    deCONZ::ZclFrame zclFrame;
+
+    req.setDstEndpoint(1); // TODO is this always 1? if not search simple descriptor for Tuya cluster
+    req.setTxOptions(deCONZ::ApsTxAcknowledgedTransmission);
+    req.setDstAddressMode(deCONZ::ApsNwkAddress);
+    req.dstAddress().setNwk(nwkAddr->toNumber());
+    req.dstAddress().setExt(extAddr->toNumber());
+    req.setClusterId(TUYA_CLUSTER_ID);
+    req.setProfileId(HA_PROFILE_ID);
+    req.setSrcEndpoint(1); // TODO
+
+    zclFrame.setSequenceNumber(zclNextSequenceNumber());
+    zclFrame.setCommandId(TY_DATA_REQUEST);
+
+    zclFrame.setFrameControl(deCONZ::ZclFCClusterCommand |
+                             deCONZ::ZclFCDirectionClientToServer |
+                             deCONZ::ZclFCDisableDefaultResponse);
+
+
+    { // payload
+        QVariant value;
+        DeviceJs engine;
+        engine.setResource(r);
+        engine.setItem(item);
+
+        if (engine.evaluate(expr) == JsEvalResult::Ok)
+        {
+            value = engine.result();
+            DBG_Printf(DBG_INFO, "Tuya write expression: %s --> %s\n", qPrintable(expr), qPrintable(value.toString()));
+        }
+        else
+        {
+            DBG_Printf(DBG_INFO, "failed to evaluate Tuya write expression for %s/%s: %s, err: %s\n", qPrintable(r->item(RAttrUniqueId)->toString()), item->descriptor().suffix, qPrintable(expr), qPrintable(engine.errorString()));
+            return result;
+        }
+
+        if (!value.isValid())
+        {
+            return result;
+        }
+
+        QDataStream stream(&zclFrame.payload(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::BigEndian); // Tuya is big endian
+
+        stream << quint16(req.id()); // use as sequence number
+        stream << quint8(dpid);
+
+        switch (dataType)
+        {
+        case deCONZ::ZclBoolean:
+        {
+            stream << quint8(TuyaDataTypeBool);
+            stream << quint16(1); // length
+            stream << quint8(value.toUInt());
+        }
+            break;
+
+        case deCONZ::Zcl32BitInt:
+        {
+            stream << quint8(TuyaDataTypeValue);
+            stream << quint16(4); // length
+            stream << qint32(value.toInt());
+        }
+            break;
+
+        case deCONZ::Zcl8BitEnum:
+        {
+            stream << quint8(TuyaDataTypeEnum);
+            stream << quint16(1); // length
+            stream << quint8(value.toUInt());
+        }
+            break;
+
+        case deCONZ::Zcl8BitBitMap:
+        {
+            stream << quint8(TuyaDataTypeBitmap);
+            stream << quint16(1); // length
+            stream << quint8(value.toUInt());
+        }
+            break;
+
+        case deCONZ::Zcl16BitBitMap:
+        {
+            stream << quint8(TuyaDataTypeBitmap);
+            stream << quint16(2); // length
+            stream << quint16(value.toUInt());
+        }
+            break;
+
+        case deCONZ::Zcl32BitBitMap:
+        {
+            stream << quint8(TuyaDataTypeBitmap);
+            stream << quint16(4); // length
+            stream << quint32(value.toUInt());
+        }
+            break;
+
+        default: // TODO unsupported datatype
+            return result;
+        }
+    }
+
+    { // ZCL frame
+        QDataStream stream(&req.asdu(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+        zclFrame.writeToStream(stream);
+    }
+
+    result = apsCtrl->apsdeDataRequest(req) == deCONZ::Success;
 
     return result;
 }
@@ -1013,12 +1492,13 @@ ParseFunction_t DA_GetParseFunction(const QVariant &params)
 {
     ParseFunction_t result = nullptr;
 
-    const std::array<ParseFunction, 4> functions =
+    const std::array<ParseFunction, 5> functions =
     {
-        ParseFunction("zcl", 1, parseZclAttribute),
-        ParseFunction("xiaomi:special", 1, parseXiaomiSpecial),
-        ParseFunction("ias:zonestatus", 1, parseIasZoneNotificationAndStatus),
-        ParseFunction("numtostr", 1, parseNumericToString)
+        ParseFunction(QLatin1String("zcl"), 1, parseZclAttribute),
+        ParseFunction(QLatin1String("xiaomi:special"), 1, parseXiaomiSpecial),
+        ParseFunction(QLatin1String("ias:zonestatus"), 1, parseIasZoneNotificationAndStatus),
+        ParseFunction(QLatin1String("tuya"), 1, parseTuyaData),
+        ParseFunction(QLatin1String("numtostr"), 1, parseNumericToString)
     };
 
     QString fnName;
@@ -1028,13 +1508,13 @@ ParseFunction_t DA_GetParseFunction(const QVariant &params)
         const auto params1 = params.toMap();
         if (params1.isEmpty())
         {  }
-        else if (params1.contains("fn"))
+        else if (params1.contains(QLatin1String("fn")))
         {
             fnName = params1["fn"].toString();
         }
         else
         {
-            fnName = "zcl"; // default
+            fnName = QLatin1String("zcl"); // default
         }
     }
 
@@ -1054,9 +1534,10 @@ ReadFunction_t DA_GetReadFunction(const QVariant &params)
 {
     ReadFunction_t result = nullptr;
 
-    const std::array<ReadFunction, 1> functions =
+    const std::array<ReadFunction, 2> functions =
     {
-        ReadFunction("zcl", 1, readZclAttribute)
+        ReadFunction(QLatin1String("zcl"), 1, readZclAttribute),
+        ReadFunction(QLatin1String("tuya"), 1, readTuyaAllData)
     };
 
     QString fnName;
@@ -1066,13 +1547,13 @@ ReadFunction_t DA_GetReadFunction(const QVariant &params)
         const auto params1 = params.toMap();
         if (params1.isEmpty())
         {  }
-        else if (params1.contains("fn"))
+        else if (params1.contains(QLatin1String("fn")))
         {
             fnName = params1["fn"].toString();
         }
         else
         {
-            fnName = "zcl"; // default
+            fnName = QLatin1String("zcl"); // default
         }
     }
 
@@ -1092,9 +1573,10 @@ WriteFunction_t DA_GetWriteFunction(const QVariant &params)
 {
     WriteFunction_t result = nullptr;
 
-    const std::array<WriteFunction, 1> functions =
+    const std::array<WriteFunction, 2> functions =
     {
-        WriteFunction("zcl", 1, writeZclAttribute)
+        WriteFunction(QLatin1String("zcl"), 1, writeZclAttribute),
+        WriteFunction(QLatin1String("tuya"), 1, writeTuyaData)
     };
 
     QString fnName;
@@ -1104,13 +1586,13 @@ WriteFunction_t DA_GetWriteFunction(const QVariant &params)
         const auto params1 = params.toMap();
         if (params1.isEmpty())
         {  }
-        else if (params1.contains("fn"))
+        else if (params1.contains(QLatin1String("fn")))
         {
             fnName = params1["fn"].toString();
         }
         else
         {
-            fnName = "zcl"; // default
+            fnName = QLatin1String("zcl"); // default
         }
     }
 

--- a/device_access_fn.h
+++ b/device_access_fn.h
@@ -35,6 +35,8 @@ typedef bool (*ParseFunction_t)(Resource *r, ResourceItem *item, const deCONZ::A
 typedef DA_ReadResult (*ReadFunction_t)(const Resource *r, const ResourceItem *item, deCONZ::ApsController *apsCtrl, const QVariant &readParameters);
 typedef bool (*WriteFunction_t)(const Resource *r, const ResourceItem *item, deCONZ::ApsController *apsCtrl, const QVariant &writeParameters);
 
+// temporary expose parseTuyaData for check in tuya.cpp
+bool parseTuyaData(Resource *r, ResourceItem *item, const deCONZ::ApsDataIndication &ind, const deCONZ::ZclFrame &zclFrame, const QVariant &parseParameters);
 ParseFunction_t DA_GetParseFunction(const QVariant &params);
 ReadFunction_t DA_GetReadFunction(const QVariant &params);
 WriteFunction_t DA_GetWriteFunction(const QVariant &params);

--- a/device_descriptions.cpp
+++ b/device_descriptions.cpp
@@ -315,6 +315,53 @@ DeviceDescriptions::DeviceDescriptions(QObject *parent) :
 
         d_ptr2->parseFunctions.push_back(fn);
     }
+
+    {
+        DDF_FunctionDescriptor fn;
+        fn.name = "tuya";
+        fn.description = "Generic function to read all Tuya datapoints. It has no parameters.";
+        d_ptr2->readFunctions.push_back(fn);
+    }
+
+    {
+        DDF_FunctionDescriptor fn;
+        fn.name = "tuya";
+        fn.description = "Generic function to parse Tuya data.";
+
+        DDF_FunctionDescriptor::Parameter param;
+
+        param.name = "Datapoint";
+        param.key = "dpid";
+        param.description = "1-255 the datapoint ID.";
+        param.dataType = DataTypeUInt8;
+        param.defaultValue = 0;
+        param.isOptional = 0;
+        param.isHexString = 0;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Javascript file";
+        param.key = "script";
+        param.description = "Relative path of a Javascript .js file.";
+        param.dataType = DataTypeString;
+        param.defaultValue = {};
+        param.isOptional = 1;
+        param.isHexString = 0;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Expression";
+        param.key = "eval";
+        param.description = "Javascript expression to transform the raw value.";
+        param.dataType = DataTypeString;
+        param.defaultValue = QLatin1String("Item.val = Attr.val");
+        param.isOptional = 1;
+        param.isHexString = 0;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        d_ptr2->parseFunctions.push_back(fn);
+    }
 }
 
 /*! Destructor. */

--- a/general.xml
+++ b/general.xml
@@ -187,6 +187,7 @@
 				<description>Set to 0x22 (0xFE) to connect (disconnect) the left button to (from) the relay.</description>
 			</attribute>
 			<!-- <attribute id="0xff0d" name="Xiaomi Sensitivity" type="u8" access="rw" required="o" mfcode="0x1037"></attribute> -->
+			<attribute id="0xfffd" name="Cluster Revision" type="u16" default="0" access="rw" required="o"></attribute>
 		</attribute-set>
 		<attribute-set id="0x0010" description="Basic Device Settings">
 			<attribute id="0x0010" name="Location Description" type="cstring" range="0,16" access="rw" required="o"></attribute>
@@ -266,7 +267,12 @@
 			<attribute id="0xFF54" name="Unknown" type="ostring" access="rw" required="o" mfcode="0x115f"></attribute>
 			<attribute id="0xFFF0" name="Unknown" type="ostring" access="rw" required="o" mfcode="0x115f"></attribute>
 		</attribute-set>
-		<attribute id="0xfffd" name="Cluster Revision" type="u16" default="0" access="rw" required="o"></attribute>
+		<attribute-set id="0xFF00" description="Tuya specific" mfcode="0x1002">
+			<attribute id="0xffde" name="Reporting1" type="u8" default="0" access="rw" required="o"></attribute>
+			<attribute id="0xffe2" name="Unknown1" type="u8" default="0" access="rw" required="o"></attribute>
+			<attribute id="0xffe4" name="Unknown2" type="u8" default="0" access="rw" required="o"></attribute>
+			<attribute id="0xfffe" name="Unknown3" type="enum8" default="0" access="rw" required="o"></attribute>
+		</attribute-set>
 		<command id="00" dir="recv" name="Reset to Factory Defaults" required="o"></command>
 		</server>
 		<client>
@@ -3919,21 +3925,30 @@ devices can operate on either battery or mains power, and can have a wide variet
     </cluster>
 
 		<!-- Tuya -->
-		<cluster id="0xef00" name="Tuya specific Cluster" mfcode="0x1002">
+		<cluster id="0xef00" name="Tuya specific" mfcode="0x1002">
 			<description>Tuya Specific clusters.</description>
 			<server>
+				<command id="00" dir="recv" name="Data Request" required="m">
+					<description>Request datapoint (fields are big-endian!)</description>
+					<payload>
+						<attribute id="0x0000" type="u16" name="Sequence number" required="m" showas="hex" default="0"></attribute>
+						<attribute id="0x0001" type="u8" name="DPID" required="m" showas="hex" default="0x00"></attribute>
+						<attribute id="0x0002" type="enum8" name="Type" required="m" showas="hex" default="0x00">
+							<value name="Raw" value="0x00"/>
+							<value name="Bool" value="0x01"/>
+							<value name="Value" value="0x02"/>
+							<value name="String" value="0x03"/>
+							<value name="Enum" value="0x04"/>
+							<value name="Bitmap" value="0x05"/>
+						</attribute>
+						<attribute id="0x0003" type="u16" name="Length" required="m" showas="hex" default="0x00"></attribute>
+						<attribute id="0x0004" type="u32" name="Value" required="m" showas="hex" default="0"></attribute>
+					</payload>
+				</command>
 
-			<command id="00" dir="recv" name="Unknow" required="m">
-				<description>Command</description>
-				<payload>
-					<attribute id="0x0000" type="u8" name="Status" required="m" showas="hex" default="0x00"></attribute>
-					<attribute id="0x0001" type="u8" name="TransID" required="m" showas="hex" default="0x00"></attribute>
-					<attribute id="0x0002" type="u16" name="Dp" required="m" showas="hex" default="0x0000"></attribute>
-					<attribute id="0x0003" type="u8" name="fn" required="m" showas="hex" default="0x00"></attribute>
-					<attribute id="0x0004" type="ostring" name="data" required="m" default="1,0x0000"></attribute>
-				</payload>
-			</command>
-
+				<command id="0x03" dir="recv" name="Data Query" required="m">
+					<description>Trigger report all datapoints.</description>
+				</command>
 			</server>
 			<client>
 			</client>

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -15,6 +15,7 @@
 #include <QVariantMap>
 #include "de_web_plugin.h"
 #include "de_web_plugin_private.h"
+#include "device_descriptions.h"
 #include "json.h"
 #include "connectivity.h"
 #include "colorspace.h"
@@ -487,6 +488,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         return REQ_READY_SEND;
     }
 
+    Device *device = static_cast<Device*>(taskRef.lightNode->parentResource());
     rsp.httpStatus = HttpStatusOk;
 
     if (!taskRef.lightNode->isAvailable())
@@ -535,6 +537,10 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         }
         // light, don't use tuya stuff (for the moment)
         else if (taskRef.lightNode->item(RStateColorMode))
+        {
+        }
+        // handle by device code
+        else if (device && device->managed())
         {
         }
         //switch and siren
@@ -931,15 +937,6 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
                     ? ONOFF_COMMAND_ON_WITH_TIMED_OFF
                     : ONOFF_COMMAND_ON;
             ok = addTaskSetOnOff(task, cmd, taskRef.onTime, 0);
-
-            StateChange change(StateChange::StateWaitSync, SC_SetOnOff, task.req.dstEndpoint());
-            change.addTargetValue(RStateOn, 0x01);
-            change.addParameter(QLatin1String("cmd"), cmd);
-            if (cmd == ONOFF_COMMAND_ON_WITH_TIMED_OFF)
-            {
-                change.addParameter(QLatin1String("ontime"), taskRef.onTime);
-            }
-            taskRef.lightNode->addStateChange(change);
         }
 
         if (ok)
@@ -1453,11 +1450,6 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
                     ? ONOFF_COMMAND_OFF_WITH_EFFECT
                     : ONOFF_COMMAND_OFF;
             ok = addTaskSetOnOff(task, cmd, 0, 0);
-
-            StateChange change(StateChange::StateWaitSync, SC_SetOnOff, task.req.dstEndpoint());
-            change.addTargetValue(RStateOn, 0x00);
-            change.addParameter(QLatin1String("cmd"), cmd);
-            taskRef.lightNode->addStateChange(change);
         }
 
         if (ok)

--- a/state_change.cpp
+++ b/state_change.cpp
@@ -188,6 +188,22 @@ void StateChange::addParameter(const QString &name, const QVariant &value)
     }
 }
 
+bool StateChange::operator==(const StateChange &other) const
+{
+     if (m_changeFunction == other.m_changeFunction && m_items.size() == other.m_items.size())
+     {
+         for (size_t i = 0; i < m_items.size(); i++)
+         {
+             if (m_items[i].suffix != other.m_items[i].suffix)
+             {
+                 return false;
+             }
+         }
+         return true;
+     }
+     return false;
+}
+
 /*! Calls the ZCL write function of item(s) to write target value(s).
 
     \returns 0 - if the command has been enqueued, or a negative number on failure.

--- a/state_change.h
+++ b/state_change.h
@@ -109,7 +109,7 @@ public:
     void verifyItemChange(const ResourceItem *item);
     void addTargetValue(const char *suffix, const QVariant &value);
     void addParameter(const QString &name, const QVariant &value);
-    bool operator==(const StateChange &other) const { return m_changeFunction == other.m_changeFunction; }
+    bool operator==(const StateChange &other) const;
     const std::vector<Item> &items() const { return m_items; }
     const std::vector<Param> &parameters() const { return m_parameters; }
     quint8 dstEndpoint() const { return m_dstEndpoint; }

--- a/tuya.cpp
+++ b/tuya.cpp
@@ -77,7 +77,6 @@ bool UseTuyaCluster(const QString &manufacturer)
     return false;
 }
 
-
 /*! Handle packets related to Tuya 0xEF00 cluster.
     \param ind the APS level data indication containing the ZCL packet
     \param zclFrame the actual ZCL frame which holds the scene cluster reponse
@@ -85,11 +84,20 @@ bool UseTuyaCluster(const QString &manufacturer)
     Taken from https://medium.com/@dzegarra/zigbee2mqtt-how-to-add-support-for-a-new-tuya-based-device-part-2-5492707e882d
  */
 
-void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame)
+void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame, Device *device)
 {
     if (zclFrame.isDefaultResponse())
     {
         return;
+    }
+
+    // Note(mpi) DDF devices that aren't using {"parse": "fn": "tuya"} might have troubles here?
+    if (device && device->managed())
+    {
+        if (zclFrame.commandId() != TUYA_TIME_SYNCHRONISATION)
+        {
+            return;
+        }
     }
 
     bool update = false;
@@ -1480,12 +1488,13 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
     {
         DBG_Printf(DBG_INFO, "Tuya debug 1 : Time sync request\n");
 
-        QDataStream stream(zclFrame.payload());
-        stream.setByteOrder(QDataStream::LittleEndian);
+        quint16 seqno;
 
-        quint16 unknowHeader;
-
-        stream >> unknowHeader;
+        {
+            QDataStream stream(zclFrame.payload());
+            stream.setByteOrder(QDataStream::BigEndian);
+            stream >> seqno;
+        }
 
         // This is disabled for the moment, need investigations
         // It seem some device send a UnknowHeader = 0x0000
@@ -1507,19 +1516,12 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
         getTime(&timeNow, &timeZone, &timeDstStart, &timeDstEnd, &timeDstShift, &timeStdTime, &timeLocalTime, UNIX_EPOCH);
         
         QByteArray data;
-        QDataStream stream2(&data, QIODevice::WriteOnly);
-        stream2.setByteOrder(QDataStream::LittleEndian);
-        
-        //Add the "magic value"
-        stream2 << unknowHeader;
-        
-        //change byter order
-        stream2.setByteOrder(QDataStream::BigEndian);
-        
-         // Add UTC time
-        stream2 << timeNow;
-        // Ad local time
-        stream2 << timeLocalTime;
+        QDataStream stream(&data, QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::BigEndian);
+
+        stream << seqno;
+        stream << timeNow;       // UTC time
+        stream << timeLocalTime; // local time
 
         sendTuyaCommand(ind, TUYA_TIME_SYNCHRONISATION, data);
 
@@ -1639,14 +1641,16 @@ bool DeRestPluginPrivate::sendTuyaRequest(TaskItem &taskRef, TaskType taskType, 
 
     // payload
     QDataStream stream(&task.zclFrame.payload(), QIODevice::WriteOnly);
-    stream.setByteOrder(QDataStream::LittleEndian);
+    stream.setByteOrder(QDataStream::LittleEndian); // TODO(mpi): should be big endian for Tuya
 
     stream << static_cast<qint8>(0x00);          // Status always 0x00
     stream << static_cast<qint8>(seq);           // TransID, use seq
     stream << static_cast<qint8>(Dp_identifier); // Dp_indentifier
     stream << static_cast<qint8>(Dp_type);       // Dp_type
+    // TODO(mpi): there is no Fn field, length is 16-bit and big endian, that's why the first byte is always 0x00
     stream << static_cast<qint8>(0x00);          // Fn, always 0
     // Data
+    // TODO(mpi): we should replace QByteArray data with int and write data and length according Dp_type
     stream << static_cast<qint8>(data.length()); // length (can be 0 for Dp_identifier = enums)
     for (int i = 0; i < data.length(); i++)
     {

--- a/tuya.cpp
+++ b/tuya.cpp
@@ -91,12 +91,23 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
         return;
     }
 
-    // Note(mpi) DDF devices that aren't using {"parse": "fn": "tuya"} might have troubles here?
+    // Note(mpi) DDF devices that are using {"parse": "fn": "tuya"} are expected
+    // to not use this function other than for time sync.
     if (device && device->managed())
     {
         if (zclFrame.commandId() != TUYA_TIME_SYNCHRONISATION)
         {
-            return;
+            // clumsy workaround to not interfere with DDF handlers
+            for (const Resource *r : device->subDevices())
+            {
+                for (int i = 0; i < r->itemCount(); i++)
+                {
+                    if (r->itemForIndex(size_t(i))->parseFunction() == parseTuyaData)
+                    {
+                        return;
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This PR adds support of DDF "read", "write" and "parse" functions for the Tuya manufacturer specific cluster (0xEF00).

Example: MoesGo Smart Dimmer Module (_TZE200_e3oitdyu): (PR https://github.com/dresden-elektronik/deconz-rest-plugin/pull/5869)

```
[
        {
          "name": "state/on",
          "parse": {"fn": "tuya", "dpid": 1, "eval": "Item.val = Attr.val;" },
          "write": {"fn": "tuya", "dpid": 1, "dt": "0x10", "eval": "Item.val == 1 ? 1 : 0;"},
          "read": {"fn": "tuya"},
          "refresh.interval": 300
        },
        {
          "name": "state/bri",
          "parse": {"fn": "tuya", "dpid": 2, "eval": "Item.val = (Attr.val / 1000.0) * 254.0;"},
          "write": {"fn": "tuya", "dpid": 2, "dt": "0x2b", "eval": "(Item.val / 254.0) * 1000.0;"},
          "read": {"fn": "none"}
        }
]
```

1. The **parse** function needs to specify the datapoint `dpid` to be parsed. The actual data type is part of the message and processed accordingly.

2. The **write** function further has to specify the data type via `dt` with a subset of ZCL data types:

```
          bool           0x10
          s32 value      0x2b
          enum           0x30
          8-bit bitmap   0x18
          16-bit bitmap  0x19
          32-bit bitmap  0x1b
```

In C++ code the write function is best used by the `StateChange` class, as this PR does for REST-API `PUT /lights/<id>/state` endpoint when settings `{"on": bool, "bri": number}`. This has the benefit that if commands didn't workout they are repeated automatically. ... more on that soon in the updated docs.

3. The **read** function is special and *must* only be specified on one item (here `state/on`). It doesn't actually read a single value but triggers the Tuya device to report all datapoints.

The read and parse functions are available via DDF editor, write will be added soon

![image](https://user-images.githubusercontent.com/383386/158289098-e7d947ea-6fa5-47b7-a0df-72c632c8e425.png)


--------

How to know which datapoints a Tuya device provides?

Exec the *Data Query* command in the Cluster Info panel of the *Tuya specific* cluster:

![image](https://user-images.githubusercontent.com/383386/158288391-e7b48758-5836-4147-83fe-14081594f7e1.png)

After a few seconds the debug log shows incoming reports for all datapoints.

```
02:35:23:168 TY_DATA_REPORT: seq 455, dpid: 0x03, type: 0x02, length: 4, val: 18328
02:35:23:279 TY_DATA_REPORT: seq 456, dpid: 0x01, type: 0x01, length: 1, val: 1
02:35:23:393 TY_DATA_REPORT: seq 457, dpid: 0x07, type: 0x01, length: 1, val: 0
02:35:23:512 TY_DATA_REPORT: seq 458, dpid: 0x02, type: 0x02, length: 4, val: 1000
02:35:23:822 TY_DATA_REPORT: seq 459, dpid: 0x08, type: 0x02, length: 4, val: 1000
02:35:24:391 TY_DATA_REPORT: seq 462, dpid: 0x09, type: 0x02, length: 4, val: 0
02:35:24:485 TY_DATA_REPORT: seq 463, dpid: 0x04, type: 0x04, length: 1, val: 0
02:35:24:595 TY_DATA_REPORT: seq 464, dpid: 0x0A, type: 0x04, length: 1, val: 0
```

Note the type here is the Tuya data type not the ZCL data type.

```
          raw     0x00
          bool    0x01
          value   0x02
          string  0x03
          enum    0x04
          bitmap  0x05
```

