### PR TITLE
Add DDF support for Tuya device time sync

### DIFF
--- a/de_web.pro
+++ b/de_web.pro
@@ -170,6 +170,7 @@ HEADERS  = bindings.h \
            utils/bufstring.h \
            utils/stringcache.h \
            utils/utils.h \
+           utils/timecluster.h \
            websocket_server.h \
            xiaomi.h \
            zcl/zcl.h \
@@ -272,6 +273,7 @@ SOURCES  = air_quality.cpp \
            utils/bufstring.cpp \
            utils/stringcache.cpp \
            utils/utils.cpp \
+           utils/timecluster.cpp \
            xiaomi.cpp \
            window_covering.cpp \
            websocket_server.cpp \

--- a/device_access_fn.cpp
+++ b/device_access_fn.cpp
@@ -1485,7 +1485,7 @@ bool parseTuyaTime(Resource *r, ResourceItem *item, const deCONZ::ApsDataIndicat
 
     stream2 << sequenceNumber;
 
-    Timecluster now = Timecluster::getCurrentTime(false);
+    Timecluster now = Timecluster::getCurrentTime(Timecluster::Epoch::UNIX);
     stream2 << now.utc_time;
     stream2 << now.local_time;
 

--- a/utils/timecluster.cpp
+++ b/utils/timecluster.cpp
@@ -1,0 +1,38 @@
+#include "timecluster.h"
+
+Timecluster::Timecluster()
+{
+    this->time_status = {MASTER | SUPERSEEDING | MASTER_ZONE_DST};
+};
+
+Timecluster Timecluster::getCurrentTime(bool useJ200Epoch = true)
+{
+    Timecluster cluster;
+    cluster.time_status = {MASTER | SUPERSEEDING | MASTER_ZONE_DST};
+
+    const QDateTime now = QDateTime::currentDateTimeUtc();
+    const QDateTime yearStart(QDate(QDate::currentDate().year(), 1, 1), QTime(0, 0), Qt::UTC);
+    const QTimeZone timeZone(QTimeZone::systemTimeZoneId());
+
+    auto epoch = (useJ200Epoch)
+                    ? QDateTime(QDate(2000, 1, 1), QTime(0, 0), Qt::UTC)
+                    : QDateTime(QDate(1970, 1, 1), QTime(0, 0), Qt::UTC);
+
+    cluster.utc_time = cluster.standard_time = cluster.local_time = epoch.secsTo(now);
+    cluster.timezone = timeZone.offsetFromUtc(yearStart);
+    if (timeZone.hasTransitions())
+    {
+        const QTimeZone::OffsetData dstStartOffsetData = timeZone.nextTransition(yearStart);
+        const QTimeZone::OffsetData dstEndOffsetData = timeZone.nextTransition(dstStartOffsetData.atUtc);
+        cluster.dst_start = epoch.secsTo(dstStartOffsetData.atUtc);
+        cluster.dst_end = epoch.secsTo(dstEndOffsetData.atUtc);
+        cluster.dst_shift = dstStartOffsetData.daylightTimeOffset;
+        cluster.standard_time = cluster.utc_time + cluster.timezone;
+
+        const bool isDaylightsavingTime = cluster.utc_time >= cluster.dst_start && cluster.utc_time <= cluster.dst_end;
+        cluster.local_time = cluster.utc_time + cluster.timezone + ((isDaylightsavingTime) ? cluster.dst_shift : 0);
+    }
+    cluster.time_valid_until = cluster.utc_time + Timecluster::default_validity_period;
+
+    return cluster;
+}

--- a/utils/timecluster.cpp
+++ b/utils/timecluster.cpp
@@ -1,22 +1,20 @@
 #include "timecluster.h"
 
-Timecluster::Timecluster()
-{
-    this->time_status = {MASTER | SUPERSEEDING | MASTER_ZONE_DST};
-};
+QDateTime Timecluster::getEpoch() {
+    return (this->epoch_base == Epoch::J2000)
+                    ? QDateTime(QDate(2000, 1, 1), QTime(0, 0), Qt::UTC)
+                    : QDateTime(QDate(1970, 1, 1), QTime(0, 0), Qt::UTC);
+}
 
-Timecluster Timecluster::getCurrentTime(bool useJ200Epoch = true)
+Timecluster Timecluster::getCurrentTime(Epoch epochBase = Epoch::J2000)
 {
-    Timecluster cluster;
+    Timecluster cluster(epochBase);
     cluster.time_status = {MASTER | SUPERSEEDING | MASTER_ZONE_DST};
 
     const QDateTime now = QDateTime::currentDateTimeUtc();
     const QDateTime yearStart(QDate(QDate::currentDate().year(), 1, 1), QTime(0, 0), Qt::UTC);
     const QTimeZone timeZone(QTimeZone::systemTimeZoneId());
-
-    auto epoch = (useJ200Epoch)
-                    ? QDateTime(QDate(2000, 1, 1), QTime(0, 0), Qt::UTC)
-                    : QDateTime(QDate(1970, 1, 1), QTime(0, 0), Qt::UTC);
+    const auto epoch = cluster.getEpoch();
 
     cluster.utc_time = cluster.standard_time = cluster.local_time = epoch.secsTo(now);
     cluster.timezone = timeZone.offsetFromUtc(yearStart);

--- a/utils/timecluster.h
+++ b/utils/timecluster.h
@@ -14,35 +14,43 @@
  *                       LocalTime = StandardTime + DstShift (during summer time)
  * 0x0008 LastSetTime
  * 0x0009 ValidUnilTime
-*/
-
-enum TimeStatus : quint8
-{
-	MASTER = 1U << 1, 
-	SYNCHRONIZED = 1U << 2,
-	SUPERSEEDING = 1U << 3, 
-	MASTER_ZONE_DST = 1U << 4, 
-	
-};
+ */
 
 class Timecluster
 {
-	static const quint32 default_validity_period = (3600 * 24);
-
 public:
+	enum TimeStatus : quint8
+	{
+		MASTER = 1U << 1,
+		SYNCHRONIZED = 1U << 2,
+		SUPERSEEDING = 1U << 3,
+		MASTER_ZONE_DST = 1U << 4,
 
-	quint32 utc_time;              // id 0x0000 Time
-	quint8 time_status;                   // id 0x0001 TimeStatus Master|MasterZoneDst|Superseding
-	qint32 timezone;              // id 0x0002 TimeZone
-	quint32 dst_start;        // id 0x0003 DstStart
-	quint32 dst_end;          // id 0x0004 DstEnd
-	qint32 dst_shift;         // id 0x0005 DstShift
-	quint32 standard_time;          // id 0x0006 StandardTime / StandardTime = Time + TimeZone
-	quint32 local_time;             // id 0x0007 LocalTime
+	};
+
+	enum class Epoch : bool
+	{
+		UNIX = false,
+		J2000 = true
+	};
+
+	quint32 utc_time;		  // id 0x0000 Time
+	quint8 time_status;		  // id 0x0001 TimeStatus Master|MasterZoneDst|Superseding
+	qint32 timezone;		  // id 0x0002 TimeZone
+	quint32 dst_start;		  // id 0x0003 DstStart
+	quint32 dst_end;		  // id 0x0004 DstEnd
+	qint32 dst_shift;		  // id 0x0005 DstShift
+	quint32 standard_time;	  // id 0x0006 StandardTime / StandardTime = Time + TimeZone
+	quint32 local_time;		  // id 0x0007 LocalTime
 	quint32 time_valid_until; // id 0x0009 ValidUntilTime
 
-public:
-	Timecluster();
+	QDateTime getEpoch();
+	static Timecluster getCurrentTime(Epoch epochbase);
 
-	static Timecluster getCurrentTime(bool useJ200Epoch);
+private:
+	static const quint32 default_validity_period = (3600 * 24);
+	
+	const Epoch epoch_base;
+	
+	Timecluster(Epoch epochBase) : epoch_base(epochBase) {};
 };

--- a/utils/timecluster.h
+++ b/utils/timecluster.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <QTimeZone>
+
+/**
+ * 0x0000 Time         / UTC Time seconds from 1/1/2000
+ * 0x0001 TimeStatus   / Master(bit-0)=1, Superseding(bit-3)= 1, MasterZoneDst(bit-2)=1
+ * 0x0002 TimeZone     / offset seconds from UTC
+ * 0x0003 DstStart     / daylight savings time start
+ * 0x0004 DstEnd       / daylight savings time end
+ * 0x0005 DstShift     / daylight savings offset
+ * 0x0006 StandardTime / StandardTime = Time + TimeZone
+ * 0x0007 LocalTime    / LocalTime = StandardTime (during winter time)
+ *                       LocalTime = StandardTime + DstShift (during summer time)
+ * 0x0008 LastSetTime
+ * 0x0009 ValidUnilTime
+*/
+
+enum TimeStatus : quint8
+{
+	MASTER = 1U << 1, 
+	SYNCHRONIZED = 1U << 2,
+	SUPERSEEDING = 1U << 3, 
+	MASTER_ZONE_DST = 1U << 4, 
+	
+};
+
+class Timecluster
+{
+	static const quint32 default_validity_period = (3600 * 24);
+
+public:
+
+	quint32 utc_time;              // id 0x0000 Time
+	quint8 time_status;                   // id 0x0001 TimeStatus Master|MasterZoneDst|Superseding
+	qint32 timezone;              // id 0x0002 TimeZone
+	quint32 dst_start;        // id 0x0003 DstStart
+	quint32 dst_end;          // id 0x0004 DstEnd
+	qint32 dst_shift;         // id 0x0005 DstShift
+	quint32 standard_time;          // id 0x0006 StandardTime / StandardTime = Time + TimeZone
+	quint32 local_time;             // id 0x0007 LocalTime
+	quint32 time_valid_until; // id 0x0009 ValidUntilTime
+
+public:
+	Timecluster();
+
+	static Timecluster getCurrentTime(bool useJ200Epoch);
+};


### PR DESCRIPTION
Allows DDF specifications to parse and respond to  TUYA_MCU_SYNC_TIME for timesync on the device.
The function should only be contained once in the DDF per device.
The actual attribute is not evaluated.

could be used in ddf on subdevice like so:
 ```json
{
  "name": "config/localtime",
  "public": false,
  "parse": { "fn": "tuyatime" }
}
```