### PR TITLE
Fix: Make Hue motion sensors configurable again

### DIFF
--- a/devices/generic/items/config_ledindication_item.json
+++ b/devices/generic/items/config_ledindication_item.json
@@ -4,5 +4,6 @@
 	"datatype": "Bool",
 	"access": "RW",
 	"public": true,
-	"description": "Activates the LED indicator."
+	"description": "Activates the LED indicator.",
+	"default": false
 }

--- a/devices/generic/items/config_sensitivity_item.json
+++ b/devices/generic/items/config_sensitivity_item.json
@@ -5,5 +5,6 @@
 	"access": "RW",
 	"public": true,
 	"range": [0, 255],
-	"description": "The sensor sensitivity."
+	"description": "The sensor sensitivity.",
+	"default": 0
 }

--- a/devices/philips/sml002_motion_sensor.json
+++ b/devices/philips/sml002_motion_sensor.json
@@ -1,14 +1,11 @@
 {
     "schema": "devcap1.schema.json",
-    "doc:path": "philips/sml001_motion_sensor.md",
-    "doc:hdr": "Motion sensor 1. Gen (SML001)",
     "manufacturername": "$MF_PHILIPS",
-    "modelid": "SML001",
+    "modelid": "SML002",
     "vendor": "Philips",
-    "product": "Hue motion sensor 1. Gen (SML001)",
+    "product": "Hue outdoor sensor 1. Gen (SML002)",
     "status": "Gold",
     "sleeper": false,
-    "md:known_issues": [ ],
     "subdevices": [
          {
             "type": "$TYPE_PRESENCE_SENSOR",
@@ -76,15 +73,17 @@
                     "read": {"at": "0x0030", "cl": "0x0406", "ep": 2, "mf": "0x100b"},
                     "write": {"at": "0x0030", "cl": "0x0406", "dt": "0x20", "ep": 2, "eval": "Item.val", "mf": "0x100b"},
                     "values": [
-                        [0, "low"],
-                        [1, "medium"],
-                        [2, "high"]
+                        [0, "verylow"],
+                        [1, "low"],
+                        [2, "medium"],
+                        [3, "high"],
+                        [4, "veryhigh"]
                     ],
                     "refresh.interval": 86400
                 },
                 {
                     "name": "config/sensitivitymax",
-                    "static": 2
+                    "static": 4
                 },
                 {
                     "name": "config/usertest",
@@ -100,34 +99,7 @@
                     "name": "state/presence",
                     "parse": {"at": "0x0000", "cl": "0x0406", "ep": 2, "eval": "Item.val = Attr.val"}
                 }
-            ],
-            "example": {
-                "config": {
-                    "alert": "none",
-                    "battery": 0,
-                    "delay": 0,
-                    "ledindication": false,
-                    "on": true,
-                    "pending": [],
-                    "reachable": true,
-                    "sensitivity": 2,
-                    "sensitivitymax": 2,
-                    "usertest": false
-                },
-                "ep": 2,
-                "etag": "7f0d4873bf1bf93df92948fe160460e6",
-                "lastseen": "2021-01-13T13:20Z",
-                "manufacturername": "Philips",
-                "modelid": "SML001",
-                "name": "Motion Sensor (2)",
-                "state": {
-                    "lastupdated": "2021-01-13T13:20:06.879",
-                    "presence": false
-                },
-                "swversion": "6.1.1.27575",
-                "type": "ZHAPresence",
-                "uniqueid": "00:17:88:01:02:00:21:f4-02-0406"
-            }
+            ]
         },
         {
             "type": "$TYPE_LIGHT_LEVEL_SENSOR",
@@ -211,36 +183,7 @@
                 {
                     "name": "state/lux"
                 }
-            ],
-            "example": {
-                "config": {
-                    "alert": "none",
-                    "battery": 0,
-                    "ledindication": false,
-                    "on": true,
-                    "pending": [],
-                    "reachable": true,
-                    "tholddark": 12000,
-                    "tholdoffset": 7000,
-                    "usertest": false
-                },
-                "ep": 2,
-                "etag": "58197854b7469e88cbb22afbe5ecf8d0",
-                "lastseen": "2021-01-13T13:20Z",
-                "manufacturername": "Philips",
-                "modelid": "SML001",
-                "name": "Motion Sensor (2)",
-                "state": {
-                    "dark": false,
-                    "daylight": true,
-                    "lastupdated": "2021-01-13T13:19:58.655",
-                    "lightlevel": 30063,
-                    "lux": 1014
-                },
-                "swversion": "6.1.1.27575",
-                "type": "ZHALightLevel",
-                "uniqueid": "00:17:88:01:02:00:21:f4-02-0400"
-            }
+            ]
         },
         {
             "type": "$TYPE_TEMPERATURE_SENSOR",
@@ -312,32 +255,7 @@
                     "name": "state/temperature",
                     "parse": {"at": "0x0000", "cl": "0x0402", "ep": 2, "eval": "Item.val = Attr.val + R.item('config/offset').val"}
                 }
