### PR TITLE
Add DDF functions to sync time

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4378,7 +4378,11 @@ void DeRestPluginPrivate::checkSensorNodeReachable(Sensor *sensor, const deCONZ:
 
             updated = true;
         }
-        if (!DEV_TestStrict())
+
+        auto *device = DEV_GetDevice(m_devices, sensor->address().ext());
+        const bool devManaged = device && device->managed();
+
+        if (!DEV_TestStrict() && !devManaged)
         {
             if (sensor->type() == QLatin1String("ZHATime") && !sensor->mustRead(READ_TIME))
             {
@@ -11184,7 +11188,10 @@ bool DeRestPluginPrivate::processZclAttributes(Sensor *sensorNode)
         }
     }
 
-    if (!DEV_TestStrict())
+    auto *device = DEV_GetDevice(m_devices, sensorNode->address().ext());
+    const bool devManaged = device && device->managed();
+
+    if (!DEV_TestStrict() && !devManaged)
     {
         if (sensorNode->mustRead(READ_TIME) && tNow > sensorNode->nextReadTime(READ_TIME))
         {
@@ -16894,7 +16901,7 @@ void DeRestPlugin::idleTimerFired()
                             }
                         }
 
-                        if (!DEV_TestStrict())
+                        if (!DEV_TestStrict() && !devManaged)
                         {
                             if (*ci == TIME_CLUSTER_ID)
                             {

--- a/device.cpp
+++ b/device.cpp
@@ -8,7 +8,6 @@
  *
  */
 
-#include <QBasicTimer>
 #include <QElapsedTimer>
 #include <QTimer>
 #include <QTimerEvent>
@@ -23,17 +22,6 @@
 #include "event.h"
 #include "event_emitter.h"
 #include "utils/utils.h"
-#include "zcl/zcl.h"
-#include "zdp/zdp.h"
-
-#define STATE_LEVEL_BINDING  StateLevel1
-#define STATE_LEVEL_POLL     StateLevel2
-
-#define MGMT_BIND_SUPPORT_UNKNOWN -1
-#define MGMT_BIND_SUPPORTED        1
-#define MGMT_BIND_NOT_SUPPORTED    0
-
-typedef void (*DeviceStateHandler)(Device *, const Event &);
 
 /*! Device state machine description can be found in the wiki:
 
@@ -60,103 +48,12 @@ void DEV_PollNextStateHandler(Device *device, const Event &event);
 void DEV_PollBusyStateHandler(Device *device, const Event &event);
 void DEV_DeadStateHandler(Device *device, const Event &event);
 
-// enable domain specific string literals
-using namespace deCONZ::literals;
-
-constexpr int RxOnWhenIdleResponseTime = 2000; // Expect shorter response delay for rxOnWhenIdle devices
-constexpr int RxOffWhenIdleResponseTime = 8000; // 7680 ms + some space for timeout
-constexpr int MaxConfirmTimeout = 20000; // If for some reason no APS-DATA.confirm is received (should almost
-constexpr int BindingAutoCheckInterval = 1000 * 60 * 60;
-constexpr int MaxPollItemRetries = 3;
-constexpr int MaxSubResources = 8;
-
 static int devManaged = -1;
-
-struct DEV_PollItem
-{
-    explicit DEV_PollItem(const Resource *r, const ResourceItem *i, const QVariant &p) :
-        resource(r), item(i), readParameters(p) {}
-    size_t retry = 0;
-    const Resource *resource = nullptr;
-    const ResourceItem *item = nullptr;
-    QVariant readParameters;
-};
 
 // special value for ReportTracker::lastConfigureCheck during zcl configure reporting step
 constexpr int64_t MarkZclConfigureBusy = 21;
 
-struct ReportTracker
-{
-    deCONZ::SteadyTimeRef lastReport;
-    deCONZ::SteadyTimeRef lastConfigureCheck;
-    uint16_t clusterId = 0;
-    uint16_t attributeId = 0;
-    uint8_t endpoint = 0;
-};
-
-struct BindingTracker
-{
-    deCONZ::SteadyTimeRef tBound;
-};
-
-struct BindingContext
-{
-    size_t bindingCheckRound = 0;
-    size_t bindingIter = 0;
-    size_t reportIter = 0;
-    int mgmtBindSupported = MGMT_BIND_SUPPORT_UNKNOWN;
-    uint8_t mgmtBindStartIndex = 0;
-    std::vector<BindingTracker> bindingTrackers;
-    std::vector<DDF_Binding> bindings;
-    std::vector<ReportTracker> reportTrackers;
-    ZCL_ReadReportConfigurationParam readReportParam;
-    ZCL_Result zclResult;
-    ZDP_Result zdpResult;
-};
-
 static ReportTracker &DEV_GetOrCreateReportTracker(Device *device, uint16_t clusterId, uint16_t attrId, uint8_t endpoint);
-
-class DevicePrivate
-{
-public:
-    void setState(DeviceStateHandler newState, DEV_StateLevel level = StateLevel0);
-    void startStateTimer(int IntervalMs, DEV_StateLevel level);
-    void stopStateTimer(DEV_StateLevel level);
-    bool hasRxOnWhenIdle() const;
-
-    Device *q = nullptr; //! reference to public interface
-    deCONZ::ApsController *apsCtrl = nullptr; //! opaque instance pointer forwarded to external functions
-
-    /*! sub-devices are not yet referenced via pointers since these may become dangling.
-        This is a helper to query the actual sub-device Resource* on demand via Resource::Handle.
-    */
-    std::array<Resource::Handle, MaxSubResources> subResourceHandles;
-    std::vector<Resource*> subResources;
-    const deCONZ::Node *node = nullptr; //! a reference to the deCONZ core node
-    DeviceKey deviceKey = 0; //! for physical devices this is the MAC address
-
-    /*! The currently active state handler function(s).
-        Indexes >0 represent sub states of StateLevel0 running in parallel.
-    */
-    std::array<DeviceStateHandler, StateLevelMax> state{};
-
-    std::array<QBasicTimer, StateLevelMax> timer; //! internal single shot timer one for each state level
-    QElapsedTimer awake; //! time to track when an end-device was last awake
-    BindingContext binding; //! only used by binding sub state machine
-    std::vector<DEV_PollItem> pollItems; //! queue of items to poll
-    bool managed = false; //! a managed device doesn't rely on legacy implementation of polling etc.
-    ZDP_Result zdpResult; //! keep track of a running ZDP request
-    DA_ReadResult readResult; //! keep track of a running "read" request
-
-    int maxResponseTime = RxOffWhenIdleResponseTime;
-
-    struct
-    {
-        unsigned char hasDdf : 1;
-        unsigned char initialRun : 1;
-        unsigned char reserved : 6;
-    } flags{};
-};
 
 //! Forward device attribute changes to core.
 void DEV_ForwardNodeChange(Device *device, const QString &key, const QString &value)

--- a/device.cpp
+++ b/device.cpp
@@ -8,6 +8,7 @@
  *
  */
 
+#include <QBasicTimer>
 #include <QElapsedTimer>
 #include <QTimer>
 #include <QTimerEvent>
@@ -22,6 +23,17 @@
 #include "event.h"
 #include "event_emitter.h"
 #include "utils/utils.h"
+#include "zcl/zcl.h"
+#include "zdp/zdp.h"
+
+#define STATE_LEVEL_BINDING  StateLevel1
+#define STATE_LEVEL_POLL     StateLevel2
+
+#define MGMT_BIND_SUPPORT_UNKNOWN -1
+#define MGMT_BIND_SUPPORTED        1
+#define MGMT_BIND_NOT_SUPPORTED    0
+
+typedef void (*DeviceStateHandler)(Device *, const Event &);
 
 /*! Device state machine description can be found in the wiki:
 
@@ -48,12 +60,103 @@ void DEV_PollNextStateHandler(Device *device, const Event &event);
 void DEV_PollBusyStateHandler(Device *device, const Event &event);
 void DEV_DeadStateHandler(Device *device, const Event &event);
 
+// enable domain specific string literals
+using namespace deCONZ::literals;
+
+constexpr int RxOnWhenIdleResponseTime = 2000; // Expect shorter response delay for rxOnWhenIdle devices
+constexpr int RxOffWhenIdleResponseTime = 8000; // 7680 ms + some space for timeout
+constexpr int MaxConfirmTimeout = 20000; // If for some reason no APS-DATA.confirm is received (should almost
+constexpr int BindingAutoCheckInterval = 1000 * 60 * 60;
+constexpr int MaxPollItemRetries = 3;
+constexpr int MaxSubResources = 8;
+
 static int devManaged = -1;
+
+struct DEV_PollItem
+{
+    explicit DEV_PollItem(const Resource *r, const ResourceItem *i, const QVariant &p) :
+        resource(r), item(i), readParameters(p) {}
+    size_t retry = 0;
+    const Resource *resource = nullptr;
+    const ResourceItem *item = nullptr;
+    QVariant readParameters;
+};
 
 // special value for ReportTracker::lastConfigureCheck during zcl configure reporting step
 constexpr int64_t MarkZclConfigureBusy = 21;
 
+struct ReportTracker
+{
+    deCONZ::SteadyTimeRef lastReport;
+    deCONZ::SteadyTimeRef lastConfigureCheck;
+    uint16_t clusterId = 0;
+    uint16_t attributeId = 0;
+    uint8_t endpoint = 0;
+};
+
+struct BindingTracker
+{
+    deCONZ::SteadyTimeRef tBound;
+};
+
+struct BindingContext
+{
+    size_t bindingCheckRound = 0;
+    size_t bindingIter = 0;
+    size_t reportIter = 0;
+    int mgmtBindSupported = MGMT_BIND_SUPPORT_UNKNOWN;
+    uint8_t mgmtBindStartIndex = 0;
+    std::vector<BindingTracker> bindingTrackers;
+    std::vector<DDF_Binding> bindings;
+    std::vector<ReportTracker> reportTrackers;
+    ZCL_ReadReportConfigurationParam readReportParam;
+    ZCL_Result zclResult;
+    ZDP_Result zdpResult;
+};
+
 static ReportTracker &DEV_GetOrCreateReportTracker(Device *device, uint16_t clusterId, uint16_t attrId, uint8_t endpoint);
+
+class DevicePrivate
+{
+public:
+    void setState(DeviceStateHandler newState, DEV_StateLevel level = StateLevel0);
+    void startStateTimer(int IntervalMs, DEV_StateLevel level);
+    void stopStateTimer(DEV_StateLevel level);
+    bool hasRxOnWhenIdle() const;
+
+    Device *q = nullptr; //! reference to public interface
+    deCONZ::ApsController *apsCtrl = nullptr; //! opaque instance pointer forwarded to external functions
+
+    /*! sub-devices are not yet referenced via pointers since these may become dangling.
+        This is a helper to query the actual sub-device Resource* on demand via Resource::Handle.
+    */
+    std::array<Resource::Handle, MaxSubResources> subResourceHandles;
+    std::vector<Resource*> subResources;
+    const deCONZ::Node *node = nullptr; //! a reference to the deCONZ core node
+    DeviceKey deviceKey = 0; //! for physical devices this is the MAC address
+
+    /*! The currently active state handler function(s).
+        Indexes >0 represent sub states of StateLevel0 running in parallel.
+    */
+    std::array<DeviceStateHandler, StateLevelMax> state{};
+
+    std::array<QBasicTimer, StateLevelMax> timer; //! internal single shot timer one for each state level
+    QElapsedTimer awake; //! time to track when an end-device was last awake
+    BindingContext binding; //! only used by binding sub state machine
+    std::vector<DEV_PollItem> pollItems; //! queue of items to poll
+    bool managed = false; //! a managed device doesn't rely on legacy implementation of polling etc.
+    ZDP_Result zdpResult; //! keep track of a running ZDP request
+    DA_ReadResult readResult; //! keep track of a running "read" request
+
+    int maxResponseTime = RxOffWhenIdleResponseTime;
+
+    struct
+    {
+        unsigned char hasDdf : 1;
+        unsigned char initialRun : 1;
+        unsigned char reserved : 6;
+    } flags{};
+};
 
 //! Forward device attribute changes to core.
 void DEV_ForwardNodeChange(Device *device, const QString &key, const QString &value)
