### PR TITLE
Update DDF for the Sinope TH1124ZB

### DIFF
--- a/devices/generic/items/config_externalsensortemp_item.json
+++ b/devices/generic/items/config_externalsensortemp_item.json
@@ -4,5 +4,5 @@
 	"datatype": "Int16",
 	"access": "RW",
 	"public": true,
-	"description": "The temperature measured by an external sensor."
+	"description": "The temperature measured by an external sensor, can be used for regulation or displayed on screen."
 }

--- a/devices/sinope/th1124zb.json
+++ b/devices/sinope/th1124zb.json
@@ -4,7 +4,7 @@
   "modelid": "TH1124ZB",
   "product": "TH1124ZB",
   "sleeper": false,
-  "status": "Gold",
+  "status": "Silver",
   "subdevices": [
     {
       "type": "$TYPE_THERMOSTAT",
@@ -84,7 +84,7 @@
         },
                 {
           "name": "config/externalsensortemp",
-          "description": "External sensor temperature.",
+          "description": "External sensor temperature used as Outdoor temperature on display.",
           "refresh.interval": 300,
           "read": {
             "at": "0x0010",

--- a/devices/sinope/th1124zb.json
+++ b/devices/sinope/th1124zb.json
@@ -1,11 +1,10 @@
 {
   "schema": "devcap1.schema.json",
-  "manufacturername": "Sinope",
+  "manufacturername": "Sinope Technologies",
   "modelid": "TH1124ZB",
   "product": "TH1124ZB",
   "sleeper": false,
-  "status": "Silver",
-  "path": "/devices/th1124zb.json",
+  "status": "Gold",
   "subdevices": [
     {
       "type": "$TYPE_THERMOSTAT",
@@ -80,7 +79,38 @@
         },
         {
           "name": "config/schedule_on",
-          "description": "Determines if on-device schedules for setting the heatsetpoint are currently used or if the thermostat is operated manually."
+          "description": "Determines if on-device schedules for setting the heatsetpoint are currently used or if the thermostat is operated manually.",
+          "default": false
+        },
+                {
+          "name": "config/externalsensortemp",
+          "description": "External sensor temperature.",
+          "refresh.interval": 300,
+          "read": {
+            "at": "0x0010",
+            "cl": "0xff01",
+            "ep": 1,
+            "fn": "zcl",
+            "mf": "0x119c"
+          },
+          "parse": {
+            "at": "0x0010",
+            "cl": "0xff01",
+            "ep": 1,
+            "eval": "Item.val = Attr.val;",
+            "fn": "zcl",
+            "mf": "0x119c"
+          },
+          "write": {
+              "at": "0x0010",
+              "cl": "0xff01",
+              "ep": 1,
+              "fn": "zcl",
+              "dt": "0x29",
+              "mf": "0x119c",
+              "eval": "Item.val"
+          },
+          "default": -32768
         },
         {
           "name": "state/lastupdated"
@@ -150,14 +180,23 @@
         },
         {
           "name": "state/current",
-          "refresh.interval": 300
+	      "description": "The measured current (in A).",
+          "refresh.interval": 300,
+          "parse": {
+            "at": "0x0508",
+            "cl": "0x0b04",
+            "ep": 1,
+            "eval": "if (Attr.val != 65535) { Item.val = Attr.val / 1000; }"
+          },
+          "default": 0
         },
         {
           "name": "state/lastupdated"
         },
         {
           "name": "state/power",
-          "refresh.interval": 300
+          "refresh.interval": 300,
+          "default": 0
         },
         {
           "name": "state/voltage",
@@ -167,7 +206,8 @@
             "cl": "0x0b04",
             "ep": 0,
             "eval": "if (Attr.val != 65535) { Item.val = Attr.val / 10 ; }"
-          }
+          },
+          "default": 0
         }
       ]
     },
@@ -224,14 +264,18 @@
         },
         {
           "name": "state/consumption",
-          "refresh.interval": 300
+          "refresh.interval": 300,
+          "default": 0
         },
         {
           "name": "state/lastupdated"
         },
         {
           "name": "state/power",
-          "refresh.interval": 300
+          "description": "The measured power (in W).",
+          "refresh.interval": 300,
+          "default": 0,
+           "parse": {"at": "0x050B", "cl": "0x0B04", "ep": 1, "eval": "if (Attr.val != -32768 && Attr.val != 32768) { Item.val = Attr.val; }", "fn": "zcl"}
         }
       ]
     },


### PR DESCRIPTION
Some corrections and add a command to send a temperature from external sensor to be displayed on the device

`sudo /usr/bin/curl -X PUT -H "Content-Type: application/json" -d '{"externalsensortemp": 2500}' "http://127.0.01:PORT/api/MY_KEY/sensors/182/config"`

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/2104