### PR TITLE
Add DDF for ubisys J1 covering controller

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -4252,9 +4252,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
         // check for older setups with multiple ZHASwitch sensors per device
         if (sensor.manufacturer() == QLatin1String("ubisys") && sensor.type() == QLatin1String("ZHASwitch"))
         {
-            if ((sensor.modelId().startsWith(QLatin1String("D1")) && sensor.fingerPrint().endpoint != 0x02) ||
-                (sensor.modelId().startsWith(QLatin1String("S2")) && sensor.fingerPrint().endpoint != 0x03) ||
-                (sensor.modelId().startsWith(QLatin1String("C4")) && sensor.fingerPrint().endpoint != 0x01))
+            if ((sensor.modelId().startsWith(QLatin1String("D1")) && sensor.fingerPrint().endpoint != 0x02))
             {
                 DBG_Printf(DBG_INFO, "ubisys sensor id: %s, endpoint 0x%02X (%s) ignored loading from database\n", qPrintable(sensor.id()), sensor.fingerPrint().endpoint, qPrintable(sensor.modelId()));
                 return 0;
@@ -4263,22 +4261,9 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             QStringList supportedModes({"momentary", "rocker", "custom"});
             item = sensor.addItem(DataTypeString, RConfigMode);
 
-            bool isWindowCovering = sensor.modelId().startsWith(QLatin1String("J1"));
-            ResourceItem *itemWindowCovering = 0;
-            if (isWindowCovering)
-            {
-                itemWindowCovering = sensor.addItem(DataTypeUInt8, RConfigWindowCoveringType);
-            }
-
             if (configCol >= 0)
             {
                 sensor.jsonToConfig(QLatin1String(colval[configCol])); // needed again otherwise item isEmpty
-            }
-
-            if (isWindowCovering)
-            {
-                int val = itemWindowCovering->toNumber(); // prevent null value
-                itemWindowCovering->setValue(val);
             }
 
             if (item->toString().isEmpty() || !supportedModes.contains(item->toString()))

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -292,9 +292,7 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_XIAOMI, "lumi.flood.agl02", xiaomiMacPrefix}, // Xiaomi Aqara T1 water leak sensor SJCGQ12LM
     { VENDOR_XIAOMI, "lumi.switch.n0agl1", lumiMacPrefix}, // Xiaomi Aqara Single Switch Module T1 (With Neutral)
     { VENDOR_UBISYS, "D1", ubisysMacPrefix },
-    { VENDOR_UBISYS, "J1", ubisysMacPrefix },
     { VENDOR_UBISYS, "S1", ubisysMacPrefix },
-    { VENDOR_UBISYS, "S2-R", ubisysMacPrefix },
     { VENDOR_NONE, "Z716A", netvoxMacPrefix },
     // { VENDOR_OSRAM_STACK, "Plug", osramMacPrefix }, // OSRAM plug - exposed only as light
     { VENDOR_OSRAM, "Lightify Switch Mini", emberMacPrefix }, // Osram 3 button remote
@@ -6528,9 +6526,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     else if (node->nodeDescriptor().manufacturerCode() == VENDOR_UBISYS)
                     {
                         if ((modelId.startsWith(QLatin1String("D1")) && i->endpoint() == 0x02) ||
-                            (modelId.startsWith(QLatin1String("J1")) && i->endpoint() == 0x02) ||
-                            (modelId.startsWith(QLatin1String("S1-R")) && i->endpoint() == 0x02) ||
-                            (modelId.startsWith(QLatin1String("S2-R")) && i->endpoint() == 0x03))
+                            (modelId.startsWith(QLatin1String("S1-R")) && i->endpoint() == 0x02))
                         {
                             // Combine multiple switch endpoints into a single ZHASwitch resource
                             fpSwitch.outClusters.push_back(ci->id());
@@ -7884,12 +7880,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             sensorNode.addItem(DataTypeString, RConfigGroup);
             item = sensorNode.addItem(DataTypeString, RConfigMode);
             item->setValue(QString("momentary"));
-
-            if (sensorNode.modelId().startsWith(QLatin1String("J1")))
-            {
-                item = sensorNode.addItem(DataTypeUInt8, RConfigWindowCoveringType);
-                item->setValue(0);
-            }
         }
     }
     else if (node->nodeDescriptor().manufacturerCode() == VENDOR_BUSCH_JAEGER)
