### PR TITLE
Fix : Thermostat variant for Centralite Pearl 3 Thermostat

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -3923,7 +3923,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     sensor.addItem(DataTypeString, RConfigMode);
                     sensor.addItem(DataTypeString, RConfigFanMode);
                 }
-                else if (sensor.modelId() == QLatin1String("3157100"))
+                else if (sensor.modelId().startsWith(QLatin1String("3157100")))
                 {
                     sensor.addItem(DataTypeInt16, RConfigCoolSetpoint);
                     sensor.addItem(DataTypeBool, RConfigLocked)->setValue(false);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -7745,7 +7745,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                 sensorNode.addItem(DataTypeString, RConfigMode);
                 sensorNode.addItem(DataTypeString, RConfigFanMode);
             }
-            else if (modelId == QLatin1String("3157100"))
+            else if (modelId.startsWith(QLatin1String("3157100")))
             {
                 sensorNode.addItem(DataTypeInt16, RConfigCoolSetpoint);
                 sensorNode.addItem(DataTypeBool, RConfigLocked)->setValue(false);

--- a/fan_control.cpp
+++ b/fan_control.cpp
@@ -78,7 +78,7 @@ void DeRestPluginPrivate::handleFanControlClusterIndication(const deCONZ::ApsDat
             case FAN_CTRL_ATTRID_FAN_MODE:
             {
                 if (sensor->modelId() == QLatin1String("AC201") ||     // Owon
-                    sensor->modelId().startsWith(QLatin1String("3157100") ||   // Centralite pearl
+                    sensor->modelId().startsWith(QLatin1String("3157100")) ||   // Centralite pearl
                     sensor->modelId() == QLatin1String("Zen-01"))      // Zen
                 {
                     qint8 mode = attr.numericValue().u8;

--- a/fan_control.cpp
+++ b/fan_control.cpp
@@ -78,7 +78,7 @@ void DeRestPluginPrivate::handleFanControlClusterIndication(const deCONZ::ApsDat
             case FAN_CTRL_ATTRID_FAN_MODE:
             {
                 if (sensor->modelId() == QLatin1String("AC201") ||     // Owon
-                    sensor->modelId() == QLatin1String("3157100") ||   // Centralite pearl
+                    sensor->modelId().startsWith(QLatin1String("3157100") ||   // Centralite pearl
                     sensor->modelId() == QLatin1String("Zen-01"))      // Zen
                 {
                     qint8 mode = attr.numericValue().u8;


### PR DESCRIPTION
See https://forum.phoscon.de/t/centralite-pearl-3-thermostat-not-presenting-all-hvac-modes-in-home-assistant/1803
Nothing special.