### PR TITLE
Fixes lux value if lightlevel is 0

### DIFF
--- a/devices/generic/illuminance_cluster/sml_light_level.js
+++ b/devices/generic/illuminance_cluster/sml_light_level.js
@@ -6,7 +6,7 @@ R.item('state/dark').val = measuredValue <= tholddark;
 R.item('state/daylight').val = measuredValue >= tholddark + tholdoffset;
 if (measuredValue >= 0 && measuredValue < 0xffff) {
 	const exp = measuredValue - 1;
-	const l = Math.pow(10, exp / 10000.0) + 0.5;
+	const l = Math.pow(10, exp / 10000.0);
 	R.item('state/lux').val = Math.floor(l);
 }
 Item.val = measuredValue;

--- a/devices/generic/illuminance_cluster/sml_light_level.js
+++ b/devices/generic/illuminance_cluster/sml_light_level.js
@@ -4,9 +4,9 @@ const measuredValue = Attr.val;
 
 R.item('state/dark').val = measuredValue <= tholddark;
 R.item('state/daylight').val = measuredValue >= tholddark + tholdoffset;
-if (measuredValue > 0 && measuredValue < 0xffff) {
+if (measuredValue >= 0 && measuredValue < 0xffff) {
 	const exp = measuredValue - 1;
 	const l = Math.pow(10, exp / 10000.0) + 0.5;
-	R.item('state/lux').val = Math.round(l);
+	R.item('state/lux').val = Math.floor(l);
 }
 Item.val = measuredValue;


### PR DESCRIPTION
Fixes https://github.com/dresden-elektronik/deconz-rest-plugin/issues/6041

If `lightlevel=0`, the `lux` value was not set. Also, `lux=0` was no longer possible.