### PR TITLE
Add initial DDF for Tuya smart knob (_TZ3000_4fjiwweb)

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -287,6 +287,9 @@ void DeRestPluginPrivate::cleanUpDb()
         // cleanup invalid ZHAAlarm resource for Xiaomi motion sensor
         "DELETE from sensors WHERE type = 'ZHAAlarm' AND modelid LIKE 'lumi.sensor_motion%'",
 
+        // cleanup invalid Tuya smart knob light resource (only has ZHASwitch)
+        "DELETE from nodes WHERE manufacturername = '_TZ3000_4fjiwweb'",
+
         // delete duplicates in device_descriptors
         //"DELETE FROM device_descriptors WHERE rowid NOT IN"
         //" (SELECT max(rowid) FROM device_descriptors GROUP BY device_id,type,endpoint)",

--- a/device_access_fn.cpp
+++ b/device_access_fn.cpp
@@ -337,13 +337,16 @@ bool evalZclFrame(Resource *r, ResourceItem *item, const deCONZ::ApsDataIndicati
             const auto res = engine.result();
             if (res.isValid())
             {
-                DBG_Printf(DBG_INFO, "expression: %s --> %s\n", qPrintable(expr), qPrintable(res.toString()));
+                if (DBG_IsEnabled(DBG_DDF))
+                {
+                    DBG_Printf(DBG_DDF, "expression: %s --> %s\n", qPrintable(expr), qPrintable(res.toString()));
+                }
                 return true;
             }
         }
         else
         {
-            DBG_Printf(DBG_INFO, "failed to evaluate expression for %s/%s: %s, err: %s\n", qPrintable(r->item(RAttrUniqueId)->toString()), item->descriptor().suffix, qPrintable(expr), qPrintable(engine.errorString()));
+            DBG_Printf(DBG_DDF, "failed to evaluate expression for %s/%s: %s, err: %s\n", qPrintable(r->item(RAttrUniqueId)->toString()), item->descriptor().suffix, qPrintable(expr), qPrintable(engine.errorString()));
         }
     }
     return false;
@@ -493,6 +496,10 @@ bool parseZclAttribute(Resource *r, ResourceItem *item, const deCONZ::ApsDataInd
         if (param.hasCommandId && param.commandId != zclFrame.commandId())
         {
             return result;
+        }
+        else if (!param.hasCommandId && param.attributeCount == 0)
+        {
+            // catch all handler
         }
         else if (!param.hasCommandId && zclFrame.commandId() != deCONZ::ZclReadAttributesResponseId && zclFrame.commandId() != deCONZ::ZclReportAttributesId)
         {

--- a/device_js/device_js.cpp
+++ b/device_js/device_js.cpp
@@ -109,6 +109,7 @@ void DeviceJs::setApsIndication(const deCONZ::ApsDataIndication &ind)
 {
     d->apsInd = &ind;
     d->engine.globalObject().setProperty("SrcEp", int(ind.srcEndpoint()));
+    d->engine.globalObject().setProperty("ClusterId", int(ind.clusterId()));
 }
 
 void DeviceJs::setZclFrame(const deCONZ::ZclFrame &zclFrame)

--- a/devices/tuya/_TZ3000_4fjiwweb_smart_knob.json
+++ b/devices/tuya/_TZ3000_4fjiwweb_smart_knob.json
@@ -1,0 +1,107 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "_TZ3000_4fjiwweb",
+  "modelid": "TS004F",
+  "vendor": "Tuya",
+  "product": "Smart Knob",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_SWITCH",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x1000"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001", "script": "tuya_swversion.js"},
+          "read": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001"}
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+            "name": "config/battery",
+            "parse": {
+                "ep": 1, "cl": "0x0001", "at": "0x0021",
+                "eval": "Item.val = Attr.val / 2"
+            },
+            "read": {
+                "ep": 1, "cl": "0x0001", "at": "0x0021"
+            },
+            "refresh.interval": 7300
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/buttonevent"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/angle",
+          "default": 0
+        },
+        {
+          "name": "state/on",
+          "public": false,
+          "parse": {"fn": "zcl", "ep": 1, "cl": "0x0006", "script": "_TZ3000_4fjiwweb_smart_knob_buttons.js"},
+          "read": {"fn": "none"},
+          "awake": true
+        },
+        {
+          "name": "state/bri",
+          "public": false,
+          "parse": {"fn": "zcl", "ep": 1, "cl": "0x0008", "script": "_TZ3000_4fjiwweb_smart_knob_buttons.js"},
+          "read": {"fn": "none"}
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 300,
+          "max": 600,
+          "change": "0x01"
+        }
+      ]
+    }
+  ]
+}

