### PR TITLE
DDF support sub device "meta" objects

### DIFF
--- a/device_descriptions.h
+++ b/device_descriptions.h
@@ -173,6 +173,7 @@ public:
         QString type;
         QString restApi;
         QStringList uniqueId; // [ "$address.ext", "01", "0405"],
+        QVariantMap meta;
         std::vector<Item> items;
         SensorFingerprint fingerPrint;
     };
@@ -244,6 +245,8 @@ public:
     const DeviceDescription &get(const Resource *resource, DDF_MatchControl match = DDF_EvalMatchExpr) const;
     void put(const DeviceDescription &ddf);
     const DeviceDescription &load(const QString &path);
+
+    const DeviceDescription::SubDevice &getSubDevice(const Resource *resource) const;
 
     QString constantToString(const QString &constant) const;
     QString stringToConstant(const QString &str) const;


### PR DESCRIPTION
A optional "meta" JSON objects can be provided which may describe static aspects of a device
not fitting in general "items" or other keywords.

One example is `group.endpoints` of an upcoming PR to describe which endpoints
reflect the index belonging to an endpoint of `config.group`.

```
{
  "meta": {
    "group.endpoints": [1, 2]
  }
}
```

The C++ code can query the meta object for a sub device as QVariantMap via 

```
Resource *r = ...;
const auto &sub = const DeviceDescription::instance()->getSubDevice(r);

if (sub.isValid())
{
     if (sub.meta.contains(QLatin1String("group.endpoints")))
     {
          // sub.meta is an QVariantMap
     }
}
```


**Warning:** It is *not* intended to add endless things to the meta object, most often it's better to find a general approach!