### PR TITLE
Update DDF for Aqara Vibration Sensor DJT11LM

### DIFF
--- a/devices/generic/items/state_tiltangle_item.json
+++ b/devices/generic/items/state_tiltangle_item.json
@@ -5,5 +5,6 @@
 	"access": "R",
 	"public": true,
 	"range": [0, 360],
-	"description": "The current tilt angle."
+	"description": "The current tilt angle.",
+	"default": 0
 }

--- a/devices/generic/items/state_vibration_item.json
+++ b/devices/generic/items/state_vibration_item.json
@@ -5,5 +5,6 @@
 	"access": "R",
 	"public": true,
 	"description": "True when vibration is detected.",
-	"parse": {"fn": "ias:zonestatus", "mask": "alarm1,alarm2"}
+	"parse": {"fn": "ias:zonestatus", "mask": "alarm1,alarm2"},
+	"default": false
 }

--- a/devices/generic/items/state_vibrationstrength_item.json
+++ b/devices/generic/items/state_vibrationstrength_item.json
@@ -5,5 +5,6 @@
 	"access": "R",
 	"public": true,
 	"range": [0, 65535],
-	"description": "The strength of the detected vibration."
+	"description": "The strength of the detected vibration.",
+	"default": 0
 }

--- a/devices/xiaomi/aq1_vibration_sensor.json
+++ b/devices/xiaomi/aq1_vibration_sensor.json
@@ -92,7 +92,8 @@
             "at": "0xff0d",
             "cl": "0x0000",
             "ep": 1,
-            "eval": "Item.val = [3, 2, 1][Attr.val - 1]",
+            "comment": "sniffed values are 1 - high, 2 - medium, 3 - low",
+            "eval": "Item.val = [2, 1, 0][Attr.val - 1]",
             "fn": "zcl",
             "mf": "0x115f"
           },
@@ -101,18 +102,22 @@
             "cl": "0x0000",
             "dt": "0x20",
             "ep": 1,
-            "eval": "Item.val = [3, 2, 1][Item.val - 1]",
+            "eval": "[3, 2, 1][Item.val]",
             "fn": "zcl",
             "mf": "0x115f"
           },
           "values": [
-              [1, "low"], [2, "medium"], [3, "high"]
+              [0, "low"], [1, "medium"], [2, "high"]
           ],
