### PR TITLE
Add a request to API, to send a Temperature value to a display

### DIFF
--- a/devices/generic/items/config_temp_to_display_item.json
+++ b/devices/generic/items/config_temp_to_display_item.json
@@ -1,13 +1,31 @@
 {
-	"schema": "resourceitem1.schema.json",
-	"id": "config/temp_to_display",
-	"datatype": "Int16",
-	"access": "RW",
-	"public": true,
-	"default": 0,
-	"description": "Temperature to display on device.",
-	"parse": {"at": "0x0010", "cl": "0xff01", "ep": 1, "eval": "Item.val = Attr.val;", "fn": "zcl"},
-	"read": {"at": "0x0010", "cl": "0xff01", "ep": 1, "fn": "zcl"},
-	"write": {"at": "0x0010", "cl": "0xff01", "ep": 1, "fn": "zcl", "dt": "0x29", "mf": "0x119c", "eval": "Item.val"},
-	"range": [500, 3200]
+  "schema": "resourceitem1.schema.json",
+  "id": "config/temp_to_display",
+  "datatype": "Int16",
+  "access": "RW",
+  "public": true,
+  "default": -32768,
+  "description": "Temperature to display on device.",
+  "parse": {
+    "at": "0x0010",
+    "cl": "0xff01",
+    "ep": 1,
+    "eval": "Item.val = Attr.val;",
+    "fn": "zcl"
+  },
+  "read": {
+    "at": "0x0010",
+    "cl": "0xff01",
+    "ep": 1,
+    "fn": "zcl"
+  },
+  "write": {
+    "at": "0x0010",
+    "cl": "0xff01",
+    "ep": 1,
+    "fn": "zcl",
+    "dt": "0x29",
+    "mf": "0x119c",
+    "eval": "Item.val"
+  }
 }

--- a/devices/generic/items/config_temp_to_display_item.json
+++ b/devices/generic/items/config_temp_to_display_item.json
@@ -1,0 +1,13 @@
+{
+	"schema": "resourceitem1.schema.json",
+	"id": "config/temp_to_display",
+	"datatype": "Int16",
+	"access": "RW",
+	"public": true,
+	"default": 0,
+	"description": "Temperature to display on device.",
+	"parse": {"at": "0x0010", "cl": "0xff01", "ep": 1, "eval": "Item.val = Attr.val;", "fn": "zcl"},
+	"read": {"at": "0x0010", "cl": "0xff01", "ep": 1, "fn": "zcl"},
+    "write": {"at": "0x0010", "cl": "0xff01", "ep": 1, "fn": "zcl", "dt": "0x29", "mf": "0x119c"},
+	"range": [500, 3200]
+}

--- a/devices/generic/items/config_temp_to_display_item.json
+++ b/devices/generic/items/config_temp_to_display_item.json
@@ -8,6 +8,6 @@
 	"description": "Temperature to display on device.",
 	"parse": {"at": "0x0010", "cl": "0xff01", "ep": 1, "eval": "Item.val = Attr.val;", "fn": "zcl"},
 	"read": {"at": "0x0010", "cl": "0xff01", "ep": 1, "fn": "zcl"},
-    "write": {"at": "0x0010", "cl": "0xff01", "ep": 1, "fn": "zcl", "dt": "0x29", "mf": "0x119c"},
+	"write": {"at": "0x0010", "cl": "0xff01", "ep": 1, "fn": "zcl", "dt": "0x29", "mf": "0x119c", "eval": "Item.val"},
 	"range": [500, 3200]
 }

--- a/devices/sinope/th1124zb.json
+++ b/devices/sinope/th1124zb.json
@@ -1,11 +1,10 @@
 {
   "schema": "devcap1.schema.json",
-  "manufacturername": "Sinope",
+  "manufacturername": "Sinope Technologies",
   "modelid": "TH1124ZB",
   "product": "TH1124ZB",
   "sleeper": false,
-  "status": "Silver",
-  "path": "/devices/th1124zb.json",
+  "status": "Gold",
   "subdevices": [
     {
       "type": "$TYPE_THERMOSTAT",
@@ -80,7 +79,38 @@
         },
         {
           "name": "config/schedule_on",
-          "description": "Determines if on-device schedules for setting the heatsetpoint are currently used or if the thermostat is operated manually."
+          "description": "Determines if on-device schedules for setting the heatsetpoint are currently used or if the thermostat is operated manually.",
+          "default": false
+        },
+                {
+          "name": "config/temp_to_display",
+          "description": "Outdoor temperature on display",
+          "refresh.interval": 300,
+          "read": {
+            "at": "0x0010",
+            "cl": "0xff01",
+            "ep": 1,
+            "fn": "zcl",
+            "mf": "0x119c"
+          },
+          "parse": {
+            "at": "0x0010",
+            "cl": "0xff01",
+            "ep": 1,
+            "eval": "Item.val = Attr.val;",
+            "fn": "zcl",
+            "mf": "0x119c"
+          },
+          "write": {
+              "at": "0x0010",
+              "cl": "0xff01",
+              "ep": 1,
+              "fn": "zcl",
+              "dt": "0x29",
+              "mf": "0x119c",
+              "eval": "Item.val"
+          },
+          "default": -32768
         },
         {
           "name": "state/lastupdated"
@@ -150,14 +180,22 @@
         },
         {
           "name": "state/current",
-          "refresh.interval": 300
+	      "description": "The measured current (in A).",
+          "refresh.interval": 300,
+          "parse": {
+            "at": "0x0508",
+            "cl": "0x0b04",
+            "ep": 1,
+            "eval": "if (Attr.val != 65535) { Item.val = Attr.val / 1000; }"
+          },
+          "default": 0
         },
         {
           "name": "state/lastupdated"
         },
-        {
           "name": "state/power",
-          "refresh.interval": 300
+          "refresh.interval": 300,
+          "default": 0
         },
         {
           "name": "state/voltage",
@@ -167,7 +205,8 @@
             "cl": "0x0b04",
             "ep": 0,
             "eval": "if (Attr.val != 65535) { Item.val = Attr.val / 10 ; }"
-          }
+          },
+          "default": 0
         }
       ]
     },
