### PR TITLE
Extended 4-button Tuya scene switch support to include TS0044 _TZ3000_wkai4ga5

### DIFF
--- a/button_maps.json
+++ b/button_maps.json
@@ -1115,7 +1115,7 @@
         "Tuya3gangMap": {
             "vendor": "Tuya",
             "doc": "3-gang remote",
-            "modelids": ["_TZ3000_bi6lpsew", "_TZ3400_keyjhapk", "_TYZB02_key8kk7r", "_TZ3400_keyjqthh", "_TZ3400_key8kk7r", "_TZ3000_vp6clf9d", "_TYZB02_keyjqthh", "_TZ3000_peszejy7", "_TZ3000_qzjcsmar", "_TZ3000_owgcnkrh", "_TZ3000_adkvzooy", "_TZ3000_arfwfgoa", "_TZ3000_a7ouggvs", "_TZ3000_rrjr1q0u", "_TZ3000_abci1hiu", "_TZ3000_dfgbtub0"],
+            "modelids": ["_TZ3000_wkai4ga5", "_TZ3000_bi6lpsew", "_TZ3400_keyjhapk", "_TYZB02_key8kk7r", "_TZ3400_keyjqthh", "_TZ3400_key8kk7r", "_TZ3000_vp6clf9d", "_TYZB02_keyjqthh", "_TZ3000_peszejy7", "_TZ3000_qzjcsmar", "_TZ3000_owgcnkrh", "_TZ3000_adkvzooy", "_TZ3000_arfwfgoa", "_TZ3000_a7ouggvs", "_TZ3000_rrjr1q0u", "_TZ3000_abci1hiu", "_TZ3000_dfgbtub0"],
             "map": [
                 [1, "0x01", "ONOFF", "0xfd", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "B1 short"],
                 [1, "0x01", "ONOFF", "0xfd", "1", "S_BUTTON_1", "S_BUTTON_ACTION_DOUBLE_PRESS", "B1 double"],

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1423,6 +1423,7 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
                              sensorNode->manufacturer() == QLatin1String("_TZ3000_rrjr1q0u") ||
                              sensorNode->manufacturer() == QLatin1String("_TZ3000_abci1hiu") ||
                              sensorNode->manufacturer() == QLatin1String("_TZ3000_vp6clf9d") ||
+                             sensorNode->manufacturer() == QLatin1String("_TZ3000_wkai4ga5") ||
                              sensorNode->manufacturer() == QLatin1String("_TZ3000_peszejy7") ||
                              sensorNode->manufacturer() == QLatin1String("_TZ3000_qzjcsmar") ||
                              sensorNode->manufacturer() == QLatin1String("_TZ3000_owgcnkrh") ||
@@ -2734,6 +2735,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
                 lightNode.manufacturer() == QLatin1String("_TZ3000_rrjr1q0u") ||
                 lightNode.manufacturer() == QLatin1String("_TZ3400_key8kk7r") ||
                 lightNode.manufacturer() == QLatin1String("_TZ3000_vp6clf9d") ||
+                lightNode.manufacturer() == QLatin1String("_TZ3000_wkai4ga5") ||
                 lightNode.manufacturer() == QLatin1String("_TZ3000_peszejy7") ||
                 lightNode.manufacturer() == QLatin1String("_TZ3000_qzjcsmar") ||
                 lightNode.manufacturer() == QLatin1String("_TZ3000_owgcnkrh") ||
@@ -5895,6 +5897,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                              manufacturer == QLatin1String("_TZ3000_rrjr1q0u") ||
                              manufacturer == QLatin1String("_TZ3000_abci1hiu") ||
                              manufacturer == QLatin1String("_TZ3000_vp6clf9d") ||
+                             manufacturer == QLatin1String("_TZ3000_wkai4ga5") ||
                              manufacturer == QLatin1String("_TZ3400_key8kk7r") ||
                              manufacturer == QLatin1String("_TZ3000_peszejy7") ||
                              manufacturer == QLatin1String("_TZ3000_qzjcsmar") ||


### PR DESCRIPTION
This adds support for the _TZ3000_wkai4ga5 variant of the TS0044 Tuya 4-Gang Scene Switch, fixes https://github.com/dresden-elektronik/deconz-rest-plugin/issues/5879.