### PR TITLE
Fix Zigbee Dual Curtain Switch _TZ3000_j1xl73iw (TS130F)

### DIFF
--- a/product_match.cpp
+++ b/product_match.cpp
@@ -92,6 +92,7 @@ static const ProductMap products[] =
     {"_TZ3000_vd43bbfq", "TS130F", "Tuya", "QS-Zigbee-C01 Module"}, // Curtain module QS-Zigbee-C01
     {"_TZ3000_kpve0q1p", "TS130F", "Tuya", "Covering Switch ESW-2ZAD-EU"},
     {"_TZ3000_fccpjz5z", "TS130F", "Tuya", "QS-Zigbee-C01 Module"}, // Curtain module QS-Zigbee-C01
+    {"_TZ3000_j1xl73iw", "TS130F", "Tuya", "Zigbee dual curtain switch"},
 
     // Other
     {"_TYST11_d0yu2xgi", "0yu2xgi", "NEO/Tuya", "NAS-AB02B0 Siren"},

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1712,6 +1712,7 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
     {
         if (taskRef.lightNode->modelId().startsWith(QLatin1String("lumi.curtain")) ||
             R_GetProductId(taskRef.lightNode) == QLatin1String("11830304 Switch") ||
+            R_GetProductId(taskRef.lightNode) == QLatin1String("Zigbee dual curtain switch") ||
             R_GetProductId(taskRef.lightNode) == QLatin1String("Covering Switch ESW-2ZAD-EU") ||
             R_GetProductId(taskRef.lightNode) == QLatin1String("QS-Zigbee-C01 Module") ||
             R_GetProductId(taskRef.lightNode) == QLatin1String("Zigbee curtain switch") ||

--- a/window_covering.cpp
+++ b/window_covering.cpp
@@ -184,6 +184,7 @@ void DeRestPluginPrivate::handleWindowCoveringClusterIndication(const deCONZ::Ap
                 // Reverse for some tuya covering
                 else if (R_GetProductId(lightNode) == QLatin1String("11830304 Switch") ||
                          R_GetProductId(lightNode) == QLatin1String("Zigbee curtain switch") ||
+                         R_GetProductId(lightNode) == QLatin1String("Zigbee dual curtain switch") ||
                          R_GetProductId(lightNode) == QLatin1String("Covering Switch ESW-2ZAD-EU") ||
                          R_GetProductId(lightNode) == QLatin1String("QS-Zigbee-C01 Module"))
                 {


### PR DESCRIPTION
Followup to #3757

I know that PRs regarding devices are not merged if they are not in DDF format, but don't stop reading here.
The logic of reversing the percentage like it is implemented is currently **not possible** with the DDF specification.

If that changes I am happy to add and test a DDF for the device.