-            ],
-            "example": {
-                "config": {
-                    "alert": "none",
-                    "battery": 0,
-                    "ledindication": false,
-                    "offset": 0,
-                    "on": true,
-                    "pending": [],
-                    "reachable": true,
-                    "usertest": false
-                },
-                "ep": 2,
-                "etag": "0f14835ede4aac034a6022f956aea426",
-                "lastseen": "2021-01-13T13:20Z",
-                "manufacturername": "Philips",
-                "modelid": "SML001",
-                "name": "Motion Sensor (2)",
-                "state": {
-                    "lastupdated": "2021-01-13T13:17:44.861",
-                    "temperature": 2142
-                },
-                "swversion": "6.1.1.27575",
-                "type": "ZHATemperature",
-                "uniqueid": "00:17:88:01:02:00:21:f4-02-0402"
-            }
+            ]
         }
     ],
     "bindings": [

--- a/devices/philips/sml003_motion_sensor.json
+++ b/devices/philips/sml003_motion_sensor.json
@@ -1,13 +1,11 @@
 {
     "schema": "devcap1.schema.json",
-    "doc:path": "philips/sml003_motion_sensor.md",
-    "doc:hdr": "Motion sensor 2. Gen (SML003)",
-    "manufacturername": "$MF_PHILIPS",
+    "manufacturername": "Signify Netherlands B.V.",
     "modelid": "SML003",
-    "product": "Motion Sensor 2. Gen (SML003)",
+    "vendor": "Philips",
+    "product": "Hue motion sensor 2. Gen (SML003)",
     "status": "Gold",
     "sleeper": false,
-    "md:known_issues": [ ],
     "subdevices": [
          {
             "type": "$TYPE_PRESENCE_SENSOR",
@@ -42,22 +40,23 @@
                 },
                 {
                     "name": "config/battery",
-                    "parse": {"ep": 2, "cl": "0x0001", "at": "0x0021", "eval": "Item.val = Attr.val / 2"},
-                    "read": {"ep": 2, "cl": "0x0001", "at": "0x0021"},
-                    "refresh.interval": 7300,
-                    "awake": true
+                    "parse": {"at": "0x0021", "cl": "0x0001", "ep": 2, "eval": "Item.val = Attr.val / 2"},
+                    "read": {"at": "0x0021", "cl": "0x0001", "ep": 2},
+                    "refresh.interval": 7300
                 },
                 {
                     "name": "config/delay",
-                    "read": {"ep": 2, "cl": "0x0406", "at": "0x0010"},
-                    "parse": {"ep": 2, "cl": "0x0406", "at": "0x0010", "eval": "Item.val = Attr.val"},
-                    "refresh.interval": 84000
+                    "parse": {"at": "0x0010", "cl": "0x0406", "ep": 2, "eval": "Item.val = Attr.val"},
+                    "read": {"at": "0x0010", "cl": "0x0406", "ep": 2},
+                    "write": {"at": "0x0010", "cl": "0x0406", "dt": "0x21", "ep": 2, "eval": "Item.val"},
+                    "refresh.interval": 86400
                 },
                 {
                     "name": "config/ledindication",
-                    "read": {"ep": 2, "cl": "0x0000", "at": "0x0033", "mf": "0x100b"},
-                    "parse": {"ep": 2, "cl": "0x0000", "at": "0x0033", "mf": "0x100b", "eval": "Item.val = Attr.val"},
-                    "refresh.interval": 84000
+                    "parse": {"at": "0x0033", "cl": "0x0000", "ep": 2, "eval": "Item.val = Attr.val", "mf": "0x100b"},
+                    "read": {"at": "0x0033", "cl": "0x0000", "ep": 2, "mf": "0x100b"},
+                    "write": {"at": "0x0033", "cl": "0x0000", "dt": "0x10", "ep": 2, "eval": "Item.val", "mf": "0x100b"},
+                    "refresh.interval": 86400
                 },
                 {
                     "name": "config/on"
@@ -70,16 +69,17 @@
                 },
                 {
                     "name": "config/sensitivity",
+                    "parse": {"at": "0x0030", "cl": "0x0406", "ep": 2, "eval": "Item.val = Attr.val", "mf": "0x100b"},
+                    "read": {"at": "0x0030", "cl": "0x0406", "ep": 2, "mf": "0x100b"},
+                    "write": {"at": "0x0030", "cl": "0x0406", "dt": "0x20", "ep": 2, "eval": "Item.val", "mf": "0x100b"},
                     "values": [
                         [0, "verylow"],
                         [1, "low"],
                         [2, "medium"],
-						[3, "high"],
-						[4, "veryhigh"]
+                        [3, "high"],
+                        [4, "veryhigh"]
                     ],
-                    "read": {"ep": 2, "cl": "0x0406", "at": "0x0030", "mf": "0x100b"},
-                    "parse": {"ep": 2, "cl": "0x0406", "at": "0x0030", "mf": "0x100b", "eval": "Item.val == 0 ? Item.val = Attr.val : Item.val"},
-                    "refresh.interval": 84000
+                    "refresh.interval": 86400
                 },
                 {
                     "name": "config/sensitivitymax",
@@ -87,46 +87,19 @@
                 },
                 {
                     "name": "config/usertest",
-                    "read": {"ep": 2, "cl": "0x0000", "at": "0x0032", "mf": "0x100b"},
-                    "parse": {"ep": 2, "cl": "0x0000", "at": "0x0032", "mf": "0x100b", "eval": "Item.val = Attr.val"},
-                    "refresh.interval": 84000
+                    "parse": {"at": "0x0032", "cl": "0x0000", "ep": 2, "mf": "0x100b", "eval": "Item.val = Attr.val"},
+                    "read": {"at": "0x0032", "cl": "0x0000", "ep": 2, "mf": "0x100b"},
+                    "write": {"at": "0x0032", "cl": "0x0000", "dt": "0x10", "ep": 2, "mf": "0x100b", "eval": "Item.val"},
+                    "refresh.interval": 86400
                 },
                 {
                     "name": "state/lastupdated"
                 },
                 {
                     "name": "state/presence",
-                    "parse": {"ep": 2, "cl": "0x0406", "at": "0x0000", "eval": "Item.val = Attr.val"},
-                    "awake": true
+                    "parse": {"at": "0x0000", "cl": "0x0406", "ep": 2, "eval": "Item.val = Attr.val"}
                 }
-            ],
-            "example": {
-                "config": {
-                    "alert": "none",
-                    "battery": 0,
-                    "delay": 0,
-                    "ledindication": false,
-                    "on": true,
-                    "pending": [],
-                    "reachable": true,
-                    "sensitivity": 2,
-                    "sensitivitymax": 4,
-                    "usertest": false
-                },
-                "ep": 2,
-                "etag": "7f0d4873bf1bf93df92948fe160460e6",
-                "lastseen": "2022-01-13T13:20Z",
-                "manufacturername": "Philips",
-                "modelid": "SML003",
-                "name": "Motion Sensor (2)",
-                "state": {
-                    "lastupdated": "2022-01-13T13:20:06.879",
-                    "presence": false
-                },
-                "swversion": "2.53.6",
-                "type": "ZHAPresence",
-                "uniqueid": "00:17:88:01:02:00:21:f4-02-0406"
-            }
+            ]
         },
         {
             "type": "$TYPE_LIGHT_LEVEL_SENSOR",
@@ -147,7 +120,8 @@
                     "name": "attr/name"
                 },
                 {
-                    "name": "attr/swversion"
+                    "name": "attr/swversion",
+                    "read": {"fn": "none"}
                 },
                 {
                     "name": "attr/type"
@@ -161,11 +135,15 @@
                 },
                 {
                     "name": "config/battery",
-                    "parse": {"ep": 2, "cl": "0x0001", "at": "0x0021", "eval": "Item.val = Attr.val / 2"}
+                    "parse": {"at": "0x0021", "cl": "0x0001", "ep": 2, "eval": "Item.val = Attr.val / 2"},
+                    "read": {"fn": "none"}
                 },
                 {
                     "name": "config/ledindication",
-                    "parse": {"ep": 2, "cl": "0x0000", "at": "0x0033", "mf": "0x100b", "eval": "Item.val = Attr.val"}
+                    "parse": {"at": "0x0033", "cl": "0x0000", "ep": 2, "eval": "Item.val = Attr.val", "mf": "0x100b"},
+                    "read": {"at": "0x0033", "cl": "0x0000", "ep": 2, "mf": "0x100b"},
+                    "write": {"at": "0x0033", "cl": "0x0000", "dt": "0x10", "ep": 2, "eval": "Item.val", "mf": "0x100b"},
+                    "refresh.interval": 86400
                 },
                 {
                     "name": "config/on"
@@ -184,7 +162,10 @@
                 },
                 {
                     "name": "config/usertest",
-                    "parse": {"ep": 2, "cl": "0x0000", "at": "0x0032", "mf": "0x100b", "eval": "Item.val = Attr.val"}
+                    "parse": {"at": "0x0032", "cl": "0x0000", "ep": 2, "eval": "Item.val = Attr.val", "mf": "0x100b"},
+                    "read": {"at": "0x0032", "cl": "0x0000", "ep": 2, "mf": "0x100b"},
+                    "write": {"at": "0x0032", "cl": "0x0000", "dt": "0x10", "ep": 2, "eval": "Item.val", "mf": "0x100b"},
+                    "refresh.interval": 86400
                 },
                 {
                     "name": "state/dark"
@@ -197,42 +178,12 @@
                 },
                 {
                     "name": "state/lightlevel",
-                    "parse": {"ep": 2, "cl": "0x0400", "at": "0x0000", "script": "../generic/illuminance_cluster/sml_light_level.js"},
-                    "awake": true
+                    "parse": {"at": "0x0000", "cl": "0x0400", "ep": 2, "script": "../generic/illuminance_cluster/sml_light_level.js"}
                 },
                 {
                     "name": "state/lux"
                 }
