### PR TITLE
Add door lock and warning device DDF types

### DIFF
--- a/devices/generic/constants.json
+++ b/devices/generic/constants.json
@@ -19,6 +19,7 @@
         "$TYPE_DIMMABLE_LIGHT": "Dimmable light",
         "$TYPE_DIMMABLE_PLUGIN_UNIT": "Dimmable plug-in unit",
         "$TYPE_DOOR_LOCK": "Door Lock",
+        "$TYPE_DOOR_LOCK_CONTROLLER": "Door lock controller",
         "$TYPE_EXTENDED_COLOR_LIGHT": "Extended color light",
         "$TYPE_SMART_PLUG": "Smart plug",
         "$TYPE_ON_OFF_LIGHT": "On/Off light",
@@ -39,6 +40,7 @@
         "$TYPE_TEMPERATURE_SENSOR": "ZHATemperature",
         "$TYPE_THERMOSTAT": "ZHAThermostat",
         "$TYPE_VIBRATION_SENSOR": "ZHAVibration",
+        "$TYPE_WARNING_DEVICE": "Warning device",
         "$TYPE_WINDOW_COVERING_DEVICE": "Window covering device",
         "$TYPE_ZGP_SWITCH": "ZGPSwitch",
         "$TYPE_SPECTRAL_SENSOR": "ZHASpectral"

--- a/devices/generic/subdevices/door_lock_controller.json
+++ b/devices/generic/subdevices/door_lock_controller.json
@@ -1,0 +1,12 @@
+{
+    "schema": "subdevice1.schema.json",
+    "type": "$TYPE_DOOR_LOCK_CONTROLLER",
+    "name": "Door Lock Controller",
+    "restapi": "/lights",
+    "order": 11,
+    "uuid": ["$address.ext", "0x01"],
+    "items": [
+        "state/reachable",
+        "state/on"
+    ]
+}

--- a/devices/generic/subdevices/warning_device.json
+++ b/devices/generic/subdevices/warning_device.json
@@ -1,0 +1,12 @@
+{
+    "schema": "subdevice1.schema.json",
+    "type": "$TYPE_WARNING_DEVICE",
+    "name": "Warning device",
+    "restapi": "/lights",
+    "order": 11,
+    "uuid": ["$address.ext", "0x01"],
+    "items": [
+        "state/reachable",
+        "state/alert"
+    ]
+}


### PR DESCRIPTION
Add 
- Door lock controller https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3973
- Warning device

I m not sure for the "Fan device", will be usefull but not used by third app ..
Can add it if needed.