### PR TITLE
Add DDF for Mijia Honeywell gas leak detector JTQJ-BF-01LM/BW and smoke detector JTYJ-GD-01LM/BW

### DIFF
--- a/device_access_fn.cpp
+++ b/device_access_fn.cpp
@@ -1760,12 +1760,12 @@ bool writeZclAttribute(const Resource *r, const ResourceItem *item, deCONZ::ApsC
             if (engine.evaluate(expr) == JsEvalResult::Ok)
             {
                 const auto res = engine.result();
-                DBG_Printf(DBG_INFO, "expression: %s --> %s\n", qPrintable(expr), qPrintable(res.toString()));
+                DBG_Printf(DBG_DDF, "%s/%s expression: %s --> %s\n", r->item(RAttrUniqueId)->toCString(), item->descriptor().suffix, qPrintable(expr), qPrintable(res.toString()));
                 attribute.setValue(res);
             }
             else
             {
-                DBG_Printf(DBG_INFO, "failed to evaluate expression for %s/%s: %s, err: %s\n", qPrintable(r->item(RAttrUniqueId)->toString()), item->descriptor().suffix, qPrintable(expr), qPrintable(engine.errorString()));
+                DBG_Printf(DBG_DDF, "failed to evaluate expression for %s/%s: %s, err: %s\n", qPrintable(r->item(RAttrUniqueId)->toString()), item->descriptor().suffix, qPrintable(expr), qPrintable(engine.errorString()));
                 return result;
             }
         }

--- a/devices/generic/items/config_selftest_item.json
+++ b/devices/generic/items/config_selftest_item.json
@@ -1,0 +1,9 @@
+{
+	"schema": "resourceitem1.schema.json",
+	"id": "config/selftest",
+	"datatype": "Bool",
+	"access": "W",
+	"public": true,
+	"description": "Activates the device self-test mode.",
+	"default": false
+}

--- a/devices/generic/items/state_carbonmonoxide_item.json
+++ b/devices/generic/items/state_carbonmonoxide_item.json
@@ -5,5 +5,6 @@
 	"access": "R",
 	"public": true,
 	"description": "True when carbonmonoxide is detected.",
-	"parse": {"fn": "ias:zonestatus", "mask": "alarm1,alarm2"}
+	"parse": {"fn": "ias:zonestatus", "mask": "alarm1,alarm2"},
+	"default": false
 }

--- a/devices/generic/items/state_test_item.json
+++ b/devices/generic/items/state_test_item.json
@@ -5,5 +5,6 @@
 	"access": "R",
 	"public": true,
 	"description": "True when a test is detected.",
-	"parse": {"fn": "ias:zonestatus"}
+	"parse": {"fn": "ias:zonestatus"},
+	"default": false
 }

--- a/devices/generic/items/state_windowopen_item.json
+++ b/devices/generic/items/state_windowopen_item.json
@@ -5,12 +5,12 @@
 	"access": "R",
 	"public": true,
 	"description": "The current window state detected by the thermostat.",
-    "default": "Quarantine",
+	"default": "Quarantine",
 	"values": [
 		["\"Quarantine\"", "Default"],
 		["\"Closed\"", "Window is closed"],
-        ["\"Hold\"", "Window is maybe about to open"],
-        ["\"Open\"", "Window is open"],
-        ["\"Open (external), closed (internal)\"", "In window open state from external, but detected closed locally"]
+		["\"Hold\"", "Window is maybe about to open"],
+		["\"Open\"", "Window is open"],
+		["\"Open (external), closed (internal)\"", "In window open state from external, but detected closed locally"]
 	]
 }

