### PR TITLE
Fixed `permitjoin` being ignored in PUT request

### DIFF
--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1387,11 +1387,11 @@ public Q_SLOTS:
     void resetDeviceSendConfirm(bool success);
 
     // lights
-    void startSearchLights();
+    void startSearchLights(int duration);
     void searchLightsTimerFired();
 
     // sensors
-    void startSearchSensors();
+    void startSearchSensors(int duration);
     void searchSensorsTimerFired();
     void checkInstaModelId(Sensor *sensor);
     void delayedFastEnddeviceProbe(const deCONZ::NodeEvent *event = nullptr);

--- a/permitJoin.cpp
+++ b/permitJoin.cpp
@@ -181,8 +181,8 @@ void DeRestPluginPrivate::permitJoin(int seconds)
     {
         int tmp = gwNetworkOpenDuration; // preserve configured duration
         gwNetworkOpenDuration = seconds;
-        startSearchSensors();
-        startSearchLights();
+        startSearchSensors(gwNetworkOpenDuration);
+        startSearchLights(gwNetworkOpenDuration);
         gwNetworkOpenDuration = tmp;
     }
     else

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -1793,8 +1793,8 @@ int DeRestPluginPrivate::modifyConfig(const ApiRequest &req, ApiResponse &rsp)
 
         if (seconds > 0)
         {
-            startSearchLights();
-            startSearchSensors();
+            startSearchLights(gwPermitJoinDuration);
+            startSearchSensors(gwPermitJoinDuration);
         }
 
         QVariantMap rspItem;

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -161,7 +161,7 @@ int DeRestPluginPrivate::searchNewLights(const ApiRequest &req, ApiResponse &rsp
     }
 
     permitJoinApiKey = req.apikey();
-    startSearchLights();
+    startSearchLights(gwNetworkOpenDuration);
     {
         QVariantMap rspItem;
         QVariantMap rspItemState;
@@ -3225,7 +3225,7 @@ void DeRestPluginPrivate::handleLightEvent(const Event &e)
 
 /*! Starts the search for new lights.
  */
-void DeRestPluginPrivate::startSearchLights()
+void DeRestPluginPrivate::startSearchLights(int duration)
 {
     if (searchLightsState == SearchLightsIdle || searchLightsState == SearchLightsDone)
     {
@@ -3240,7 +3240,7 @@ void DeRestPluginPrivate::startSearchLights()
         DBG_Assert(searchLightsState == SearchLightsActive);
     }
 
-    searchLightsTimeout = gwNetworkOpenDuration;
+    searchLightsTimeout = duration;
     setPermitJoinDuration(searchLightsTimeout);
 }
 

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -2564,7 +2564,7 @@ int DeRestPluginPrivate::searchNewSensors(const ApiRequest &req, ApiResponse &rs
     }
 
     permitJoinApiKey = req.apikey();
-    startSearchSensors();
+    startSearchSensors(gwNetworkOpenDuration);
     {
         QVariantMap rspItem;
         QVariantMap rspItemState;
@@ -3254,7 +3254,7 @@ void DeRestPluginPrivate::handleSensorEvent(const Event &e)
 
 /*! Starts the search for new sensors.
  */
-void DeRestPluginPrivate::startSearchSensors()
+void DeRestPluginPrivate::startSearchSensors(int duration)
 {
     if (searchSensorsState == SearchSensorsIdle || searchSensorsState == SearchSensorsDone)
     {
@@ -3273,7 +3273,7 @@ void DeRestPluginPrivate::startSearchSensors()
         Q_ASSERT(searchSensorsState == SearchSensorsActive);
     }
 
-    searchSensorsTimeout = gwNetworkOpenDuration;
+    searchSensorsTimeout = duration;
     setPermitJoinDuration(searchSensorsTimeout);
 }
 


### PR DESCRIPTION
Fixed the value of `permitjoin` in the JSON body in a PUT request to
`/api/<apikey>/config` being ignored. It was ignored due to
`startSearchLights()` and `startSearchSensors()` overriding
`gwPermitJoinDuration` to `gwNetworkOpenDuration`.

Now both functions take a duration to specify the duration of the permit
join commmand.