### PR TITLE
Fix DDF joining issues

### DIFF
--- a/de_otau.cpp
+++ b/de_otau.cpp
@@ -46,13 +46,13 @@ void DeRestPluginPrivate::initOtau()
     otauIdleTicks = 0;
     otauBusyTicks = 0;
     otauIdleTotalCounter = 0;
-    otauUnbindIdleTotalCounter = 0;
 
     otauTimer = new QTimer(this);
     otauTimer->setSingleShot(false);
     connect(otauTimer, SIGNAL(timeout()),
             this, SLOT(otauTimerFired()));
 
+    otauTimer->start(1000);
 }
 
 /*! Handler for incoming otau packets.
@@ -159,6 +159,11 @@ bool DeRestPluginPrivate::isOtauBusy()
     return false;
 }
 
+bool DEV_OtauBusy()
+{
+    return plugin->isOtauBusy();
+}
+
 /*! Returns true if otau is activated.
  */
 bool DeRestPluginPrivate::isOtauActive()
@@ -214,6 +219,4 @@ void DeRestPluginPrivate::otauTimerFired()
             updateEtag(gwConfigEtag);
         }
     }
-
-    otauIdleTicks = 0;
 }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -942,7 +942,7 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
     connect(pollManager, &PollManager::done, this, &DeRestPluginPrivate::pollNextDevice);
 
     auto *deviceTick = new DeviceTick(m_devices, this);
-    connect(this, &DeRestPluginPrivate::eventNotify, deviceTick, &DeviceTick::handleEvent);
+    connect(eventEmitter, &EventEmitter::eventNotify, deviceTick, &DeviceTick::handleEvent);
     connect(deviceTick, &DeviceTick::eventNotify, eventEmitter, &EventEmitter::enqueueEvent);
 
     const deCONZ::Node *node;
@@ -17794,6 +17794,15 @@ Resource *DEV_AddResource(const Sensor &sensor)
         plugin->sensors.push_back(sensor);
         r = &plugin->sensors.back();
         r->setHandle(R_CreateResourceHandle(r, plugin->sensors.size() - 1));
+
+        if (plugin->searchSensorsState == DeRestPluginPrivate::SearchSensorsActive || plugin->permitJoinFlag)
+        {
+            const ResourceItem *idItem = r->item(RAttrId);
+            if (idItem)
+            {
+                enqueueEvent(Event(sensor.prefix(), REventAdded, idItem->toString()));
+            }
+        }
     }
 
     return r;
@@ -17810,6 +17819,15 @@ Resource *DEV_AddResource(const LightNode &lightNode)
         plugin->nodes.push_back(lightNode);
         r = &plugin->nodes.back();
         r->setHandle(R_CreateResourceHandle(r, plugin->nodes.size() - 1));
+
+        if (plugin->searchLightsState == DeRestPluginPrivate::SearchLightsActive || plugin->permitJoinFlag)
+        {
+            const ResourceItem *idItem = r->item(RAttrId);
+            if (idItem)
+            {
+                enqueueEvent(Event(r->prefix(), REventAdded, idItem->toString()));
+            }
+        }
     }
 
     return r;

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -12331,35 +12331,6 @@ void DeRestPluginPrivate::handleZclAttributeReportIndication(const deCONZ::ApsDa
     {
         handleZclAttributeReportIndicationXiaomiSpecial(ind, zclFrame);
     }
-
-    if (otauLastBusyTimeDelta() < (60 * 60))
-    {
-        if ((idleTotalCounter - otauUnbindIdleTotalCounter) > 5)
-        {
-            LightNode *lightNode = getLightNodeForAddress(ind.srcAddress());
-
-            if (lightNode && lightNode->modelId().startsWith(QLatin1String("FLS-")))
-            {
-                otauUnbindIdleTotalCounter = idleTotalCounter;
-                DBG_Printf(DBG_INFO, "ZCL attribute report 0x%016llX for cluster 0x%04X --> unbind (otau busy)\n", ind.srcAddress().ext(), ind.clusterId());
-
-                BindingTask bindingTask;
-                Binding &bnd = bindingTask.binding;
-
-                bindingTask.action = BindingTask::ActionUnbind;
-                bindingTask.state = BindingTask::StateIdle;
-
-                bnd.srcAddress = lightNode->address().ext();
-                bnd.srcEndpoint = ind.srcEndpoint();
-                bnd.clusterId = ind.clusterId();
-                bnd.dstAddress.ext = apsCtrl->getParameter(deCONZ::ParamMacAddress);
-                bnd.dstAddrMode = deCONZ::ApsExtAddress;
-                bnd.dstEndpoint = endpoint();
-
-                queueBindingTask(bindingTask);
-            }
-        }
-    }
 }
 
 void DeRestPluginPrivate::queuePollNode(RestNodeBase *node)
@@ -16394,7 +16365,6 @@ void DeRestPlugin::idleTimerFired()
     {
         d->idleTotalCounter = 0;
         d->otauIdleTotalCounter = 0;
-        d->otauUnbindIdleTotalCounter = 0;
         d->saveDatabaseIdleTotalCounter = 0;
         d->recoverOnOff.clear();
     }

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1891,7 +1891,6 @@ public:
     int otauIdleTicks;
     int otauBusyTicks;
     int otauIdleTotalCounter;
-    int otauUnbindIdleTotalCounter;
 
     // touchlink
 

--- a/device_tick.cpp
+++ b/device_tick.cpp
@@ -18,8 +18,10 @@
 #define DEV_TICK_BOOT_TIME 8000
 #define TICK_INTERVAL_JOIN 500
 #define TICK_INTERVAL_IDLE 1000
+#define TICK_INTERVAL_IDLE_OTAU 6000
 
 extern int DEV_ApsQueueSize();
+extern bool DEV_OtauBusy();
 
 struct JoinDevice
 {
@@ -158,11 +160,12 @@ static void DT_StateIdle(DeviceTickPrivate *d, const Event &event)
     {
         if (event.what() == REventStateTimeout)
         {
+            int timeout = DEV_OtauBusy() ? TICK_INTERVAL_IDLE_OTAU : TICK_INTERVAL_IDLE;
             if (DEV_ApsQueueSize() < 4)
             {
                 DT_PollNextIdleDevice(d);
             }
-            DT_StartTimer(d, TICK_INTERVAL_IDLE);
+            DT_StartTimer(d, timeout);
         }
         else if (event.what() == REventStateEnter)
         {


### PR DESCRIPTION
- Fix missing emitting Websocket "added" event after sensor or lights where added via DDF.
- Fix starting fast polling `DeviceTick` after Permit Join gets enabled.
- Continue fast polling after Permit Join is disabled for 20 seconds to let setup tasks finish in time.
- Additionally slow down idle polling during OTA updates with raising tick time from 1 to 8 seconds, otherwise sending OTA responses too often fails since the queue is occupied.

Overall this results in a much faster joining and setup process. Main problem was the that the fast poll Qt signal wasn't updated after introducing the `EventEmitter` class a while ago.