-          "default": 3
+          "default": 2
         },
         {
           "name": "config/sensitivitymax",
-          "default": 3
+          "default": 2
+        },
+        {
+          "name": "config/temperature",
+          "parse": {"fn": "xiaomi:special", "at": "0xff01", "idx": "0x03", "eval": "Item.val = Attr.val * 100"}
         },
         {
           "name": "state/orientation"
@@ -141,8 +146,7 @@
             "ep": 1,
             "eval": "Item.val = Attr.val",
             "fn": "zcl"
-          },
-          "default": 0
+          }
         },
         {
           "name": "state/vibration",
@@ -152,8 +156,7 @@
             "ep": 1,
             "eval": "Item.val = Attr.val == 1 ? true : false",
             "fn": "zcl"
-          },
-          "default": false
+          }
         },
         {
           "name": "state/vibrationstrength",
@@ -163,8 +166,7 @@
             "ep": 1,
             "eval": "Item.val = Attr.val >> 16",
             "fn": "zcl"
-          },
-          "default": 0
+          }
         },
         {
           "name": "state/lastupdated"

--- a/devices/xiaomi/aq1_vibration_sensor.json
+++ b/devices/xiaomi/aq1_vibration_sensor.json
@@ -1,137 +1,203 @@
 {
-    "schema": "devcap1.schema.json",
-    "doc:path": "xiaomi/aq_vibration_sensor.md",
-    "doc:hdr": "Vibration sensor DJT11LM",
-    "manufacturername": "$MF_LUMI",
-    "modelid": "lumi.vibration.aq1",
-    "vendor": "Xiaomi",
-    "product": "Aqara Vibration Sensor DJT11LM",
-    "status": "Bronze",
-    "sleeper": true,
-    "md:known_issues": [ "xiaomi_known_issues1.md" ],
-    "subdevices": [
+  "schema": "devcap1.schema.json",
+  "doc:path": "xiaomi/aq_vibration_sensor.md",
+  "doc:hdr": "Vibration sensor DJT11LM",
+  "manufacturername": "$MF_LUMI",
+  "modelid": "lumi.vibration.aq1",
+  "vendor": "Xiaomi",
+  "product": "Aqara Vibration Sensor DJT11LM",
+  "status": "Gold",
+  "sleeper": true,
+  "md:known_issues": [ "xiaomi_known_issues1.md" ],
+  "subdevices": [
+    {
+      "type": "$TYPE_VIBRATION_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0101"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x000a",
+        "endpoint": "0x01",
+        "in": ["0x0101"]
+      },
+      "items": [
         {
-            "type": "$TYPE_VIBRATION_SENSOR",
-            "restapi": "/sensors",
-            "uuid": [ "$address.ext", "0x01", "0x0101"],
-            "fingerprint": { "profile": "0x0104", "device": "0x000a", "endpoint": "0x01", "in": ["0x0101"] },
-            "items": [
-                {
-                    "name": "attr/lastseen"
-                },
-                {
-                    "name": "attr/manufacturername"
-                },
-                {
-                    "name": "attr/modelid"
-                },
-                {
-                    "name": "attr/name"
-                },
-                {
-                    "name": "attr/swversion",
-                    "read": {"cl": "0x0000", "at": "0x0006"},
-                    "parse": {"cl": "0x0000", "at": "0x0006", "eval": "Item.val = Attr.val"}
-                },
-                {
-                    "name": "attr/type"
-                },
-                {
-                    "name": "attr/uniqueid"
-                },
-                {
-                    "name": "config/on"
-                },
-                {
-                    "name": "config/reachable"
-                },
-                {
-                    "name": "config/pending"
-                },
-                {
-                    "name": "config/battery",
-                    "parse": {"fn": "xiaomi:special", "at": "0xff01", "idx": "0x01", "script": "xiaomi_battery.js"},
-                    "awake": true
-                },
-                {
-                    "name": "config/temperature",
-                    "parse": {"fn": "xiaomi:special", "at": "0xff01", "idx": "0x03", "eval": "Item.val = Attr.val * 100"}
-                },
-                {
-                    "name": "config/sensitivity",
-                    "read": {"cl": "0x0000", "at": "0xff0d", "mf": "0x11F5"},
-                    "parse": {"cl": "0x0000", "at": "0xff0d", "eval": "Item.val == 0 ? Item.val = Attr.val : Item.val"},
-                    "write": {"cl": "0x0000", "at": "0xff0d",  "dt": "0x20", "mf": "0x11F5", "eval": "Item.val"},
-                    "values": [
-                        ["low", 21], ["medium", 11], ["high", 1]
-                    ],
-                    "default": 1,
-                    "refresh.interval": 84000
-                },
-                {
-                    "name": "config/sensitivitymax",
-                    "default": 21
-                },
-                {
-                    "name": "state/orientation"
-                },
-                {
-                    "name": "state/orientation_x",
-                    "parse": {"cl": "0x0101", "at": "0x0508", "script": "aq1_vibration_sensor_orientation.js"}
-                },
-                {
-                    "name": "state/orientation_y"
-                },
-                {
-                    "name": "state/orientation_z"
-                },
-                {
-                    "name": "state/tiltangle",
-                    "parse": {"cl": "0x0101", "at": "0x0503", "eval": "Item.val = Attr.val"},
-                    "default": 0
-                },
-                {
-                    "name": "state/vibration",
-                    "parse": {"cl": "0x0101", "at": "0x0055", "eval": "if (Attr.val == 1) { Item.val = true; }"},
-                    "comment": "TODO durationDue needs to be a ResourceItem",
-                    "default": false
-                },
-                {
-                    "name": "state/vibrationstrength",
-                    "parse": {"cl": "0x0101", "at": "0x0505", "eval": "Item.val = Attr.val >> 16"},
-                    "default": 0
-                },
-                {
-                    "name": "state/lastupdated"
-                }
-            ],
-            "example": {
-                "config": {
-                    "battery": 95,
-                    "on": true,
-                    "pending": [],
-                    "reachable": true,
-                    "sensitivity": 1,
-                    "sensitivitymax": 21,
-                    "temperature": 2800
-                },
-                "lastseen": "2020-12-29T22:03Z",
-                "manufacturername": "LUMI",
-                "modelid": "lumi.vibration.aq1",
-                "name": "Vibration Sensor",
-                "state": {
-                    "lastupdated": "2020-12-29T22:02:50.534",
-                    "orientation": [
-                        81, 1, 9
-                    ],
-                    "tiltangle": 84,
-                    "vibration": false,
-                    "vibrationstrength": 11
-                },
-                "swversion": "20180130",
-                "type": "ZHAVibration",
-                "uniqueid": "00:15:8d:00:02:af:95:f9-01-0101"
-            }
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid",
+          "awake": true
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "refresh.interval": 86400,
+          "read": {
+            "at": "0x0006",
+            "cl": "0x0000",
+            "ep": 1,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0006",
+            "cl": "0x0000",
+            "ep": 1,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/autoreset",
+          "static": true,
+          "public": false
+        },
+        {
+          "name": "config/duration",
+          "default": 65
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/battery",
+          "parse": {
+            "at": "0xff01",
+            "fn": "xiaomi:special",
+            "idx": "0x01",
+            "script": "xiaomi_battery.js"
+          },
+          "awake": true
+        },
+        {
+          "name": "config/sensitivity",
+          "refresh.interval": 86400,
+          "read": {
+            "at": "0xff0d",
+            "cl": "0x0000",
+            "ep": 1,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0xff0d",
+            "cl": "0x0000",
+            "ep": 1,
+            "eval": "Item.val == 0 ? Item.val = Attr.val : Item.val",
+            "fn": "zcl"
+          },
+          "write": {
+            "at": "0xff0d",
+            "cl": "0x0000",
+            "dt": "0x20",
+            "ep": 1,
+            "eval": "Item.val",
+            "fn": "zcl"
+          },
+          "values": [
+              ["low", 21], ["medium", 11], ["high", 1]
+          ],
+          "default": 1
+        },
+        {
+          "name": "config/sensitivitymax",
+          "default": 21
+        },
+        {
+          "name": "state/orientation"
+        },
+        {
+          "name": "state/orientation_x",
+          "parse": {
+            "at": "0x0508",
+            "cl": "0x0101",
+            "ep": 1,
+            "fn": "zcl",
+            "script": "aq1_vibration_sensor_orientation.js"
+          }
+        },
+        {
+          "name": "state/orientation_y"
+        },
+        {
+          "name": "state/orientation_z"
+        },
+        {
+          "name": "state/tiltangle",
+          "parse": {
+            "at": "0x0503",
+            "cl": "0x0101",
+            "ep": 1,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl"
+          },
+          "default": 0
+        },
+        {
+          "name": "state/vibration",
+          "parse": {
+            "at": "0x0055",
+            "cl": "0x0101",
+            "ep": 1,
+            "eval": "if (Attr.val == 1) ? Item.val = true : Item.val = false",
+            "fn": "zcl"
+          },
+          "default": false
+        },
+        {
+          "name": "state/vibrationstrength",
+          "parse": {
+            "at": "0x0505",
+            "cl": "0x0101",
+            "ep": 1,
+            "eval": "Item.val = Attr.val >> 16",
+            "fn": "zcl"
+          },
+          "default": 0
+        },
+        {
+          "name": "state/lastupdated"
         }
-    ]
+      ],
+      "example": {
+        "config": {
+          "battery": 95,
+          "duration": 65,
+          "on": true,
+          "reachable": true,
+          "sensitivity": 1,
+          "sensitivitymax": 21
+        },
+        "lastseen": "2020-12-29T22:03Z",
+        "manufacturername": "LUMI",
+        "modelid": "lumi.vibration.aq1",
+        "name": "Vibration Sensor",
+        "state": {
+          "lastupdated": "2020-12-29T22:02:50.534",
+          "orientation": [
+            81, 1, 9
+          ],
+          "tiltangle": 84,
+          "vibration": false,
+          "vibrationstrength": 11
+        },
+        "swversion": "20180130",
+        "type": "ZHAVibration",
+        "uniqueid": "00:15:8d:00:02:af:95:f9-01-0101"
+      }
+    }
+  ]
 }

--- a/devices/xiaomi/aq1_vibration_sensor.json
+++ b/devices/xiaomi/aq1_vibration_sensor.json
@@ -1,7 +1,5 @@
 {
   "schema": "devcap1.schema.json",
-  "doc:path": "xiaomi/aq_vibration_sensor.md",
-  "doc:hdr": "Vibration sensor DJT11LM",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.vibration.aq1",
   "vendor": "Xiaomi",
@@ -40,19 +38,16 @@
         },
         {
           "name": "attr/swversion",
-          "refresh.interval": 86400,
-          "read": {
-            "at": "0x0006",
-            "cl": "0x0000",
-            "ep": 1,
-            "fn": "zcl"
-          },
+          "awake": true,
           "parse": {
-            "at": "0x0006",
-            "cl": "0x0000",
+            "at": "0xff01",
             "ep": 1,
-            "eval": "Item.val = Attr.val",
-            "fn": "zcl"
+            "fn": "xiaomi:special",
+            "idx": "0x08",
+            "script": "xiaomi_firmware.js"
+          },
+          "read": {
+            "fn": "none"
           }
         },
         {
@@ -67,21 +62,21 @@
           "public": false
         },
         {
-          "name": "config/duration",
-          "default": 65
-        },
-        {
-          "name": "config/on"
-        },
-        {
           "name": "config/battery",
+          "awake": true,
           "parse": {
             "at": "0xff01",
             "fn": "xiaomi:special",
             "idx": "0x01",
             "script": "xiaomi_battery.js"
-          },
-          "awake": true
+          }
+        },
+        {
+          "name": "config/duration",
+          "default": 65
+        },
+        {
+          "name": "config/on"
         },
         {
           "name": "config/sensitivity",
@@ -90,31 +85,34 @@
             "at": "0xff0d",
             "cl": "0x0000",
             "ep": 1,
-            "fn": "zcl"
+            "fn": "zcl",
+            "mf": "0x115f"
           },
           "parse": {
             "at": "0xff0d",
             "cl": "0x0000",
             "ep": 1,
-            "eval": "Item.val == 0 ? Item.val = Attr.val : Item.val",
-            "fn": "zcl"
+            "eval": "Item.val = [3, 2, 1][Attr.val - 1]",
+            "fn": "zcl",
+            "mf": "0x115f"
           },
           "write": {
             "at": "0xff0d",
             "cl": "0x0000",
             "dt": "0x20",
             "ep": 1,
-            "eval": "Item.val",
-            "fn": "zcl"
+            "eval": "Item.val = [3, 2, 1][Item.val - 1]",
+            "fn": "zcl",
+            "mf": "0x115f"
           },
           "values": [
-              ["low", 21], ["medium", 11], ["high", 1]
+              [1, "low"], [2, "medium"], [3, "high"]
           ],
