### PR TITLE
Fix: Guard against non-existent device to prevent SIGSEGV

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -18265,7 +18265,7 @@ void DeRestPluginPrivate::pollNextDevice()
                 if (l.parentResource())
                 {
                     Device *device = static_cast<Device*>(l.parentResource());
-                    if (device->managed())
+                    if (device && device->managed())
                     {
                         continue;
                     }
@@ -18283,7 +18283,7 @@ void DeRestPluginPrivate::pollNextDevice()
                 if (s.parentResource())
                 {
                     Device *device = static_cast<Device*>(s.parentResource());
-                    if (device->managed())
+                    if (device && device->managed())
                     {
                         continue;
                     }

--- a/device.cpp
+++ b/device.cpp
@@ -187,6 +187,11 @@ void DEV_EnqueueEvent(Device *device, const char *event)
 
 Resource *DEV_GetSubDevice(Device *device, const char *prefix, const QString &identifier)
 {
+    if (!device)
+    {
+        return nullptr;
+    }
+    
     for (auto &sub : device->subDevices())
     {
         if (prefix && sub->prefix() != prefix)


### PR DESCRIPTION
While changing the settings of the Daylight sensor, the code runs into a segmentation fault in `DEV_GetSubDevice()`, trying to iterate over the available sub devices of the device provided, although a nullptr was given.

In addition to the above, two further missing guards were added.