### PR TITLE
Add support for TS011F_TZ3000_amdymr7l

### DIFF
--- a/devices/blitzwolf/bw_shp13_smart_plug.json
+++ b/devices/blitzwolf/bw_shp13_smart_plug.json
@@ -1,7 +1,7 @@
 {
   "schema": "devcap1.schema.json",
-  "manufacturername": "_TZ3000_g5xawfcq",
-  "modelid": "TS0121",
+  "manufacturername": ["_TZ3000_g5xawfcq", "_TZ3000_amdymr7l"],
+  "modelid": ["TS0121", "TS011F"],
   "product": "BW-SHP13",
   "vendor": "Blitzwolf",
   "sleeper": false,


### PR DESCRIPTION
Because TS011F_TZ3000_amdymr7l was not able to recognize the power consumption and energy readings in Home assistant with Deconz. Added Manufacturername and modelid.