@@ -10771,7 +10761,7 @@ bool DeRestPluginPrivate::processZclAttributes(Sensor *sensorNode)
         // whitelist by Model ID
         if (sensorNode->modelId().startsWith(QLatin1String("FLS-NB")) ||
             sensorNode->modelId().startsWith(QLatin1String("D1")) || sensorNode->modelId().startsWith(QLatin1String("S1-R")) ||
-            sensorNode->modelId().startsWith(QLatin1String("S2-R")) || sensorNode->manufacturer().startsWith(QLatin1String("BEGA")))
+            sensorNode->manufacturer().startsWith(QLatin1String("BEGA")))
         {
             ok = true;
         }
@@ -17965,7 +17955,7 @@ void DeRestPluginPrivate::pushSensorInfoToCore(Sensor *sensor)
     if (sensor->modelId().startsWith(QLatin1String("FLS-NB")))
     { } // use name from light
     else if (sensor->modelId().startsWith(QLatin1String("D1")) || sensor->modelId().startsWith(QLatin1String("S1-R")) ||
-             sensor->modelId().startsWith(QLatin1String("S2")) ||sensor->modelId().startsWith(QLatin1String("lumi.ctrl_")))
+             sensor->modelId().startsWith(QLatin1String("lumi.ctrl_")))
     { } // use name from light
     else if (sensor->type() == QLatin1String("ZHAConsumption") || sensor->type() == QLatin1String("ZHAPower"))
     { } // use name from light

--- a/devices/generic/items/config_windowcoveringtype_item.json
+++ b/devices/generic/items/config_windowcoveringtype_item.json
@@ -15,6 +15,6 @@
 		[6, "Shutter"],
 		[7, "Tilt Blind Lift only"],
 		[8, "Tilt Blind lift & tilt"],
-		[9, "Projector Screen"],
+		[9, "Projector Screen"]
 	]
 }

--- a/devices/generic/items/config_windowcoveringtype_item.json
+++ b/devices/generic/items/config_windowcoveringtype_item.json
@@ -1,0 +1,20 @@
+{
+	"schema": "resourceitem1.schema.json",
+	"id": "config/windowcoveringtype",
+	"datatype": "UInt8",
+	"access": "RW",
+	"public": true,
+	"description": "The window cover type.",
+	"values": [
+		[0, "Roller Shade"],
+		[1, "Roller Shade two motors"],
+		[2, "Roller Shade exterior"],
+		[3, "Roller Shade two motors ext"],
+		[4, "Drapery"],
+		[5, "Awning"],
+		[6, "Shutter"],
+		[7, "Tilt Blind Lift only"],
+		[8, "Tilt Blind lift & tilt"],
+		[9, "Projector Screen"],
+	]
+}

--- a/devices/generic/items/state_lift_item.json
+++ b/devices/generic/items/state_lift_item.json
@@ -5,5 +5,9 @@
 	"access": "RW",
 	"public": true,
 	"range": [0, 254],
-	"description": "The lift state of a roller blind."
+	"description": "The lift state of a roller blind.",
+	"parse": {"at": "0x0008", "cl": "0x0102", "ep": 0, "eval": "Item.val = Attr.val;", "fn": "zcl"},
+	"read": {"at": "0x0008", "cl": "0x0102", "ep": 0, "fn": "zcl"},
+	"refresh.interval": 300,
+	"default": 0
 }

--- a/devices/generic/items/state_tilt_item.json
+++ b/devices/generic/items/state_tilt_item.json
@@ -5,5 +5,9 @@
 	"access": "RW",
 	"public": true,
 	"range": [0, 254],
-	"description": "The tilt state of a shutter or blind."
+	"description": "The tilt state of a shutter or blind.",
+	"parse": {"at": "0x0009", "cl": "0x0102", "ep": 0, "eval": "Item.val = Attr.val;", "fn": "zcl"},
+	"read": {"at": "0x0009", "cl": "0x0102", "ep": 0, "fn": "zcl"},
+	"refresh.interval": 300,
+	"default": 0
 }