-            ],
-            "example": {
-                "config": {
-                    "alert": "none",
-                    "battery": 0,
-                    "ledindication": false,
-                    "on": true,
-                    "pending": [],
-                    "reachable": true,
-                    "tholddark": 12000,
-                    "tholdoffset": 7000,
-                    "usertest": false
-                },
-                "ep": 2,
-                "etag": "58197854b7469e88cbb22afbe5ecf8d0",
-                "lastseen": "2022-01-13T13:20Z",
-                "manufacturername": "Philips",
-                "modelid": "SML003",
-                "name": "Motion Sensor (2)",
-                "state": {
-                    "dark": false,
-                    "daylight": true,
-                    "lastupdated": "2022-01-13T13:19:58.655",
-                    "lightlevel": 30063,
-                    "lux": 1014
-                },
-                "swversion": "2.53.6",
-                "type": "ZHALightLevel",
-                "uniqueid": "00:17:88:01:02:00:21:f4-02-0400"
-            }
+            ]
         },
         {
             "type": "$TYPE_TEMPERATURE_SENSOR",
@@ -253,7 +204,8 @@
                     "name": "attr/name"
                 },
                 {
-                    "name": "attr/swversion"
+                    "name": "attr/swversion",
+                    "read": {"fn": "none"}
                 },
                 {
                     "name": "attr/type"
@@ -267,11 +219,15 @@
                 },
                 {
                     "name": "config/battery",
-                    "parse": {"ep": 2, "cl": "0x0001", "at": "0x0021", "eval": "Item.val = Attr.val / 2"}
+                    "parse": {"at": "0x0021", "cl": "0x0001", "ep": 2, "eval": "Item.val = Attr.val / 2"},
+                    "read": {"fn": "none"}
                 },
                 {
                     "name": "config/ledindication",
-                    "parse": {"ep": 2, "cl": "0x0000", "at": "0x0033", "mf": "0x100b", "eval": "Item.val = Attr.val"}
+                    "parse": {"at": "0x0033", "cl": "0x0000", "ep": 2, "eval": "Item.val = Attr.val", "mf": "0x100b"},
+                    "read": {"at": "0x0033", "cl": "0x0000", "ep": 2, "mf": "0x100b"},
+                    "write": {"at": "0x0033", "cl": "0x0000", "dt": "0x10", "ep": 2, "eval": "Item.val", "mf": "0x100b"},
+                    "refresh.interval": 86400
                 },
                 {
                     "name": "config/offset"
@@ -287,42 +243,19 @@
                 },
                 {
                     "name": "config/usertest",
-                    "parse": {"ep": 2, "cl": "0x0000", "at": "0x0032", "mf": "0x100b", "eval": "Item.val = Attr.val"}
+                    "parse": {"at": "0x0032", "cl": "0x0000", "ep": 2, "eval": "Item.val = Attr.val", "mf": "0x100b"},
+                    "read": {"at": "0x0032", "cl": "0x0000", "ep": 2, "mf": "0x100b"},
+                    "write": {"at": "0x0032", "cl": "0x0000", "dt": "0x10", "ep": 2, "eval": "Item.val", "mf": "0x100b"},
+                    "refresh.interval": 86400
                 },
                 {
                     "name": "state/lastupdated"
                 },
                 {
                     "name": "state/temperature",
-                    "parse": {"ep": 2, "cl": "0x0402", "at": "0x0000", "eval": "Item.val = Attr.val + R.item('config/offset').val"},
-                    "awake": true
+                    "parse": {"at": "0x0000", "cl": "0x0402", "ep": 2, "eval": "Item.val = Attr.val + R.item('config/offset').val"}
                 }