-          "default": 1
+          "default": 3
         },
         {
           "name": "config/sensitivitymax",
-          "default": 21
+          "default": 3
         },
         {
           "name": "state/orientation"
@@ -152,7 +150,7 @@
             "at": "0x0055",
             "cl": "0x0101",
             "ep": 1,
-            "eval": "if (Attr.val == 1) ? Item.val = true : Item.val = false",
+            "eval": "Item.val = Attr.val == 1 ? true : false",
             "fn": "zcl"
           },
           "default": false
@@ -171,33 +169,7 @@
         {
           "name": "state/lastupdated"
         }
-      ],
-      "example": {
-        "config": {
-          "battery": 95,
-          "duration": 65,
-          "on": true,
-          "reachable": true,
-          "sensitivity": 1,
-          "sensitivitymax": 21
-        },
-        "lastseen": "2020-12-29T22:03Z",
-        "manufacturername": "LUMI",
-        "modelid": "lumi.vibration.aq1",
-        "name": "Vibration Sensor",
-        "state": {
-          "lastupdated": "2020-12-29T22:02:50.534",
-          "orientation": [
-            81, 1, 9
-          ],
-          "tiltangle": 84,
-          "vibration": false,
-          "vibrationstrength": 11
-        },
-        "swversion": "20180130",
-        "type": "ZHAVibration",
-        "uniqueid": "00:15:8d:00:02:af:95:f9-01-0101"
-      }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This PR depends on #6165.

This is a major overhaul of the DDF:
- Promotion to Gold status
- Removed <s>`config/temperature` and</s> `config/pending` resource items
- Add `config/duration` and `config/autoreset` resource items. The vibration status does apparently not get reset automatically, but now this can be defined to happen after the time defined in duration.
- The functions for parsing/writing had an inappropriate mfc set, which got corrected
- Sentitivity values got corrected based on a sniff of a native gateway
- Some minor adjustments

Respective legacy code shall be removed by a follow up PR, to allow easy fallback in case of errors.