### PR TITLE
DEV improve robustness of ZCL attribute polling

### DIFF
--- a/de_web.pro
+++ b/de_web.pro
@@ -12,6 +12,7 @@ QMAKE_CXXFLAGS += -Wno-attributes \
 
 CONFIG(debug, debug|release) {
     LIBS += -L../../debug
+    DEFINES += DECONZ_DEBUG_BUILD
 }
 
 CONFIG(release, debug|release) {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -35,7 +35,6 @@
 #include <cmath>
 #include "air_quality.h"
 #include "alarm_system_device_table.h"
-#include "colorspace.h"
 #include "database.h"
 #include "device_ddf_init.h"
 #include "device_descriptions.h"
@@ -636,6 +635,10 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
 
     DEV_SetTestManaged(deCONZ::appArgumentNumeric("--dev-test-managed", 0));
 
+#ifdef DECONZ_DEBUG_BUILD
+    EventTestZclPacking();
+#endif
+
     pollManager = new PollManager(this);
 
     databaseTimer = new QTimer(this);
@@ -1027,12 +1030,12 @@ void DeRestPluginPrivate::apsdeDataIndicationDevice(const deCONZ::ApsDataIndicat
         else if (zclFrame.commandId() == deCONZ::ZclReadAttributesResponseId && zclFrame.payload().size() >= 3)
         {
             const auto status = quint8(zclFrame.payload().at(2));
-            enqueueEvent(Event(device->prefix(), REventZclResponse, EventZclResponsePack(zclFrame.sequenceNumber(), status), device->key()));
+            enqueueEvent(Event(device->prefix(), REventZclResponse, EventZclResponsePack(ind.clusterId(), zclFrame.sequenceNumber(), status), device->key()));
         }
         else if (zclFrame.commandId() == deCONZ::ZclConfigureReportingResponseId && zclFrame.payload().size() >= 1)
         {
             const auto status = quint8(zclFrame.payload().at(0));
-            enqueueEvent(Event(device->prefix(), REventZclResponse, EventZclResponsePack(zclFrame.sequenceNumber(), status), device->key()));
+            enqueueEvent(Event(device->prefix(), REventZclResponse, EventZclResponsePack(ind.clusterId(), zclFrame.sequenceNumber(), status), device->key()));
         }
         else if (zclFrame.commandId() == deCONZ::ZclReadReportingConfigResponseId)
         {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1025,7 +1025,13 @@ void DeRestPluginPrivate::apsdeDataIndicationDevice(const deCONZ::ApsDataIndicat
 
         if (!zclFrame.isProfileWideCommand())
         {
-
+            if (zclFrame.frameControl() & deCONZ::ZclFCDirectionServerToClient)
+            {
+                // Keep Device poll state machine happy for non profile wide responses.
+                // There a response is assumed by 'server to client' direction.
+                // The status is set to SUCCESS since not all responses contain a status field.
+                enqueueEvent(Event(device->prefix(), REventZclResponse, EventZclResponsePack(ind.clusterId(), zclFrame.sequenceNumber(), deCONZ::ZclSuccessStatus), device->key()));
+            }
         }
         else if (zclFrame.commandId() == deCONZ::ZclReadAttributesResponseId && zclFrame.payload().size() >= 3)
         {

--- a/device.cpp
+++ b/device.cpp
@@ -1865,6 +1865,21 @@ void DEV_PollNextStateHandler(Device *device, const Event &event)
     }
 }
 
+/*! Increments retry counter of an item, or throws it away if maximum is reached. */
+static void checkPollItemRetry(std::vector<DEV_PollItem> &pollItems)
+{
+    if (!pollItems.empty())
+    {
+        auto &pollItem = pollItems.back();
+        pollItem.retry++;
+
+        if (pollItem.retry >= MaxPollItemRetries)
+        {
+            pollItems.pop_back();
+        }
+    }
+}
+
 /*! This state waits for APS confirm or timeout for an ongoing poll request.
     In any case it moves back to PollNext state.
     If the request is successful the DEV_PollItem will be removed from the queue.
@@ -1883,9 +1898,8 @@ void DEV_PollBusyStateHandler(Device *device, const Event &event)
     }
     else if (event.what() == REventApsConfirm && EventApsConfirmId(event) == d->readResult.apsReqId)
     {
-        DBG_Printf(DBG_DEV, "DEV Poll Busy %s/0x%016llX APS-DATA.confirm id: %u, status: 0x%02X\n",
-                   event.resource(), event.deviceKey(), d->readResult.apsReqId, EventApsConfirmStatus(event));
-        Q_ASSERT(!d->pollItems.empty());
+        DBG_Printf(DBG_DEV, "DEV Poll Busy %s/0x%016llX APS-DATA.confirm id: %u, ZCL seq: %u, status: 0x%02X\n",
+                   event.resource(), event.deviceKey(), d->readResult.apsReqId, d->readResult.sequenceNumber, EventApsConfirmStatus(event));
 
         if (EventApsConfirmStatus(event) == deCONZ::ApsSuccessStatus)
         {
@@ -1894,22 +1908,18 @@ void DEV_PollBusyStateHandler(Device *device, const Event &event)
         }
         else
         {
-            auto &pollItem = d->pollItems.back();
-            pollItem.retry++;
-
-            if (pollItem.retry >= MaxPollItemRetries)
-            {
-                d->pollItems.pop_back();
-            }
+            checkPollItemRetry(d->pollItems);
             d->setState(DEV_PollNextStateHandler, STATE_LEVEL_POLL);
         }
     }
     else if (event.what() == REventZclResponse)
     {
-        if (d->readResult.sequenceNumber == EventZclSequenceNumber(event))
+        if (d->readResult.clusterId != EventZclClusterId(event))
+        { }
+        else if (d->readResult.sequenceNumber == EventZclSequenceNumber(event) || d->readResult.ignoreResponseSequenceNumber)
         {
-            DBG_Printf(DBG_DEV, "DEV Poll Busy %s/0x%016llX ZCL response seq: %u, status: 0x%02X\n",
-                   event.resource(), event.deviceKey(), d->readResult.sequenceNumber, EventZclStatus(event));
+            DBG_Printf(DBG_DEV, "DEV Poll Busy %s/0x%016llX ZCL response seq: %u, status: 0x%02X, cluster: 0x%04X\n",
+                   event.resource(), event.deviceKey(), d->readResult.sequenceNumber, EventZclStatus(event), d->readResult.clusterId);
 
             d->pollItems.pop_back();
             d->setState(DEV_PollNextStateHandler, STATE_LEVEL_POLL);
@@ -1917,6 +1927,9 @@ void DEV_PollBusyStateHandler(Device *device, const Event &event)
     }
     else if (event.what() == REventStateTimeout)
     {
+        DBG_Printf(DBG_DEV, "DEV Poll Busy %s/0x%016llX timeout seq: %u, cluster: 0x%04X\n",
+           event.resource(), event.deviceKey(), d->readResult.sequenceNumber, d->readResult.clusterId);
+        checkPollItemRetry(d->pollItems);
         d->setState(DEV_PollNextStateHandler, STATE_LEVEL_POLL);
     }
 }

--- a/device_access_fn.h
+++ b/device_access_fn.h
@@ -27,8 +27,10 @@ namespace deCONZ {
 struct DA_ReadResult
 {
     bool isEnqueued = false;
+    bool ignoreResponseSequenceNumber = false;
     quint8 apsReqId = 0;
     quint8 sequenceNumber = 0;
+    quint16 clusterId = 0;
 };
 
 typedef bool (*ParseFunction_t)(Resource *r, ResourceItem *item, const deCONZ::ApsDataIndication &ind, const deCONZ::ZclFrame &zclFrame, const QVariant &parseParameters);

--- a/event.cpp
+++ b/event.cpp
@@ -23,6 +23,23 @@ quint16 allocDataBuffer()
     return int(_eventDataIter);
 }
 
+#ifdef DECONZ_DEBUG_BUILD
+/*! Verify that ZCL packing functions work as expected
+    TODO(mpi) move to separate testing code.
+*/
+void EventTestZclPacking()
+{
+    uint clusterId = 0xf123;
+    uint status = 0x83;
+    uint seqno = 24;
+    Event e(RDevices, REventZclResponse, EventZclResponsePack(clusterId, seqno, status), 0x11111);
+
+    Q_ASSERT(EventZclClusterId(e) == clusterId);
+    Q_ASSERT(EventZclSequenceNumber(e) == seqno);
+    Q_ASSERT(EventZclStatus(e) == status);
+}
+#endif
+
 /*! Constructor.
  */
 Event::Event()

--- a/event.h
+++ b/event.h
@@ -106,10 +106,17 @@ inline int EventZdpResponsePack(quint8 seq, quint8 status)
     return seq << 8 | status;
 }
 
-//! Unpacks Zcl sequence number.
+//! Unpacks ZCL ClusterID.
+inline unsigned EventZclClusterId(const Event &event)
+{
+    uint32_t n = static_cast<uint32_t>(event.num());
+    return (n >> 16) & 0xFFFF;
+}
+
+//! Unpacks ZCL sequence number.
 inline quint8 EventZclSequenceNumber(const Event &event)
 {
-    return event.num() >> 8 & 0xFF;
+    return (event.num() >> 8) & 0xFF;
 }
 
 //! Unpacks ZCL command status.
@@ -118,11 +125,23 @@ inline quint8 EventZclStatus(const Event &event)
     return event.num() & 0xFF;
 }
 
-//! Packs ZCL sequence number and command status into an \c int used as `num` parameter for REventZclResponse.
-inline int EventZclResponsePack(quint8 seq, quint8 status)
+//! Packs cluster ID, ZCL sequence number and command status into an \c int used as `num` parameter for REventZclResponse.
+inline int EventZclResponsePack(uint16_t clusterId, uint8_t seq, uint8_t status)
 {
-    return seq << 8 | status;
+    uint32_t n;
+
+    n = clusterId;
+    n <<= 8;
+    n |= seq;
+    n <<= 8;
+    n |= status;
+
+    return static_cast<int>(n);
 }
+
+#ifdef DECONZ_DEBUG_BUILD
+void EventTestZclPacking();
+#endif
 
 //! Packs timer into an \c int used as `num` parameter for REventStartTimer and REventStopTimer.
 inline int EventTimerPack(int timerId, int timeoutMs)

--- a/zcl/zcl.h
+++ b/zcl/zcl.h
@@ -33,7 +33,8 @@ struct ZCL_Param
         uint8_t valid : 1;
         uint8_t hasCommandId : 1;
         uint8_t attributeCount : 3;
-        uint8_t _pad0 : 3;
+        uint8_t ignoreResponseSeq: 1;
+        uint8_t _pad0 : 2;
     };
     uint8_t _pad1;
 };


### PR DESCRIPTION
- Fix timeout didn't increase the retry counter of a poll item, machine was stuck in infinite retries.
- Also check that clusterId is the one from the request.
- Allow to optional specify `"noseq": true` in DDF item read parameters to ignore the response ZCL sequence number and only match against clusterId. This is needed for devices like Danfoss Ally which respond with a random sequence number.
- Fix potential rare SEGV when poll items are already empty.