### PR TITLE
Fix ZCL report configuration for more than 6 entries

### DIFF
--- a/zcl/zcl.h
+++ b/zcl/zcl.h
@@ -53,6 +53,7 @@ struct ZCL_Result
 
 struct ZCL_ReadReportConfigurationParam
 {
+    enum Constants { MaxRecords = 6 };
     quint64 extAddress = 0;
     quint16 nwkAddress = 0;
     quint16 manufacturerCode = 0;
@@ -70,6 +71,7 @@ struct ZCL_ReadReportConfigurationParam
 
 struct ZCL_ConfigureReportingParam
 {
+    enum Constants { MaxRecords = 6 };
     quint64 extAddress = 0;
     quint16 nwkAddress = 0;
     quint16 manufacturerCode = 0;
@@ -92,7 +94,7 @@ struct ZCL_ConfigureReportingParam
 
 struct ZCL_ReadReportConfigurationRsp
 {
-    enum { MaxRecords = 8 };
+    enum { MaxRecords = 6 };
     quint16 manufacturerCode = 0;
     quint16 clusterId = 0;
     quint8 sequenceNumber = 0;


### PR DESCRIPTION
As report configuration for one cluster is merged into one ZCL command, the resulting APS frame can be too large.

Such commands could cause overwriting invalid memory in core (now fixed). This PR splits up ZCL reporting read and configure into multiple ZCL commands.

The problem was exposed by Ikea Starkvind PR which needs to configure 9 attribute reports: https://github.com/dresden-elektronik/deconz-rest-plugin/pull/6124