### PR TITLE
Fix : change state/action for keypad Develco/Frient

### DIFF
--- a/devices/frient/kepzb-110_keypad.json
+++ b/devices/frient/kepzb-110_keypad.json
@@ -83,6 +83,9 @@
                "name":"state/lowbattery"
             },
             {
+              "name": "state/seconds_remaining"
+            },
+            {
                "name":"state/panel",
                "default":"exit_delay"
             },

--- a/devices/frient/kepzb-110_keypad.json
+++ b/devices/frient/kepzb-110_keypad.json
@@ -74,7 +74,7 @@
             },
             {
                "name":"state/action",
-               "public":false
+               "public":true
             },
             {
                "name":"state/lastupdated"

--- a/devices/generic/items/state_seconds_remaining_item.json
+++ b/devices/generic/items/state_seconds_remaining_item.json
@@ -1,0 +1,10 @@
+{
+	"schema": "resourceitem1.schema.json",
+	"id": "state/seconds_remaining",
+	"datatype": "UInt32",
+	"access": "RW",
+	"public": true,
+	"managed": true,
+	"description": "The IAS panel seconds remaining.",
+	"default": 0
+}


### PR DESCRIPTION
Concern devices
- Develco Products A/S
- frient A/S

Add the support for "state/seconds_remaining"

Else the keypad can't work because of code 

```
            ResourceItem *panel = r->item(RStatePanel);
            ResourceItem *secondsRemaining = r->item(RStateSecondsRemaining);

            if (!panel || !secondsRemaining) { continue; }
```