### PR TITLE
Fix: add missing eval to parsing functions

### DIFF
--- a/devices/generic/items/state_lastset_item.json
+++ b/devices/generic/items/state_lastset_item.json
@@ -5,7 +5,7 @@
 	"access": "R",
 	"public": true,
 	"description": "Timestamp when the time attribute was last set on the device.",
-	"parse": {"at": "0x0008", "cl": "0x000A", "ep": 0, "fn": "zcl"},
+	"parse": {"at": "0x0008", "cl": "0x000A", "ep": 0, "eval": "Item.val = Attr.val;", "fn": "zcl"},
 	"read": {"at": "0x0008", "cl": "0x000A", "ep": 0, "fn": "zcl"},
 	"refresh.interval": 3600
 }

--- a/devices/generic/items/state_localtime_item.json
+++ b/devices/generic/items/state_localtime_item.json
@@ -5,7 +5,7 @@
 	"access": "R",
 	"public": true,
 	"description": "The current local time set on the device.",
-	"parse": {"at": "0x0007", "cl": "0x000A", "ep": 0, "fn": "zcl"},
+	"parse": {"at": "0x0007", "cl": "0x000A", "ep": 0, "eval": "Item.val = Attr.val;", "fn": "zcl"},
 	"read": {"at": "0x0007", "cl": "0x000A", "ep": 0, "fn": "zcl"},
 	"refresh.interval": 3600
 }

--- a/devices/generic/items/state_utc_item.json
+++ b/devices/generic/items/state_utc_item.json
@@ -5,7 +5,7 @@
 	"access": "RW",
 	"public": true,
 	"description": "Current timestamp in UTC set on the device.",
-	"parse": {"at": "0x0000", "cl": "0x000A", "ep": 0, "fn": "zcl"},
+	"parse": {"at": "0x0000", "cl": "0x000A", "ep": 0, "eval": "Item.val = Attr.val;", "fn": "zcl"},
 	"read": { "at": "0x0000", "cl": "0x000A", "ep": 0, "fn": "zcl"},
 	"refresh.interval": 3600
 }


### PR DESCRIPTION
The time related resource items had the respective evals missing in the parsing functions.