### PR TITLE
Adapt approach to auto-reset presence/vibration for DDF devices

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1372,7 +1372,7 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
             break;
 
         case OCCUPANCY_SENSING_CLUSTER_ID:
-            if (!DEV_TestStrict()) { handleOccupancySensingClusterIndication(ind, zclFrame); }
+            if (!DEV_TestStrict() && !devManaged) { handleOccupancySensingClusterIndication(ind, zclFrame); }
             break;
 
         default:

--- a/devices/generic/items/config_autoreset_item.json
+++ b/devices/generic/items/config_autoreset_item.json
@@ -1,0 +1,8 @@
+{
+    "schema": "resourceitem1.schema.json",
+    "id": "config/autoreset",
+    "datatype": "Bool",
+    "access": "R",
+    "public": true,
+    "description": "Reset presence or vibration state automatically to false if not supported by the device."
+}

--- a/devices/xiaomi/xiaomi_rtcgq14lm_p1_presence_sensor.json
+++ b/devices/xiaomi/xiaomi_rtcgq14lm_p1_presence_sensor.json
@@ -55,6 +55,11 @@
           "name": "attr/uniqueid"
         },
         {
+          "name": "config/autoreset",
+          "static": true,
+          "public": false
+        },
+        {
           "name": "config/battery",
           "awake": true,
           "parse": {

--- a/devices/xiaomi/xiaomi_rtcgqq11lm_presence_sensor.json
+++ b/devices/xiaomi/xiaomi_rtcgqq11lm_presence_sensor.json
@@ -4,7 +4,7 @@
   "modelid": "lumi.sensor_motion.aq2",
   "vendor": "Xiaomi",
   "product": "Aqara motion sensor RTCGQ11LM",
-  "sleeper": false,
+  "sleeper": true,
   "status": "Gold",
   "subdevices": [
     {
@@ -52,6 +52,10 @@
         },
         {
           "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/autoreset",
+          "static": true
         },
         {
           "name": "config/battery",

--- a/resource.cpp
+++ b/resource.cpp
@@ -167,6 +167,8 @@ const QStringList RStateEffectValuesMueller({
     "none", "colorloop", "sunset", "party", "worklight", "campfire", "romance", "nightlight"
 });
 
+const char *RConfigAlert = "config/alert";
+const char *RConfigAllowTouchlink = "config/allowtouchlink";
 const char *RConfigArmMode = "config/armmode";
 const char *RConfigArmedAwayEntryDelay = "config/armed_away_entry_delay";
 const char *RConfigArmedAwayExitDelay = "config/armed_away_exit_delay";
@@ -177,9 +179,7 @@ const char *RConfigArmedStayTriggerDuration = "config/armed_stay_trigger_duratio
 const char *RConfigArmedNightEntryDelay = "config/armed_night_entry_delay";
 const char *RConfigArmedNightExitDelay = "config/armed_night_exit_delay";
 const char *RConfigArmedNightTriggerDuration = "config/armed_night_trigger_duration";
-const char *RConfigAlert = "config/alert";
-const char *RConfigAllowTouchlink = "config/allowtouchlink";
-const char *RConfigLock = "config/lock";
+const char *RConfigAutoReset = "config/autoreset";
 const char *RConfigBattery = "config/battery";
 const char *RConfigClickMode = "config/clickmode";
 const char *RConfigColorCapabilities = "config/colorcapabilities";
@@ -212,6 +212,7 @@ const char *RConfigLat = "config/lat";
 const char *RConfigLedIndication = "config/ledindication";
 const char *RConfigLevelMin = "config/levelmin";
 const char *RConfigLocalTime = "config/localtime";
+const char *RConfigLock = "config/lock";
 const char *RConfigLocked = "config/locked";
 const char *RConfigLong = "config/long";
 const char *RConfigMode = "config/mode";
@@ -406,6 +407,7 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, QVariant::Double, RConfigArmedNightEntryDelay, 0, 255));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, QVariant::Double, RConfigArmedNightExitDelay, 0, 255));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, QVariant::Double, RConfigArmedNightTriggerDuration, 0, 255));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, QVariant::Bool, RConfigAutoReset));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, QVariant::Bool, RConfigLock));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, QVariant::Double, RConfigBattery, 0, 100));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, QVariant::String, RConfigClickMode));

