### PR TITLE
Fix lastseen attribute changes causing frequent database writes

### DIFF
--- a/light_node.cpp
+++ b/light_node.cpp
@@ -266,7 +266,10 @@ uint8_t LightNode::colorLoopSpeed() const
 void LightNode::didSetValue(ResourceItem *i)
 {
     enqueueEvent(Event(RLights, i->descriptor().suffix, id(), i));
-    setNeedSaveDatabase(true);
+    if (i->descriptor().suffix != RAttrLastSeen) // prevent flooding database writes
+    {
+        setNeedSaveDatabase(true);
+    }
 }
 
 /*! Mark received command and update lastseen. */

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -271,7 +271,10 @@ void Sensor::setModelId(const QString &mid)
 void Sensor::didSetValue(ResourceItem *i)
 {
     enqueueEvent(Event(RSensors, i->descriptor().suffix, id(), i));
-    setNeedSaveDatabase(true);
+    if (i->descriptor().suffix != RAttrLastSeen) // prevent flooding database writes
+    {
+        setNeedSaveDatabase(true);
+    }
 }
 
 /*! Mark received command and update lastseen. */


### PR DESCRIPTION
Updating the `lastseen` attribute is done very often especially for lights.

In my 100 node test setup this caused frequent storing of all lights state, taking 5-7 seconds on a Raspberry Pi SD-card.
This PR skips setting the needSaveDatabase flag for `RAttrLastSeen`.