### PR TITLE
Update DDF for Aqara TVOC sensor

### DIFF
--- a/devices/xiaomi/xiaomi_airmonitor_acn01.json
+++ b/devices/xiaomi/xiaomi_airmonitor_acn01.json
@@ -76,11 +76,7 @@
           "name": "config/reachable"
         },
         {
-          "name": "config/temperature"
-        },
-        {
           "name": "state/airqualityppb",
-          "awake": true,
           "parse": {
             "at": "0x0055",
             "cl": "0x000c",
@@ -186,9 +182,6 @@
         },
         {
           "name": "config/reachable"
-        },
-        {
-          "name": "config/temperature"
         },
         {
           "name": "state/humidity",

--- a/devices/xiaomi/xiaomi_airmonitor_acn01.json
+++ b/devices/xiaomi/xiaomi_airmonitor_acn01.json
@@ -96,11 +96,18 @@
             "at": "0x0129",
             "cl": "0xfcc0",
             "ep": 1,
-            "eval": "if (Attr.val === 1) {Item.val = 'excellent'} else if (Attr.val === 2) {Item.val = 'good'} else if (Attr.val === 3) {Item.val = 'moderate'} else if (Attr.val === 4) {Item.val = 'poor'} else if (Attr.val === 5) {Item.val = 'unhealthy'}",
+            "eval": "Item.val = ['excellent', 'good', 'moderate', 'poor', 'unhealthy'][Attr.val]",
             "fn": "zcl",
             "mfc": "0x115f"
           },
-          "default": "excellent"
+          "default": "excellent",
+          "values": [
+            [1, "excellent"],
+            [2, "good"],
+            [3, "moderate"],
+            [4, "poor"],
+            [5, "unhealthy"]
+          ]
         },
         {
           "name": "state/lastupdated"

--- a/devices/xiaomi/xiaomi_airmonitor_acn01.json
+++ b/devices/xiaomi/xiaomi_airmonitor_acn01.json
@@ -5,7 +5,7 @@
   "vendor": "Xiaomi",
   "product": "Aqara TVOC Air Quality Monitor VOCKQJK11LM",
   "sleeper": true,
-  "status": "Silver",
+  "status": "Gold",
   "subdevices": [
     {
       "type": "$TYPE_AIR_QUALITY_SENSOR",
@@ -39,13 +39,25 @@
           "name": "attr/manufacturername"
         },
         {
-          "name": "attr/modelid"
+          "name": "attr/modelid",
+          "awake": true
         },
         {
           "name": "attr/name"
         },
         {
-          "name": "attr/swversion"
+          "name": "attr/swversion",
+          "awake": true,
+          "parse": {
+            "at": "0x00f7",
+            "ep": 1,
+            "eval": "let b = Attr.val.toString(16); c = [0,2].map(function(o) {if (b.length % 2) {b = '0' + b} return b.slice(o,o+2)}); f = parseInt(c[1], 16).toString(); x = ''; for (i = 0; i < (f.length % 4); i++) {x += '0'}; Item.val = '0.0.0_' + x + f;",
+            "fn": "xiaomi:special",
+            "idx": "0x08"
+          },
+          "read": {
+            "fn": "none"
+          }
         },
         {
           "name": "attr/type"
@@ -81,11 +93,14 @@
         {
           "name": "state/airquality",
           "parse": {
-            "fn": "numtostr",
-            "op": "le",
-            "srcitem": "state/airqualityppb",
-            "to": [65, "excellent", 220, "good", 660, "moderate", 10000, "unhealthy", 65535, "out of scale"]
-          }
+            "at": "0x0129",
+            "cl": "0xfcc0",
+            "ep": 1,
+            "eval": "if (Attr.val === 1) {Item.val = 'excellent'} else if (Attr.val === 2) {Item.val = 'good'} else if (Attr.val === 3) {Item.val = 'moderate'} else if (Attr.val === 4) {Item.val = 'poor'} else if (Attr.val === 5) {Item.val = 'unhealthy'}",
+            "fn": "zcl",
+            "mfc": "0x115f"
+          },
+          "default": "excellent"
         },
         {
           "name": "state/lastupdated"
@@ -125,13 +140,25 @@
           "name": "attr/manufacturername"
         },
         {
-          "name": "attr/modelid"
+          "name": "attr/modelid",
+          "awake": true
         },
         {
           "name": "attr/name"
         },
         {
-          "name": "attr/swversion"
+          "name": "attr/swversion",
+          "awake": true,
+          "parse": {
+            "at": "0x00f7",
+            "ep": 1,
+            "eval": "let b = Attr.val.toString(16); c = [0,2].map(function(o) {if (b.length % 2) {b = '0' + b} return b.slice(o,o+2)}); f = parseInt(c[1], 16).toString(); x = ''; for (i = 0; i < (f.length % 4); i++) {x += '0'}; Item.val = '0.0.0_' + x + f;",
+            "fn": "xiaomi:special",
+            "idx": "0x08"
+          },
+          "read": {
+            "fn": "none"
+          }
         },
         {
           "name": "attr/type"
@@ -198,13 +225,25 @@
           "name": "attr/manufacturername"
         },
         {
-          "name": "attr/modelid"
+          "name": "attr/modelid",
+          "awake": true
         },
         {
           "name": "attr/name"
         },
         {
-          "name": "attr/swversion"
+          "name": "attr/swversion",
+          "awake": true,
+          "parse": {
+            "at": "0x00f7",
+            "ep": 1,
+            "eval": "let b = Attr.val.toString(16); c = [0,2].map(function(o) {if (b.length % 2) {b = '0' + b} return b.slice(o,o+2)}); f = parseInt(c[1], 16).toString(); x = ''; for (i = 0; i < (f.length % 4); i++) {x += '0'}; Item.val = '0.0.0_' + x + f;",
+            "fn": "xiaomi:special",
+            "idx": "0x08"
+          },
+          "read": {
+            "fn": "none"
+          }
         },
         {
           "name": "attr/type"
@@ -232,6 +271,23 @@
         {
           "name": "state/temperature",
           "default": 0
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x000C",
+      "report": [
+        {
+          "at": "0x0055",
+          "dt": "0x39",
+          "min": 60,
+          "max": 1800,
+          "change": "0x41200000"
         }
       ]
     }

--- a/devices/xiaomi/xiaomi_airmonitor_acn01.json
+++ b/devices/xiaomi/xiaomi_airmonitor_acn01.json
@@ -51,9 +51,9 @@
           "parse": {
             "at": "0x00f7",
             "ep": 1,
-            "eval": "let b = Attr.val.toString(16); c = [0,2].map(function(o) {if (b.length % 2) {b = '0' + b} return b.slice(o,o+2)}); f = parseInt(c[1], 16).toString(); x = ''; for (i = 0; i < (f.length % 4); i++) {x += '0'}; Item.val = '0.0.0_' + x + f;",
             "fn": "xiaomi:special",
-            "idx": "0x08"
+            "idx": "0x08",
+            "script": "xiaomi_swversion.js"
           },
           "read": {
             "fn": "none"
@@ -152,9 +152,9 @@
           "parse": {
             "at": "0x00f7",
             "ep": 1,
-            "eval": "let b = Attr.val.toString(16); c = [0,2].map(function(o) {if (b.length % 2) {b = '0' + b} return b.slice(o,o+2)}); f = parseInt(c[1], 16).toString(); x = ''; for (i = 0; i < (f.length % 4); i++) {x += '0'}; Item.val = '0.0.0_' + x + f;",
             "fn": "xiaomi:special",
-            "idx": "0x08"
+            "idx": "0x08",
+            "script": "xiaomi_swversion.js"
           },
           "read": {
             "fn": "none"
@@ -237,9 +237,9 @@
           "parse": {
             "at": "0x00f7",
             "ep": 1,
-            "eval": "let b = Attr.val.toString(16); c = [0,2].map(function(o) {if (b.length % 2) {b = '0' + b} return b.slice(o,o+2)}); f = parseInt(c[1], 16).toString(); x = ''; for (i = 0; i < (f.length % 4); i++) {x += '0'}; Item.val = '0.0.0_' + x + f;",
             "fn": "xiaomi:special",
-            "idx": "0x08"
+            "idx": "0x08",
+            "script": "xiaomi_swversion.js"
           },
           "read": {
             "fn": "none"

--- a/devices/xiaomi/xiaomi_swversion.js
+++ b/devices/xiaomi/xiaomi_swversion.js
@@ -1,7 +1,18 @@
-const v = (Attr.val & 0x00ff);
 let s = "0.0.0_";
+let v = 0;
+
+if (Attr.dataType == 33)
+{
+    v = (Attr.val & 0x00ff);
+}
+else if (Attr.dataType == 35)
+{
+    v = (Attr.val & 0x000000ff);
+}
+
 for (i = 0; i < (v.toString().length % 4); i++)
 {
     s += "0";
 }
+
 Item.val = s + v;

--- a/devices/xiaomi/xiaomi_swversion.js
+++ b/devices/xiaomi/xiaomi_swversion.js
@@ -1,0 +1,7 @@
+const v = (Attr.val & 0x00ff);
+let s = "0.0.0_";
+for (i = 0; i < (v.toString().length % 4); i++)
+{
+    s += "0";
+}
+Item.val = s + v;

--- a/devices/xiaomi/xiaomi_swversion.js
+++ b/devices/xiaomi/xiaomi_swversion.js
@@ -10,9 +10,4 @@ else if (Attr.dataType == 35)
     v = (Attr.val & 0x000000ff);
 }
 
-for (i = 0; i < (v.toString().length % 4); i++)
-{
-    s += "0";
-}
-
-Item.val = s + v;
+Item.val = s + v.toString().padStart(4, "0");


### PR DESCRIPTION
Update includes:

- Promote DDF to Gold status
- Change processing of `state/airquality`, as the device reports it via attribute 0x0129 on the 0xfcc0 cluster. The applicable scale is the one of the WHO
- Change `attr/swversion`. Recent discovery is that item 0x08 of the Xiaomi special reporting holds the true firmware version (also displayed and confirmed by the Xiaomi App). In rare cases, it can also be item 0x0d on different devices
- Consider the device as awake, when `attr/modelid` is recieved. This usually happens when the device button is pressed (it does mac poll then, should be standard for all Xiaomi battery powered devices)
- Set a binding and attribute reporting for `state/airqualityppb`. Some people mentioned reporting would eventually stop otherwise. Has been tested for more than 10 days and reports were still coming in, the actual value hasn't changed much though