### PR TITLE
Fix battery icon not shown for DDF devices

### DIFF
--- a/device.cpp
+++ b/device.cpp
@@ -158,11 +158,24 @@ public:
     } flags{};
 };
 
+Device *DEV_ParentDevice(Resource *r)
+{
+    if (r && r->parentResource() && r->parentResource()->prefix() == RDevices)
+    {
+        return static_cast<Device*>(r->parentResource());
+    }
+
+    return nullptr;
+}
+
 //! Forward device attribute changes to core.
 void DEV_ForwardNodeChange(Device *device, const QString &key, const QString &value)
 {
-    QMetaObject::invokeMethod(device->d->apsCtrl, "onRestNodeUpdated", Qt::DirectConnection,
+    if (device)
+    {
+        QMetaObject::invokeMethod(device->d->apsCtrl, "onRestNodeUpdated", Qt::DirectConnection,
                               Q_ARG(quint64, device->key()), Q_ARG(QString, key), Q_ARG(QString, value));
+    }
 }
 
 void DEV_EnqueueEvent(Device *device, const char *event)

--- a/device.h
+++ b/device.h
@@ -117,6 +117,11 @@ Q_SIGNALS:
     void eventNotify(const Event&); //! The device emits an event, which needs to be enqueued in a higher layer.
 };
 
+Device *DEV_ParentDevice(Resource *r);
+
+/*! Helper to forward attributes to core (modelid, battery, etc.). */
+void DEV_ForwardNodeChange(Device *device, const QString &key, const QString &value);
+
 using DeviceContainer = std::vector<std::unique_ptr<Device>>;
 
 Resource *DEV_GetSubDevice(Device *device, const char *prefix, const QString &identifier);

--- a/device_ddf_init.cpp
+++ b/device_ddf_init.cpp
@@ -255,6 +255,11 @@ bool DEV_InitDeviceFromDescription(Device *device, const DeviceDescription &ddf)
                 DEV_AllocateGroup(device, rsub, item);
             }
 
+            if (item->descriptor().suffix == RConfigBattery || item->descriptor().suffix == RStateBattery)
+            {
+                DEV_ForwardNodeChange(device, QLatin1String(item->descriptor().suffix), QString::number(item->toNumber()));
+            }
+
             if (item->descriptor().suffix == RConfigCheckin)
             {
                 if (PC_GetPollControlEndpoint(device->node()) > 0)

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -2773,6 +2773,8 @@ void DeRestPluginPrivate::handleSensorEvent(const Event &e)
         return;
     }
 
+    Device *device = DEV_ParentDevice(sensor);
+
     // speedup sensor state check
     if ((e.what() == RStatePresence || e.what() == RStateButtonEvent) &&
         sensor && sensor->durationDue.isValid())
@@ -2789,6 +2791,11 @@ void DeRestPluginPrivate::handleSensorEvent(const Event &e)
             if (item->descriptor().suffix == RStatePresence && item->toBool())
             {
                 globalLastMotion = item->lastSet(); // remember
+            }
+
+            if (e.what() == RStateBattery)
+            {
+                DEV_ForwardNodeChange(device, QLatin1String(e.what()), QString::number(item->toNumber()));
             }
 
             if (!(item->needPushSet() || item->needPushChange()))
@@ -2894,6 +2901,11 @@ void DeRestPluginPrivate::handleSensorEvent(const Event &e)
             if (e.what() == RConfigGroup)
             {
                 checkSensorBindingsForClientClusters(sensor);
+            }
+
+            if (e.what() == RConfigBattery)
+            {
+                DEV_ForwardNodeChange(device, QLatin1String(e.what()), QString::number(item->toNumber()));
             }
 
             if (!(item->needPushSet() || item->needPushChange()))

--- a/xiaomi.cpp
+++ b/xiaomi.cpp
@@ -657,7 +657,6 @@ void DeRestPluginPrivate::handleZclAttributeReportIndicationXiaomiSpecial(const 
             {
                 item->setValue(batteryPercentage);
                 enqueueEvent(Event(RSensors, RStateBattery, sensor.id(), item));
-                q_ptr->nodeUpdated(sensor.address().ext(), QLatin1String(item->descriptor().suffix), QString::number(batteryPercentage));
                 sensor.updateStateTimestamp();
                 if (item->lastSet() == item->lastChanged())
                 {
@@ -687,7 +686,6 @@ void DeRestPluginPrivate::handleZclAttributeReportIndicationXiaomiSpecial(const 
 
                 item->setValue(quint8(bat));
                 enqueueEvent(Event(RSensors, RConfigBattery, sensor.id(), item));
-                emit q_ptr->nodeUpdated(sensor.address().ext(), QLatin1String(item->descriptor().suffix), QString::number(bat));
 
                 if (item->lastSet() == item->lastChanged())
                 {


### PR DESCRIPTION
The battery state needs to be pushed to deCONZ core in order to be shown.
Looks like prior also this was only done once per deCONZ start, now it's updated when the value is refreshed.