### PR TITLE
Set `config/delay` resource item default to 60

### DIFF
--- a/devices/generic/items/config_delay_item.json
+++ b/devices/generic/items/config_delay_item.json
@@ -4,6 +4,6 @@
 	"datatype": "UInt16",
 	"access": "RW",
 	"public": true,
-    "default": 0,
+    "default": 60,
 	"description": "The occupied to unoccupied delay in seconds."
 }


### PR DESCRIPTION
A default of 0 can lead to irritation presence detection is not working properly. State jumps from `true` back to `false` within the second.