### PR TITLE
Add DDF for Danalock V3

### DIFF
--- a/devices/danalock/danalock_v3.json
+++ b/devices/danalock/danalock_v3.json
@@ -1,0 +1,79 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "Danalock",
+  "modelid": "V3-BTZBE",
+  "product": "Danalock V3",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_DOOR_LOCK",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/swversion",
+          "refresh.interval": 84000,
+          "read": {"cl": "0x0000", "at": "0x0006", "ep": 1, "fn": "zcl"},
+          "parse": {"cl": "0x0000", "at": "0x0006", "ep": 1, "eval": "Item.val = Attr.val", "fn": "zcl"}
+        },
+        {
+          "name": "config/pending",
+          "public": false
+        },
+        {
+          "name": "config/checkin",
+          "awake": true
+        },
+        {
+          "name": "state/alert",
+          "default": "none"
+        },
+        {
+          "name": "state/reachable"
+        },
+        {
+          "name": "state/on",
+          "read": {"cl": "0x0101", "at": "0x0000", "ep": 1, "fn": "zcl"},
+          "parse": {"cl": "0x0101", "at": "0x0000", "ep": 1, "eval": "Item.val = (Attr.val === 1)", "fn": "zcl"},
+          "refresh.interval": 600,
+          "awake": true
+        },
+        {
+          "name": "state/battery",
+          "refresh.interval": 3700,
+          "public": false,
+          "awake": true
+        }
+      ]
+    }
+  ],
+  "bindings": [
+      {
+          "bind": "unicast",
+          "src.ep": 1,
+          "cl": "0x0101",
+          "report": [ {"at": "0x0000", "dt": "0x30", "min": 1, "max": 300 } ]
+      },
+      {
+          "bind": "unicast",
+          "src.ep": 1,
+          "cl": "0x0020"
+      },
+      {
+          "bind": "unicast",
+          "src.ep": 1,
+          "cl": "0x0001",
+          "report": [ {"at": "0x0021", "dt": "0x20", "min": 600, "max": 3600, "change": "0x00" } ]
+      }
+  ]
+}


### PR DESCRIPTION
Compared to the legacy implementation the PR configures bindings and reporting for Power Configuration, Poll Control and Doorlock clusters.

This yields a bit more traffic towards the gateway and shows the battery symbol in the GUI.

### Connection get lost issue

There are several reports that the device has difficulties keeping the connection (this seems to also happen with other gateways). Looking at various sniffer logs one reason is when the lock changes the parent from a router to the coordinator, this wasn't handled correctly in all cases. The bug is fixed in the new ConBee || and RaspBee II firmware 0x26780700 ([firmware changelog](https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Firmware-Changelog)).

The lock runs fine now in my setup for a few days with the new firmware and DDF.

However the sniffer logs show another problem which needs to be addressed in the Danalock V3 firmware: The lock detects than a parent is not reachable (aka powered off) and correctly rejoins via another parent. But it doesn't detect if the parent router plays nice, when commands are send to the gateway via a router the lock doesn't rejoin the network if it doesn't receive APS ACKs or ZCL Default Reponses from the gateway for a few times. The fix should be fairly simple and bring robustness like the Philips Hue motion sensor has.

