### PR TITLE
Fix battery values for Aqara H1 WRS-R02

### DIFF
--- a/devices/xiaomi/xiaomi_wrs-r02_h1_switch.json
+++ b/devices/xiaomi/xiaomi_wrs-r02_h1_switch.json
@@ -66,8 +66,8 @@
             "at": "0x0020",
             "cl": "0x0001",
             "ep": 1,
-            "fn": "zcl",
-            "script": "xiaomi_battery.js"
+            "eval": "const vmin = 25; const vmax = 30; let bat = Attr.val; if (bat > vmax) { bat = vmax; } else if (bat < vmin) { bat = vmin; } bat = ((bat - vmin) / (vmax - vmin)) * 100; if (bat > 100) { bat = 100; } else if (bat <= 0)  { bat = 1; } Item.val = bat;",
+            "fn": "zcl"
           },
           "read": {
             "fn": "None"


### PR DESCRIPTION
As the device is configured to make use of the power configuration cluster, usage of the Xiaomi javascript to calculate battery values is inappropriate.