### PR TITLE
DDF initial support for top level "matchexpr" property

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -3222,7 +3222,8 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
 
         if (!isClip)
         {
-            const auto ddf = d->deviceDescriptions->get(&sensor);
+            // ignore DDF "matchexpr" at this stage since the node is not yet fully loaded
+            const auto &ddf = d->deviceDescriptions->get(&sensor, DDF_IgnoreMatchExpr);
             if (ddf.isValid())
             {
                 unsigned ep = endpointFromUniqueId(sensor.uniqueId());

--- a/device.cpp
+++ b/device.cpp
@@ -200,7 +200,11 @@ void DEV_InitStateHandler(Device *device, const Event &event)
 
         if ((event.deviceKey() & 0x00212E0000000000LLU) == 0x00212E0000000000LLU)
         {
-            d->node = DEV_GetCoreNode(device->key());
+            if (!d->node)
+            {
+                d->node = DEV_GetCoreNode(device->key());
+            }
+
             if (d->node && d->node->isCoordinator())
             {
                 d->setState(DEV_DeadStateHandler);

--- a/device_descriptions.cpp
+++ b/device_descriptions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2022 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -18,6 +18,7 @@
 #include <deconz/dbg_trace.h>
 #include "device_ddf_init.h"
 #include "device_descriptions.h"
+#include "device_js/device_js.h"
 #include "event.h"
 #include "resource.h"
 
@@ -524,7 +525,7 @@ void DeviceDescriptions::handleEvent(const Event &event)
 /*! Get the DDF object for a \p resource.
     \returns The DDF object, DeviceDescription::isValid() to check for success.
  */
-const DeviceDescription &DeviceDescriptions::get(const Resource *resource) const
+const DeviceDescription &DeviceDescriptions::get(const Resource *resource, DDF_MatchControl match) const
 {
     Q_ASSERT(resource);
     Q_ASSERT(resource->item(RAttrModelId));
@@ -543,7 +544,29 @@ const DeviceDescription &DeviceDescriptions::get(const Resource *resource) const
 
     if (i != d->descriptions.end())
     {
-        return *i;
+        if (!i->matchExpr.isEmpty() && match == DDF_EvalMatchExpr)
+        {
+            DeviceJs *djs = DeviceJs::instance();
+            djs->reset();
+            djs->setResource(resource->parentResource() ? resource->parentResource() : resource);
+            if (djs->evaluate(i->matchExpr) == JsEvalResult::Ok)
+            {
+                const auto res = djs->result();
+                DBG_Printf(DBG_DDF, "matchexpr: %s --> %s\n", qPrintable(i->matchExpr), qPrintable(res.toString()));
+                if (res.toBool()) // needs to evaluate to true
+                {
+                    return *i;
+                }
+            }
+            else
+            {
+                DBG_Printf(DBG_DDF, "failed to evaluate matchexpr for %s: %s, err: %s\n", qPrintable(resource->item(RAttrUniqueId)->toString()), qPrintable(i->matchExpr), qPrintable(djs->errorString()));
+            }
+        }
+        else
+        {
+            return *i;
+        }
     }
 
     return d->invalidDescription;
@@ -1504,6 +1527,11 @@ static DeviceDescription DDF_ParseDeviceObject(const QJsonObject &obj, const QSt
     if (obj.contains(QLatin1String("sleeper")))
     {
         result.sleeper = obj.value(QLatin1String("sleeper")).toBool() ? 1 : 0;
+    }
+
+    if (obj.contains(QLatin1String("matchexpr")))
+    {
+        result.matchExpr = obj.value(QLatin1String("matchexpr")).toString();
     }
 
     const auto keys = obj.keys();

--- a/device_descriptions.h
+++ b/device_descriptions.h
@@ -99,6 +99,7 @@ public:
     QString vendor; // optional: friendly name of manufacturer
     QString product;
     QString status;
+    QString matchExpr;
 
     int handle = -1; // index in container
     int sleeper = -1;
@@ -225,6 +226,12 @@ class DeviceDescriptionsPrivate;
 
 using DDF_Items = std::vector<DeviceDescription::Item>;
 
+enum DDF_MatchControl
+{
+    DDF_EvalMatchExpr,
+    DDF_IgnoreMatchExpr
+};
+
 class DeviceDescriptions : public QObject
 {
     Q_OBJECT
@@ -234,7 +241,7 @@ public:
     ~DeviceDescriptions();
     void setEnabledStatusFilter(const QStringList &filter);
     const QStringList &enabledStatusFilter() const;
-    const DeviceDescription &get(const Resource *resource) const;
+    const DeviceDescription &get(const Resource *resource, DDF_MatchControl match = DDF_EvalMatchExpr) const;
     void put(const DeviceDescription &ddf);
     const DeviceDescription &load(const QString &path);
 

--- a/device_js/device_js.h
+++ b/device_js/device_js.h
@@ -48,6 +48,7 @@ namespace deCONZ
     ### Object Methods
 
     R.item(suffix) -> gets Item object, for example the 'config.offset'
+    R.endpoints    -> array of active device endpoints, e.g. [1, 2]  (read only)
     Item.val       -> ResourceItem value (read/write)
     Item.name      -> ResourceItem name like 'state/on' (read only)
     Attr.id        -> attribute id (number, read only)
@@ -102,6 +103,7 @@ public:
     QVariant result();
     void reset();
     QString errorString() const;
+    static DeviceJs *instance();
 
 private:
     std::unique_ptr<DeviceJsPrivate> d;

--- a/device_js/device_js_wrappers.cpp
+++ b/device_js/device_js_wrappers.cpp
@@ -10,6 +10,24 @@
 
 #include "resource.h"
 #include "device_js_wrappers.h"
+#include "device.h"
+#include "utils/utils.h"
+
+static const deCONZ::Node *getResourceCoreNode(const Resource *r)
+{
+    if (r)
+    {
+        const ResourceItem *uuid = r->item(RAttrUniqueId);
+
+        if (uuid && !uuid->toString().isEmpty())
+        {
+            const uint64_t extAddr = extAddressFromUniqueId(uuid->toString());
+
+            return DEV_GetCoreNode(extAddr);
+        }
+    }
+    return nullptr;
+}
 
 JsResource::JsResource(QJSEngine *parent) :
     QObject(parent)
@@ -38,6 +56,24 @@ QJSValue JsResource::item(const QString &suffix)
     }
 
     return {};
+}
+
+QVariant JsResource::endpoints()
+{
+    QVariantList result;
+    if (cr)
+    {
+        const deCONZ::Node *node = getResourceCoreNode(cr);
+        if (node)
+        {
+            for (auto ep : node->endpoints())
+            {
+                result.push_back(int(ep));
+            }
+        }
+    }
+
+    return result;
 }
 
 JsResourceItem::JsResourceItem(QObject *parent) :

--- a/device_js/device_js_wrappers.h
+++ b/device_js/device_js_wrappers.h
@@ -28,7 +28,9 @@ namespace deCONZ
 
 class JsResource : public QObject
 {
-Q_OBJECT
+    Q_OBJECT
+
+    Q_PROPERTY(QVariant endpoints READ endpoints CONSTANT)
 
 public:
     Resource *r = nullptr;
@@ -38,6 +40,7 @@ public:
 
 public Q_SLOTS:
     QJSValue item(const QString &suffix);
+    QVariant endpoints();
 };
 
 class JsResourceItem : public QObject
@@ -45,7 +48,7 @@ class JsResourceItem : public QObject
     Q_OBJECT
 
     Q_PROPERTY(QVariant val READ value WRITE setValue NOTIFY valueChanged)
-    Q_PROPERTY(QString name READ name)
+    Q_PROPERTY(QString name READ name CONSTANT)
 
 public:
     ResourceItem *item = nullptr;
@@ -67,9 +70,9 @@ class JsZclAttribute : public QObject
 {
     Q_OBJECT
 
-    Q_PROPERTY(QVariant val READ value)
-    Q_PROPERTY(int id READ id)
-    Q_PROPERTY(int dataType READ dataType)
+    Q_PROPERTY(QVariant val READ value CONSTANT)
+    Q_PROPERTY(int id READ id CONSTANT)
+    Q_PROPERTY(int dataType READ dataType CONSTANT)
 
 public:
     const deCONZ::ZclAttribute *attr = nullptr;
@@ -86,9 +89,9 @@ class JsZclFrame : public QObject
 {
     Q_OBJECT
 
-    Q_PROPERTY(int cmd READ cmd)
-    Q_PROPERTY(int payloadSize READ payloadSize)
-    Q_PROPERTY(bool isClCmd READ isClCmd)
+    Q_PROPERTY(int cmd READ cmd CONSTANT)
+    Q_PROPERTY(int payloadSize READ payloadSize CONSTANT)
+    Q_PROPERTY(bool isClCmd READ isClCmd CONSTANT)
 
 public:
     const deCONZ::ZclFrame *zclFrame = nullptr;

--- a/rest_devices.cpp
+++ b/rest_devices.cpp
@@ -469,6 +469,11 @@ bool ddfSerializeV1(JsonDoc &doc, const DeviceDescription &ddf, char *buf, size_
 
     doc["status"] = ddf.status.toStdString();
 
+    if (!ddf.matchExpr.isEmpty())
+    {
+        doc["matchexpr"] = ddf.matchExpr.toStdString();
+    }
+
     if (!ddf.path.isEmpty())
     {
         int idx = ddf.path.indexOf(QLatin1String("/devices/"));


### PR DESCRIPTION
This allows to select a DDF not only by modelid and manufacturer name
but optionally also other aspects as endpoints of the device.

The initial version supports `R.endpoints` property which returns an array of active endpoints of the node
e.g. `[1, 2]`. So it can be queried for specific endpoints or simply the number e.g.:

```
{
  ....
  "modelid": "ACME",
  "matchexpr": "R.endpoints.length === 2",
  ...
}
```

Note this should only be used in very specific cases!