### PR TITLE
Initial support for zigfred uno and zigfred plus smart in-wall switches by Siglis

### DIFF
--- a/devices/siglis/zigfred_plus_wired_switch.json
+++ b/devices/siglis/zigfred_plus_wired_switch.json
@@ -1,0 +1,647 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "Siglis",
+  "modelid": "zigfred plus",
+  "product": "zigfred plus",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_SWITCH",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x05",
+        "0xFC42"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/buttonevent",
+          "awake": true,
+          "parse": {
+            "cl": "0xFC42",
+            "cmd": "0x02",
+            "eval": "const eventLookup = [0x03, 0x00, 0x04, 0x01]; Item.val = (ZclFrame.at(0)+1) * 1000 + eventLookup[ZclFrame.at(1)]"
+          }
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_COLOR_DIMMABLE_LIGHT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x05"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert",
+          "default": "none"
+        },
+        {
+          "name": "state/bri",
+          "refresh.interval": 600
+        },
+        {
+          "name": "state/colormode"
+        },
+        {
+          "name": "state/effect",
+          "default": "none"
+        },
+        {
+          "name": "state/hue"
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 600
+        },
+        {
+          "name": "state/reachable"
+        },
+        {
+          "name": "state/sat",
+          "refresh.interval": 600
+        },
+        {
+          "name": "state/x",
+          "refresh.interval": 600
+        },
+        {
+          "name": "state/y"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_DIMMABLE_LIGHT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x07"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert",
+          "default": "none"
+        },
+        {
+          "name": "state/bri",
+          "refresh.interval": 600
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 600
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_DIMMABLE_LIGHT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x08"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert",
+          "default": "none"
+        },
+        {
+          "name": "state/bri",
+          "refresh.interval": 600
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 600
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_DIMMABLE_LIGHT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x09"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert",
+          "default": "none"
+        },
+        {
+          "name": "state/bri",
+          "refresh.interval": 600
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 600
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_DIMMABLE_LIGHT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x10"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert",
+          "default": "none"
+        },
+        {
+          "name": "state/bri",
+          "refresh.interval": 600
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 600
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_WINDOW_COVERING_DEVICE",
+      "restapi": "/lights",
+      "uuid": ["$address.ext", "0xa1"],
+      "items": [
+          {
+              "name": "attr/manufacturername"
+          },
+          {
+              "name": "attr/modelid"
+          },
+          {
+              "name": "attr/name"
+          },
+          {
+              "name": "attr/swversion"
+          },
+          {
+              "name": "attr/type"
+          },
+          {
+              "name": "attr/uniqueid"
+          },
+          {
+              "name": "attr/lastannounced"
+          },
+          {
+              "name": "attr/lastseen"
+          },
+          {
+              "name": "state/lift",
+              "parse": {"cl": "0x0102", "at": "0x0008", "eval": "Item.val = Attr.val"},
+              "read": {"cl": "0x0102", "at": "0x0008"},
+              "refresh.interval": 600
+          },
+          {
+            "name": "state/tilt",
+            "parse": {"cl": "0x0102", "at": "0x0009", "eval": "Item.val = Attr.val"},
+            "read": {"cl": "0x0102", "at": "0x0009"},
+            "refresh.interval": 600
+          },
+          {
+              "name": "state/open",
+              "parse": {"cl": "0x0102", "at": "0x0008", "eval": "Item.val = Attr.val < 100"}
+          },
+          {
+              "name": "state/reachable"
+          }
+      ]
+    },
+    {
+      "type": "$TYPE_WINDOW_COVERING_DEVICE",
+      "restapi": "/lights",
+      "uuid": ["$address.ext", "0xa2"],
+      "items": [
+          {
+              "name": "attr/manufacturername"
+          },
+          {
+              "name": "attr/modelid"
+          },
+          {
+              "name": "attr/name"
+          },
+          {
+              "name": "attr/swversion"
+          },
+          {
+              "name": "attr/type"
+          },
+          {
+              "name": "attr/uniqueid"
+          },
+          {
+              "name": "attr/lastannounced"
+          },
+          {
+              "name": "attr/lastseen"
+          },
+          {
+              "name": "state/lift",
+              "parse": {"cl": "0x0102", "at": "0x0008", "eval": "Item.val = Attr.val"},
+              "read": {"cl": "0x0102", "at": "0x0008"},
+              "refresh.interval": 600
+          },
+          {
+            "name": "state/tilt",
+            "parse": {"cl": "0x0102", "at": "0x0009", "eval": "Item.val = Attr.val"},
+            "read": {"cl": "0x0102", "at": "0x0009"},
+            "refresh.interval": 600
+          },
+          {
+              "name": "state/open",
+              "parse": {"cl": "0x0102", "at": "0x0008", "eval": "Item.val = Attr.val < 100"}
+          },
+          {
+              "name": "state/reachable"
+          }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 5,
+      "cl": "0x0006",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 1800
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 5,
+      "cl": "0x0008",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x20",
+          "min": 1,
+          "max": 1800,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 5,
+      "cl": "0x0300",
+      "report": [
+        {
+          "at": "0x0003",
+          "dt": "0x21",
+          "min": 5,
+          "max": 1800,
+          "change": "0x0000000A"
+        },
+        {
+          "at": "0x0004",
+          "dt": "0x21",
+          "min": 5,
+          "max": 1800,
+          "change": "0x0000000A"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 7,
+      "cl": "0x0006",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 1800
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 7,
+      "cl": "0x0008",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x20",
+          "min": 1,
+          "max": 1800,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 8,
+      "cl": "0x0006",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 1800
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 8,
+      "cl": "0x0008",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x20",
+          "min": 1,
+          "max": 1800,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 9,
+      "cl": "0x0006",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 1800
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 9,
+      "cl": "0x0008",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x20",
+          "min": 1,
+          "max": 1800,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 10,
+      "cl": "0x0006",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 1800
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 10,
+      "cl": "0x0008",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x20",
+          "min": 1,
+          "max": 1800,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 11,
+      "cl": "0x0102",
+      "report": [
+        {
+          "at": "0x0008",
+          "dt": "0x20",
+          "min": 1,
+          "max": 1800,
+          "change": "0x00000001"
+        },
+        {
+          "at": "0x0009",
+          "dt": "0x20",
+          "min": 1,
+          "max": 1800,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 12,
+      "cl": "0x0102",
+      "report": [
+        {
+          "at": "0x0008",
+          "dt": "0x20",
+          "min": 1,
+          "max": 1800,
+          "change": "0x00000001"
+        },
+        {
+          "at": "0x0009",
+          "dt": "0x20",
+          "min": 1,
+          "max": 1800,
+          "change": "0x00000001"
+        }
+      ]
+    }
+  ]
+}

--- a/devices/siglis/zigfred_uno_wired_switch.json
+++ b/devices/siglis/zigfred_uno_wired_switch.json
@@ -5,7 +5,6 @@
   "product": "zigfred uno",
   "sleeper": false,
   "status": "Gold",
-  "path": "/devices/zigfred_uno.json",
   "subdevices": [
     {
       "type": "$TYPE_SWITCH",

--- a/devices/siglis/zigfred_uno_wired_switch.json
+++ b/devices/siglis/zigfred_uno_wired_switch.json
@@ -1,0 +1,240 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "Siglis",
+  "modelid": "zigfred uno",
+  "product": "zigfred uno",
+  "sleeper": false,
+  "status": "Gold",
+  "path": "/devices/zigfred_uno.json",
+  "subdevices": [
+    {
+      "type": "$TYPE_SWITCH",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x05",
+        "0xFC42"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/buttonevent",
+          "awake": true,
+          "parse": {
+            "cl": "0xFC42",
+            "cmd": "0x02",
+            "eval": "Item.val = (ZclFrame.at(0)+1) * 1000 + ZclFrame.at(1)"
+          }
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_COLOR_DIMMABLE_LIGHT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x05"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert",
+          "default": "none"
+        },
+        {
+          "name": "state/bri",
+          "refresh.interval": 5
+        },
+        {
+          "name": "state/colormode",
+        },
+        {
+          "name": "state/effect",
+          "default": "none"
+        },
+        {
+          "name": "state/hue",
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 5
+        },
+        {
+          "name": "state/reachable"
+        },
+        {
+          "name": "state/sat",
+          "refresh.interval": 5
+        },
+        {
+          "name": "state/x",
+          "refresh.interval": 5
+        },
+        {
+          "name": "state/y",
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_ON_OFF_LIGHT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x06"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert",
+          "default": "none"
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 5
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_DIMMABLE_LIGHT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x07"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert",
+          "default": "none"
+        },
+        {
+          "name": "state/bri",
+          "refresh.interval": 5
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 5
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    }
+  ]
+}

--- a/devices/siglis/zigfred_uno_wired_switch.json
+++ b/devices/siglis/zigfred_uno_wired_switch.json
@@ -54,7 +54,7 @@
           "parse": {
             "cl": "0xFC42",
             "cmd": "0x02",
-            "eval": "Item.val = (ZclFrame.at(0)+1) * 1000 + ZclFrame.at(1)"
+            "eval": "const eventLookup = [0x03, 0x00, 0x04, 0x01]; Item.val = (ZclFrame.at(0)+1) * 1000 + eventLookup[ZclFrame.at(1)]"
           }
         },
         {
@@ -103,35 +103,35 @@
         },
         {
           "name": "state/bri",
-          "refresh.interval": 5
+          "refresh.interval": 600
         },
         {
-          "name": "state/colormode",
+          "name": "state/colormode"
         },
         {
           "name": "state/effect",
           "default": "none"
         },
         {
-          "name": "state/hue",
+          "name": "state/hue"
         },
         {
           "name": "state/on",
-          "refresh.interval": 5
+          "refresh.interval": 600
         },
         {
           "name": "state/reachable"
         },
         {
           "name": "state/sat",
-          "refresh.interval": 5
+          "refresh.interval": 600
         },
         {
           "name": "state/x",
-          "refresh.interval": 5
+          "refresh.interval": 600
         },
         {
-          "name": "state/y",
+          "name": "state/y"
         }
       ]
     },
@@ -176,7 +176,7 @@
         },
         {
           "name": "state/on",
-          "refresh.interval": 5
+          "refresh.interval": 600
         },
         {
           "name": "state/reachable"
@@ -224,14 +224,104 @@
         },
         {
           "name": "state/bri",
-          "refresh.interval": 5
+          "refresh.interval": 600
         },
         {
           "name": "state/on",
-          "refresh.interval": 5
+          "refresh.interval": 600
         },
         {
           "name": "state/reachable"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 5,
+      "cl": "0x0006",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 1800
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 5,
+      "cl": "0x0008",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x20",
+          "min": 1,
+          "max": 1800,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 5,
+      "cl": "0x0300",
+      "report": [
+        {
+          "at": "0x0003",
+          "dt": "0x21",
+          "min": 5,
+          "max": 1800,
+          "change": "0x0000000A"
+        },
+        {
+          "at": "0x0004",
+          "dt": "0x21",
+          "min": 5,
+          "max": 1800,
+          "change": "0x0000000A"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 6,
+      "cl": "0x0006",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 1800
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 7,
+      "cl": "0x0006",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 1800
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 7,
+      "cl": "0x0008",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x20",
+          "min": 1,
+          "max": 1800,
+          "change": "0x00000001"
         }
       ]
     }


### PR DESCRIPTION
Initial support for zigfred uno and zigfred plus smart in-wall switches by Siglis.

This pull request builds upon and supersedes pull request GH-6280 and #6258

Many thanks go to @WhistleMaster and @Smanar for the initial code.


Best regards
Markus, Team zigfred