### PR TITLE
Fix state.lastupdated event fired multiple times

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1133,6 +1133,9 @@ void DeRestPluginPrivate::apsdeDataIndicationDevice(const deCONZ::ApsDataIndicat
             }
         }
 
+        // for state/* changes, only emit the state/lastupdated event once for the first state/* item.
+        bool eventLastUpdatedEmitted = false;
+
         for (int i = 0; i < r->itemCount(); i++)
         {
             ResourceItem *item = r->itemForIndex(i);
@@ -1184,11 +1187,12 @@ void DeRestPluginPrivate::apsdeDataIndicationDevice(const deCONZ::ApsDataIndicat
                     }
                 }
 
-                if (item->descriptor().suffix[0] == 's') // state/*
+                if (!eventLastUpdatedEmitted && item->descriptor().suffix[0] == 's') // state/*
                 {
                     ResourceItem *lastUpdated = r->item(RStateLastUpdated);
                     if (lastUpdated && idItem)
                     {
+                        eventLastUpdatedEmitted = true;
                         lastUpdated->setValue(item->lastSet());
                         enqueueEvent(Event(r->prefix(), lastUpdated->descriptor().suffix, idItem->toString(), device->key()));
                     }


### PR DESCRIPTION
The event was emitted for each `state/*` item which was changed in one received message. This could be seen in Philips Hue dimmer switch button handler, provoking wrong rule handling but is a general problem.

The PR compresses multiple state updates to only one `state/lastupdated` event.

Fixes https://github.com/dresden-elektronik/deconz-rest-plugin/issues/6059