### PR TITLE
Extend Xiaomi special report parsing

### DIFF
--- a/devices/generic/items/config_xiaomispecial_item.json
+++ b/devices/generic/items/config_xiaomispecial_item.json
@@ -1,0 +1,8 @@
+{
+  "schema": "resourceitem1.schema.json",
+  "id": "config/xiaomispecial",
+  "datatype": "UInt32",
+  "access": "RW",
+  "public": false,
+  "description": "Non-public dummy item to allow more extensive extraction of Xiaomi special reporting."
+}

--- a/devices/xiaomi/xiaomi_rtcgq14lm_p1_presence_sensor.json
+++ b/devices/xiaomi/xiaomi_rtcgq14lm_p1_presence_sensor.json
@@ -66,6 +66,17 @@
           "name": "attr/uniqueid"
         },
         {
+          "name": "config/xiaomispecial",
+          "awake": true,
+          "parse": {
+            "at": "0xff07",
+            "ep": 1,
+            "eval": "if (Attr.id == 0x69) { R.item('config/duration').val = Attr.val; } else if (Attr.id == 0x6b) { R.item('config/ledindication').val = Attr.val; } else if (Attr.id == 0x6a) { R.item('config/sensitivity').val = Attr.val; }",
+            "fn": "xiaomi:special",
+            "idx": ["0x69", "0x6b", "0x6a"]
+          }
+        },
+        {
           "name": "config/battery",
           "awake": true,
           "parse": {
@@ -79,13 +90,13 @@
         {
           "name": "config/duration",
           "refresh.interval": 3600,
-          "awake": true,
           "parse": {
-            "at": "0xff07",
+            "at": "0x0102",
+            "cl": "0xFCC0",
             "ep": 1,
             "eval": "Item.val = Attr.val",
-            "fn": "xiaomi:special",
-            "idx": "0x69"
+            "fn": "zcl",
+            "mf": "0x115F"
           },
           "read": {
             "at": "0x0102",
@@ -109,13 +120,13 @@
         {
           "name": "config/ledindication",
           "refresh.interval": 3600,
-          "awake": true,
           "parse": {
-            "at": "0xff07",
+            "at": "0x0152",
+            "cl": "0xFCC0",
             "ep": 1,
             "eval": "Item.val = Attr.val",
-            "fn": "xiaomi:special",
-            "idx": "0x6b"
+            "fn": "zcl",
+            "mf": "0x115F"
           },
           "read": {
             "at": "0x0152",
@@ -148,13 +159,13 @@
         {
           "name": "config/sensitivity",
           "refresh.interval": 3600,
-          "awake": true,
           "parse": {
-            "at": "0xff07",
+            "at": "0x010C",
+            "cl": "0xFCC0",
             "ep": 1,
             "eval": "Item.val = Attr.val",
-            "fn": "xiaomi:special",
-            "idx": "0x6a"
+            "fn": "zcl",
+            "mf": "0x115F"
           },
           "read": {
             "at": "0x010C",
@@ -257,6 +268,17 @@
           "name": "attr/uniqueid"
         },
         {
+          "name": "config/xiaomispecial",
+          "awake": true,
+          "parse": {
+            "at": "0xff07",
+            "ep": 1,
+            "eval": "if (Attr.id == 0x6b) { R.item('config/ledindication').val = Attr.val; }",
+            "fn": "xiaomi:special",
+            "idx": "0x6b"
+          }
+        },
+        {
           "name": "config/battery",
           "awake": true,
           "parse": {
@@ -270,13 +292,13 @@
         {
           "name": "config/ledindication",
           "refresh.interval": 3600,
-          "awake": true,
           "parse": {
-            "at": "0xff07",
+            "at": "0x0152",
+            "cl": "0xFCC0",
             "ep": 1,
             "eval": "Item.val = Attr.val",
-            "fn": "xiaomi:special",
-            "idx": "0x6b"
+            "fn": "zcl",
+            "mf": "0x115F"
           },
           "read": {
             "at": "0x0152",

--- a/resource.cpp
+++ b/resource.cpp
@@ -270,6 +270,7 @@ const char *RConfigUbisysJ1AdditionalSteps = "config/ubisys_j1_additionalsteps";
 const char *RConfigUbisysJ1InactivePowerThreshold = "config/ubisys_j1_inactivepowerthreshold";
 const char *RConfigUbisysJ1StartupSteps = "config/ubisys_j1_startupsteps";
 const char *RConfigAlarmSystemId = "config/alarmsystemid";
+const char *RConfigXiaomiSpecial = "config/xiaomispecial";
 
 const QStringList RConfigDeviceModeValues({
     "singlerocker", "singlepushbutton", "dualrocker", "dualpushbutton"
@@ -501,6 +502,7 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, QVariant::Double, RConfigUbisysJ1InactivePowerThreshold));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, QVariant::Double, RConfigUbisysJ1StartupSteps));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, QVariant::Double, RConfigAlarmSystemId));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt32, QVariant::Double, RConfigXiaomiSpecial));
 }
 
 const char *getResourcePrefix(const QString &str)

--- a/resource.h
+++ b/resource.h
@@ -292,6 +292,7 @@ extern const char *RConfigUbisysJ1AdditionalSteps;
 extern const char *RConfigUbisysJ1InactivePowerThreshold;
 extern const char *RConfigUbisysJ1StartupSteps;
 extern const char *RConfigAlarmSystemId;
+extern const char *RConfigXiaomiSpecial;
 
 #define R_ALERT_DEFAULT             QVariant(QLatin1String("none"))
 #define R_SENSITIVITY_MAX_DEFAULT   2


### PR DESCRIPTION
The idea of this PR is to dedicate a non-public resource item to a Xiaomi resource, allowing to extract more than 1 item out of the special report (provided as string list), while setting the respective values of up to 3 resource items (could probably be extended to 4).

With the currently given read/write/parse functions, one has to decide how to obtain the current state values:
- either by reading an attribute (polling) or 
- by parsing the respective item of the special report

While the 2nd option is quite charming, as data arrives in more or less defined intervals, it actually gets tricky when a configuration setting should be changed by a state change (SC). The SC tries to write an attribute value, then reads that value, which is then evaluated by the parser. When now read and parse are async (read goes for attribute XYZ and parse uses the special reporting), the SC cannot succeed as a correctly written value cannot be confirmed. In case a write wouldn't succeed, deconz holds the assumed written value while it truly remained untouched on the device and that would eventually never be corrected.

The above is especially relevant for sleeping devices like sensors. Detaching the special report parsing from all or, more precisely, the most relevant resource items could aid in the SCs to work properly and succeed, reduce polling while allowing to use the device's awake time more efficiently and still update 3 resource items in one go.

This is certainly not the silver bullets to cater with all Xiaomi specifics and there could be more items of interest from the special reports, but I consider this as a low hanging fruit to improve device experience.

An example of how an amended DDF could look like is part of the PR (P1 motion sensor). Below the debug output of 3 resource items being set on one special report.

```
20:44:29:576 JsResourceItem.setValue(config/duration) = 25
20:44:29:577 54:ef:44:10:00:49:01:ac-01-0406/config/xiaomispecial expression: if (Attr.id == 0x69) { R.item('config/duration').val = Attr.val; } else if (Attr.id == 0x6b) { R.item('config/ledindication').val = Attr.val; } else if (Attr.id == 0x6a) { R.item('config/sensitivity').val = Attr.val; } --> 25

20:44:29:577 JsResourceItem.setValue(config/ledindication) = 0
20:44:29:578 54:ef:44:10:00:49:01:ac-01-0406/config/xiaomispecial expression: if (Attr.id == 0x69) { R.item('config/duration').val = Attr.val; } else if (Attr.id == 0x6b) { R.item('config/ledindication').val = Attr.val; } else if (Attr.id == 0x6a) { R.item('config/sensitivity').val = Attr.val; } --> 0

20:44:29:578 JsResourceItem.setValue(config/sensitivity) = 2
20:44:29:578 54:ef:44:10:00:49:01:ac-01-0406/config/xiaomispecial expression: if (Attr.id == 0x69) { R.item('config/duration').val = Attr.val; } else if (Attr.id == 0x6b) { R.item('config/ledindication').val = Attr.val; } else if (Attr.id == 0x6a) { R.item('config/sensitivity').val = Attr.val; } --> 2
```

**EDIT**
Small caviat on this approach is that the event emitter misses that the referred to items have been set. It only fires on `config/xiaomispecial`, but does not consider the 3 ones actually set above. Based on that, the change state machine cannot leverage any received values.