### PR TITLE
Don't create DeviceJs instance on each "parse" invocation

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -40,6 +40,7 @@
 #include "device_ddf_init.h"
 #include "device_descriptions.h"
 #include "device_tick.h"
+#include "device_js/device_js.h"
 #include "de_web_plugin.h"
 #include "de_web_plugin_private.h"
 #include "de_web_widget.h"
@@ -669,6 +670,8 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
 
     alarmSystems.reset(new AlarmSystems);
 
+    deviceJs = new DeviceJs();
+
     deviceDescriptions = new DeviceDescriptions(this);
     connect(deviceDescriptions, &DeviceDescriptions::eventNotify, eventEmitter, &EventEmitter::enqueueEvent);
     connect(eventEmitter, &EventEmitter::eventNotify, deviceDescriptions, &DeviceDescriptions::handleEvent);
@@ -993,6 +996,8 @@ DeRestPluginPrivate::~DeRestPluginPrivate()
         inetDiscoveryManager->deleteLater();
         inetDiscoveryManager = 0;
     }
+    delete deviceJs;
+    deviceJs = nullptr;
     eventEmitter = nullptr;
 }
 

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -722,6 +722,7 @@ extern const char *HttpContentSVG;
 // Forward declarations
 class DeviceDescriptions;
 class DeviceWidget;
+class DeviceJs;
 class Gateway;
 class GatewayScanner;
 class QUdpSocket;
@@ -2134,6 +2135,7 @@ public:
     std::vector<BindingTableReader> bindingTableReaders;
 
     DeviceDescriptions *deviceDescriptions = nullptr;
+    DeviceJs *deviceJs = nullptr;
 
     // IAS
     std::unique_ptr<AS_DeviceTable> alarmSystemDeviceTable;

--- a/device_access_fn.cpp
+++ b/device_access_fn.cpp
@@ -282,7 +282,8 @@ bool evalZclAttribute(Resource *r, ResourceItem *item, const deCONZ::ApsDataIndi
 
     if (!expr.isEmpty())
     {
-        DeviceJs engine;
+        DeviceJs &engine = *DeviceJs::instance();
+        engine.reset();
         engine.setResource(r);
         engine.setItem(item);
         engine.setZclAttribute(attr);
@@ -316,7 +317,8 @@ bool evalZclFrame(Resource *r, ResourceItem *item, const deCONZ::ApsDataIndicati
 
     if (!expr.isEmpty())
     {
-        DeviceJs engine;
+        DeviceJs &engine = *DeviceJs::instance();
+        engine.reset();
         engine.setResource(r);
         engine.setItem(item);
         engine.setZclFrame(zclFrame);
@@ -871,7 +873,8 @@ bool writeTuyaData(const Resource *r, const ResourceItem *item, deCONZ::ApsContr
 
     { // payload
         QVariant value;
-        DeviceJs engine;
+        DeviceJs &engine = *DeviceJs::instance();
+        engine.reset();
         engine.setResource(r);
         engine.setItem(item);
 
@@ -1448,7 +1451,8 @@ bool writeZclAttribute(const Resource *r, const ResourceItem *item, deCONZ::ApsC
 
         if (!expr.isEmpty())
         {
-            DeviceJs engine;
+            DeviceJs &engine = *DeviceJs::instance();
+            engine.reset();
             engine.setResource(r);
             engine.setItem(item);
 


### PR DESCRIPTION
Create JS engine instance as singleton only once. Likely speeds up parsing but also allows to use the JS engine for other purposes (separate PR).