### PR TITLE
DDF updates and additions

### DIFF
--- a/devices/develco/aqszb-110_voc_sensor.json
+++ b/devices/develco/aqszb-110_voc_sensor.json
@@ -95,7 +95,7 @@
             "ep": 38,
             "fn": "zcl",
             "mf": "0x1015",
-            "eval": "Item.val = Attr.val;"
+            "eval": "if (Attr.val != 65535) { Item.val = Attr.val; }"
           }
         },
         {

--- a/devices/develco/splzb-131_smart_plug.json
+++ b/devices/develco/splzb-131_smart_plug.json
@@ -232,7 +232,22 @@
           "name": "state/lastupdated"
         },
         {
-          "name": "state/power"
+          "name": "state/power",
+          "refresh.interval": 300,
+          "read": {
+            "at": "0x0400", 
+            "cl": "0x0702", 
+            "ep": 2,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0400",
+            "cl": "0x0702",
+            "ep": 2,
+            "eval": "if (Attr.val != -16777215 && Attr.val != 16777215) { Item.val = Attr.val; }",
+            "fn": "zcl"
+          },
+          "default": 0
         }
       ]
     }

--- a/devices/develco/splzb-131_smart_plug.json
+++ b/devices/develco/splzb-131_smart_plug.json
@@ -151,7 +151,14 @@
           "name": "state/power"
         },
         {
-          "name": "state/voltage"
+          "name": "state/voltage",
+          "parse": {
+            "at": "0x0505",
+            "cl": "0x0b04",
+            "ep": 2,
+            "eval": "Item.val = Math.round(Attr.val / 100);",
+            "fn": "zcl"
+          }
         }
       ]
     },

--- a/devices/frient/aqszb-110_voc_sensor.json
+++ b/devices/frient/aqszb-110_voc_sensor.json
@@ -95,7 +95,7 @@
             "ep": 38,
             "fn": "zcl",
             "mf": "0x1015",
-            "eval": "Item.val = Attr.val;"
+            "eval": "if (Attr.val != 65535) { Item.val = Attr.val; }"
           }
         },
         {

--- a/devices/frient/splzb-131_smart_plug.json
+++ b/devices/frient/splzb-131_smart_plug.json
@@ -232,7 +232,22 @@
           "name": "state/lastupdated"
         },
         {
-          "name": "state/power"
+          "name": "state/power",
+          "refresh.interval": 300,
+          "read": {
+            "at": "0x0400", 
+            "cl": "0x0702", 
+            "ep": 2,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0400",
+            "cl": "0x0702",
+            "ep": 2,
+            "eval": "if (Attr.val != -16777215 && Attr.val != 16777215) { Item.val = Attr.val; }",
+            "fn": "zcl"
+          },
+          "default": 0
         }
       ]
     }

--- a/devices/frient/splzb-131_smart_plug.json
+++ b/devices/frient/splzb-131_smart_plug.json
@@ -151,7 +151,14 @@
           "name": "state/power"
         },
         {
-          "name": "state/voltage"
+          "name": "state/voltage",
+          "parse": {
+            "at": "0x0505",
+            "cl": "0x0b04",
+            "ep": 2,
+            "eval": "Item.val = Math.round(Attr.val / 100);",
+            "fn": "zcl"
+          }
         }
       ]
     },

--- a/devices/generic/items/state_consumption_item.json
+++ b/devices/generic/items/state_consumption_item.json
@@ -7,5 +7,6 @@
     "description": "The measured consumption (in Wh).",
     "read": {"at": "0x0000", "cl": "0x0702", "ep": 0, "fn": "zcl" },
     "parse": {"at": "0x0000", "cl": "0x0702", "ep": 0, "eval": "Item.val = Attr.val"},
-    "refresh.interval": 300
+    "refresh.interval": 300,
+    "default": 0
 }

--- a/devices/generic/items/state_current_item.json
+++ b/devices/generic/items/state_current_item.json
@@ -7,5 +7,6 @@
     "description": "The measured current (in mA).",
     "read": {"at": "0x0508", "cl": "0x0b04", "ep": 0, "fn": "zcl" },
     "parse": {"at": "0x0508", "cl": "0x0b04", "ep": 0, "eval": "if (Attr.val != 65535) { Item.val = Attr.val; }"},
-    "refresh.interval": 300
+    "refresh.interval": 300,
+    "default": 0
 }

