### PR TITLE
Device code improve pairing

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -15272,6 +15272,11 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
 
         if (!hasNodeDescriptor)
         {
+            if (DEV_TestManaged())
+            {
+                return; // Device code handles this
+            }
+
             DBG_Printf(DBG_INFO, "[1] get node descriptor for 0x%016llx\n", sc->address.ext());
 
             if (ZDP_NodeDescriptorReq(sc->address, apsCtrl))
@@ -15287,6 +15292,11 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
 
         if (!hasActiveEndpoints)
         {
+            if (DEV_TestManaged())
+            {
+                return; // Device code handles this
+            }
+
             DBG_Printf(DBG_INFO, "[2] get active endpoints for 0x%016llx\n", sc->address.ext());
 
             if (ZDP_ActiveEndpointsReq(sc->address, apsCtrl))
@@ -15315,7 +15325,12 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
                     }
                 }
 
-                if (ep) // fetch this
+                if (DEV_TestManaged())
+                {
+                    return; // Device code handles this
+                }
+
+                if (ep) // fetch
                 {
                     DBG_Printf(DBG_INFO, "[3] get simple descriptor 0x%02X for 0x%016llx\n", ep, sc->address.ext());
 

--- a/device.cpp
+++ b/device.cpp
@@ -1730,7 +1730,7 @@ void DEV_PollIdleStateHandler(Device *device, const Event &event)
     {
         DBG_Printf(DBG_DEV, "DEV Poll Idle enter %s/0x%016llX\n", event.resource(), event.deviceKey());
     }
-    else if (event.what() == REventPoll)
+    else if (event.what() == REventPoll || event.what() == REventAwake)
     {
         d->pollItems = DEV_GetPollItems(device);
 

--- a/device.cpp
+++ b/device.cpp
@@ -938,15 +938,13 @@ void DEV_BindingTableReadHandler(Device *device, const Event &event)
     else if (event.what() == REventZdpMgmtBindResponse)
     {
         uint8_t buf[128];
-        if (event.hasData() && event.dataSize() >= 5 && event.dataSize() < sizeof(buf))
+        if (event.hasData() && event.dataSize() >= 2 && event.dataSize() < sizeof(buf))
         {
             if (event.getData(buf, event.dataSize()))
             {
                 const uint8_t seq = buf[0];
                 const uint8_t status = buf[1];
-                const uint8_t size = buf[2];
-                const uint8_t index = buf[3];
-                const uint8_t count = buf[4];
+
 
                 if (seq != d->zdpResult.zdpSeq)
                 {
@@ -958,6 +956,17 @@ void DEV_BindingTableReadHandler(Device *device, const Event &event)
                     d->stopStateTimer(STATE_LEVEL_BINDING);
 
                     d->binding.mgmtBindSupported = MGMT_BIND_SUPPORTED;
+
+                    uint8_t size = 0;
+                    uint8_t index = 0;
+                    uint8_t count = 0;
+
+                    if (event.dataSize() >= 5)
+                    {
+                        size = buf[2];
+                        index = buf[3];
+                        count = buf[4];
+                    }
 
                     if (size > index + count)
                     {

--- a/device.cpp
+++ b/device.cpp
@@ -1732,6 +1732,15 @@ void DEV_PollIdleStateHandler(Device *device, const Event &event)
     }
     else if (event.what() == REventPoll || event.what() == REventAwake)
     {
+        if (device->node()) // update nwk address if needed
+        {
+            const auto &addr = device->node()->address();
+            if (addr.hasNwk() && addr.nwk() != device->item(RAttrNwkAddress)->toNumber())
+            {
+                device->item(RAttrNwkAddress)->setValue(addr.nwk());
+            }
+        }
+
         d->pollItems = DEV_GetPollItems(device);
 
         if (!d->pollItems.empty())


### PR DESCRIPTION
- In legacy `delayedFastEnddeviceProbe()` function don't interfere with Device code ZDP requests for Node Descriptor, Active Endpoints and Simple Descriptors.
- Consider already available data in Basic cluster attributes during pairing, which is needed for some Xiaomi sensors that send the modelid in a report.
- Fix handling of unsupported binding table status (Xiaomi sensors send a response which has only 2 bytes of payload).
- Check if there is polling needed after awake event, that's useful during pairing to quickly query all needed attributes.
- Sync NWK address changes from core to device `attr/nwkaddress` resource item.

Related issue https://github.com/dresden-elektronik/deconz-rest-plugin/issues/5974