@@ -224,14 +263,18 @@
         },
         {
           "name": "state/consumption",
-          "refresh.interval": 300
+          "refresh.interval": 300,
+          "default": 0
         },
         {
           "name": "state/lastupdated"
         },
         {
           "name": "state/power",
-          "refresh.interval": 300
+          "description": "The measured power (in W).",
+          "refresh.interval": 300,
+          "default": 0,
+           "parse": {"at": "0x050B", "cl": "0x0B04", "ep": 1, "eval": "if (Attr.val != -32768 && Attr.val != 32768) { Item.val = Attr.val; }", "fn": "zcl"}
         }
       ]
     },

--- a/devices/sinope/th1124zb.json
+++ b/devices/sinope/th1124zb.json
@@ -193,6 +193,7 @@
         {
           "name": "state/lastupdated"
         },
+        {
           "name": "state/power",
           "refresh.interval": 300,
           "default": 0

--- a/resource.cpp
+++ b/resource.cpp
@@ -177,6 +177,7 @@ const char *RConfigAllowTouchlink = "config/allowtouchlink";
 const char *RConfigLock = "config/lock";
 const char *RConfigBattery = "config/battery";
 const char *RConfigClickMode = "config/clickmode";
+const char *RConfigTempToDisplay = "config/temp_to_display";
 const char *RConfigColorCapabilities = "config/colorcapabilities";
 const char *RConfigConfigured = "config/configured";
 const char *RConfigControlSequence = "config/controlsequence";
@@ -396,6 +397,7 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, QVariant::Bool, RConfigLock));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, QVariant::Double, RConfigBattery, 0, 100));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, QVariant::String, RConfigClickMode));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeInt16, QVariant::Double, RConfigTempToDisplay));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, QVariant::Double, RConfigColorCapabilities));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, QVariant::Double, RConfigCtMin));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, QVariant::Double, RConfigCtMax));

--- a/resource.h
+++ b/resource.h
@@ -199,6 +199,7 @@ extern const char *RConfigAllowTouchlink;
 extern const char *RConfigLock;
 extern const char *RConfigBattery;
 extern const char *RConfigClickMode;
+extern const char *RConfigTempToDisplay;
 extern const char *RConfigColorCapabilities;
 extern const char *RConfigConfigured;
 extern const char *RConfigControlSequence;

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -780,7 +780,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                         }
                     }
                 }
-                else if (rid.suffix == RConfigClickMode) // Signed integer
+                else if (rid.suffix == RConfigTempToDisplay) // Signed integer
                 {
                     if (devManaged && rsub)
                     {

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -789,7 +789,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                         updated = true;
                     }
                 }
-                else if (rid.suffix == RConfigTempToDisplay && !data.string.isEmpty()) // String
+                else if (rid.suffix == RConfigClickMode && !data.string.isEmpty()) // String
                 {
                     if (devManaged && rsub)
                     {

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -780,7 +780,16 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                         }
                     }
                 }
-                else if (rid.suffix == RConfigClickMode && !data.string.isEmpty()) // String
+                else if (rid.suffix == RConfigClickMode) // Signed integer
+                {
+                    if (devManaged && rsub)
+                    {
+                        change.addTargetValue(rid.suffix, data.integer);
+                        rsub->addStateChange(change);
+                        updated = true;
+                    }
+                }
+                else if (rid.suffix == RConfigTempToDisplay && !data.string.isEmpty()) // String
                 {
                     if (devManaged && rsub)
                     {


### PR DESCRIPTION
Used for exemple by the Sinope thermostat
See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/2104

`$ curl -H 'Content-Type: application/json' -X PUT -d '{"temp_to_display": 18}' http://127.0.0.1/api/_<my API key>_/sensors/18/config`

The DDF is updated too, to use this command