--- a/resource.h
+++ b/resource.h
@@ -201,6 +201,7 @@ extern const char *RConfigArmedStayTriggerDuration;
 extern const char *RConfigArmedNightEntryDelay;
 extern const char *RConfigArmedNightExitDelay;
 extern const char *RConfigArmedNightTriggerDuration;
+extern const char *RConfigAutoReset;
 extern const char *RConfigBattery;
 extern const char *RConfigClickMode;
 extern const char *RConfigColorCapabilities;

--- a/xiaomi.cpp
+++ b/xiaomi.cpp
@@ -74,62 +74,6 @@ void DeRestPluginPrivate::handleXiaomiLumiClusterIndication(const deCONZ::ApsDat
             }
                 break;
 
-            case XIAOMI_ATTRID_MOTION_SENSITIVITY:
-            {
-                Sensor *sensor = getSensorNodeForAddressEndpointAndCluster(ind.srcAddress(), ind.srcEndpoint(), XIAOMI_CLUSTER_ID);
-
-                if (sensor)
-                {
-                    sensor->setZclValue(updateType, ind.srcEndpoint(), XIAOMI_CLUSTER_ID, XIAOMI_ATTRID_MOTION_SENSITIVITY, attr.numericValue());
-
-                    quint8 sensitivity = attr.numericValue().u8;
-                    sensor->setValue(RConfigSensitivity, sensitivity);
-                }
-            }
-                break;
-
-            case XIAOMI_ATTRID_P1_MOTION_DETECTION:
-            {
-                // Workaround to set P1 presence sensor back to unoccupied, as the pure reception of this report is considered
-                // as presence = true state, but this is not reset by the device automatically. Ideally, deCONZ will have some timers
-                // for such cases available in future.
-                Sensor *sensor = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), ind.srcEndpoint());
-                
-                if (sensor)
-                {
-                    bool occupancy = true;
-                    ResourceItem *item = nullptr;
-                    item = sensor->item(RStatePresence);
-                    
-                    if (item)
-                    {
-                        item->setValue(occupancy);
-                        enqueueEvent(Event(RSensors, RStatePresence, sensor->id(), item));
-    
-                        ResourceItem *item2 = nullptr;
-                        item2 = sensor->item(RConfigDuration);
-    
-                        if (item2 && item2->toNumber() > 0)
-                        {
-                            // As unoccupied state is not reportable, add duration seconds after a occupied = true to automatically set to false
-                            sensor->durationDue = item->lastSet().addSecs(item2->toNumber());
-                        }
-                    }
-    
-                    deCONZ::NumericUnion occ;
-                    occ.u64 = occupancy;
-    
-                    sensor->setZclValue(updateType, ind.srcEndpoint(), OCCUPANCY_SENSING_CLUSTER_ID, XIAOMI_ATTRID_P1_MOTION_DETECTION, occ);
-    
-                    sensor->updateStateTimestamp();
-                    enqueueEvent(Event(RSensors, RStateLastUpdated, sensor->id()));
-                    updateSensorEtag(&*sensor);
-                    sensor->setNeedSaveDatabase(true);
-                    queSaveDb(DB_SENSORS, DB_SHORT_SAVE_DELAY);
-                }
-            }
-                break;
-
             case XIAOMI_ATTRID_SPEED:
             {
                 LightNode *lightNode = getLightNodeForAddress(ind.srcAddress(), ind.srcEndpoint());


### PR DESCRIPTION
This PR is aimed at circumventing usage of `durationDue`, which is one of the reasons the new code ignoring the cluster handlers cannot be more widely applied (e.g. occupancy sensing cluster).

In essence, a new resource item, `config/autoreset`, is introduced, which shall indicate if e.g. the presence state of a device needs to be reset automatically. As this item will be only available on DDF supported devices, it shall also serve for distinction. The actual role of `durationDue` will be taken over by `item->lastZclReport()`. In conjuction with `config/duration`, which must be present as well if auto-reset is required, it is checked if the current time is larger than the last report time + duration.

This has successfully been tested with the Xiaomi presence sensor lumi.sensor_motion.aq2. Further devices which are affected by this are the Aqara vibration sensor lumi.vibration.aq1(#6167), Aqara high presicion sensor lumi.motion.agl04 (#6168) and Aqara P1 presence sensor lumi.motion.ac02.
The legacy code path is still followed for devices without DDF.