### PR TITLE
DDF cosmetic, use default description of items

### DIFF
--- a/devices/frient/aqszb-110_voc_sensor.json
+++ b/devices/frient/aqszb-110_voc_sensor.json
@@ -188,7 +188,6 @@
         },
         {
           "name": "config/offset",
-          "description": "Relative offset to the main measured value.",
           "default": 0
         },
         {

--- a/devices/frient/splzb-131_smart_plug.json
+++ b/devices/frient/splzb-131_smart_plug.json
@@ -60,7 +60,6 @@
         },
         {
           "name": "state/alert",
-          "description": "The currently active alert effect.",
           "default": "none"
         },
         {
@@ -246,8 +245,8 @@
           "name": "state/power",
           "refresh.interval": 360,
           "read": {
-            "at": "0x0400", 
-            "cl": "0x0702", 
+            "at": "0x0400",
+            "cl": "0x0702",
             "ep": 2,
             "fn": "zcl"
           },

--- a/devices/ikea/tredansen_block-out_cellul_blind.json
+++ b/devices/ikea/tredansen_block-out_cellul_blind.json
@@ -44,23 +44,19 @@
         },
         {
           "name": "state/alert",
-          "description": "The currently active alert effect.",
           "default": "none"
         },
         {
           "name": "state/bri",
-          "description": "The current brightness.",
           "refresh.interval": 5
         },
         {
           "name": "state/lift",
-          "description": "The lift state of a roller blind.",
           "refresh.interval": 300,
           "default": 0
         },
         {
           "name": "state/on",
-          "description": "True when device is on; false when off.",
           "refresh.interval": 5
         },
         {

--- a/devices/namron/4512737_thermostat.json
+++ b/devices/namron/4512737_thermostat.json
@@ -55,17 +55,14 @@
         },
         {
           "name": "config/heatsetpoint",
-          "description": "Target temperature of a thermostat.",
           "default": 0
         },
         {
           "name": "config/mode",
-          "description": "Mode of the device.",
          "default": "off"
         },
         {
           "name": "config/offset",
-          "description": "Relative offset to the main measured value.",
           "default": 0
         },
         {
@@ -79,7 +76,6 @@
         },
         {
           "name": "state/on",
-          "description": "True when device is on; false when off.",
           "refresh.interval": 5
         },
         {
@@ -141,7 +137,7 @@
         },
         {
           "name": "state/current",
-	      "description": "The measured current (in A).",
+          "description": "The measured current (in A).",
           "refresh.interval": 300,
           "parse": {
             "at": "0x0508",

--- a/devices/neo/NAS-WR01B.json
+++ b/devices/neo/NAS-WR01B.json
@@ -44,7 +44,6 @@
           },
           {
             "name": "state/alert",
-            "description": "The currently active alert effect.",
             "default": "none"
           },
           {
@@ -98,7 +97,8 @@
             "name": "config/reachable"
           },
           {
-            "name": "state/consumption"        },
+            "name": "state/consumption"
+          },
           {
             "name": "state/lastupdated"
           }

--- a/devices/sengled/E12-N1E.json
+++ b/devices/sengled/E12-N1E.json
@@ -44,35 +44,28 @@
         },
         {
           "name": "state/alert",
-          "description": "The currently active alert effect.",
           "default": "none"
         },
         {
           "name": "state/bri",
-          "description": "The current brightness.",
           "refresh.interval": 5
         },
         {
-          "name": "state/colormode",
-          "description": "The currently active color mode."
+          "name": "state/colormode"
         },
         {
           "name": "state/ct",
-          "description": "The current Mired color temperature of the light. Where Mired is 1000000 / color temperature (in kelvins).",
           "refresh.interval": 5
         },
         {
           "name": "state/effect",
-          "description": "The currently active effect.",
           "default": "none"
         },
         {
-          "name": "state/hue",
-          "description": "The current color hue."
+          "name": "state/hue"
         },
         {
           "name": "state/on",
-          "description": "True when device is on; false when off.",
           "refresh.interval": 5
         },
         {
@@ -80,17 +73,14 @@
         },
         {
           "name": "state/sat",
-          "description": "The current color saturation.",
           "refresh.interval": 5
         },
         {
           "name": "state/x",
-          "description": "The current color x coordinate.",
           "refresh.interval": 5
         },
         {
-          "name": "state/y",
-          "description": "The current color y coordinate."
+          "name": "state/y"
         }
       ]
     }

