### PR TITLE
Fix Device code async state enter

### DIFF
--- a/event.cpp
+++ b/event.cpp
@@ -30,6 +30,7 @@ Event::Event()
     m_num = 0;
     m_numPrev = 0;
     m_hasData = 0;
+    m_urgent = 0;
 }
 
 Event::Event(const char *resource, const char *what, const QString &id, ResourceItem *item, DeviceKey deviceKey) :
@@ -39,7 +40,8 @@ Event::Event(const char *resource, const char *what, const QString &id, Resource
     m_num(0),
     m_numPrev(0),
     m_deviceKey(deviceKey),
-    m_hasData(0)
+    m_hasData(0),
+    m_urgent(0)
 {
     DBG_Assert(item != 0);
     if (item)
@@ -58,7 +60,8 @@ Event::Event(const char *resource, const char *what, const QString &id, DeviceKe
     m_num(0),
     m_numPrev(0),
     m_deviceKey(deviceKey),
-    m_hasData(0)
+    m_hasData(0),
+    m_urgent(0)
 {
 
 }
@@ -72,7 +75,8 @@ Event::Event(const char *resource, const char *what, const QString &id, int num,
     m_num(num),
     m_numPrev(0),
     m_deviceKey(deviceKey),
-    m_hasData(0)
+    m_hasData(0),
+    m_urgent(0)
 {
 
 }
@@ -85,7 +89,8 @@ Event::Event(const char *resource, const char *what, int num, DeviceKey deviceKe
     m_num(num),
     m_numPrev(0),
     m_deviceKey(deviceKey),
-    m_hasData(0)
+    m_hasData(0),
+    m_urgent(0)
 {
     if (resource == RGroups)
     {
@@ -97,7 +102,8 @@ Event::Event(const char *resource, const char *what, const void *data, size_t si
     m_resource(resource),
     m_what(what),
     m_deviceKey(deviceKey),
-    m_hasData(1)
+    m_hasData(1),
+    m_urgent(0)
 {
     Q_ASSERT(data);
     Q_ASSERT(size > 0 && size <= MaxEventDataSize);

--- a/event.h
+++ b/event.h
@@ -30,6 +30,8 @@ public:
     bool hasData() const;
     quint16 dataSize() const { return m_dataSize; }
     bool getData(void *dst, size_t size) const;
+    bool isUrgent() const { return m_urgent == 1; }
+    void setUrgent(bool urgent) { m_urgent = urgent ? 1 : 0; }
 
 private:
     const char *m_resource = nullptr;
@@ -54,7 +56,8 @@ private:
     struct
     {
         unsigned char m_hasData : 1;
-        unsigned char _pad : 7;
+        unsigned char m_urgent : 1;
+        unsigned char _pad : 6;
     };
 };
 

--- a/event_emitter.cpp
+++ b/event_emitter.cpp
@@ -16,6 +16,26 @@
 
 static EventEmitter *instance_ = nullptr;
 
+static bool isDuplicate(size_t pos, const std::vector<Event> &queue, const Event &e)
+{
+    for (size_t i = pos; i < queue.size(); i++)
+    {
+        const Event &x = queue[i];
+
+        if (e.deviceKey() != x.deviceKey()) {continue;}
+        if (e.resource() != x.resource()) continue;
+        if (e.what() != x.what()) continue;
+        if (e.num() != x.num()) continue;
+        if (e.id() != x.id()) continue;
+        if (e.hasData() != x.hasData()) continue;
+        if (e.hasData() && e.dataSize() != x.dataSize()) continue;
+
+        return true;
+    }
+
+    return false;
+}
+
 EventEmitter::EventEmitter(QObject *parent) :
     QObject(parent)
 {
@@ -23,7 +43,7 @@ EventEmitter::EventEmitter(QObject *parent) :
 
     m_timer = new QTimer(this);
     m_timer->setSingleShot(true);
-    m_timer->setInterval(1);
+    m_timer->setInterval(0);
     connect(m_timer, &QTimer::timeout, this, &EventEmitter::timerFired);
 
     Q_ASSERT(instance_ == nullptr);
@@ -52,15 +72,25 @@ void EventEmitter::enqueueEvent(const Event &event)
         }
     }
 
-    if (restNode && restNode->address().ext() > 0)
+    if (event.isUrgent())
     {
-        Event e2 = event;
-        e2.setDeviceKey(restNode->address().ext());
-        m_queue.push_back(e2);
+        m_urgentQueue.push_back(event);
     }
     else
     {
-        m_queue.push_back(event);
+        if (restNode && restNode->address().ext() > 0)
+        {
+            Event e2 = event;
+            e2.setDeviceKey(restNode->address().ext());
+            if (!isDuplicate(m_pos, m_queue, e2))
+            {
+                m_queue.push_back(e2);
+            }
+        }
+        else if (!isDuplicate(m_pos, m_queue, event))
+        {
+            m_queue.push_back(event);
+        }
     }
 
     if (!m_timer->isActive())
@@ -74,22 +104,45 @@ EventEmitter::~EventEmitter()
     instance_ = nullptr;
 }
 
-void EventEmitter::timerFired()
+void EventEmitter::process()
 {
     QElapsedTimer t;
     t.start();
-    while (m_pos < m_queue.size() && t.elapsed() < 10)
+
+    while (t.elapsed() < 10 && (m_urgentQueue.size() || m_queue.size()))
     {
-        emit eventNotify(m_queue[m_pos]);
-        m_pos++;
-        if (m_pos == m_queue.size())
+        size_t i = 0;
+        while (i < m_urgentQueue.size())
         {
-            m_queue.clear();
-            m_pos = 0;
+            emit eventNotify(m_urgentQueue[i]);
+            i++;
+
+            if (i == m_urgentQueue.size())
+            {
+                m_urgentQueue.clear();
+                break;
+            }
+        }
+
+        DBG_Assert(m_urgentQueue.empty());
+        if (m_pos < m_queue.size())
+        {
+            m_pos++;
+            emit eventNotify(m_queue[m_pos - 1]);
+            if (m_pos == m_queue.size())
+            {
+                m_queue.clear();
+                m_pos = 0;
+            }
         }
     }
+}
 
-    if (!m_queue.empty())
+void EventEmitter::timerFired()
+{
+    process();
+
+    if (!m_queue.empty() && !m_timer->isActive())
     {
         m_timer->start();
     }

--- a/event_emitter.h
+++ b/event_emitter.h
@@ -28,6 +28,7 @@ public:
     ~EventEmitter();
 
 public Q_SLOTS:
+    void process();
     void enqueueEvent(const Event &event);
     void timerFired();
 
@@ -38,6 +39,7 @@ private:
     size_t m_pos = 0;
     QTimer *m_timer = nullptr;
     std::vector<Event> m_queue;
+    std::vector<Event> m_urgentQueue;
 };
 
 #endif // EVENT_EMITTER_H


### PR DESCRIPTION
This was a tricky one. A state handler function must not process any events before the `state.enter` event arrives. Since this event is delivered asynchronously, to not blow up the stack if another state is entered from this event, we could get into troubles and invalid state if other events arrive before the enter event was handled.

- The PR processes all `state.enter` events (marked as urgent) before any other events.
- Removed the dead code for start/stop timer events.
- The event queue drops duplicated events now, so we don't have multiple awake events and similar floating around.
- Speedup of processing events directly after an APS request is processed. No need to wait for the idle timer.