--- a/devices/generic/items/state_power_item.json
+++ b/devices/generic/items/state_power_item.json
@@ -7,5 +7,6 @@
 	"description": "The measured power (in W).",
     "read": {"at": "0x050b", "cl": "0x0b04", "ep": 0, "fn": "zcl" },
     "parse": {"at": "0x050b", "cl": "0x0b04", "ep": 0, "eval": "if (Attr.val != -32768 && Attr.val != 32768) { Item.val = Attr.val; }"},
-    "refresh.interval": 300
+    "refresh.interval": 300,
+    "default": 0
 }

--- a/devices/generic/items/state_power_item.json
+++ b/devices/generic/items/state_power_item.json
@@ -6,6 +6,6 @@
 	"public": true,
 	"description": "The measured power (in W).",
     "read": {"at": "0x050b", "cl": "0x0b04", "ep": 0, "fn": "zcl" },
-    "parse": {"at": "0x050b", "cl": "0x0b04", "ep": 0, "eval": "if (Attr.val != -32768) { Item.val = Attr.val; }"},
+    "parse": {"at": "0x050b", "cl": "0x0b04", "ep": 0, "eval": "if (Attr.val != -32768 && Attr.val != 32768) { Item.val = Attr.val; }"},
     "refresh.interval": 300
 }

--- a/devices/generic/items/state_voltage_item.json
+++ b/devices/generic/items/state_voltage_item.json
@@ -7,5 +7,6 @@
 	"description": "The measured voltage (in V).",
     "read": {"at": "0x0505", "cl": "0x0b04", "ep": 0, "fn": "zcl" },
     "parse": {"at": "0x0505", "cl": "0x0b04", "ep": 0, "eval": "if (Attr.val != 65535) { Item.val = Attr.val; }"},
-    "refresh.interval": 300
+    "refresh.interval": 300,
+    "default": 0
 }

--- a/devices/immax/07048L_smart_plug.json
+++ b/devices/immax/07048L_smart_plug.json
@@ -3,9 +3,9 @@
   "manufacturername": "Immax",
   "modelid": "Plug-230V-ZB3.0",
   "vendor": "Immax Neo",
-  "product": "07048L",
+  "product": "07048L smart plug",
   "sleeper": false,
-  "status": "Silver",
+  "status": "Gold",
   "subdevices": [
     {
       "type": "$TYPE_SMART_PLUG",
@@ -43,12 +43,10 @@
           "name": "attr/uniqueid"
         },
         {
-          "name": "state/alert",
-          "default": "none"
+          "name": "state/alert"
         },
         {
-          "name": "state/on",
-          "refresh.interval": 5
+          "name": "state/on"
         },
         {
           "name": "state/reachable"
@@ -109,20 +107,7 @@
           "name": "state/lastupdated"
         },
         {
-          "name": "state/power",
-          "refresh.interval": 360,
-          "read": {
-            "at": "0x050b",
-            "cl": "0x0b04",
-            "ep": 1,
-            "fn": "zcl"
-          },
-          "parse": {
-            "at": "0x050b",
-            "cl": "0x0b04",
-            "ep": 1,
-            "eval": "if (Attr.val != -32768) { Item.val = Attr.val; }"
-          }
+          "name": "state/power"
         }
       ]
     },
@@ -177,20 +162,7 @@
           "name": "config/reachable"
         },
         {
-          "name": "state/consumption",
-          "refresh.interval": 360,
-          "read": {
-            "at": "0x0000",
-            "cl": "0x0702",
-            "ep": 1,
-            "fn": "zcl"
-          },
-          "parse": {
-            "at": "0x0000",
-            "cl": "0x0702",
-            "ep": 1,
-            "eval": "Item.val = Attr.val * 10;"
-          }
+          "name": "state/consumption"
         },
         {
           "name": "state/lastupdated"


### PR DESCRIPTION
Some DDF updates/additions:

- Prevent fakeouts of air quality raw values (65535) for develco/frient aqszb-110 voc sensor
- Prevent fakeouts of power values by ignoring values positive max values as well (32768)
- Promote immax 07048L smart plug DDF to gold and remove unnecessary entries
- Add correct power handling to develco/frient splzb-131 smart plug for `state/power` in ZHAConsumption sensor
- Fix voltage calculation for develco/frient splzb-131
- Set `"default": 0` for `state/voltage`, `state/current`, `state/power` and `state/consumption` resource item