### PR TITLE
Improve loading DDF sensor data from legacy DB tables

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -22,6 +22,7 @@
 #include "gateway.h"
 #include "json.h"
 #include "product_match.h"
+#include "utils/ArduinoJson.h"
 #include "utils/utils.h"
 
 constexpr size_t MAX_SQL_LEN = 2048;
@@ -33,6 +34,8 @@ static const char *pragmaFreeListCount = "PRAGMA freelist_count";
 
 static sqlite3 *db = nullptr; // TODO should be member of Database class
 static char sqlBuf[MAX_SQL_LEN];
+
+static StaticJsonDocument<1024 * 1024 * 2> dbJson; /* 2 mega bytes*/
 
 struct DB_Callback {
   DeRestPluginPrivate *d = nullptr;
@@ -5229,6 +5232,15 @@ void DeRestPluginPrivate::saveDb()
                 continue;
             }
 
+            if (i->parentResource())
+            {
+                Device *device = static_cast<Device*>(i->parentResource());
+                if (device && device->managed())
+                {
+                    DB_StoreSubDeviceItems(&*i);
+                }
+            }
+
             std::vector<GroupInfo>::const_iterator gi = i->groups().begin();
             std::vector<GroupInfo>::const_iterator gend = i->groups().end();
 
@@ -5659,6 +5671,15 @@ void DeRestPluginPrivate::saveDb()
                 if (ep == 0xFF || ep == 0)
                 {
                     continue;
+                }
+            }
+
+            if (i->parentResource())
+            {
+                Device *device = static_cast<Device*>(i->parentResource());
+                if (device && device->managed())
+                {
+                    DB_StoreSubDeviceItems(&*i);
                 }
             }
 
@@ -6854,9 +6875,53 @@ static int DB_LoadLegacyValueCallback(void *user, int ncols, char **colval , cha
     Q_ASSERT(result);
     Q_ASSERT(ncols == 1);
 
-    result->value.setString(colval[0]);
+    if (colval[0][0] == '{') // state and config json objects
+    {
+        BufString<32> key; // config/offset -> offset
+        for (size_t i = 0; i < result->column.size(); i++)
+        {
+            if (result->column.c_str()[i] == '/')
+            {
+                key.setString(&result->column.c_str()[i + 1]);
+                break;
+            }
+        }
 
-    return 0;
+        if (!key.empty() && DeserializationError::Ok == deserializeJson(dbJson, static_cast<const char*>(colval[0])))
+        {
+            if (dbJson.containsKey(key.c_str()))
+            {
+                auto var = dbJson[key.c_str()];
+                if (var.is<int>())
+                {
+                    result->value.setString(std::to_string(var.as<int>()).c_str());
+                    return 0;
+                }
+                else if (var.is<double>())
+                {
+                    result->value.setString(std::to_string(var.as<double>()).c_str());
+                    return 0;
+                }
+                else if (var.is<const char*>())
+                {
+                    result->value.setString(var.as<const char*>());
+                    return 0;
+                }
+                else if (var.is<bool>())
+                {
+                    result->value.setString((var.as<bool>() ? "true" : "false"));
+                    return 0;
+                }
+            }
+        }
+    }
+    else if (colval[0][0])
+    {
+        result->value.setString(colval[0]);
+        return 0;
+    }
+
+    return 1;
 };
 
 bool DB_LoadLegacySensorValue(DB_LegacyItem *litem)
@@ -6871,8 +6936,23 @@ bool DB_LoadLegacySensorValue(DB_LegacyItem *litem)
 
     litem->value.clear();
 
+    BufString<32> column; // config/* -> config, state/* -> state
+    for (size_t i = 0; i < litem->column.size(); i++)
+    {
+        if (litem->column.c_str()[i] == '/')
+        {
+            column.setString(litem->column.c_str(), i);
+            break;
+        }
+    }
+
+    if (column.empty())
+    {
+        column = litem->column;
+    }
+
     int ret = snprintf(sqlBuf, sizeof(sqlBuf), "SELECT %s FROM sensors WHERE uniqueid = '%s' AND deletedState = 'normal'",
-                       litem->column.c_str(), litem->uniqueId.c_str());
+                       column.c_str(), litem->uniqueId.c_str());
 
     assert(size_t(ret) < sizeof(sqlBuf));
     if (size_t(ret) < sizeof(sqlBuf))

--- a/device_ddf_init.cpp
+++ b/device_ddf_init.cpp
@@ -136,7 +136,31 @@ static ResourceItem *DEV_InitDeviceDescriptionItem(const DeviceDescription::Item
             item->setTimeStamps(QDateTime::fromMSecsSinceEpoch(dbItem->timestampMs));
         }
     }
-    else if (ddfItem.defaultValue.isValid())
+    else if (!ddfItem.isStatic && dbItem == dbItems.cend() && !item->lastSet().isValid())
+    {
+        // try load from legacy sensors/nodes db tables
+        auto dbLegacyItem = std::make_unique<DB_LegacyItem>();
+        dbLegacyItem->uniqueId = uniqueId;
+        dbLegacyItem->column.setString(item->descriptor().suffix);
+
+        if (rsub->prefix() == RSensors)
+        {
+            DB_LoadLegacySensorValue(dbLegacyItem.get());
+        }
+        // TODO lights needs some more investigation, might not be needed..
+//        else if (rsub->prefix() == RLights)
+//        {
+//            DB_LoadLegacyLightValue(dbLegacyItem.get());
+//        }
+
+        if (!dbLegacyItem->value.empty())
+        {
+            item->setValue(QVariant(QString(dbLegacyItem->value.c_str())));
+            item->setTimeStamps(item->lastSet().addSecs(-120)); // TODO extract from 'lastupdated'?
+        }
+    }
+
+    if (ddfItem.defaultValue.isValid())
     {
         if (ddfItem.isStatic || !item->lastSet().isValid())
         {


### PR DESCRIPTION
If there aren't already entries in 'resource_items' extract them from 'config' and 'state' of the sensors table.

Also store managed device data in the legacy DB store function for now, needs a better solution later on.