### PR TITLE
Fix PUT sensor/state/localtime

### DIFF
--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -2341,6 +2341,20 @@ int DeRestPluginPrivate::changeSensorState(const ApiRequest &req, ApiResponse &r
                         }
                     }
                 }
+
+                if (rid.suffix == RStateLocaltime)
+                {
+                    // convert to QDateTime here, otherwise the time string would be interpretet
+                    // as UTC in item->setValue()
+                    const auto str = val.toString();
+                    auto fmt = str.contains('.') ? QLatin1String("yyyy-MM-ddTHH:mm:ss.zzz")
+                                                 : QLatin1String("yyyy-MM-ddTHH:mm:ss");
+                    auto dt = QDateTime::fromString(str, fmt);
+
+                    if (dt.isValid()) { val = dt; }
+                    else              { val = ""; } // mark invalid but keep processing to return proper error
+                }
+
                 if (item->setValue(val))
                 {
                     rspItemState[QString("/sensors/%1/state/%2").arg(id).arg(pi.key())] = val;


### PR DESCRIPTION
Used by `CLIPDaylightOffset` sensor, the time string passed to `item->setValue(QVariant)` is automatically interpreted as UTC.

The PR creates a `QDateTime` as local time and passes this to `setValue()` to be handled without modification.