-            ],
-            "example": {
-                "config": {
-                    "alert": "none",
-                    "battery": 0,
-                    "ledindication": false,
-                    "offset": 0,
-                    "on": true,
-                    "pending": [],
-                    "reachable": true,
-                    "usertest": false
-                },
-                "ep": 2,
-                "etag": "0f14835ede4aac034a6022f956aea426",
-                "lastseen": "2022-01-13T13:20Z",
-                "manufacturername": "Philips",
-                "modelid": "SML003",
-                "name": "Motion Sensor (2)",
-                "state": {
-                    "lastupdated": "2022-01-13T13:17:44.861",
-                    "temperature": 2142
-                },
-                "swversion": "2.53.6",
-                "type": "ZHATemperature",
-                "uniqueid": "00:17:88:01:02:00:21:f4-02-0402"
-            }
+            ]
         }
     ],
     "bindings": [

--- a/devices/philips/sml004_motion_sensor.json
+++ b/devices/philips/sml004_motion_sensor.json
@@ -1,13 +1,11 @@
 {
     "schema": "devcap1.schema.json",
-    "doc:path": "philips/sml004_motion_sensor.md",
-    "doc:hdr": "Motion sensor 3. Gen (SML004)",
-    "manufacturername": "$MF_PHILIPS",
+    "manufacturername": "Signify Netherlands B.V.",
     "modelid": "SML004",
-    "product": "Motion Sensor 3. Gen (SML004)",
-    "status": "Bronze",
+    "vendor": "Philips",
+    "product": "Hue outdoor sensor 2. Gen (SML004)",
+    "status": "Gold",
     "sleeper": false,
-    "md:known_issues": [ ],
     "subdevices": [
          {
             "type": "$TYPE_PRESENCE_SENSOR",
@@ -42,22 +40,23 @@
                 },
                 {
                     "name": "config/battery",
-                    "parse": {"ep": 2, "cl": "0x0001", "at": "0x0021", "eval": "Item.val = Attr.val / 2"},
-                    "read": {"ep": 2, "cl": "0x0001", "at": "0x0021"},
-                    "refresh.interval": 7300,
-                    "awake": true
+                    "parse": {"at": "0x0021", "cl": "0x0001", "ep": 2, "eval": "Item.val = Attr.val / 2"},
+                    "read": {"at": "0x0021", "cl": "0x0001", "ep": 2},
+                    "refresh.interval": 7300
                 },
                 {
                     "name": "config/delay",
-                    "read": {"ep": 2, "cl": "0x0406", "at": "0x0010"},
-                    "parse": {"ep": 2, "cl": "0x0406", "at": "0x0010", "eval": "Item.val = Attr.val"},
-                    "refresh.interval": 84000
+                    "parse": {"at": "0x0010", "cl": "0x0406", "ep": 2, "eval": "Item.val = Attr.val"},
+                    "read": {"at": "0x0010", "cl": "0x0406", "ep": 2},
+                    "write": {"at": "0x0010", "cl": "0x0406", "dt": "0x21", "ep": 2, "eval": "Item.val"},
+                    "refresh.interval": 86400
                 },
                 {
                     "name": "config/ledindication",
-                    "read": {"ep": 2, "cl": "0x0000", "at": "0x0033", "mf": "0x100b"},
-                    "parse": {"ep": 2, "cl": "0x0000", "at": "0x0033", "mf": "0x100b", "eval": "Item.val = Attr.val"},
-                    "refresh.interval": 84000
+                    "parse": {"at": "0x0033", "cl": "0x0000", "ep": 2, "eval": "Item.val = Attr.val", "mf": "0x100b"},
+                    "read": {"at": "0x0033", "cl": "0x0000", "ep": 2, "mf": "0x100b"},
+                    "write": {"at": "0x0033", "cl": "0x0000", "dt": "0x10", "ep": 2, "eval": "Item.val", "mf": "0x100b"},
+                    "refresh.interval": 86400
                 },
                 {
                     "name": "config/on"
@@ -70,16 +69,17 @@
                 },
                 {
                     "name": "config/sensitivity",
+                    "parse": {"at": "0x0030", "cl": "0x0406", "ep": 2, "eval": "Item.val = Attr.val", "mf": "0x100b"},
+                    "read": {"at": "0x0030", "cl": "0x0406", "ep": 2, "mf": "0x100b"},
+                    "write": {"at": "0x0030", "cl": "0x0406", "dt": "0x20", "ep": 2, "eval": "Item.val", "mf": "0x100b"},
                     "values": [
                         [0, "verylow"],
                         [1, "low"],
                         [2, "medium"],
-                                                [3, "high"],
-                                                [4, "veryhigh"]
+                        [3, "high"],
+                        [4, "veryhigh"]
                     ],
-                    "read": {"ep": 2, "cl": "0x0406", "at": "0x0030", "mf": "0x100b"},
-                    "parse": {"ep": 2, "cl": "0x0406", "at": "0x0030", "mf": "0x100b", "eval": "Item.val == 0 ? Item.val = Attr.val : Item.val"},
-                    "refresh.interval": 84000
+                    "refresh.interval": 86400
                 },
                 {
                     "name": "config/sensitivitymax",
@@ -87,46 +87,19 @@
                 },
                 {
                     "name": "config/usertest",
-                    "read": {"ep": 2, "cl": "0x0000", "at": "0x0032", "mf": "0x100b"},
-                    "parse": {"ep": 2, "cl": "0x0000", "at": "0x0032", "mf": "0x100b", "eval": "Item.val = Attr.val"},
-                    "refresh.interval": 84000
+                    "parse": {"at": "0x0032", "cl": "0x0000", "ep": 2, "mf": "0x100b", "eval": "Item.val = Attr.val"},
+                    "read": {"at": "0x0032", "cl": "0x0000", "ep": 2, "mf": "0x100b"},
+                    "write": {"at": "0x0032", "cl": "0x0000", "dt": "0x10", "ep": 2, "mf": "0x100b", "eval": "Item.val"},
+                    "refresh.interval": 86400
                 },
                 {
                     "name": "state/lastupdated"
                 },
                 {
                     "name": "state/presence",
-                    "parse": {"ep": 2, "cl": "0x0406", "at": "0x0000", "eval": "Item.val = Attr.val"},
-                    "awake": true
+                    "parse": {"at": "0x0000", "cl": "0x0406", "ep": 2, "eval": "Item.val = Attr.val"}
                 }
-            ],
-            "example": {
-                "config": {
-                    "alert": "none",
-                    "battery": 0,
-                    "delay": 0,
-                    "ledindication": false,
-                    "on": true,
-                    "pending": [],
-                    "reachable": true,
-                    "sensitivity": 2,
-                    "sensitivitymax": 4,
-                    "usertest": false
-                },
-                "ep": 2,
-                "etag": "7f0d4873bf1bf93df92948fe160460e6",
-                "lastseen": "2022-01-13T13:20Z",
-                "manufacturername": "Philips",
-                "modelid": "SML004",
-                "name": "Motion Sensor (2)",
-                "state": {
-                    "lastupdated": "2022-01-13T13:20:06.879",
-                    "presence": false
-                },
-                "swversion": "2.53.6",
-                "type": "ZHAPresence",
-                "uniqueid": "00:17:88:01:02:00:21:f4-02-0406"
-            }
+            ]
         },
         {
             "type": "$TYPE_LIGHT_LEVEL_SENSOR",
@@ -147,7 +120,8 @@
                     "name": "attr/name"
                 },
                 {
-                    "name": "attr/swversion"
+                    "name": "attr/swversion",
+                    "read": {"fn": "none"}
                 },
                 {
                     "name": "attr/type"
@@ -161,11 +135,15 @@
                 },
                 {
                     "name": "config/battery",
-                    "parse": {"ep": 2, "cl": "0x0001", "at": "0x0021", "eval": "Item.val = Attr.val / 2"}
+                    "parse": {"at": "0x0021", "cl": "0x0001", "ep": 2, "eval": "Item.val = Attr.val / 2"},
+                    "read": {"fn": "none"}
                 },
                 {
                     "name": "config/ledindication",
-                    "parse": {"ep": 2, "cl": "0x0000", "at": "0x0033", "mf": "0x100b", "eval": "Item.val = Attr.val"}
+                    "parse": {"at": "0x0033", "cl": "0x0000", "ep": 2, "eval": "Item.val = Attr.val", "mf": "0x100b"},
+                    "read": {"at": "0x0033", "cl": "0x0000", "ep": 2, "mf": "0x100b"},
+                    "write": {"at": "0x0033", "cl": "0x0000", "dt": "0x10", "ep": 2, "eval": "Item.val", "mf": "0x100b"},
+                    "refresh.interval": 86400
                 },
                 {
                     "name": "config/on"
@@ -184,7 +162,10 @@
                 },
                 {
                     "name": "config/usertest",
-                    "parse": {"ep": 2, "cl": "0x0000", "at": "0x0032", "mf": "0x100b", "eval": "Item.val = Attr.val"}
+                    "parse": {"at": "0x0032", "cl": "0x0000", "ep": 2, "eval": "Item.val = Attr.val", "mf": "0x100b"},
+                    "read": {"at": "0x0032", "cl": "0x0000", "ep": 2, "mf": "0x100b"},
+                    "write": {"at": "0x0032", "cl": "0x0000", "dt": "0x10", "ep": 2, "eval": "Item.val", "mf": "0x100b"},
+                    "refresh.interval": 86400
                 },
                 {
                     "name": "state/dark"
@@ -197,42 +178,12 @@
                 },
                 {
                     "name": "state/lightlevel",
-                    "parse": {"ep": 2, "cl": "0x0400", "at": "0x0000", "script": "../generic/illuminance_cluster/sml_light_level.js"},
-                    "awake": true
+                    "parse": {"at": "0x0000", "cl": "0x0400", "ep": 2, "script": "../generic/illuminance_cluster/sml_light_level.js"}
                 },
                 {
                     "name": "state/lux"
                 }
