### PR TITLE
Fix processing rules referencing DDF devices

### DIFF
--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -90,6 +90,7 @@ using namespace deCONZ::literals;
 #define IDLE_ATTR_REPORT_BIND_LIMIT_SHORT 5
 #define BUTTON_ATTR_REPORT_BIND_LIMIT 120
 #define WARMUP_TIME 120
+#define RULE_CHECK_DELAY 4 // seconds
 
 #define MAX_UNLOCK_GATEWAY_TIME 600
 #define MAX_RECOVER_ENTRY_AGE 600
@@ -2078,6 +2079,7 @@ public:
     std::vector<Resourcelinks> resourcelinks;
 
     // rules
+    int needRuleCheck;
     std::vector<int> fastRuleCheck;
     QTimer *fastRuleCheckTimer;
 

--- a/event_queue.cpp
+++ b/event_queue.cpp
@@ -34,6 +34,10 @@ void DeRestPluginPrivate::handleEvent(const Event &e)
             deviceWidget->handleEvent(e);
         }
     }
+    else if (e.resource() == RDevices && e.what() == REventDDFInitResponse)
+    {
+        needRuleCheck = RULE_CHECK_DELAY;
+    }
 
     if (e.deviceKey() != 0)
     {

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -4032,7 +4032,7 @@ void DeRestPluginPrivate::handleIndicationSearchSensors(const deCONZ::ApsDataInd
 
             if (changed)
             {
-                indexRulesTriggers();
+                needRuleCheck = RULE_CHECK_DELAY;
                 queSaveDb(DB_RULES, DB_SHORT_SAVE_DELAY);
             }
         }


### PR DESCRIPTION
Since DDF devices and their light and sensor resources are created async, the rule triggers can't be indexed in the plugin constructor.

The PR delays/debounces the indexing so that all devices are handled properly. This is also a bit faster since prior for each device useless container calls where made during startup.