### PR TITLE
Add DDF for Xiaomi H1 single rocker switch (neutral wire) WS-EUK03

### DIFF
--- a/devices/xiaomi/xiaomi_ws-euk03_h1_switch.json
+++ b/devices/xiaomi/xiaomi_ws-euk03_h1_switch.json
@@ -1,0 +1,413 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "$MF_LUMI",
+  "modelid": "lumi.switch.n1aeu1",
+  "vendor": "Xiaomi",
+  "product": "Aqara H1 single rocker switch (neutral wire) WS-EUK03",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_ON_OFF_LIGHT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "refresh.interval": 86400,
+          "read": {
+            "at": "0x0006",
+            "cl": "0x0000",
+            "ep": 1,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0006",
+            "cl": "0x0000",
+            "ep": 1,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert"
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 86400
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_SWITCH",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x29",
+        "0x0012"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0100",
+        "endpoint": "0x29",
+        "in": [
+          "0x0012"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "refresh.interval": 86400,
+          "read": {
+            "at": "0x0006",
+            "cl": "0x0000",
+            "ep": 1,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0006",
+            "cl": "0x0000",
+            "ep": 1,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/clickmode",
+          "refresh.interval": 86400,
+          "read": {
+            "at": "0x0200",
+            "cl": "0xfcc0",
+            "ep": 1,
+            "fn": "zcl",
+            "mf": "0x115f"
+          },
+          "parse": {
+            "at": "0x0200",
+            "cl": "0xfcc0",
+            "ep": 1,
+            "eval": "if (Attr.val == 0) { Item.val = 'decoupled' } else if (Attr.val == 1) { Item.val = 'coupled' } else { Item.val = 'unknown' }",
+            "fn": "zcl",
+            "mf": "0x115f"
+          },
+          "write": {
+            "at": "0x0200",
+            "cl": "0xfcc0",
+            "dt": "0x20",
+            "ep": 1,
+            "eval": "if (Item.val == 'decoupled') { 0 } else if (Item.val == 'coupled') { 1 } else { 'unknown' }",
+            "fn": "zcl",
+            "mf": "0x115f"
+          },
+          "values": [
+            ["\"decoupled\"", "Decoupled Mode"],
+            ["\"coupled\"", "Coupled Mode"] 
+          ],
+          "default": "coupled"
+        },
+        {
+          "name": "config/devicemode",
+          "refresh.interval": 86400,
+          "read": {
+            "at": "0x0009",
+            "cl": "0xfcc0",
+            "ep": 1,
+            "fn": "zcl",
+            "mf": "0x115f"
+          },
+          "parse": {
+            "at": "0x0009",
+            "cl": "0xfcc0",
+            "ep": 1,
+            "eval": "if (Attr.val == 1) { Item.val = 'compatibility' } else if (Attr.val == 2) { Item.val = 'zigbee' } else { Item.val = 'unknown' }",
+            "fn": "zcl",
+            "mf": "0x115f"
+          },
+          "write": {
+            "at": "0x0009",
+            "cl": "0xfcc0",
+            "dt": "0x20",
+            "ep": 1,
+            "eval": "if (Item.val == 'compatibility') { 1 } else if (Item.val == 'zigbee') { 2 } else { 'unknown' }",
+            "fn": "zcl",
+            "mf": "0x115f"
+          },
+          "values": [
+            ["\"compatibility\"", "Default mode for Xiaomi devices"],
+            ["\"zigbee\"", "Closer to zigbee standard"] 
+          ],
+          "default": "compatibility"
+        },
+        {
+          "name": "config/ledindication",
+          "refresh.interval": 86400,
+          "read": {
+            "at": "0x0203",
+            "cl": "0xfcc0",
+            "ep": 1,
+            "fn": "zcl",
+            "mf": "0x115f"
+          },
+          "parse": {
+            "at": "0x0203",
+            "cl": "0xfcc0",
+            "ep": 1,
+            "eval": "Attr.val ? Item.val = false : Item.val = true",
+            "fn": "zcl",
+            "mf": "0x115f"
+          },
+          "write": {
+            "at": "0x0203",
+            "cl": "0xfcc0",
+            "dt": "0x20",
+            "ep": 1,
+            "eval": "Item.val ? false : true",
+            "fn": "zcl",
+            "mf": "0x115f"
+          },
+          "values": [
+            [true, "Device LED always on"],
+            [false, "Device LED off from 9pm - 9am"] 
+          ],
+          "default": true
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/buttonevent"
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_POWER_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x15",
+        "0x000c"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0100",
+        "endpoint": "0x15",
+        "in": [
+          "0x000C"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "refresh.interval": 86400,
+          "read": {
+            "at": "0x0006",
+            "cl": "0x0000",
+            "ep": 1,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0006",
+            "cl": "0x0000",
+            "ep": 1,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/power",
+          "refresh.interval": 10,
+          "read": {
+            "at": "0x0055",
+            "cl": "0x000C",
+            "ep": 21,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0055",
+            "cl": "0x000C",
+            "ep": 21,
+            "eval": "Item.val = Math.round(Attr.val);"
+          }
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_CONSUMPTION_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x1f",
+        "0x000c"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0100",
+        "endpoint": "0x1F",
+        "in": [
+          "0x000C"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "refresh.interval": 86400,
+          "read": {
+            "at": "0x0006",
+            "cl": "0x0000",
+            "ep": 1,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0006",
+            "cl": "0x0000",
+            "ep": 1,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/consumption",
+          "refresh.interval": 300,
+          "read": {
+            "at": "0x0055",
+            "cl": "0x000C",
+            "ep": 31,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0055",
+            "cl": "0x000C",
+            "ep": 31,
+            "eval": "Item.val = Math.round(Attr.val * 1000);"
+          }
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds the respective DDF. Device specific code will be removed later to prevent merge conflicts.