### PR TITLE
Followup LIDL/Silvercrest door bell (HG06668)

### DIFF
--- a/button_maps.json
+++ b/button_maps.json
@@ -1565,7 +1565,7 @@
         "lidlDoorbellMap": {
             "vendor": "LIDL Silvercrest",
             "doc": "Lidl / Silvercrest doorbell (_TZ1800_ladpngdx)",
-            "modelids": ["HG06668","_TZ1800_ladpngdx"],
+            "modelids": ["HG06668","_TZ1800_ladpngdx", "TS0211"],
             "buttons": [
                 {"S_BUTTON_1": "Button"}
             ],

--- a/devices/tuya/_TZ1800_ladpngdx_lild_doorbell.json
+++ b/devices/tuya/_TZ1800_ladpngdx_lild_doorbell.json
@@ -1,7 +1,7 @@
 {
   "schema": "devcap1.schema.json",
-  "manufacturername": "_TZ1800_ladpngdx",
-  "modelid": "TS0211",
+  "manufacturername": ["_TZ1800_ladpngdx", "LIDL Silvercrest", "LIDL Silvercrest"],
+  "modelid": ["TS0211", "TS0211", "HG06668"],
   "product": "Silvercrest Doorbell",
   "sleeper": true,
   "status": "Gold",
@@ -54,26 +54,22 @@
         },
         {
           "name": "config/battery",
-          "description": "The current device battery level in 0–100 %.",
           "default": 0
         },
         {
-          "name": "config/enrolled",
-          "description": "State of IAS enrollment process."
+          "name": "config/enrolled"
         },
         {
           "name": "config/on"
         },
         {
-          "name": "config/pending",
-          "description": "Pending tasks to configure the device."
+          "name": "config/pending"
         },
         {
           "name": "config/reachable"
         },
         {
-          "name": "state/buttonevent",
-          "description": "The last received button event."
+          "name": "state/buttonevent"
         },
         {
           "name": "state/lastupdated"


### PR DESCRIPTION
Additions for PR: https://github.com/dresden-elektronik/deconz-rest-plugin/pull/6071

The DDF didn't load due 0-100% "invalid utf8" in config/battery. It's actually valid but needs another fix...

Main problem is that we have different modelid/manufacturernames in the databases out there. The variants are added so the DDF is picked up for each of these. Note for later we need to have something like:

"apimodelid"
"apimanufacturername"

To express what should actually be exposed and be backward compatible, since the legacy code sometimes replaces the original Zigbee values (Lidl/Tuya).