### PR TITLE
Fix Xiaomi multi sensors exposing config/temperature: 0

### DIFF
--- a/devices/xiaomi/xiaomi_wsdcgq01lm_temp_hum_sensor.json
+++ b/devices/xiaomi/xiaomi_wsdcgq01lm_temp_hum_sensor.json
@@ -82,6 +82,10 @@
           "name": "config/reachable"
         },
         {
+          "name": "config/temperature",
+          "public": false
+        },
+        {
           "name": "state/lastupdated"
         },
         {
@@ -163,6 +167,10 @@
         },
         {
           "name": "config/reachable"
+        },
+        {
+          "name": "config/temperature",
+          "public": false
         },
         {
           "name": "state/humidity",

--- a/devices/xiaomi/xiaomi_wsdcgq11lm_temp_hum_press_sensor.json
+++ b/devices/xiaomi/xiaomi_wsdcgq11lm_temp_hum_press_sensor.json
@@ -83,6 +83,10 @@
           "name": "config/reachable"
         },
         {
+          "name": "config/temperature",
+          "public": false
+        },
+        {
           "name": "state/humidity"
         },
         {
@@ -157,6 +161,10 @@
           "name": "config/reachable"
         },
         {
+          "name": "config/temperature",
+          "public": false
+        },
+        {
           "name": "state/lastupdated"
         },
         {
@@ -229,6 +237,10 @@
         },
         {
           "name": "config/reachable"
+        },
+        {
+          "name": "config/temperature",
+          "public": false
         },
         {
           "name": "state/lastupdated"


### PR DESCRIPTION
The WSDCGQ01LM and WSDCGQ11LM have proper state/temperature, the DDF didn't include config/temperature but these were leftovers from legacy code.

The PR simply hides config/temperature items leaving only state/temperature.