### PR TITLE
Add DDF for ORVIBO Zigbee Dry Contact CM10ZW

### DIFF
--- a/devices/orvibo/CM10ZW.json
+++ b/devices/orvibo/CM10ZW.json
@@ -1,0 +1,178 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "ORVIBO",
+  "modelid": "396483ce8b3f4e0d8e9d79079a35a420",
+  "vendor": "Orvibo",
+  "product": "ORVIBO Zigbee Dry Contact CM10ZW",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_ON_OFF_PLUGIN_UNIT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert"
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 360
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_ON_OFF_PLUGIN_UNIT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x02"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert"
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 360
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_ON_OFF_PLUGIN_UNIT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x03"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert"
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 360
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    ],
+    "bindings":  [
+        {
+            "bind": "unicast",
+            "src.ep": 1,
+            "cl": "0x0006",
+            "report": [
+                {"at": "0x0000", "dt": "0x10", "min": 5, "max": 300 }
+            ]
+        },
+        {
+            "bind": "unicast",
+            "src.ep": 2,
+            "cl": "0x0006",
+            "report": [
+                {"at": "0x0000", "dt": "0x10", "min": 5, "max": 300 }
+            ]
+        },
+        {
+            "bind": "unicast",
+            "src.ep": 3,
+            "cl": "0x0006",
+            "report": [
+                {"at": "0x0000", "dt": "0x10", "min": 5, "max": 300 }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This device have many version.
The first one is supported by legacy code, but not this one.
See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3973