### PR TITLE
Fix setting lastannounced and sensor reachable

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1108,7 +1108,7 @@ void DeRestPluginPrivate::apsdeDataIndicationDevice(const deCONZ::ApsDataIndicat
                     }
                 }
             }
-            break;
+            continue;
         }
 
         {   // TODO this is too messy

--- a/zdp/zdp_handlers.cpp
+++ b/zdp/zdp_handlers.cpp
@@ -41,6 +41,13 @@ void DeRestPluginPrivate::handleDeviceAnnceIndication(const deCONZ::ApsDataIndic
     Q_ASSERT(device);
     enqueueEvent(Event(device->prefix(), REventDeviceAnnounce, int(macCapabilities), device->key()));
 
+    const QDateTime now = QDateTime::currentDateTimeUtc();
+
+    for (Resource *r : device->subDevices())
+    {
+        r->setValue(RAttrLastAnnounced, now);
+    }
+
     for (; i != end; ++i)
     {
         if (i->state() != LightNode::StateNormal)
@@ -51,7 +58,6 @@ void DeRestPluginPrivate::handleDeviceAnnceIndication(const deCONZ::ApsDataIndic
         if (i->address().ext() == ext)
         {
             i->rx();
-            i->setValue(RAttrLastAnnounced, i->lastRx().toUTC());
 
             // clear to speedup polling
             for (NodeValue &val : i->zclValues())
@@ -167,7 +173,6 @@ void DeRestPluginPrivate::handleDeviceAnnceIndication(const deCONZ::ApsDataIndic
         if (si->address().ext() == ext)
         {
             si->rx();
-            si->setValue(RAttrLastAnnounced, si->lastRx().toUTC());
             found++;
             DBG_Printf(DBG_INFO, "DeviceAnnce of SensorNode: 0x%016llX [1]\n", si->address().ext());
 


### PR DESCRIPTION
For non DDF devices with multiple resources the sensor.config.reachable wasn't set for sensors which weren't at the first index.

This was seen with the Heiman sirene which has a WarningDevice at index 0 and ZHAAlarm sensor at index 1, other devices might have been affected as well.