### PR TITLE
Add DDF: Hue Outdoor Motion Sensor rev. SML004

### DIFF
--- a/devices/philips/sml004_motion_sensor.json
+++ b/devices/philips/sml004_motion_sensor.json
@@ -1,0 +1,354 @@
+{
+    "schema": "devcap1.schema.json",
+    "doc:path": "philips/sml004_motion_sensor.md",
+    "doc:hdr": "Motion sensor 3. Gen (SML004)",
+    "manufacturername": "$MF_PHILIPS",
+    "modelid": "SML004",
+    "product": "Motion Sensor 3. Gen (SML004)",
+    "status": "Bronze",
+    "sleeper": false,
+    "md:known_issues": [ ],
+    "subdevices": [
+         {
+            "type": "$TYPE_PRESENCE_SENSOR",
+            "restapi": "/sensors",
+            "uuid": [ "$address.ext", "0x02", "0x0406"],
+            "fingerprint": { "profile": "0x0104", "device": "0x0107", "endpoint": "0x02", "in": ["0x0000", "0x0001", "0x0406"] },
+            "items": [
+                {
+                    "name": "attr/lastseen"
+                },
+                {
+                    "name": "attr/manufacturername"
+                },
+                {
+                    "name": "attr/modelid"
+                },
+                {
+                    "name": "attr/name"
+                },
+                {
+                    "name": "attr/swversion"
+                },
+                {
+                    "name": "attr/type"
+                },
+                {
+                    "name": "attr/uniqueid"
+                },
+                {
+                    "name": "config/alert",
+                    "default": "none"
+                },
+                {
+                    "name": "config/battery",
+                    "parse": {"ep": 2, "cl": "0x0001", "at": "0x0021", "eval": "Item.val = Attr.val / 2"},
+                    "read": {"ep": 2, "cl": "0x0001", "at": "0x0021"},
+                    "refresh.interval": 7300,
+                    "awake": true
+                },
+                {
+                    "name": "config/delay",
+                    "read": {"ep": 2, "cl": "0x0406", "at": "0x0010"},
+                    "parse": {"ep": 2, "cl": "0x0406", "at": "0x0010", "eval": "Item.val = Attr.val"},
+                    "refresh.interval": 84000
+                },
+                {
+                    "name": "config/ledindication",
+                    "read": {"ep": 2, "cl": "0x0000", "at": "0x0033", "mf": "0x100b"},
+                    "parse": {"ep": 2, "cl": "0x0000", "at": "0x0033", "mf": "0x100b", "eval": "Item.val = Attr.val"},
+                    "refresh.interval": 84000
+                },
+                {
+                    "name": "config/on"
+                },
+                {
+                    "name": "config/pending"
+                },
+                {
+                    "name": "config/reachable"
+                },
+                {
+                    "name": "config/sensitivity",
+                    "values": [
+                        [0, "verylow"],
+                        [1, "low"],
+                        [2, "medium"],
+                                                [3, "high"],
+                                                [4, "veryhigh"]
+                    ],
+                    "read": {"ep": 2, "cl": "0x0406", "at": "0x0030", "mf": "0x100b"},
+                    "parse": {"ep": 2, "cl": "0x0406", "at": "0x0030", "mf": "0x100b", "eval": "Item.val == 0 ? Item.val = Attr.val : Item.val"},
+                    "refresh.interval": 84000
+                },
+                {
+                    "name": "config/sensitivitymax",
+                    "static": 4
+                },
+                {
+                    "name": "config/usertest",
+                    "read": {"ep": 2, "cl": "0x0000", "at": "0x0032", "mf": "0x100b"},
+                    "parse": {"ep": 2, "cl": "0x0000", "at": "0x0032", "mf": "0x100b", "eval": "Item.val = Attr.val"},
+                    "refresh.interval": 84000
+                },
+                {
+                    "name": "state/lastupdated"
+                },
+                {
+                    "name": "state/presence",
+                    "parse": {"ep": 2, "cl": "0x0406", "at": "0x0000", "eval": "Item.val = Attr.val"},
+                    "awake": true
+                }
+            ],
+            "example": {
+                "config": {
+                    "alert": "none",
+                    "battery": 0,
+                    "delay": 0,
+                    "ledindication": false,
+                    "on": true,
+                    "pending": [],
+                    "reachable": true,
+                    "sensitivity": 2,
+                    "sensitivitymax": 4,
+                    "usertest": false
+                },
+                "ep": 2,
+                "etag": "7f0d4873bf1bf93df92948fe160460e6",
+                "lastseen": "2022-01-13T13:20Z",
+                "manufacturername": "Philips",
+                "modelid": "SML004",
+                "name": "Motion Sensor (2)",
+                "state": {
+                    "lastupdated": "2022-01-13T13:20:06.879",
+                    "presence": false
+                },
+                "swversion": "2.53.6",
+                "type": "ZHAPresence",
+                "uniqueid": "00:17:88:01:02:00:21:f4-02-0406"
+            }
+        },
+        {
+            "type": "$TYPE_LIGHT_LEVEL_SENSOR",
+            "restapi": "/sensors",
+            "uuid": [ "$address.ext", "0x02", "0x0400"],
+            "fingerprint": { "profile": "0x0104", "device": "0x0107", "endpoint": "0x02", "in": ["0x0000", "0x0001", "0x0400"] },
+            "items": [
+                {
+                    "name": "attr/lastseen"
+                },
+                {
+                    "name": "attr/manufacturername"
+                },
+                {
+                    "name": "attr/modelid"
+                },
+                {
+                    "name": "attr/name"
+                },
+                {
+                    "name": "attr/swversion"
+                },
+                {
+                    "name": "attr/type"
+                },
+                {
+                    "name": "attr/uniqueid"
+                },
+                {
+                    "name": "config/alert",
+                    "default": "none"
+                },
+                {
+                    "name": "config/battery",
+                    "parse": {"ep": 2, "cl": "0x0001", "at": "0x0021", "eval": "Item.val = Attr.val / 2"}
+                },
+                {
+                    "name": "config/ledindication",
+                    "parse": {"ep": 2, "cl": "0x0000", "at": "0x0033", "mf": "0x100b", "eval": "Item.val = Attr.val"}
+                },
+                {
+                    "name": "config/on"
+                },
+                {
+                    "name": "config/pending"
+                },
+                {
+                    "name": "config/reachable"
+                },
+                {
+                    "name": "config/tholddark"
+                },
+                {
+                    "name": "config/tholdoffset"
+                },
+                {
+                    "name": "config/usertest",
+                    "parse": {"ep": 2, "cl": "0x0000", "at": "0x0032", "mf": "0x100b", "eval": "Item.val = Attr.val"}
+                },
+                {
+                    "name": "state/dark"
+                },
+                {
+                    "name": "state/daylight"
+                },
+                {
+                    "name": "state/lastupdated"
+                },
+                {
+                    "name": "state/lightlevel",
+                    "parse": {"ep": 2, "cl": "0x0400", "at": "0x0000", "script": "../generic/illuminance_cluster/sml_light_level.js"},
+                    "awake": true
+                },
+                {
+                    "name": "state/lux"
+                }
+            ],
+            "example": {
+                "config": {
+                    "alert": "none",
+                    "battery": 0,
+                    "ledindication": false,
+                    "on": true,
+                    "pending": [],
+                    "reachable": true,
+                    "tholddark": 12000,
+                    "tholdoffset": 7000,
+                    "usertest": false
+                },
+                "ep": 2,
+                "etag": "58197854b7469e88cbb22afbe5ecf8d0",
+                "lastseen": "2022-01-13T13:20Z",
+                "manufacturername": "Philips",
+                "modelid": "SML004",
+                "name": "Motion Sensor (2)",
+                "state": {
+                    "dark": false,
+                    "daylight": true,
+                    "lastupdated": "2022-01-13T13:19:58.655",
+                    "lightlevel": 30063,
+                    "lux": 1014
+                },
+                "swversion": "2.53.6",
+                "type": "ZHALightLevel",
+                "uniqueid": "00:17:88:01:02:00:21:f4-02-0400"
+            }
+        },
+        {
+            "type": "$TYPE_TEMPERATURE_SENSOR",
+            "restapi": "/sensors",
+            "uuid": [ "$address.ext", "0x02", "0x0402"],
+            "fingerprint": { "profile": "0x0104", "device": "0x0107", "endpoint": "0x02", "in": ["0x0000", "0x0001", "0x0402"] },
+            "items": [
+                {
+                    "name": "attr/lastseen"
+                },
+                {
+                    "name": "attr/manufacturername"
+                },
+                {
+                    "name": "attr/modelid"
+                },
+                {
+                    "name": "attr/name"
+                },
+                {
+                    "name": "attr/swversion"
+                },
+                {
+                    "name": "attr/type"
+                },
+                {
+                    "name": "attr/uniqueid"
+                },
+                {
+                    "name": "config/alert",
+                    "default": "none"
+                },
+                {
+                    "name": "config/battery",
+                    "parse": {"ep": 2, "cl": "0x0001", "at": "0x0021", "eval": "Item.val = Attr.val / 2"}
+                },
+                {
+                    "name": "config/ledindication",
+                    "parse": {"ep": 2, "cl": "0x0000", "at": "0x0033", "mf": "0x100b", "eval": "Item.val = Attr.val"}
+                },
+                {
+                    "name": "config/offset"
+                },
+                {
+                    "name": "config/on"
+                },
+                {
+                    "name": "config/pending"
+                },
+                {
+                    "name": "config/reachable"
+                },
+                {
+                    "name": "config/usertest",
+                    "parse": {"ep": 2, "cl": "0x0000", "at": "0x0032", "mf": "0x100b", "eval": "Item.val = Attr.val"}
+                },
+                {
+                    "name": "state/lastupdated"
+                },
+                {
+                    "name": "state/temperature",
+                    "parse": {"ep": 2, "cl": "0x0402", "at": "0x0000", "eval": "Item.val = Attr.val + R.item('config/offset').val"},
+                    "awake": true
+                }
+            ],
+            "example": {
+                "config": {
+                    "alert": "none",
+                    "battery": 0,
+                    "ledindication": false,
+                    "offset": 0,
+                    "on": true,
+                    "pending": [],
+                    "reachable": true,
+                    "usertest": false
+                },
+                "ep": 2,
+                "etag": "0f14835ede4aac034a6022f956aea426",
+                "lastseen": "2022-01-13T13:20Z",
+                "manufacturername": "Philips",
+                "modelid": "SML004",
+                "name": "Motion Sensor (2)",
+                "state": {
+                    "lastupdated": "2022-01-13T13:17:44.861",
+                    "temperature": 2142
+                },
+                "swversion": "2.53.6",
+                "type": "ZHATemperature",
+                "uniqueid": "00:17:88:01:02:00:21:f4-02-0402"
+            }
+        }
+    ],
+    "bindings": [
+        {
+            "bind": "unicast",
+            "src.ep": 2,
+            "cl": "0x0406",
+            "report": [ {"at": "0x0000", "dt": "0x18", "min": 1, "max": 300 } ]
+        },
+        {
+            "bind": "unicast",
+            "src.ep": 2,
+            "cl": "0x0400",
+            "report": [ {"at": "0x0000", "dt": "0x21", "min": 5, "max": 300, "change": "0x07d0" } ]
+        },
+        {
+            "bind": "unicast",
+            "src.ep": 2,
+            "cl": "0x0402",
+            "report": [ {"at": "0x0000", "dt": "0x29", "min": 10, "max": 300, "change": "0x14" } ]
+        },
+        {
+            "bind": "unicast",
+            "src.ep": 2,
+            "cl": "0x0001",
+            "report": [ {"at": "0x0021", "dt": "0x20", "min": 7200, "max": 7200, "change": "0x00" } ]
+        }
+    ]
+}


### PR DESCRIPTION
Add DDF for this device. It is a simple copy/paste from sml003_motion-sensor.json with only replacing "SML003" with "SML004". Reporting of motion, illuminance, battery, temperature works fine. Other features I did not test extensively, but no issues so far.