-            ],
-            "example": {
-                "config": {
-                    "alert": "none",
-                    "battery": 0,
-                    "ledindication": false,
-                    "on": true,
-                    "pending": [],
-                    "reachable": true,
-                    "tholddark": 12000,
-                    "tholdoffset": 7000,
-                    "usertest": false
-                },
-                "ep": 2,
-                "etag": "58197854b7469e88cbb22afbe5ecf8d0",
-                "lastseen": "2022-01-13T13:20Z",
-                "manufacturername": "Philips",
-                "modelid": "SML004",
-                "name": "Motion Sensor (2)",
-                "state": {
-                    "dark": false,
-                    "daylight": true,
-                    "lastupdated": "2022-01-13T13:19:58.655",
-                    "lightlevel": 30063,
-                    "lux": 1014
-                },
-                "swversion": "2.53.6",
-                "type": "ZHALightLevel",
-                "uniqueid": "00:17:88:01:02:00:21:f4-02-0400"
-            }
+            ]
         },
         {
             "type": "$TYPE_TEMPERATURE_SENSOR",
@@ -253,7 +204,8 @@
                     "name": "attr/name"
                 },
                 {
-                    "name": "attr/swversion"
+                    "name": "attr/swversion",
+                    "read": {"fn": "none"}
                 },
                 {
                     "name": "attr/type"
@@ -267,11 +219,15 @@
                 },
                 {
                     "name": "config/battery",
-                    "parse": {"ep": 2, "cl": "0x0001", "at": "0x0021", "eval": "Item.val = Attr.val / 2"}
+                    "parse": {"at": "0x0021", "cl": "0x0001", "ep": 2, "eval": "Item.val = Attr.val / 2"},
+                    "read": {"fn": "none"}
                 },
                 {
                     "name": "config/ledindication",
-                    "parse": {"ep": 2, "cl": "0x0000", "at": "0x0033", "mf": "0x100b", "eval": "Item.val = Attr.val"}
+                    "parse": {"at": "0x0033", "cl": "0x0000", "ep": 2, "eval": "Item.val = Attr.val", "mf": "0x100b"},
+                    "read": {"at": "0x0033", "cl": "0x0000", "ep": 2, "mf": "0x100b"},
+                    "write": {"at": "0x0033", "cl": "0x0000", "dt": "0x10", "ep": 2, "eval": "Item.val", "mf": "0x100b"},
+                    "refresh.interval": 86400
                 },
                 {
                     "name": "config/offset"
@@ -287,42 +243,19 @@
                 },
                 {
                     "name": "config/usertest",
-                    "parse": {"ep": 2, "cl": "0x0000", "at": "0x0032", "mf": "0x100b", "eval": "Item.val = Attr.val"}
+                    "parse": {"at": "0x0032", "cl": "0x0000", "ep": 2, "eval": "Item.val = Attr.val", "mf": "0x100b"},
+                    "read": {"at": "0x0032", "cl": "0x0000", "ep": 2, "mf": "0x100b"},
+                    "write": {"at": "0x0032", "cl": "0x0000", "dt": "0x10", "ep": 2, "eval": "Item.val", "mf": "0x100b"},
+                    "refresh.interval": 86400
                 },
                 {
                     "name": "state/lastupdated"
                 },
                 {
                     "name": "state/temperature",
-                    "parse": {"ep": 2, "cl": "0x0402", "at": "0x0000", "eval": "Item.val = Attr.val + R.item('config/offset').val"},
-                    "awake": true
+                    "parse": {"at": "0x0000", "cl": "0x0402", "ep": 2, "eval": "Item.val = Attr.val + R.item('config/offset').val"}
                 }