--- a/devices/ubisys/j1_5502.json
+++ b/devices/ubisys/j1_5502.json
@@ -145,7 +145,13 @@
           "default": "auto"
         },
         {
-          "name": "config/mode"
+          "name": "config/mode",
+          "default" : "momentary",
+          "values": [
+            ["\"momentary\"", "Momentary mode"],
+		    ["\"rocker\"", "Rocker mode"],
+		    ["\"custom\"", "Custom mode"]
+          ]
         },
         {
           "name": "config/on"
@@ -154,7 +160,8 @@
           "name": "config/reachable"
         },
         {
-          "name": "config/windowcoveringtype"
+          "name": "config/windowcoveringtype",
+          "default" : 0
         },
         {
           "name": "state/buttonevent"

--- a/devices/ubisys/j1_5502.json
+++ b/devices/ubisys/j1_5502.json
@@ -337,6 +337,12 @@
       ]
     },
     {
+      "bind": "groupcast",
+      "config.group": 0,
+      "src.ep": 2,
+      "cl": "0x0102"
+    },
+    {
       "bind": "unicast",
       "src.ep": 3,
       "cl": "0x0702",

--- a/devices/ubisys/j1_5502.json
+++ b/devices/ubisys/j1_5502.json
@@ -1,0 +1,347 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "ubisys",
+  "modelid": "J1 (5502)",
+  "vendor": "ubisys",
+  "product": "J1 (5502) cover controller",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_WINDOW_COVERING_DEVICE",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/bri",
+          "parse": {
+            "at": "0x0008",
+            "cl": "0x0102",
+            "ep": 1,
+            "eval": "Item.val = (254 * Attr.val) / 100;",
+            "fn": "zcl"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "state/lift"
+        },
+        {
+          "name": "state/on",
+          "parse": {
+            "at": "0x0008",
+            "cl": "0x0102",
+            "ep": 1,
+            "eval": "if (Attr.val == 100) { Item.val = true; } else { Item.val = false; }",
+            "fn": "zcl"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "state/open",
+          "parse": {
+            "at": "0x0008",
+            "cl": "0x0102",
+            "ep": 1,
+            "eval": "if (Attr.val == 100) { Item.val = false; } else { Item.val = true; }",
+            "fn": "zcl"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "state/tilt"
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_SWITCH",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x02",
+        "0x0102"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0203",
+        "endpoint": "0x02",
+        "in": [
+          "0x0000"
+        ],
+        "out": [
+          "0x0005",
+          "0x0102"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/group",
+          "default": "auto"
+        },
+        {
+          "name": "config/mode"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "config/windowcoveringtype"
+        },
+        {
+          "name": "state/buttonevent"
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_POWER_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x03",
+        "0x0b04"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0501",
+        "endpoint": "0x03",
+        "in": [
+          "0x0B04"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/current",
+          "refresh.interval": 10
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/power",
+          "refresh.interval": 10
+        },
+        {
+          "name": "state/voltage",
+          "refresh.interval": 10
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_CONSUMPTION_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x03",
+        "0x0702"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0501",
+        "endpoint": "0x03",
+        "in": [
+          "0x0702"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/consumption",
+          "refresh.interval": 10
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/power",
+          "read": {
+            "at": "0x0400",
+            "cl": "0x0702",
+            "ep": 3,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0400",
+            "cl": "0x0702",
+            "ep": 3,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl"
+          }
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0102",
+      "report": [
+        {
+          "at": "0x0008",
+          "dt": "0x20",
+          "min": 1,
+          "max": 300,
+          "change": "0x00000001"
+        },
+        {
+          "at": "0x0009",
+          "dt": "0x20",
+          "min": 1,
+          "max": 300,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 3,
+      "cl": "0x0702",
+      "report": [
+        {
+          "at": "0x0400",
+          "dt": "0x2A",
+          "min": 1,
+          "max": 300,
+          "change": "0x00000001"
+        }
+      ]
+    }
+  ]
+}

--- a/devices/ubisys/j1_5502.json
+++ b/devices/ubisys/j1_5502.json
@@ -149,8 +149,8 @@
           "default" : "momentary",
           "values": [
             ["\"momentary\"", "Momentary mode"],
-		    ["\"rocker\"", "Rocker mode"],
-		    ["\"custom\"", "Custom mode"]
+            ["\"rocker\"", "Rocker mode"],
+            ["\"custom\"", "Custom mode"]
           ]
         },
         {

--- a/electrical_measurement.cpp
+++ b/electrical_measurement.cpp
@@ -198,8 +198,6 @@ void DeRestPluginPrivate::handleElectricalMeasurementClusterIndication(const deC
                         modelId == QLatin1String("PoP") ||                                        // Apex Smart Plug
                         modelId == QLatin1String("TS011F") ||                                     // Tuya plugs
                         modelId.startsWith(QLatin1String("S1-R")) ||                              // Ubisys S1-R
-                        modelId.startsWith(QLatin1String("S2-R")) ||                              // Ubisys S2-R
-                        modelId.startsWith(QLatin1String("J1")) ||                                // Ubisys J1/J1-R
                         modelId.startsWith(QLatin1String("D1")))                                  // Ubisys D1/D1-R
                     {
                         // already in mA


### PR DESCRIPTION
Adds DDF, removes some ubisys related legacy code, adds missing `config/windowconveringtype` resource item and adds default functions for `state/lift` and `state/tilt`.