### PR TITLE
DDF add manufacturer name "frient A/S" for keypad KEPZB-110

### DIFF
--- a/devices/frient/kepzb-110_keypad.json
+++ b/devices/frient/kepzb-110_keypad.json
@@ -1,7 +1,7 @@
 {
    "schema":"devcap1.schema.json",
    "manufacturername": ["Develco Products A/S", "frient A/S"],
-   "modelid":"KEPZB-110",
+   "product":"KEPZB-110 Keypad",
    "vendor": "Develco Products",
    "modelid": ["KEPZB-110", "KEPZB-110"],
    "sleeper":false,

--- a/devices/frient/kepzb-110_keypad.json
+++ b/devices/frient/kepzb-110_keypad.json
@@ -1,6 +1,6 @@
 {
    "schema":"devcap1.schema.json",
-   "manufacturername":"Develco Products A/S",
+   "manufacturername":"frient A/S",
    "modelid":"KEPZB-110",
    "vendor": "Develco Products",
    "product":"KEPZB-110 Keypad",

--- a/devices/frient/kepzb-110_keypad.json
+++ b/devices/frient/kepzb-110_keypad.json
@@ -1,9 +1,9 @@
 {
    "schema":"devcap1.schema.json",
-   "manufacturername":"frient A/S",
+   "manufacturername": ["Develco Products A/S", "frient A/S"],
    "modelid":"KEPZB-110",
    "vendor": "Develco Products",
-   "product":"KEPZB-110 Keypad",
+   "modelid": ["KEPZB-110", "KEPZB-110"],
    "sleeper":false,
    "status":"Bronze",
    "subdevices":[


### PR DESCRIPTION
If frient is not mention it doesn't work why this keypad.