--- a/devices/xiaomi/xiaomi_jtqj-bf-01lm_gas_leak_detector.json
+++ b/devices/xiaomi/xiaomi_jtqj-bf-01lm_gas_leak_detector.json
@@ -1,0 +1,169 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "$MF_LUMI",
+  "modelid": "lumi.sensor_natgas",
+  "vendor": "Xiaomi",
+  "product": "Mijia Honeywell gas leak detector JTQJ-BF-01LM/BW",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "ZHACarbonMonoxide",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0500"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0101",
+        "endpoint": "0x01",
+        "in": [
+          "0x0500",
+          "0x0000",
+          "0x0001"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {
+            "at": "0xff01",
+            "ep": 1,
+            "fn": "xiaomi:special",
+            "idx": "0x08",
+            "script": "xiaomi_swversion.js"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "parse": {
+            "at": "0xff01",
+            "fn": "xiaomi:special",
+            "idx": "0x01",
+            "script": "xiaomi_battery.js"
+          }
+        },
+        {
+          "name": "config/enrolled",
+          "public": false,
+          "static": 1
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/pending"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "config/selftest",
+          "parse": {
+            "cl": "0x0500",
+            "cmd": "0x04",
+            "ep": 1,
+            "eval": "Item.val = (ZclFrame.payloadSize == 1 && ZclFrame.at(0) == 0x00) ? false : true;",
+            "fn": "zcl",
+            "mf": "0x115F"
+          },
+          "read": {
+            "fn": "none"
+          },
+          "write": {
+            "at": "0xFFF1",
+            "cl": "0x0500",
+            "dt": "0x23",
+            "ep": 1,
+            "eval": "if (Item.val) { 0x03010000 }",
+            "fn": "zcl",
+            "mf": "0x115F"
+          },
+          "values": [
+            [true, "Initiate self-test"],
+            [false, "Self-test not initiated"]
+          ]
+        },
+        {
+          "name": "config/sensitivity",
+          "refresh.interval": 3600,
+          "parse": {
+            "at": "0xFFF0",
+            "cl": "0x0500",
+            "ep": 1,
+            "eval": "const i = Number(Attr.val).toString(16)[2]; Item.val = [0, 1, 2][i - 1];",
+            "fn": "zcl",
+            "mf": "0x115F"
+          },
+          "read": {
+            "at": "0xFFF0",
+            "cl": "0x0500",
+            "ep": 1,
+            "fn": "zcl",
+            "mf": "0x115F"
+          },
+          "write": {
+            "at": "0xFFF1",
+            "cl": "0x0500",
+            "dt": "0x23",
+            "ep": 1,
+            "eval": "0x04000000 + [0x00010000, 0x00020000, 0x00030000][Item.val];",
+            "fn": "zcl",
+            "mf": "0x115F"
+          },
+          "values": [
+            [0, "Low"],
+            [1, "Medium"],
+            [2, "High"]
+          ],
+          "default": 1
+        },
+        {
+          "name": "state/carbonmonoxide"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/lowbattery"
+        },
+        {
+          "name": "state/test",
+          "parse": {
+            "fn": "ias:zonestatus",
+            "mask": "alarm2"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/devices/xiaomi/xiaomi_jtyj-gd-01lm_smoke_detector.json
+++ b/devices/xiaomi/xiaomi_jtyj-gd-01lm_smoke_detector.json
@@ -1,0 +1,168 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "$MF_LUMI",
+  "modelid": "lumi.sensor_smoke",
+  "vendor": "Xiaomi",
+  "product": "Mijia Honeywell smoke detector JTYJ-GD-01LM/BW",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_FIRE_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0500"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0402",
+        "endpoint": "0x01",
+        "in": [
+          "0x0500",
+          "0x0001"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {
+            "at": "0xff01",
+            "ep": 1,
+            "fn": "xiaomi:special",
+            "idx": "0x08",
+            "script": "xiaomi_swversion.js"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "parse": {
+            "at": "0xff01",
+            "fn": "xiaomi:special",
+            "idx": "0x01",
+            "script": "xiaomi_battery.js"
+          }
+        },
+        {
+          "name": "config/enrolled",
+          "public": false,
+          "static": 1
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/pending"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "config/selftest",
+          "parse": {
+            "cl": "0x0500",
+            "cmd": "0x04",
+            "ep": 1,
+            "eval": "Item.val = (ZclFrame.payloadSize == 1 && ZclFrame.at(0) == 0x00) ? false : true;",
+            "fn": "zcl",
+            "mf": "0x115F"
+          },
+          "read": {
+            "fn": "none"
+          },
+          "write": {
+            "at": "0xFFF1",
+            "cl": "0x0500",
+            "dt": "0x23",
+            "ep": 1,
+            "eval": "if (Item.val) { 0x03010000 }",
+            "fn": "zcl",
+            "mf": "0x115F"
+          },
+          "values": [
+            [true, "Initiate self-test"],
+            [false, "Self-test not initiated"]
+          ]
+        },
+        {
+          "name": "config/sensitivity",
+          "refresh.interval": 3600,
+          "parse": {
+            "at": "0xFFF0",
+            "cl": "0x0500",
+            "ep": 1,
+            "eval": "const i = Number(Attr.val).toString(16)[2]; Item.val = [0, 1, 2][i - 1];",
+            "fn": "zcl",
+            "mf": "0x115F"
+          },
+          "read": {
+            "at": "0xFFF0",
+            "cl": "0x0500",
+            "ep": 1,
+            "fn": "zcl",
+            "mf": "0x115F"
+          },
+          "write": {
+            "at": "0xFFF1",
+            "cl": "0x0500",
+            "dt": "0x23",
+            "ep": 1,
+            "eval": "0x04000000 + [0x00010000, 0x00020000, 0x00030000][Item.val];",
+            "fn": "zcl",
+            "mf": "0x115F"
+          },
+          "values": [
+            [0, "Low"],
+            [1, "Medium"],
+            [2, "High"]
+          ],
+          "default": 1
+        },
+        {
+          "name": "state/fire"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/lowbattery"
+        },
+        {
+          "name": "state/test",
+          "parse": {
+            "fn": "ias:zonestatus",
+            "mask": "alarm2"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/general.xml
+++ b/general.xml
@@ -3041,7 +3041,7 @@ controller device, that supports a keypad and LCD screen.</description>
 			<attribute-set id="0x0500" description="AC (Single Phase or Phase A) Measurements">
 				<attribute id="0x0505" name="RMS Voltage" type="u16" access="r" required="o" default="0xFFFF"></attribute>
 				<attribute id="0x0508" name="RMS Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-                <attribute id="0x050a" name="Max Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+				<attribute id="0x050a" name="Max Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
 				<attribute id="0x050b" name="Active Power" type="s16" access="r" required="o" default="0x8000">
 					<description>Represents the single phase or Phase A, current demand of active power delivered or received at the premises, in Watts (W). Positive values indicate power delivered to the premises where negative values indicate power received from the premises.</description>
 				</attribute>
@@ -3060,14 +3060,14 @@ controller device, that supports a keypad and LCD screen.</description>
 			<attribute-set id="0x0900" description="AC (Phase B) Measurements">
 				<attribute id="0x0905" name="RMS Voltage" type="u16" access="r" required="o" default="0xFFFF"></attribute>
 				<attribute id="0x0908" name="RMS Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-                <attribute id="0x090a" name="Max Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-                <attribute id="0x090f" name="RMS Power" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+				<attribute id="0x090a" name="Max Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+				<attribute id="0x090f" name="RMS Power" type="u16" access="r" required="o" default="0xFFFF"></attribute>
 			</attribute-set>
 			<attribute-set id="0x0a00" description="AC (Phase C) Measurements">
 				<attribute id="0x0a05" name="RMS Voltage" type="u16" access="r" required="o" default="0xFFFF"></attribute>
 				<attribute id="0x0a08" name="RMS Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-                <attribute id="0x0a0a" name="Max Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-                <attribute id="0x0a0f" name="RMS Power" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+				<attribute id="0x0a0a" name="Max Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+				<attribute id="0x0a0f" name="RMS Power" type="u16" access="r" required="o" default="0xFFFF"></attribute>
 			</attribute-set>
 		</server>
 		<client>
@@ -3167,9 +3167,8 @@ controller device, that supports a keypad and LCD screen.</description>
 					<attribute id="0x8000" name="Zone Status Interval" type="u16" access="rw" required="o" mfcode="0x1015"></attribute>
 					<attribute id="0x8001" name="Alarm Off Delay" type="u16" access="rw" required="o" mfcode="0x1015"></attribute>
 				</attribute-set>
-                <attribute-set id="0xf000" description="Xiaomi specific" mfcode="0x1037">
-                    <attribute id="0xfff0" name="Sensitivity" type="u32" access="r" required="o" mfcode="0x1037"></attribute>
-					<attribute id="0xfff1" name="Selftest/Density" type="u32" access="rw" required="o" mfcode="0x1037"></attribute>
+				<attribute-set id="0xf000" description="Xiaomi specific" mfcode="0x1037">
+					<attribute id="0xfff0" name="Device config" type="u64" access="r" required="o" mfcode="0x115f"></attribute>
 				</attribute-set>
 				<command id="0x00" dir="recv" name="Zone Enroll Response" required="m">
 					<payload>

--- a/resource.cpp
+++ b/resource.cpp
@@ -239,6 +239,7 @@ const char *RConfigReachable = "config/reachable";
 const char *RConfigResetPresence = "config/resetpresence";
 const char *RConfigSchedule = "config/schedule";
 const char *RConfigScheduleOn = "config/schedule_on";
+const char *RConfigSelfTest = "config/selftest";
 const char *RConfigSensitivity = "config/sensitivity";
 const char *RConfigSensitivityMax = "config/sensitivitymax";
 const char *RConfigSetValve = "config/setvalve";
@@ -469,6 +470,7 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, QVariant::Bool, RConfigResetPresence));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, QVariant::String, RConfigSchedule));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, QVariant::Bool, RConfigScheduleOn));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, QVariant::Bool, RConfigSelfTest));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, QVariant::Double, RConfigSensitivity));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, QVariant::Double, RConfigSensitivityMax));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeInt8, QVariant::Double, RConfigSunriseOffset, -120, 120));

