### PR TITLE
Add DDF for tuya sensor _TZE200_bjawzodf (hum + temp)

### DIFF
--- a/devices/tuya/_TZE200_bjawzodf_hum_temp.json
+++ b/devices/tuya/_TZE200_bjawzodf_hum_temp.json
@@ -61,6 +61,12 @@
           "default": 0
         },
         {
+          "name": "config/battery",
+          "parse": {"fn": "tuya", "dpid": 4, "eval": "Item.val = Attr.val;" },
+          "read": {"fn": "none"},
+          "default": 0
+        },
+        {
           "name": "state/lastupdated"
         }
       ]
@@ -104,6 +110,12 @@
         {
           "name": "config/offset",
           "description": "Relative offset to the main measured value.",
+          "default": 0
+        },
+        {
+          "name": "config/battery",
+          "parse": {"fn": "tuya", "dpid": 4, "eval": "Item.val = Attr.val;" },
+          "read": {"fn": "none"},
           "default": 0
         },
         {

--- a/devices/tuya/_TZE200_bjawzodf_hum_temp.json
+++ b/devices/tuya/_TZE200_bjawzodf_hum_temp.json
@@ -1,0 +1,127 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "_TZE200_bjawzodf",
+  "modelid": "TS0601",
+  "product": "TS0601",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_HUMIDITY_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0405"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/offset",
+          "description": "Relative offset to the main measured value.",
+          "default": 0
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/humidity",
+          "description": "The current relative humidity in percent.",
+          "parse": {"fn": "tuya", "dpid": 2, "eval": "Item.val = 10 * Attr.val;" },
+          "read": {"fn": "tuya"},
+          "default": 0
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_TEMPERATURE_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0402"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/offset",
+          "description": "Relative offset to the main measured value.",
+          "default": 0
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/temperature",
+          "parse": {"fn": "tuya", "dpid": 1, "eval": "Item.val = 10 * Attr.val;" },
+          "read": {"fn": "none"},
+          "default": 0
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This device use tuya cluster.
Battery not tested, see https://github.com/dresden-elektronik/deconz-rest-plugin/issues/5927