### PR TITLE
Add DDF for Xiaomi Mijia smart plug ZNCZ04LM with newer FW version

### DIFF
--- a/devices/xiaomi/xiaomi_zncz04lm_smart_plug_v24.json
+++ b/devices/xiaomi/xiaomi_zncz04lm_smart_plug_v24.json
@@ -6,8 +6,8 @@
   "product": "Mijia smart plug ZNCZ04LM",
   "sleeper": false,
   "status": "Gold",
-  "comment": "DDF for device firmwares equal or below 0.0.0_0022",
-  "matchexpr": "R.endpoints.includes(0x15) && R.endpoints.includes(0x16)",
+  "comment": "DDF for device firmwares equal or above 0.0.0_0024",
+  "matchexpr": "R.endpoints.includes(0x15) && R.endpoints.includes(0x1F)",
   "subdevices": [
     {
       "type": "$TYPE_SMART_PLUG",
@@ -60,7 +60,8 @@
           "default": "none"
         },
         {
-          "name": "state/on"
+          "name": "state/on",
+          "refresh.interval": 300
         },
         {
           "name": "state/reachable"
@@ -180,13 +181,13 @@
       "restapi": "/sensors",
       "uuid": [
         "$address.ext",
-        "0x16",
+        "0x1F",
         "0x000C"
       ],
       "fingerprint": {
         "profile": "0x0104",
         "device": "0x0051",
-        "endpoint": "0x16",
+        "endpoint": "0x1F",
         "in": [
           "0x000C"
         ]
@@ -244,34 +245,18 @@
           "read": {
             "at": "0x0055",
             "cl": "0x000C",
-            "ep": 22,
+            "ep": 31,
             "fn": "zcl"
           },
           "parse": {
             "at": "0x0055",
             "cl": "0x000C",
-            "ep": 22,
+            "ep": 31,
             "eval": "Item.val = Math.round(Attr.val * 1000);"
           }
         },
         {
           "name": "state/lastupdated"
-        }
-      ]
-    }
-  ],
-  "bindings": [
-    {
-      "bind": "unicast",
-      "src.ep": 1,
-      "dst.ep": 1,
-      "cl": "0x0006",
-      "report": [
-        {
-          "at": "0x0000",
-          "dt": "0x10",
-          "min": 1,
-          "max": 300
         }
       ]
     }


### PR DESCRIPTION
Devices with firmware version 24 have a different endpoint for consumption measurement