### PR TITLE
Add additional Xiaomi MFC for ZDP handler

### DIFF
--- a/zdp/zdp_handlers.cpp
+++ b/zdp/zdp_handlers.cpp
@@ -289,10 +289,11 @@ struct MapMfCode
     quint16 serverMask;
 };
 
-static const std::array<MapMfCode, 2> mapMfCode = {
+static const std::array<MapMfCode, 3> mapMfCode = {
     {
         { 0x04cf8c0000000000ULL, 0x115F, 0x0040}, // Xiaomi
-        { 0x54ef440000000000ULL, 0x115F, 0x0040}  // Xiaomi
+        { 0x54ef440000000000ULL, 0x115F, 0x0040},  // Xiaomi
+        { 0x54ef440000000000ULL, 0x1234, 0x0040}  // Xiaomi
     }
 };
 


### PR DESCRIPTION
There's apparently a new Xiaomi related MFC, so we want to make sure that one gets a proper node descriptor response as well.