### PR TITLE
Button maps support specify endpoint for buttons

### DIFF
--- a/button_maps.h
+++ b/button_maps.h
@@ -30,6 +30,7 @@ struct ButtonMeta
     {
         QString name;
         int button;
+        int endpoint;
     };
 
     std::vector<ButtonMeta::Button> buttons;

--- a/button_maps.json
+++ b/button_maps.json
@@ -1084,7 +1084,90 @@
         "sunricherMap": {
             "vendor": "Sunricher",
             "doc": "Wireless switches from Sunricher, Namron, SLC and EcoDim",
-            "modelids": ["ED-10010", "ED-10011", "ED-10012", "ED-10013", "ED-10014", "ED-10015", "ZG2833K8_EU05", "ZG2833K4_EU06", "ZG2835", "4512700", "4512701", "4512702", "4512703", "4512705", "4512714", "4512719", "4512720", "4512721", "4512722", "4512729", "S57003", "ROB_200-008", "ROB_200-009-0", "ROB_200-008-0", "ROB_200-007-0"],
+            "modelids": ["ZG2835", "4512700", "4512705"],
+            "map": [
+                [1, "0x01", "ONOFF", "ON", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],
+                [1, "0x01", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_HOLD", "Move up (with on/off)"],
+                [1, "0x01", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ (with on/off)"],
+                [1, "0x01", "ONOFF", "OFF", "0", "S_BUTTON_2", "S_BUTTON_ACTION_SHORT_RELEASED", "Off"],
+                [1, "0x01", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "1", "S_BUTTON_2", "S_BUTTON_ACTION_HOLD", "Move down (with on/off)"],
+                [1, "0x01", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "1", "S_BUTTON_2", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ (with on/off)"],
+                [1, "0x02", "ONOFF", "ON", "0", "S_BUTTON_3", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],
+                [1, "0x02", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "0", "S_BUTTON_3", "S_BUTTON_ACTION_HOLD", "Move up (with on/off)"],
+                [1, "0x02", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "0", "S_BUTTON_3", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ (with on/off)"],
+                [1, "0x02", "ONOFF", "OFF", "0", "S_BUTTON_4", "S_BUTTON_ACTION_SHORT_RELEASED", "Off"],
+                [1, "0x02", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "1", "S_BUTTON_4", "S_BUTTON_ACTION_HOLD", "Move down (with on/off)"],
+                [1, "0x02", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "1", "S_BUTTON_4", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ (with on/off)"],
+                [1, "0x03", "ONOFF", "ON", "0", "S_BUTTON_5", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],
+                [1, "0x03", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "0", "S_BUTTON_5", "S_BUTTON_ACTION_HOLD", "Move up (with on/off)"],
+                [1, "0x03", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "0", "S_BUTTON_5", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ (with on/off)"],
+                [1, "0x03", "ONOFF", "OFF", "0", "S_BUTTON_6", "S_BUTTON_ACTION_SHORT_RELEASED", "Off"],
+                [1, "0x03", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "1", "S_BUTTON_6", "S_BUTTON_ACTION_HOLD", "Move down (with on/off)"],
+                [1, "0x03", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "1", "S_BUTTON_6", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ (with on/off)"],
+                [1, "0x04", "ONOFF", "ON", "0", "S_BUTTON_7", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],
+                [1, "0x04", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "0", "S_BUTTON_7", "S_BUTTON_ACTION_HOLD", "Move up (with on/off)"],
+                [1, "0x04", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "0", "S_BUTTON_7", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ (with on/off)"],
+                [1, "0x04", "ONOFF", "OFF", "0", "S_BUTTON_8", "S_BUTTON_ACTION_SHORT_RELEASED", "Off"],
+                [1, "0x04", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "1", "S_BUTTON_8", "S_BUTTON_ACTION_HOLD", "Move down (with on/off)"],
+                [1, "0x04", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "1", "S_BUTTON_8", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ (with on/off)"]
+            ]
+        },
+        "sunricherMap2": {
+            "vendor": "Sunricher",
+            "doc": "2 button switches from Sunricher, Namron, SLC and EcoDim",
+            "modelids": ["ED-10010", "ED-10011", "4512701", "4512702", "ROB_200-009-0"],
+            "buttons": [
+                {"S_BUTTON_1": "On"},
+                {"S_BUTTON_2": "Off"}
+            ],
+            "map": [
+                [1, "0x01", "ONOFF", "ON", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],
+                [1, "0x01", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_HOLD", "Move up (with on/off)"],
+                [1, "0x01", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ (with on/off)"],
+                [1, "0x01", "ONOFF", "OFF", "0", "S_BUTTON_2", "S_BUTTON_ACTION_SHORT_RELEASED", "Off"],
+                [1, "0x01", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "1", "S_BUTTON_2", "S_BUTTON_ACTION_HOLD", "Move down (with on/off)"],
+                [1, "0x01", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "1", "S_BUTTON_2", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ (with on/off)"]                
+            ]
+        },
+        "sunricherMap4": {
+            "vendor": "Sunricher",
+            "doc": "4 button switches from Sunricher, Namron, SLC and EcoDim",
+            "modelids": ["ED-10012", "ED-10013", "ZG2833K4_EU06", "4512719", "4512729", "ROB_200-008", "ROB_200-008-0"],
+            "buttons": [
+                {"S_BUTTON_1": "On 1", "ep": 1},
+                {"S_BUTTON_2": "Off 1", "ep": 1},
+                {"S_BUTTON_3": "On 2", "ep": 2},
+                {"S_BUTTON_4": "Off 2", "ep": 2}
+            ],
+            "map": [
+                [1, "0x01", "ONOFF", "ON", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],
+                [1, "0x01", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_HOLD", "Move up (with on/off)"],
+                [1, "0x01", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ (with on/off)"],
+                [1, "0x01", "ONOFF", "OFF", "0", "S_BUTTON_2", "S_BUTTON_ACTION_SHORT_RELEASED", "Off"],
+                [1, "0x01", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "1", "S_BUTTON_2", "S_BUTTON_ACTION_HOLD", "Move down (with on/off)"],
+                [1, "0x01", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "1", "S_BUTTON_2", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ (with on/off)"],
+                [1, "0x02", "ONOFF", "ON", "0", "S_BUTTON_3", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],
+                [1, "0x02", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "0", "S_BUTTON_3", "S_BUTTON_ACTION_HOLD", "Move up (with on/off)"],
+                [1, "0x02", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "0", "S_BUTTON_3", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ (with on/off)"],
+                [1, "0x02", "ONOFF", "OFF", "0", "S_BUTTON_4", "S_BUTTON_ACTION_SHORT_RELEASED", "Off"],
+                [1, "0x02", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "1", "S_BUTTON_4", "S_BUTTON_ACTION_HOLD", "Move down (with on/off)"],
+                [1, "0x02", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "1", "S_BUTTON_4", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ (with on/off)"]
+            ]
+        },
+        "sunricherMap8": {
+            "vendor": "Sunricher",
+            "doc": "8 button switches from Sunricher, Namron, SLC and EcoDim",
+            "modelids": ["ED-10014", "ED-10015", "ZG2833K8_EU05", "4512703", "4512714", "4512721", "4512722", "S57003", "ROB_200-007-0", "ROB_200-025-0"],
+            "buttons": [
+                {"S_BUTTON_1": "On 1", "ep": 1},
+                {"S_BUTTON_2": "Off 1", "ep": 1},
+                {"S_BUTTON_3": "On 2", "ep": 2},
+                {"S_BUTTON_4": "Off 2", "ep": 2},
+                {"S_BUTTON_5": "On 3", "ep": 3},
+                {"S_BUTTON_6": "Off 3", "ep": 3},
+                {"S_BUTTON_7": "On 4", "ep": 4},
+                {"S_BUTTON_8": "Off 4", "ep": 4}
+            ],
             "map": [
                 [1, "0x01", "ONOFF", "ON", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],
                 [1, "0x01", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_HOLD", "Move up (with on/off)"],

--- a/read_files.cpp
+++ b/read_files.cpp
@@ -565,22 +565,37 @@ std::vector<ButtonMeta> loadButtonMetaJson(const QJsonDocument &buttonMapsDoc, c
 
             const QJsonObject buttonObj = j->toObject();
             const auto keys = buttonObj.keys();
+
+            bool ok = false;
+            ButtonMeta::Button b{};
+
+            Q_ASSERT(b.button == 0);
+            Q_ASSERT(b.endpoint == 0);
+
             for (const auto &k : keys)
             {
-                if (!k.startsWith(buttonPrefix))
+                if (k.startsWith(buttonPrefix))
                 {
-                    continue;
+                    b.button = k.midRef(buttonPrefix.size()).toInt(&ok);
+
+                    if (ok)
+                    {
+                        b.name = buttonObj.value(k).toString();
+                    }
                 }
-
-                bool ok = false;
-                ButtonMeta::Button b;
-                b.button = k.midRef(buttonPrefix.size()).toInt(&ok);
-
-                if (ok)
+                else if (k == QLatin1String("ep"))
                 {
-                    b.name = buttonObj.value(k).toString();
-                    meta.buttons.push_back(b);
+                    b.endpoint = buttonObj.value(k).toInt(0);
+                    if (b.endpoint < 0 || b.endpoint > 255)
+                    {
+                        b.endpoint = 0;
+                    }
                 }
+            }
+
+            if (b.button > 0 && !b.name.isEmpty())
+            {
+                meta.buttons.push_back(b);
             }
         }
 


### PR DESCRIPTION
Needed for Sunricher (EcoDim Namron, SLC, ROBB) switches which use multiple ZHASwitch sensors for specific button events.
With this change the introspection only returns filtered buttons and events for the requested sensor.

Background: It's not possible to change the switches to use only one sensor (which they should) without breaking existing setups.
This PR allows clients to generically query which sensors of a switch support which events with the /devices introspection.

The Phoscon App switch editor and generic switch icons where adapted to use this change.