### PR TITLE
Fix potentially jumpy reachable state for sensors

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4276,7 +4276,9 @@ void DeRestPluginPrivate::checkSensorNodeReachable(Sensor *sensor, const deCONZ:
                 reachable = true;
             }
 
-            // check that all clusters from fingerprint are present
+            bool found = false;
+
+            // check if any cluster from fingerprint is present
             for (const deCONZ::SimpleDescriptor &sd : sensor->node()->simpleDescriptors())
             {
                 if (!reachable)
@@ -4291,7 +4293,6 @@ void DeRestPluginPrivate::checkSensorNodeReachable(Sensor *sensor, const deCONZ:
 
                 for (quint16 clusterId : sensor->fingerPrint().inClusters)
                 {
-                    bool found = false;
                     for (const deCONZ::ZclCluster &cl : sd.inClusters())
                     {
                         if (clusterId == cl.id())
@@ -4300,31 +4301,32 @@ void DeRestPluginPrivate::checkSensorNodeReachable(Sensor *sensor, const deCONZ:
                             break;
                         }
                     }
-                    if (!found)
+                    if (found)
                     {
-                        reachable = false;
+                        reachable = true;
                         break;
                     }
                 }
 
-                for (quint16 clusterId : sensor->fingerPrint().outClusters)
+                if (!found)
                 {
-                    bool found = false;
-                    for (const deCONZ::ZclCluster &cl : sd.outClusters())
+                    for (quint16 clusterId : sensor->fingerPrint().outClusters)
                     {
-                        if (clusterId == cl.id())
+                        for (const deCONZ::ZclCluster &cl : sd.outClusters())
                         {
-                            found = true;
+                            if (clusterId == cl.id())
+                            {
+                                found = true;
+                                break;
+                            }
+                        }
+                        if (found)
+                        {
+                            reachable = true;
                             break;
                         }
                     }
-                    if (!found)
-                    {
-                        reachable = false;
-                        break;
-                    }
                 }
-
             }
         }
     }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -4262,72 +4262,9 @@ void DeRestPluginPrivate::checkSensorNodeReachable(Sensor *sensor, const deCONZ:
     }
     else if (sensor->node() && !sensor->node()->isZombie())
     {
-        // look if fingerprint endpoint is in active endpoint list
-        std::vector<quint8>::const_iterator it;
-
-        it = std::find(sensor->node()->endpoints().begin(),
-                       sensor->node()->endpoints().end(),
-                       sensor->fingerPrint().endpoint);
-
-        if (it != sensor->node()->endpoints().end())
+        if (sensor->lastRx().isValid() && sensor->lastRx().secsTo(now) < (60 * 60 * 24))
         {
-            if (sensor->lastRx().isValid() && sensor->lastRx().secsTo(now) < (60 * 60 * 24))
-            {
-                reachable = true;
-            }
-
-            bool found = false;
-
-            // check if any cluster from fingerprint is present
-            for (const deCONZ::SimpleDescriptor &sd : sensor->node()->simpleDescriptors())
-            {
-                if (!reachable)
-                {
-                    break;
-                }
-
-                if (sd.endpoint() != sensor->fingerPrint().endpoint)
-                {
-                    continue;
-                }
-
-                for (quint16 clusterId : sensor->fingerPrint().inClusters)
-                {
-                    for (const deCONZ::ZclCluster &cl : sd.inClusters())
-                    {
-                        if (clusterId == cl.id())
-                        {
-                            found = true;
-                            break;
-                        }
-                    }
-                    if (found)
-                    {
-                        reachable = true;
-                        break;
-                    }
-                }
-
-                if (!found)
-                {
-                    for (quint16 clusterId : sensor->fingerPrint().outClusters)
-                    {
-                        for (const deCONZ::ZclCluster &cl : sd.outClusters())
-                        {
-                            if (clusterId == cl.id())
-                            {
-                                found = true;
-                                break;
-                            }
-                        }
-                        if (found)
-                        {
-                            reachable = true;
-                            break;
-                        }
-                    }
-                }
-            }
+            reachable = true;
         }
     }
 


### PR DESCRIPTION
When a sensor has a cluster in its fingerprint, which doesn't exist under the sensor's endpoint, function `checkSensorNodeReachable()` will set the respective sensor unreachable, as it checks for existence of **all** clusters.

While it makes sense to add those non-existent clusters to leverage some advantages on the legacy code, it apparently impacts the overall sensor status (falsely). To resolve this, the last check in the function to check for all clusters has been made lazy to just find one fit and then move on.

It's more unlikely this will occur on DDF supported devices, but can happen there as well (especially if the device is not newly paired). Eventually, this cluster check can be removed completely, as it seems to be a too tight precaution.