### PR TITLE
Filter inappropriate illumination values for Aqara P1 presence sensor

### DIFF
--- a/devices/xiaomi/xiaomi_rtcgq14lm_lux_to_lightlevel.js
+++ b/devices/xiaomi/xiaomi_rtcgq14lm_lux_to_lightlevel.js
@@ -3,7 +3,7 @@ const tholdoffset = R.item('config/tholdoffset').val;
 const lux = (Attr.val - 65536);
 let ll = 0;
 
-if (lux > 0 && lux < 0xffff) {
+if (lux > 0 && lux < 65520) {
     ll = Math.round(10000 * Math.log10(lux) + 1);
 }
 
@@ -11,4 +11,4 @@ R.item('state/lightlevel').val = ll;
 R.item('state/dark').val = ll <= tholddark;
 R.item('state/daylight').val = ll >= tholddark + tholdoffset;
 
-Item.val = lux;
+Item.val = lux < 65520 ? lux : 0;


### PR DESCRIPTION
Apparently, when there's not much light, the sensor seems to report extremely high values not making any sense. While testing, the value lux value has not gone below 65531 lux. However, to allow for some buffer, the maximum allowed lux value has been set to 65519, anything above will be considered as 0.

It's unknown if that is a bug in the device firmware or maybe even a hardware issue. As of now, Xiaomi hasn't released an updated firmware.