### PR TITLE
DDF for MoesGo/Tuya Smart Dimmer Module (_TZE200_e3oitdyu)

### DIFF
--- a/devices/tuya/_TZE200_e3oitdyu_smart_dimmer_module.json
+++ b/devices/tuya/_TZE200_e3oitdyu_smart_dimmer_module.json
@@ -1,0 +1,133 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "_TZE200_e3oitdyu",
+  "modelid": "TS0601",
+  "vendor": "$MF_TUYA",
+  "product": "Smart Dimmer Module",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_DIMMABLE_PLUGIN_UNIT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001", "script": "tuya_swversion.js"},
+          "read": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001"}
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert",
+          "default": "none",
+          "public": false
+        },
+        {
+          "name": "state/on",
+          "parse": {"fn": "tuya", "dpid": 1, "eval": "Item.val = Attr.val;" },
+          "write": {"fn": "tuya", "dpid": 1, "dt": "0x10", "eval": "Item.val == 1 ? 1 : 0;"},
+          "read": {"fn": "tuya"},
+          "refresh.interval": 300
+        },
+        {
+          "name": "state/bri",
+          "parse": {"fn": "tuya", "dpid": 2, "eval": "Item.val = (Attr.val / 1000.0) * 254.0;"},
+          "write": {"fn": "tuya", "dpid": 2, "dt": "0x2b", "eval": "(Item.val / 254.0) * 1000.0;"},
+          "read": {"fn": "none"},
+          "refresh.interval": 84000
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_DIMMABLE_PLUGIN_UNIT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x02"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001", "script": "tuya_swversion.js"},
+          "read": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001"}
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert",
+          "default": "none",
+          "public": false
+        },
+        {
+          "name": "state/on",
+          "parse": {"fn": "tuya", "dpid": 7, "eval": "Item.val = Attr.val;" },
+          "write": {"fn": "tuya", "dpid": 7, "dt": "0x10", "eval": "Item.val == 1 ? 1 : 0;"},
+          "read": {"fn": "none"},
+          "refresh.interval": 84000
+        },
+        {
+          "name": "state/bri",
+          "parse": {"fn": "tuya", "dpid": 8, "eval": "Item.val = (Attr.val / 1000.0) * 254.0;" },
+          "write": {"fn": "tuya", "dpid": 8, "dt": "0x2b", "eval": "(Item.val / 254.0) * 1000.0;"},
+          "read": {"fn": "none"},
+          "refresh.interval": 84000
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    }
+  ]
+}

--- a/devices/tuya/tuya_swversion.js
+++ b/devices/tuya/tuya_swversion.js
@@ -1,0 +1,2 @@
+let v = Attr.val;
+Item.val = String((v & 192) >> 6) + '.' + String((v & 48) >> 4) + '.' + String(v & 15);


### PR DESCRIPTION
The PR depends on https://github.com/dresden-elektronik/deconz-rest-plugin/pull/5868

For Tuya devices it adds the `devices/tuya/tuya_swversion.js` which should be used to correctly parse the `attr/swversion` item.

```
        {
          "name": "attr/swversion",
          "parse": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001", "script": "tuya_swversion.js"},
          "read": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001"}
        }
```

The Tuya firmware version is stored in *ZCL Basic* cluster *Application Version* 8-bit attribute as packed major.minor.patch version. For example: 0x41 results in `0b 01 00 0001 = 1.0.1`.

The device provides two REST-API lights with on/off and dimming, unfortunately no button events.

```
{
"1": {
    "etag": "660b09d282b480796bb1e995af7b6efc",
    "hascolor": false,
    "lastannounced": null,
    "lastseen": "2022-03-15T01:55Z",
    "manufacturername": "_TZE200_e3oitdyu",
    "modelid": "TS0601",
    "name": "Smart plug 30",
    "state": {
        "alert": "none",
        "bri": 254,
        "on": true,
        "reachable": true
    },
    "swversion": "1.0.4",
    "type": "Dimmable plug-in unit",
    "uniqueid": "84:fd:27:ff:fe:60:94:0b-01"
},
"2": {
    "etag": "2d99e09a6b625a5b6b82bc5da16110f7",
    "hascolor": false,
    "lastannounced": null,
    "lastseen": "2022-03-15T01:55Z",
    "manufacturername": "_TZE200_e3oitdyu",
    "modelid": "TS0601",
    "name": "Dimmable plug-in unit 31",
    "state": {
        "alert": "none",
        "bri": 254,
        "on": false,
        "reachable": true
    },
    "swversion": "1.0.4",
    "type": "Dimmable plug-in unit",
    "uniqueid": "84:fd:27:ff:fe:60:94:0b-02"
}
}
```

