### PR TITLE
Debounce resource item value changes and API events while using write state changes for sensors

### DIFF
--- a/rest_sensors.cpp.bak
+++ b/rest_sensors.cpp.bak
@@ -1891,33 +1891,17 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
 
                 if (updated)
                 {
-                    bool isStateChange = false;
-
-                    const auto sc = std::find_if(change.items().cbegin(), change.items().cend(), [rid](const auto stateChange)
-                    {
-                        return (rid.suffix == stateChange.suffix );
-                    });
-
-                    if (sc != change.items().cend())
-                    {
-                        isStateChange = true;
-                    }
-
-                    if (isStateChange || (!isStateChange && item->setValue(val)))
+                    if (item->setValue(val))
                     {
                         QVariantMap rspItem;
                         QVariantMap rspItemState;
                         rspItemState[QString("/sensors/%1/config/%2").arg(id).arg(pi.key())] = val;
                         rspItem[QLatin1String("success")] = rspItemState;
                         rsp.list.append(rspItem);
+                        Event e(RSensors, rid.suffix, id, item);
+                        enqueueEvent(e);
 
-                        if (!isStateChange)
-                        {
-                            Event e(RSensors, rid.suffix, id, item);
-                            enqueueEvent(e);
-                        }
-
-                        if (devManaged)
+                        if (device && device->managed())
                         {
                             DB_StoreSubDeviceItem(sensor, item);
                         }


### PR DESCRIPTION
This is some kind of paradigm change when using state changes to write values for sensor resources. The legacy approach works like this:

- set a value via API
- Resource item value assumes the wanted value and emits a websocket event
- Value is tried to be written to the device
- On success, all's good. On failure, the intended value for the item remains and you just get to know it was unsuccessful by the next value update from the device -> device and API are out of sync meanwhile

As state changes have been introduced recently for writing values via API for some resource items, this gets more robust with regard to verification of the writes. However, this can lead to some unwanted updates of the respective resource item(s).

Worst case for a sleeping end device could be:
- Initial value is e.g. delay = 10
- set a value via API
- Resource item value assumes the wanted value and emits a websocket event, e.g. delay = 55
- Value is NOT written to the device unless it is determined as awake
- Device sends an attribute report, resource item value assumes value 10 (out of sync)
- Device is determined to be awake and the current value is read
- Device sends a response, resource item value assumes value 10
- Current (10) and target value (55) do not match, write is initiated
- Another read is initiated to verify if value was set as intended
- Device sends a response, resource item value assumes value 55

So, in short, the value jumps back and forth 10 -> 55 -> 10 -> 55.

The change in this PR detects if a state change is used to write a value and would in that case skip setting the item value directly after sending the API request. Instead, the value will remain until the verification read of the state change receives a response, the worst case example above would become 10 -> 10 -> 55