--- a/devices/tuya/_TZ3000_4fjiwweb_smart_knob_buttons.js
+++ b/devices/tuya/_TZ3000_4fjiwweb_smart_knob_buttons.js
@@ -1,0 +1,35 @@
+
+const cmd = ZclFrame.cmd;
+const pl0 = ZclFrame.at(0);
+let btnev = 0;
+let angle = 0;
+if (ClusterId === 6) {
+	if (cmd === 253) {
+		if (pl0 === 0) btnev = 1002;
+		else if (pl0 === 1) btnev = 1004;
+	}
+	else if (cmd === 2 && pl0 === 0) btnev = 1002;
+	else if (cmd === 252 && pl0 === 0) btnev = 1030;
+	else if (cmd === 252 && pl0 === 1) btnev = 1031;
+} else if (ClusterId === 8) {
+	if (cmd === 2) {
+		angle = ZclFrame.at(1);
+		if (pl0 === 0) btnev = 1030;
+		else if (pl0 === 1) { btnev = 1031; angle = -angle; }
+	}
+}
+
+if (btnev) {
+	R.item('state/buttonevent').val = btnev;
+}
+
+if (angle) {
+	let a = R.item('state/angle').val;
+	a += angle;
+	if (a > 360) a -= 360;
+	else if (a < 0) a = 360 + a;
+	R.item('state/angle').val = a;
+}
+
+if (btnev || angle) // for state/lastupdated
+	Item.val = !Item.val;


### PR DESCRIPTION
It's a weird device having two modes, 'scenes' and 'remote', which can be toggled by pressing the knob 3 times very quickly (less than 0.5 seconds). The knob doesn't require bindings for button handling since it sends all commands to group 0x0000 per default.

- This PR also adds support to parse any ZCL command in a DDF and exposes the `ClusterId` to the Javascript engine.
- The database is cleaned up from older invalid light resources for this device.
- Creating group bindings is confirmed by the device but they are ignored, in order to let the knob address another group the *Groups* cluster *Add to group* command is needed which is currently not implemented for the DDF "auto" group mechanism which uses bindings.

Depending on the mode following button events are emitted:

Mode scenes:
- 1002 single press
- 1030 rotate clockwise
- 1031 rotate counter-clockwise

The `state.angle` gives the rotation angle 0-360 degrees.

Mode remote:
- 1002 single press
- 1004 double press
- 1030 rotate clockwise
- 1031 rotate counter-clockwise

In this mode `state.angle` isn't updated.

**TODO:** There are further functions available when rotating the knob while the button is pressed, these are not implemented yet.

Implementation details: The DDF is a bit hacky in that it uses `state/on` and `state/bri` items to parse the *On/Off* and *Level Control* clusters, the items are set to `"public": false` and are not exposed to the REST-API. Two items are needed since the cluster needs to be specified in the DDF "parse" function.

The `_TZ3000_4fjiwweb_smart_knob_buttons.js` Javascript file does the leg work to parse the plain ZCL commands with non standard payload.


```json
{
    "config": {
        "battery": 100,
        "on": true,
        "reachable": true
    },
    "etag": "c025269568475ff46ccacef5541ab523",
    "lastannounced": null,
    "lastseen": "2022-08-06T13:30Z",
    "manufacturername": "_TZ3000_4fjiwweb",
    "mode": 1,
    "modelid": "TS004F",
    "name": "Switch 251",
    "state": {
        "angle": 162,
        "buttonevent": 1031,
        "lastupdated": "2022-08-06T13:30:45.470"
    },
    "swversion": "1.0.3",
    "type": "ZHASwitch",
    "uniqueid": "00:3c:84:ff:fe:b1:3d:1f-01-1000"
}
```
