### PR TITLE
Edit DDF for sinope thermostat TH1123ZB and TH1124ZB

### DIFF
--- a/devices/sinope/th1124zb.json
+++ b/devices/sinope/th1124zb.json
@@ -82,7 +82,7 @@
           "description": "Determines if on-device schedules for setting the heatsetpoint are currently used or if the thermostat is operated manually.",
           "default": false
         },
-                {
+        {
           "name": "config/externalsensortemp",
           "description": "External sensor temperature used as Outdoor temperature on display.",
           "refresh.interval": 300,
@@ -102,15 +102,45 @@
             "mf": "0x119c"
           },
           "write": {
-              "at": "0x0010",
-              "cl": "0xff01",
-              "ep": 1,
-              "fn": "zcl",
-              "dt": "0x29",
-              "mf": "0x119c",
-              "eval": "Item.val"
+            "at": "0x0010",
+            "cl": "0xff01",
+            "ep": 1,
+            "fn": "zcl",
+            "dt": "0x29",
+            "mf": "0x119c",
+            "eval": "Item.val"
           },
           "default": -32768
+        },
+        {
+          "name": "config/ledindication",
+          "description": "Use it for Backlight configuration.\nfalse = On demand\ntrue = Always ON",
+          "refresh.interval": 300,
+          "read": {
+            "at": "0x0402",
+            "cl": "0x0201",
+            "ep": 1,
+            "fn": "zcl",
+            "mf": "0x119c"
+          },
+          "write": {
+            "at": "0x0402",
+            "cl": "0x0201",
+            "dt": "0x30",
+            "ep": 1,
+            "eval": "Item.val",
+            "fn": "zcl",
+            "mf": "0x119c"
+          },
+          "parse": {
+            "at": "0x0402",
+            "cl": "0x0201",
+            "ep": 1,
+            "eval": "Item.val = Attr.val;",
+            "fn": "zcl",
+            "mf": "0x119c"
+          },
+          "default": true
         },
         {
           "name": "state/lastupdated"
@@ -180,7 +210,7 @@
         },
         {
           "name": "state/current",
-	      "description": "The measured current (in A).",
+          "description": "The measured current (in A).",
           "refresh.interval": 300,
           "parse": {
             "at": "0x0508",
@@ -275,77 +305,18 @@
           "description": "The measured power (in W).",
           "refresh.interval": 300,
           "default": 0,
-           "parse": {"at": "0x050B", "cl": "0x0B04", "ep": 1, "eval": "if (Attr.val != -32768 && Attr.val != 32768) { Item.val = Attr.val; }", "fn": "zcl"}
-        }
-      ]
-    },
-    {
-      "type": "$TYPE_TEMPERATURE_SENSOR",
-      "restapi": "/sensors",
-      "uuid": [
-        "$address.ext",
-        "0x01",
-        "0x0402"
-      ],
-      "fingerprint": {
-        "profile": "0x0104",
-        "device": "0x0301",
-        "endpoint": "0x01",
-        "in": [
-          "0x0000",
-          "0x0402"
-        ]
-      },
-      "items": [
-        {
-          "name": "attr/id"
-        },
-        {
-          "name": "attr/lastannounced"
-        },
-        {
-          "name": "attr/lastseen"
-        },
-        {
-          "name": "attr/manufacturername"
-        },
-        {
-          "name": "attr/modelid"
-        },
-        {
-          "name": "attr/name"
-        },
-        {
-          "name": "attr/swversion"
-        },
-        {
-          "name": "attr/type"
-        },
-        {
-          "name": "attr/uniqueid"
-        },
-        {
-          "name": "config/offset",
-          "description": "Relative offset to the main measured value.",
-          "default": 0
-        },
-        {
-          "name": "config/on"
-        },
-        {
-          "name": "config/reachable"
-        },
-        {
-          "name": "state/lastupdated"
-        },
-        {
-          "name": "state/temperature",
-          "default": 0
+          "parse": {
+            "at": "0x050B",
+            "cl": "0x0B04",
+            "ep": 1,
+            "eval": "if (Attr.val != -32768 && Attr.val != 32768) { Item.val = Attr.val; }",
+            "fn": "zcl"
+          }
         }
       ]
     }
   ],
-    "bindings": [
+  "bindings": [
     {
       "bind": "unicast",
       "src.ep": 1,


### PR DESCRIPTION
- Remove the ZHATemperatur device (not usefull as there is too a ZHAThermostat
- Add "config/ledindication" that impact the display mode.

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/2104