### PR TITLE
Add JS 'Utils' object to provide log10() missing on older Qt versions

### DIFF
--- a/device_js/device_js.cpp
+++ b/device_js/device_js.cpp
@@ -26,6 +26,7 @@ public:
     JsZclAttribute *jsZclAttribute = nullptr;
     JsZclFrame *jsZclFrame = nullptr;
     JsResourceItem *jsItem = nullptr;
+    JsUtils *jsUtils = nullptr;
     const deCONZ::ApsDataIndication *apsInd = nullptr;
 };
 
@@ -52,6 +53,10 @@ DeviceJs::DeviceJs() :
     d->jsItem = new JsResourceItem(&d->engine);
     auto jsItem = d->engine.newQObject(d->jsItem);
     d->engine.globalObject().setProperty("Item", jsItem);
+
+    d->jsUtils = new JsUtils(&d->engine);
+    auto jsUtils = d->engine.newQObject(d->jsUtils);
+    d->engine.globalObject().setProperty("Utils", jsUtils);
 
     _djs = this;
 }

--- a/device_js/device_js_wrappers.cpp
+++ b/device_js/device_js_wrappers.cpp
@@ -8,6 +8,7 @@
  *
  */
 
+#include <math.h>
 #include "resource.h"
 #include "device_js_wrappers.h"
 #include "device.h"
@@ -291,4 +292,15 @@ bool JsZclFrame::isClCmd() const
     }
 
     return false;
+}
+
+JsUtils::JsUtils(QObject *parent) :
+    QObject(parent)
+{
+
+}
+
+double JsUtils::log10(double x) const
+{
+    return ::log10(x);
 }

--- a/device_js/device_js_wrappers.h
+++ b/device_js/device_js_wrappers.h
@@ -105,4 +105,15 @@ public Q_SLOTS:
     bool isClCmd() const;
 };
 
+class JsUtils : public QObject
+{
+    Q_OBJECT
+
+public:
+    JsUtils(QObject *parent = nullptr);
+
+public Q_SLOTS:
+    double log10(double x) const;
+};
+
 #endif // DEVICE_JS_WRAPPERS_H

--- a/devices/generic/illuminance_cluster/lux_to_lightlevel.js
+++ b/devices/generic/illuminance_cluster/lux_to_lightlevel.js
@@ -4,7 +4,7 @@ const lux = Attr.val;
 let ll = 0;
 
 if (lux > 0 && lux < 0xffff) {
-    ll = Math.round(10000 * Math.log10(lux) + 1);
+    ll = Math.round(10000 * Utils.log10(lux) + 1);
 }
 
 R.item('state/lightlevel').val = ll;

--- a/devices/xiaomi/xiaomi_rtcgq14lm_lux_to_lightlevel.js
+++ b/devices/xiaomi/xiaomi_rtcgq14lm_lux_to_lightlevel.js
@@ -4,7 +4,7 @@ const lux = (Attr.val - 65536);
 let ll = 0;
 
 if (lux > 0 && lux < 0xffff) {
-    ll = Math.round(10000 * Math.log10(lux) + 1);
+    ll = Math.round(10000 * Utils.log10(lux) + 1);
 }
 
 R.item('state/lightlevel').val = ll;


### PR DESCRIPTION
The `Math.log10()` function is missing on some setups: see: https://forum.phoscon.de/t/rtcgq11lm-light-level-broken-since-2-17/2104/7

In the `Utils` object we can add functions to do some basic tasks or provide some math mojo.

Fixes `state/lux` not updated on Xiaomi RTCGQ11LM motion sensor.