--- a/devices/sengled/e1c-nb7.json
+++ b/devices/sengled/e1c-nb7.json
@@ -44,12 +44,10 @@
         },
         {
           "name": "state/alert",
-          "description": "The currently active alert effect.",
           "default": "none"
         },
         {
           "name": "state/on",
-          "description": "True when device is on; false when off.",
           "refresh.interval": 5
         },
         {

--- a/devices/sinope/sp2610zb_smart_switch.json
+++ b/devices/sinope/sp2610zb_smart_switch.json
@@ -43,7 +43,6 @@
         },
         {
           "name": "state/alert",
-          "description": "The currently active alert effect.",
           "default": "none"
         },
         {

--- a/devices/sinope/th1124zb.json
+++ b/devices/sinope/th1124zb.json
@@ -55,16 +55,13 @@
         },
         {
           "name": "config/heatsetpoint",
-          "description": "Target temperature of a thermostat.",
           "default": 0
         },
         {
-          "name": "config/mode",
-          "description": "Mode of the device."
+          "name": "config/mode"
         },
         {
           "name": "config/offset",
-          "description": "Relative offset to the main measured value.",
           "default": 0
         },
         {
@@ -147,12 +144,10 @@
         },
         {
           "name": "state/on",
-          "description": "True when device is on; false when off.",
           "refresh.interval": 5
         },
         {
           "name": "state/temperature",
-          "description": "The current temperature in °C &times; 100.",
           "default": 0
         }
       ]
@@ -302,7 +297,6 @@
         },
         {
           "name": "state/power",
-          "description": "The measured power (in W).",
           "refresh.interval": 300,
           "default": 0,
           "parse": {

--- a/devices/sonoff/zbmini-l_relay.json
+++ b/devices/sonoff/zbmini-l_relay.json
@@ -43,7 +43,6 @@
         },
         {
           "name": "state/on",
-          "description": "True when device is on; false when off.",
           "refresh.interval": 5
         },
         {

--- a/devices/third_reality/3RMS16BZ_motion_sensor.json
+++ b/devices/third_reality/3RMS16BZ_motion_sensor.json
@@ -56,8 +56,7 @@
           "name": "attr/uniqueid"
         },
         {
-          "name": "config/alert",
-          "description": "The currently active alert."
+          "name": "config/alert"
         },
         {
           "name": "config/battery",

--- a/devices/tuya/_TZE200_bjawzodf_hum_temp.json
+++ b/devices/tuya/_TZE200_bjawzodf_hum_temp.json
@@ -44,7 +44,6 @@
         },
         {
           "name": "config/offset",
-          "description": "Relative offset to the main measured value.",
           "default": 0
         },
         {
@@ -55,7 +54,6 @@
         },
         {
           "name": "state/humidity",
-          "description": "The current relative humidity in percent.",
           "parse": {"fn": "tuya", "dpid": 2, "eval": "Item.val = 10 * Attr.val;" },
           "read": {"fn": "tuya"},
           "default": 0
@@ -109,7 +107,6 @@
         },
         {
           "name": "config/offset",
-          "description": "Relative offset to the main measured value.",
           "default": 0
         },
         {

--- a/devices/wiser/fuga_socket_outlet.json
+++ b/devices/wiser/fuga_socket_outlet.json
@@ -44,7 +44,6 @@
 				},
 				{
 					"name": "state/alert",
-					"description": "The currently active alert effect.",
 					"default": "none"
 				},
 				{

--- a/devices/woox/woox_r7060_ts0101.json
+++ b/devices/woox/woox_r7060_ts0101.json
@@ -45,7 +45,6 @@
         },
         {
           "name": "state/alert",
-          "description": "The currently active alert effect.",
           "default": "none"
         },
         {


### PR DESCRIPTION
In a DDF the item description needs only be specified when it differs from the default item description.
The DDF editor should detect this, but currently this fails in some cases.