### PR TITLE
Better precision for big value in API result.

### DIFF
--- a/json.cpp
+++ b/json.cpp
@@ -137,10 +137,14 @@ QByteArray Json::serialize(const QVariant &data, bool &success)
 		.toAscii();
 #endif
 	}
-	else if(data.type() == QVariant::Double) // double?
-	{
-		str = QByteArray::number(data.toDouble());
-	}
+    else if(data.type() == QVariant::Double) // double?
+    {
+#if (QT_VERSION >= QT_VERSION_CHECK(5,7, 0))
+        str = QByteArray::number(data.toDouble(), 'f', QLocale::FloatingPointShortest);
+#else
+        str = QByteArray::number(data.toDouble());
+#endif
+    }
 	else if (data.type() == QVariant::Bool) // boolean value?
 	{
 		str = data.toBool() ? "true" : "false";

--- a/json.cpp
+++ b/json.cpp
@@ -3,6 +3,7 @@
  */
  
 #include "json.h"
+#include <QLocale>
 
 static QString sanitizeString(QString str)
 {


### PR DESCRIPTION
This issue can impact state/consumption with big value.

To reproduce the issue.

- take a DDF for a sensor
- add the config/powerup field (UInt32)
- set the "static defaut value"
- try values

1999999 result > 2000000
12345678 result 12345700

This patch will work only on recent QT version, no change for older.