@@ -534,7 +637,7 @@ void DEV_BasicClusterStateHandler(Device *device, const Event &event)
         d->stopStateTimer(StateLevel0);
     }
     else if (event.what() == REventApsConfirm)
-    {       
+    {
         if (d->readResult.apsReqId == EventApsConfirmId(event))
         {
             if (EventApsConfirmStatus(event) == deCONZ::ApsSuccessStatus)
@@ -705,6 +808,12 @@ void DEV_BindingHandler(Device *device, const Event &event)
     if (event.what() == REventStateEnter)
     {
         DBG_Printf(DBG_DEV, "DEV Binding enter %s/0x%016llX\n", event.resource(), event.deviceKey());
+
+        if (!d->node->isRouter())
+        {
+            // most end devices support it, however disable for now until further testing
+            d->binding.mgmtBindSupported = MGMT_BIND_NOT_SUPPORTED;
+        }
     }
     else if (event.what() == REventPoll || event.what() == REventAwake || event.what() == REventBindingTick)
     {

--- a/device.cpp
+++ b/device.cpp
@@ -808,12 +808,6 @@ void DEV_BindingHandler(Device *device, const Event &event)
     if (event.what() == REventStateEnter)
     {
         DBG_Printf(DBG_DEV, "DEV Binding enter %s/0x%016llX\n", event.resource(), event.deviceKey());
-
-        if (!d->node->isRouter())
-        {
-            // most end devices support it, however disable for now until further testing
-            d->binding.mgmtBindSupported = MGMT_BIND_NOT_SUPPORTED;
-        }
     }
     else if (event.what() == REventPoll || event.what() == REventAwake || event.what() == REventBindingTick)
     {

--- a/device.h
+++ b/device.h
@@ -12,18 +12,8 @@
 #define DEVICE_H
 
 #include <memory>
-#include <QBasicTimer>
 #include <QObject>
 #include "resource.h"
-#include "zcl/zcl.h"
-#include "zdp/zdp.h"
-
-#define STATE_LEVEL_BINDING  StateLevel1
-#define STATE_LEVEL_POLL     StateLevel2
-
-#define MGMT_BIND_SUPPORT_UNKNOWN -1
-#define MGMT_BIND_SUPPORTED        1
-#define MGMT_BIND_NOT_SUPPORTED    0
 
 class Event;
 class EventEmitter;
@@ -48,55 +38,6 @@ enum DEV_StateLevel {
     StateLevel2 = 2,
 
     StateLevelMax
-};
-
-// enable domain specific string literals
-using namespace deCONZ::literals;
-
-constexpr int RxOnWhenIdleResponseTime = 2000; // Expect shorter response delay for rxOnWhenIdle devices
-constexpr int RxOffWhenIdleResponseTime = 8000; // 7680 ms + some space for timeout
-constexpr int MaxConfirmTimeout = 20000; // If for some reason no APS-DATA.confirm is received (should almost
-constexpr int BindingAutoCheckInterval = 1000 * 60 * 60;
-constexpr int MaxPollItemRetries = 3;
-constexpr int MaxSubResources = 8;
-
-struct DEV_PollItem
-{
-    explicit DEV_PollItem(const Resource *r, const ResourceItem *i, const QVariant &p) :
-        resource(r), item(i), readParameters(p) {}
-    size_t retry = 0;
-    const Resource *resource = nullptr;
-    const ResourceItem *item = nullptr;
-    QVariant readParameters;
-};
-
-struct ReportTracker
-{
-    deCONZ::SteadyTimeRef lastReport;
-    deCONZ::SteadyTimeRef lastConfigureCheck;
-    uint16_t clusterId = 0;
-    uint16_t attributeId = 0;
-    uint8_t endpoint = 0;
-};
-
-struct BindingTracker
-{
-    deCONZ::SteadyTimeRef tBound;
-};
-
-struct BindingContext
-{
-    size_t bindingCheckRound = 0;
-    size_t bindingIter = 0;
-    size_t reportIter = 0;
-    int mgmtBindSupported = MGMT_BIND_SUPPORT_UNKNOWN;
-    uint8_t mgmtBindStartIndex = 0;
-    std::vector<BindingTracker> bindingTrackers;
-    std::vector<DDF_Binding> bindings;
-    std::vector<ReportTracker> reportTrackers;
-    ZCL_ReadReportConfigurationParam readReportParam;
-    ZCL_Result zclResult;
-    ZDP_Result zdpResult;
 };
 
 /*! \class Device
@@ -174,50 +115,6 @@ public:
 
 Q_SIGNALS:
     void eventNotify(const Event&); //! The device emits an event, which needs to be enqueued in a higher layer.
-};
-
-typedef void (*DeviceStateHandler)(Device *, const Event &);
-
-class DevicePrivate
-{
-public:
-    void setState(DeviceStateHandler newState, DEV_StateLevel level = StateLevel0);
-    void startStateTimer(int IntervalMs, DEV_StateLevel level);
-    void stopStateTimer(DEV_StateLevel level);
-    bool hasRxOnWhenIdle() const;
-
-    Device *q = nullptr; //! reference to public interface
-    deCONZ::ApsController *apsCtrl = nullptr; //! opaque instance pointer forwarded to external functions
-
-    /*! sub-devices are not yet referenced via pointers since these may become dangling.
-        This is a helper to query the actual sub-device Resource* on demand via Resource::Handle.
-    */
-    std::array<Resource::Handle, MaxSubResources> subResourceHandles;
-    std::vector<Resource*> subResources;
-    const deCONZ::Node *node = nullptr; //! a reference to the deCONZ core node
-    DeviceKey deviceKey = 0; //! for physical devices this is the MAC address
-
-    /*! The currently active state handler function(s).
-        Indexes >0 represent sub states of StateLevel0 running in parallel.
-    */
-    std::array<DeviceStateHandler, StateLevelMax> state{};
-
-    std::array<QBasicTimer, StateLevelMax> timer; //! internal single shot timer one for each state level
-    QElapsedTimer awake; //! time to track when an end-device was last awake
-    BindingContext binding; //! only used by binding sub state machine
-    std::vector<DEV_PollItem> pollItems; //! queue of items to poll
-    bool managed = false; //! a managed device doesn't rely on legacy implementation of polling etc.
-    ZDP_Result zdpResult; //! keep track of a running ZDP request
-    DA_ReadResult readResult; //! keep track of a running "read" request
-
-    int maxResponseTime = RxOffWhenIdleResponseTime;
-
-    struct
-    {
-        unsigned char hasDdf : 1;
-        unsigned char initialRun : 1;
-        unsigned char reserved : 6;
-    } flags{};
 };
 
 using DeviceContainer = std::vector<std::unique_ptr<Device>>;

--- a/device_access_fn.cpp
+++ b/device_access_fn.cpp
@@ -1423,7 +1423,7 @@ bool writeTimeData(const Resource *r, const ResourceItem *item, deCONZ::ApsContr
     return result;
 }
 
-/*! A function to parse read/report commands time (utc), local and last set time of the time cluster.
+/*! A specialized function to parse time (utc), local and last set time from read/report commands of the time cluster and auto-sync time if needed.
     The item->parseParameters() is expected to be an object (given in the device description file).
 
     {"fn": "time"}
@@ -1523,6 +1523,10 @@ bool parseAndSyncTime(Resource *r, ResourceItem *item, const deCONZ::ApsDataIndi
                             }
                         }
                     }
+                }
+                else
+                {
+                    DBG_Printf(DBG_DDF, "%s/%s : NO considerable time drift detected, %d seconds to now\n", r->item(RAttrUniqueId)->toCString(), suffix, drift);
                 }
 
                 item->setLastZclReport(deCONZ::steadyTimeRef().ref);    // Treat as report

--- a/device_access_fn.cpp
+++ b/device_access_fn.cpp
@@ -1868,11 +1868,10 @@ WriteFunction_t DA_GetWriteFunction(const QVariant &params)
 {
     WriteFunction_t result = nullptr;
 
-    const std::array<WriteFunction, 3> functions =
+    const std::array<WriteFunction, 2> functions =
     {
         WriteFunction(QLatin1String("zcl"), 1, writeZclAttribute),
-        WriteFunction(QLatin1String("tuya"), 1, writeTuyaData),
-        WriteFunction(QLatin1String("time"), 1, writeTimeData)
+        WriteFunction(QLatin1String("tuya"), 1, writeTuyaData)
     };
 
     QString fnName;

--- a/device_descriptions.cpp
+++ b/device_descriptions.cpp
@@ -267,6 +267,14 @@ DeviceDescriptions::DeviceDescriptions(QObject *parent) :
 
         d_ptr2->parseFunctions.push_back(fn);
     }
+    
+    {
+        DDF_FunctionDescriptor fn;
+        fn.name = "time";
+        fn.description = "Specialized function to parse time, local and last set time from read/report commands of the time cluster and auto-sync time if needed.";
+
+        d_ptr2->parseFunctions.push_back(fn);
+    }
 
     {
         DDF_FunctionDescriptor fn;

--- a/devices/danfoss/etrv0100_thermostat.json
+++ b/devices/danfoss/etrv0100_thermostat.json
@@ -400,18 +400,18 @@
         },
         {
           "name": "state/lastset",
-          "refresh.interval": 10900
+          "refresh.interval": 3700
         },
         {
           "name": "state/lastupdated"
         },
         {
           "name": "state/localtime",
-          "refresh.interval": 10900
+          "refresh.interval": 3700
         },
         {
           "name": "state/utc",
-          "refresh.interval": 10900
+          "refresh.interval": 3700
         }
       ]
     }

--- a/devices/generic/items/state_lastset_item.json
+++ b/devices/generic/items/state_lastset_item.json
@@ -5,7 +5,7 @@
 	"access": "R",
 	"public": true,
 	"description": "Timestamp when the time attribute was last set on the device.",
-	"parse": {"at": "0x0008", "cl": "0x000A", "ep": 0, "eval": "Item.val = Attr.val;", "fn": "zcl"},
+	"parse": {"fn": "time"},
 	"read": {"at": "0x0008", "cl": "0x000A", "ep": 0, "fn": "zcl"},
 	"refresh.interval": 3600
 }

--- a/devices/generic/items/state_localtime_item.json
+++ b/devices/generic/items/state_localtime_item.json
@@ -5,7 +5,7 @@
 	"access": "R",
 	"public": true,
 	"description": "The current local time set on the device.",
-	"parse": {"at": "0x0007", "cl": "0x000A", "ep": 0, "eval": "Item.val = Attr.val;", "fn": "zcl"},
+	"parse": {"fn": "time"},
 	"read": {"at": "0x0007", "cl": "0x000A", "ep": 0, "fn": "zcl"},
 	"refresh.interval": 3600
 }

--- a/devices/generic/items/state_utc_item.json
+++ b/devices/generic/items/state_utc_item.json
@@ -7,6 +7,5 @@
 	"description": "Current timestamp in UTC set on the device.",
 	"parse": {"fn": "time"},
 	"read": {"at": "0x0000", "cl": "0x000A", "ep": 0, "fn": "zcl"},
-    "write": {"fn": "time"},
 	"refresh.interval": 3600
 }

--- a/devices/generic/items/state_utc_item.json
+++ b/devices/generic/items/state_utc_item.json
@@ -5,7 +5,8 @@
 	"access": "RW",
 	"public": true,
 	"description": "Current timestamp in UTC set on the device.",
-	"parse": {"at": "0x0000", "cl": "0x000A", "ep": 0, "eval": "Item.val = Attr.val;", "fn": "zcl"},
-	"read": { "at": "0x0000", "cl": "0x000A", "ep": 0, "fn": "zcl"},
+	"parse": {"fn": "time"},
+	"read": {"at": "0x0000", "cl": "0x000A", "ep": 0, "fn": "zcl"},
+    "write": {"fn": "time"},
 	"refresh.interval": 3600
 }

--- a/time.cpp
+++ b/time.cpp
@@ -70,155 +70,161 @@ void DeRestPluginPrivate::handleTimeClusterIndication(const deCONZ::ApsDataIndic
     }
     else
     {
-        Sensor *sensor = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), ind.srcEndpoint(), QLatin1String("ZHATime"));
-    
-        if (!sensor)
+        auto *device = DEV_GetDevice(m_devices, ind.srcAddress().ext());
+        const bool devManaged = device && device->managed();
+
+        if (!devManaged)
         {
-            DBG_Printf(DBG_INFO, "0x%016llX No sensor having time cluster found for endpoint: 0x%02X\n", ind.srcAddress().ext(), ind.srcEndpoint());
-            return;
-        }
-    
-        bool isReadAttr = false;
-        bool isReporting = false;
-        bool isWriteResponse = false;
-    
-        if (zclFrame.isProfileWideCommand() && zclFrame.commandId() == deCONZ::ZclReadAttributesResponseId)
-        {
-            isReadAttr = true;
-        }
-        if (zclFrame.isProfileWideCommand() && zclFrame.commandId() == deCONZ::ZclReportAttributesId)
-        {
-            isReporting = true;
-        }
-        if (zclFrame.isProfileWideCommand() && zclFrame.commandId() == deCONZ::ZclWriteAttributesResponseId)
-        {
-            isWriteResponse = true;
-        }
-    
-        // Read ZCL reporting and ZCL Read Attributes Response
-        if (isReadAttr || isReporting)
-        {
-            const NodeValue::UpdateType updateType = isReadAttr ? NodeValue::UpdateByZclRead : NodeValue::UpdateByZclReport;
-    
-            bool stateUpdated = false;
-            const QDateTime epoch = QDateTime(QDate(2000, 1, 1), QTime(0, 0), Qt::UTC);
-    
-            QDataStream stream(zclFrame.payload());
-            stream.setByteOrder(QDataStream::LittleEndian);
-    
-            while (!stream.atEnd())
+            Sensor *sensor = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), ind.srcEndpoint(), QLatin1String("ZHATime"));
+
+            if (!sensor)
             {
-                quint16 attrId;
-                quint8 attrTypeId;
-    
-                stream >> attrId;
-                if (isReadAttr)
+                DBG_Printf(DBG_INFO, "0x%016llX No sensor having time cluster found for endpoint: 0x%02X\n", ind.srcAddress().ext(), ind.srcEndpoint());
+                return;
+            }
+
+            bool isReadAttr = false;
+            bool isReporting = false;
+            bool isWriteResponse = false;
+
+            if (zclFrame.isProfileWideCommand() && zclFrame.commandId() == deCONZ::ZclReadAttributesResponseId)
+            {
+                isReadAttr = true;
+            }
+            if (zclFrame.isProfileWideCommand() && zclFrame.commandId() == deCONZ::ZclReportAttributesId)
+            {
+                isReporting = true;
+            }
+            if (zclFrame.isProfileWideCommand() && zclFrame.commandId() == deCONZ::ZclWriteAttributesResponseId)
+            {
+                isWriteResponse = true;
+            }
+
+            // Read ZCL reporting and ZCL Read Attributes Response
+            if (isReadAttr || isReporting)
+            {
+                const NodeValue::UpdateType updateType = isReadAttr ? NodeValue::UpdateByZclRead : NodeValue::UpdateByZclReport;
+
+                bool stateUpdated = false;
+                const QDateTime epoch = QDateTime(QDate(2000, 1, 1), QTime(0, 0), Qt::UTC);
+
+                QDataStream stream(zclFrame.payload());
+                stream.setByteOrder(QDataStream::LittleEndian);
+
+                while (!stream.atEnd())
                 {
-                    quint8 status;
-                    stream >> status;  // Read Attribute Response status
-                    if (status != deCONZ::ZclSuccessStatus)
+                    quint16 attrId;
+                    quint8 attrTypeId;
+
+                    stream >> attrId;
+                    if (isReadAttr)
+                    {
+                        quint8 status;
+                        stream >> status;  // Read Attribute Response status
+                        if (status != deCONZ::ZclSuccessStatus)
+                        {
+                            continue;
+                        }
+                    }
+                    stream >> attrTypeId;
+
+                    deCONZ::ZclAttribute attr(attrId, attrTypeId, QLatin1String(""), deCONZ::ZclRead, false);
+
+                    if (!attr.readFromStream(stream))
                     {
                         continue;
                     }
+
+                    switch (attrId)
+                    {
+                        case 0x0000: // Time (utc, in UTC)
+                        {
+                            QDateTime time = epoch.addSecs(attr.numericValue().u32);
+                            ResourceItem *item = sensor->item(RStateUtc);
+
+                            if (item && item->toVariant().toDateTime().toMSecsSinceEpoch() != time.toMSecsSinceEpoch())
+                            {
+                                item->setValue(time);
+                                enqueueEvent(Event(RSensors, RStateUtc, sensor->id(), item));
+                                stateUpdated = true;
+                            }
+
+                            const qint32 drift = QDateTime::currentDateTimeUtc().secsTo(time);
+                            DBG_Printf(DBG_INFO, "  >>> %s sensor %s: drift %d\n", qPrintable(sensor->type()), qPrintable(sensor->name()), drift);
+
+                            if (drift < -10 || drift > 10)
+                            {
+                                DBG_Printf(DBG_INFO, "  >>> %s sensor %s: drift: %d: set WRITE_TIME\n", qPrintable(sensor->type()), qPrintable(sensor->name()), drift);
+                                sensor->setNextReadTime(WRITE_TIME, queryTime);
+                                sensor->setLastRead(WRITE_TIME, idleTotalCounter);
+                                sensor->enableRead(WRITE_TIME);
+                                queryTime = queryTime.addSecs(1);
+                            }
+                            else
+                            {
+                                DBG_Printf(DBG_INFO, "  >>> %s sensor %s: NO CONSIDERABLE TIME DRIFT\n", qPrintable(sensor->type()), qPrintable(sensor->name()));
+                            }
+
+                            sensor->setZclValue(updateType, ind.srcEndpoint(), TIME_CLUSTER_ID, attrId, attr.numericValue());
+                        }
+                            break;
+
+                        case 0x0007: // Local Time (u32, in local time)
+                        {
+                            QDateTime time = epoch.addSecs(attr.numericValue().u32 - QDateTime::currentDateTime().offsetFromUtc());
+                            ResourceItem *item = sensor->item(RStateLocaltime);
+
+                            if (item && item->toVariant().toDateTime().toMSecsSinceEpoch() != time.toMSecsSinceEpoch())
+                            {
+                                item->setValue(time);
+                                enqueueEvent(Event(RSensors, RStateLocaltime, sensor->id(), item));
+                                stateUpdated = true;
+                            }
+
+                            sensor->setZclValue(updateType, ind.srcEndpoint(), TIME_CLUSTER_ID, attrId, attr.numericValue());
+                        }
+                            break;
+
+                        case 0x0008: // Last set time (utc, in UTC)
+                        {
+                            QDateTime time = epoch.addSecs(attr.numericValue().u32);
+                            ResourceItem *item = sensor->item(RStateLastSet);
+
+                            if (item && item->toVariant().toDateTime().toMSecsSinceEpoch() != time.toMSecsSinceEpoch())
+                            {
+                                item->setValue(time);
+                                enqueueEvent(Event(RSensors, RStateLastSet, sensor->id(), item));
+                                stateUpdated = true;
+                            }
+
+                            sensor->setZclValue(updateType, ind.srcEndpoint(), TIME_CLUSTER_ID, attrId, attr.numericValue());
+                        }
+                            break;
+
+                        default:
+                            break;
+                    }
                 }
-                stream >> attrTypeId;
-    
-                deCONZ::ZclAttribute attr(attrId, attrTypeId, QLatin1String(""), deCONZ::ZclRead, false);
-    
-                if (!attr.readFromStream(stream))
+
+                if (stateUpdated)
                 {
-                    continue;
-                }
-    
-                switch (attrId)
-                {
-                    case 0x0000: // Time (utc, in UTC)
-                    {
-                        QDateTime time = epoch.addSecs(attr.numericValue().u32);
-                        ResourceItem *item = sensor->item(RStateUtc);
-    
-                        if (item && item->toVariant().toDateTime().toMSecsSinceEpoch() != time.toMSecsSinceEpoch())
-                        {
-                            item->setValue(time);
-                            enqueueEvent(Event(RSensors, RStateUtc, sensor->id(), item));
-                            stateUpdated = true;
-                        }
-    
-                        const qint32 drift = QDateTime::currentDateTimeUtc().secsTo(time);
-                        DBG_Printf(DBG_INFO, "  >>> %s sensor %s: drift %d\n", qPrintable(sensor->type()), qPrintable(sensor->name()), drift);
-    
-                        if (drift < -10 || drift > 10)
-                        {
-                            DBG_Printf(DBG_INFO, "  >>> %s sensor %s: drift: %d: set WRITE_TIME\n", qPrintable(sensor->type()), qPrintable(sensor->name()), drift);
-                            sensor->setNextReadTime(WRITE_TIME, queryTime);
-                            sensor->setLastRead(WRITE_TIME, idleTotalCounter);
-                            sensor->enableRead(WRITE_TIME);
-                            queryTime = queryTime.addSecs(1);
-                        }
-                        else
-                        {
-                            DBG_Printf(DBG_INFO, "  >>> %s sensor %s: NO CONSIDERABLE TIME DRIFT\n", qPrintable(sensor->type()), qPrintable(sensor->name()));
-                        }
-    
-                        sensor->setZclValue(updateType, ind.srcEndpoint(), TIME_CLUSTER_ID, attrId, attr.numericValue());
-                    }
-                        break;
-    
-                    case 0x0007: // Local Time (u32, in local time)
-                    {
-                        QDateTime time = epoch.addSecs(attr.numericValue().u32 - QDateTime::currentDateTime().offsetFromUtc());
-                        ResourceItem *item = sensor->item(RStateLocaltime);
-    
-                        if (item && item->toVariant().toDateTime().toMSecsSinceEpoch() != time.toMSecsSinceEpoch())
-                        {
-                            item->setValue(time);
-                            enqueueEvent(Event(RSensors, RStateLocaltime, sensor->id(), item));
-                            stateUpdated = true;
-                        }
-    
-                        sensor->setZclValue(updateType, ind.srcEndpoint(), TIME_CLUSTER_ID, attrId, attr.numericValue());
-                    }
-                        break;
-    
-                    case 0x0008: // Last set time (utc, in UTC)
-                    {
-                        QDateTime time = epoch.addSecs(attr.numericValue().u32);
-                        ResourceItem *item = sensor->item(RStateLastSet);
-    
-                        if (item && item->toVariant().toDateTime().toMSecsSinceEpoch() != time.toMSecsSinceEpoch())
-                        {
-                            item->setValue(time);
-                            enqueueEvent(Event(RSensors, RStateLastSet, sensor->id(), item));
-                            stateUpdated = true;
-                        }
-                        
-                        sensor->setZclValue(updateType, ind.srcEndpoint(), TIME_CLUSTER_ID, attrId, attr.numericValue());
-                    }
-                        break;
-    
-                    default:
-                        break;
+                    sensor->updateStateTimestamp();
+                    enqueueEvent(Event(RSensors, RStateLastUpdated, sensor->id()));
+                    updateSensorEtag(&*sensor);
+                    sensor->setNeedSaveDatabase(true);
+                    queSaveDb(DB_SENSORS, DB_SHORT_SAVE_DELAY);
                 }
             }
-    
-            if (stateUpdated)
+
+            // ZCL Write Attributes Response
+            if (isWriteResponse)
             {
-                sensor->updateStateTimestamp();
-                enqueueEvent(Event(RSensors, RStateLastUpdated, sensor->id()));
-                updateSensorEtag(&*sensor);
-                sensor->setNeedSaveDatabase(true);
-                queSaveDb(DB_SENSORS, DB_SHORT_SAVE_DELAY);
+                DBG_Printf(DBG_INFO, "  >>> %s sensor %s: set READ_TIME from handleTimeClusterIndication()\n", qPrintable(sensor->type()), qPrintable(sensor->name()));
+                sensor->setNextReadTime(READ_TIME, queryTime);
+                sensor->setLastRead(READ_TIME, idleTotalCounter);
+                sensor->enableRead(READ_TIME);
+                queryTime = queryTime.addSecs(1);
             }
-        }
-    
-        // ZCL Write Attributes Response
-        if (isWriteResponse)
-        {
-            DBG_Printf(DBG_INFO, "  >>> %s sensor %s: set READ_TIME from handleTimeClusterIndication()\n", qPrintable(sensor->type()), qPrintable(sensor->name()));
-            sensor->setNextReadTime(READ_TIME, queryTime);
-            sensor->setLastRead(READ_TIME, idleTotalCounter);
-            sensor->enableRead(READ_TIME);
-            queryTime = queryTime.addSecs(1);
         }
     }
 }


### PR DESCRIPTION
Make the function `time` available for DDFs as a 2in1 function, allowing data from time server cluster to be parsed for `config/utc`, `config/localtime` and `config/lastset`. For `config/utc`, a time drift of +/-11 seconds triggers an automatic time sync by writing current time data to the device while confirming the success with another read.

This is basically just a transition of the previous approach for ZHATime sensors.

```
01:01:57:841 cc:cc:cc:ff:xx:xx:xx:xx-01-000a/state/utc : time drift detected, -13 seconds to now
01:01:57:841 cc:cc:cc:ff:xx:xx:xx:xx-01-000a correcting time drift...
01:01:57:842 cc:cc:cc:ff:xx:xx:xx:xx-01-000a time verification queued...

...

01:01:59:273 cc:cc:cc:ff:xx:xx:xx:xx-01-000a/state/utc : NO considerable time drift detected, -2 seconds to now
```