-            ],
-            "example": {
-                "config": {
-                    "alert": "none",
-                    "battery": 0,
-                    "ledindication": false,
-                    "offset": 0,
-                    "on": true,
-                    "pending": [],
-                    "reachable": true,
-                    "usertest": false
-                },
-                "ep": 2,
-                "etag": "0f14835ede4aac034a6022f956aea426",
-                "lastseen": "2022-01-13T13:20Z",
-                "manufacturername": "Philips",
-                "modelid": "SML004",
-                "name": "Motion Sensor (2)",
-                "state": {
-                    "lastupdated": "2022-01-13T13:17:44.861",
-                    "temperature": 2142
-                },
-                "swversion": "2.53.6",
-                "type": "ZHATemperature",
-                "uniqueid": "00:17:88:01:02:00:21:f4-02-0402"
-            }
+            ]
         }
     ],
     "bindings": [

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -890,10 +890,22 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                 }
                 else if (rid.suffix == RConfigUsertest) // Boolean
                 {
-                    pendingMask |= R_PENDING_USERTEST;
-                    sensor->enableRead(WRITE_USERTEST);
-                    sensor->setNextReadTime(WRITE_USERTEST, QTime::currentTime());
-                    updated = true;
+                    if (!devManaged)
+                    {
+                        pendingMask |= R_PENDING_USERTEST;
+                        sensor->enableRead(WRITE_USERTEST);
+                        sensor->setNextReadTime(WRITE_USERTEST, QTime::currentTime());
+                        updated = true;
+                    }
+                    else
+                    {
+                        if (rsub)
+                        {
+                            change.addTargetValue(rid.suffix, data.boolean);
+                            rsub->addStateChange(change);
+                            updated = true;
+                        }
+                    }
                 }
                 else if (rid.suffix == RConfigLat || rid.suffix == RConfigLong) // String
                 {


### PR DESCRIPTION
Basically, the sensors were missing the respective write functions to actually trigger the configuration change. On that occasion, the DDFs have been reworked:

- An attribute query loop has been resolved
- Polling and has been amended and minimized
- Manufacturer name for SML003 and SML004 has been corrected
- DDF for2nd gen outdoor sensor has been promoted to gold
- DDF for 1st gen Hue outdoor sensor has been added
- State change for `config/usertest` has been added

Based on this change, the associated legacy code could be removed. `config/pending` is effectively not used anymore and could be removed as well. However, that needs to be done cautiously in the respective code, as other sensors using occupancy cluster probably still rely on its usage.