### PR TITLE
FIX, Add DDF for the lidl Silvercrest Doorbell

### DIFF
--- a/button_maps.json
+++ b/button_maps.json
@@ -1565,7 +1565,7 @@
         "lidlDoorbellMap": {
             "vendor": "LIDL Silvercrest",
             "doc": "Lidl / Silvercrest doorbell (_TZ1800_ladpngdx)",
-            "modelids": ["HG06668"],
+            "modelids": ["HG06668","_TZ1800_ladpngdx"],
             "buttons": [
                 {"S_BUTTON_1": "Button"}
             ],

--- a/devices/tuya/_TZ1800_ladpngdx_lild_doorbell.json
+++ b/devices/tuya/_TZ1800_ladpngdx_lild_doorbell.json
@@ -1,0 +1,107 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "_TZ1800_ladpngdx",
+  "modelid": "TS0211",
+  "product": "Silvercrest Doorbell",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_SWITCH",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0500"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0402",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x0500"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "description": "The current device battery level in 0–100 %.",
+          "default": 0
+        },
+        {
+          "name": "config/enrolled",
+          "description": "State of IAS enrollment process."
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/pending",
+          "description": "Pending tasks to configure the device."
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/buttonevent",
+          "description": "The last received button event."
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 60,
+          "max": 3600,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0500"
+    }
+  ]
+}


### PR DESCRIPTION
As, the original PR with code edition is locked https://github.com/dresden-elektronik/deconz-rest-plugin/pull/5702
This PR can make the doorbell working using DDF, see https://github.com/Smanar/Domoticz-deCONZ/issues/125

tuya device  : _TZ1800_ladpngdx