### PR TITLE
Add DDF for Ikea Starkvind

### DIFF
--- a/device_js/device_js_wrappers.cpp
+++ b/device_js/device_js_wrappers.cpp
@@ -131,7 +131,10 @@ void JsResourceItem::setValue(const QVariant &val)
     if (item)
     {
 //        DBG_Printf(DBG_INFO, "JsResourceItem.setValue(%s) = %s\n", item->descriptor().suffix, qPrintable(val.toString()));
-        item->setValue(val, ResourceItem::SourceDevice);
+        if (!item->setValue(val, ResourceItem::SourceDevice))
+        {
+            DBG_Printf(DBG_DDF, "JS failed to set Item.val for %s\n", item->descriptor().suffix);
+        }
     }
 }
 

--- a/devices/ikea/starkvind_air_purifier.json
+++ b/devices/ikea/starkvind_air_purifier.json
@@ -1,0 +1,107 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "$MF_IKEA",
+  "modelid": "STARKVIND Air purifier",
+  "product": "STARKVIND Air purifier",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_AIR_QUALITY_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0xfc7d"
+      ],
+      "meta": {
+        "values": {
+          "config/mode": {"off": 0, "auto": 1, "speed_1": 10, "speed_2": 20, "speed_3": 30, "speed_4": 40, "speed_5": 50}
+        }
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/mode",
+          "values": [
+              ["off", 0], ["auto", 1], ["speed_1", 10], ["speed_2", 20], ["speed_3", 30], ["speed_4", 40], ["speed_5", 50]
+          ],
+          "parse": {"at": "0x0006", "cl": "0xfc7d", "ep": 1, "fn": "zcl", "mf": "0x117c", "script": "starkvind_parse_target_mode.js"},
+          "read": {"fn": "zcl", "ep": 1, "cl": "0xfc7d", "at": "0x0006", "mf": "0x117c"},
+          "write": {"at": "0x0006", "cl": "0xfc7d", "dt": "0x20", "ep": 1, "mf": "0x117c", "script": "starkvind_write_target_mode.js"},
+          "refresh.interval": 30,
+          "default": "off"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/airqualityppb",
+          "parse": {"at": "0x0004", "cl": "0xfc7d", "ep": 1, "fn": "zcl", "mf": "0x117c", "eval": "if (Attr.val != 65535) { Item.val = Attr.val; }"},
+          "read": {"fn": "zcl", "ep": 1, "cl": "0xfc7d", "at": "0x0004", "mf": "0x117c"},
+          "refresh.interval": 30
+        },
+        {
+          "name": "state/airquality",
+          "parse": {
+            "fn": "numtostr",
+            "srcitem": "state/airqualityppb",
+            "op": "le", "to": [65, "excellent", 220, "good", 660, "moderate", 5000, "unhealthy", 65535, "out of scale"]
+          }
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/speed",
+          "access": "R",
+          "parse": {"at": "0x0007", "cl": "0xfc7d", "ep": 1, "fn": "zcl", "mf": "0x117c", "script": "starkvind_parse_speed.js"},
+          "read": {"fn": "zcl", "ep": 1, "cl": "0xfc7d", "at": "0x0007", "mf": "0x117c"},
+          "refresh.interval": 30,
+          "default": 0
+        }
+      ]
+    }
+  ],
+    "bindings": [
+        {
+            "bind": "unicast",
+            "src.ep": 1,
+            "cl": "0xfc7d",
+            "report": [
+                {"at": "0x0004", "dt": "0x21", "mf": "0x117c", "min": 5, "max": 1800, "change": "0x0005" },
+                {"at": "0x0006", "dt": "0x20", "mf": "0x117c", "min": 1, "max": 1800, "change": "0x0001" },
+                {"at": "0x0007", "dt": "0x20", "mf": "0x117c", "min": 1, "max": 1800, "change": "0x0001" }
+            ]
+        }
+    ]
+}

--- a/devices/ikea/starkvind_parse_speed.js
+++ b/devices/ikea/starkvind_parse_speed.js
@@ -1,0 +1,7 @@
+const max = 50.0;
+let speed = Attr.val;
+
+speed = (speed <= max) ? speed : 0;
+speed = speed / max * 100.0;
+
+Item.val = speed;

--- a/devices/ikea/starkvind_parse_target_mode.js
+++ b/devices/ikea/starkvind_parse_target_mode.js
@@ -1,0 +1,11 @@
+let mode = Attr.val;
+
+if (mode === 0) mode = 'off';
+else if (mode === 1) mode = 'auto';
+else if (mode <= 10) mode = 'speed_1';
+else if (mode <= 20) mode = 'speed_2';
+else if (mode <= 30) mode = 'speed_3';
+else if (mode <= 40) mode = 'speed_4';
+else mode = 'speed_5';
+
+Item.val = mode;

--- a/devices/ikea/starkvind_write_target_mode.js
+++ b/devices/ikea/starkvind_write_target_mode.js
@@ -1,0 +1,12 @@
+let mode = Item.val;
+
+if (mode === 'off') mode = 0;
+else if (mode === 'auto') mode = 1;
+else if (mode === 'speed_1') mode = 10;
+else if (mode === 'speed_2') mode = 20;
+else if (mode === 'speed_3') mode = 30;
+else if (mode === 'speed_4') mode = 40;
+else if (mode === 'speed_5') mode = 50;
+else mode = 0;
+
+mode;

--- a/resource.cpp
+++ b/resource.cpp
@@ -366,7 +366,7 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, QVariant::Double, RStateSpectralX));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, QVariant::Double, RStateSpectralY));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, QVariant::Double, RStateSpectralZ));
-    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, QVariant::Double, RStateSpeed, 0, 6));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, QVariant::Double, RStateSpeed, 0, 255));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeInt32, QVariant::Double, RStateStatus));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeTime, QVariant::String, RStateSunrise));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeTime, QVariant::String, RStateSunset));


### PR DESCRIPTION
The device can be controlled via `config.mode` with the values which reflect the on device states:

```
"off", "auto", "speed_1", "speed_2", "speed_3", "speed_4", "speed_5"
```

The **read-only** `state.speed` attribute reflects the current speed as normalized number 0..100.
When the mode is changed manually with the knob the `config.mode` is updated automatically.

**Note 1:** The device target/current values might not always be in steps of 10, e.g. 10..20, 20..30, etc. in which case they are mapped to the best fitting `config.mode` value, so 3 &rarr; 10 aka `"step_1"`.

**Note 2:** the `state.airquality` string values might need to be changed to better reflect the numeric values.

JSON view:

```
{
    "config": {
        "mode": "off",
        "on": true,
        "reachable": true
    },
    "etag": "80ae0dff37324f2582044ec71f3755ae",
    "lastannounced": null,
    "lastseen": "2022-06-06T18:08Z",
    "manufacturername": "IKEA of Sweden",
    "modelid": "STARKVIND Air purifier",
    "name": "AirQuality 234",
    "state": {
        "airquality": "excellent",
        "airqualityppb": 19,
        "lastupdated": "2022-06-06T18:09:00.681",
        "speed": 0
    },
    "swversion": "1.0.033",
    "type": "ZHAAirQuality",
    "uniqueid": "0c:43:14:ff:fe:6e:65:55-01-fc7d"
}
```

This PR only contains the basics to make the Ikea Starkvind controllable, other features as locking and filter monitoring should be added in future.