--- a/resource.h
+++ b/resource.h
@@ -259,6 +259,7 @@ extern const char *RConfigReachable;
 extern const char *RConfigResetPresence;
 extern const char *RConfigSchedule;
 extern const char *RConfigScheduleOn;
+extern const char *RConfigSelfTest;
 extern const char *RConfigSensitivity;
 extern const char *RConfigSensitivityMax;
 extern const char *RConfigSetValve;

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -949,6 +949,16 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                         updated = true;
                     }
                 }
+                else if (rid.suffix == RConfigSelfTest) // Boolean
+                {
+                    if (devManaged && rsub)
+                    {
+                        change.addTargetValue(rid.suffix, data.boolean);
+                        change.setChangeTimeoutMs(60000);    // 1 min
+                        rsub->addStateChange(change);
+                        updated = true;
+                    }
+                }
                 else if (rid.suffix == RConfigAlert) // String
                 {
                     const std::array<KeyValMap, 3> RConfigAlertValues = { { {QLatin1String("none"), 0}, {QLatin1String("select"), 2}, {QLatin1String("lselect"), 15} } };


### PR DESCRIPTION
Superseedes #5210 and relies on #6264

This PR adds `config/sensitivity` and `config/selftest` to the Honeywell smoke and gas sensors.

The selftest is a bit challenging for the smoke sensor, as it mac polls just every 15 secs (instead of the usual 7.5, a quite remarkable deviation). It's handled via a state change with a duration of 1 min. The successful write of the required value to trigger the audio test is used behind the scenes to set the item back to false. The gas sensor reacts instantly (mains powered).

As for the sensitivity, the same scale for the allowed values and the meaning is applied as for the Hue motion sensor (0 - low, 1 - medium, 2 - high).

Additionally, the tamper state is removed, as both devices do not support it anyway. They have also been excluded from the IAS enrollment process, as they do not comply with the zigbee specs in this regard, so the devices do not get hammered with unnecessary requests (will be marked as enrolled).