### PR TITLE
Expedite state changes via optional write function attribute `state.timeout`

### DIFF
--- a/device_ddf_init.cpp
+++ b/device_ddf_init.cpp
@@ -257,9 +257,18 @@ bool DEV_InitDeviceFromDescription(Device *device, const DeviceDescription &ddf)
 
                 if (writeFunction.isEmpty() || writeFunction == QLatin1String("zcl"))
                 {
+                    bool ok;
+                    const auto stateTimeout = ddfItem.writeParameters.toMap()[QLatin1String("state.timeout")].toUInt(&ok);
+                    
                     StateChange stateChange(StateChange::StateWaitSync, SC_WriteZclAttribute, sub.uniqueId.at(1).toUInt());
                     stateChange.addTargetValue(item->descriptor().suffix, item->toVariant());
                     stateChange.setChangeTimeoutMs(1000 * 60 * 60);
+
+                    if (ok && stateTimeout > 0)
+                    {
+                        stateChange.setStateTimeoutMs(1000 * stateTimeout);
+                    }
+
                     rsub->addStateChange(stateChange);
                 }
             }

--- a/device_ddf_init.cpp
+++ b/device_ddf_init.cpp
@@ -262,7 +262,7 @@ bool DEV_InitDeviceFromDescription(Device *device, const DeviceDescription &ddf)
                     stateChange.addTargetValue(item->descriptor().suffix, item->toVariant());
                     stateChange.setChangeTimeoutMs(1000 * 60 * 60);
 
-                    if (writeParam.contains(QLatin1String("state.timeout"))
+                    if (writeParam.contains(QLatin1String("state.timeout")))
                     {
                         int stateTimeout = writeParam.value(QLatin1String("state.timeout")).toInt(&ok);
 

--- a/device_ddf_init.cpp
+++ b/device_ddf_init.cpp
@@ -247,26 +247,29 @@ bool DEV_InitDeviceFromDescription(Device *device, const DeviceDescription &ddf)
             if (!ddfItem.defaultValue.isNull() && !ddfItem.writeParameters.isNull())
             {
                 QString writeFunction;
+                const auto writeParam = ddfItem.writeParameters.toMap();
+                
+                if (writeParam.contains(QLatin1String("fn")))
                 {
-                    const auto writeParam = ddfItem.writeParameters.toMap();
-                    if (writeParam.contains(QLatin1String("fn")))
-                    {
-                        writeFunction = writeParam.value(QLatin1String("fn")).toString();
-                    }
+                    writeFunction = writeParam.value(QLatin1String("fn")).toString();
                 }
 
                 if (writeFunction.isEmpty() || writeFunction == QLatin1String("zcl"))
                 {
                     bool ok;
-                    const auto stateTimeout = ddfItem.writeParameters.toMap()[QLatin1String("state.timeout")].toUInt(&ok);
                     
                     StateChange stateChange(StateChange::StateWaitSync, SC_WriteZclAttribute, sub.uniqueId.at(1).toUInt());
                     stateChange.addTargetValue(item->descriptor().suffix, item->toVariant());
                     stateChange.setChangeTimeoutMs(1000 * 60 * 60);
 
-                    if (ok && stateTimeout > 0)
+                    if (writeParam.contains(QLatin1String("state.timeout"))
                     {
-                        stateChange.setStateTimeoutMs(1000 * stateTimeout);
+                        int stateTimeout = writeParam.value(QLatin1String("state.timeout")).toInt(&ok);
+
+                        if (ok && stateTimeout > 0)
+                        {
+                            stateChange.setStateTimeoutMs(1000 * stateTimeout);
+                        }
                     }
 
                     rsub->addStateChange(stateChange);

--- a/devices/xiaomi/xiaomi_rtcgq14lm_p1_presence_sensor.json
+++ b/devices/xiaomi/xiaomi_rtcgq14lm_p1_presence_sensor.json
@@ -81,11 +81,12 @@
           "refresh.interval": 3600,
           "awake": true,
           "parse": {
-            "at": "0xff07",
+            "at": "0x0102",
+            "cl": "0xFCC0",
             "ep": 1,
             "eval": "Item.val = Attr.val",
-            "fn": "xiaomi:special",
-            "idx": "0x69"
+            "fn": "zcl",
+            "mf": "0x115F"
           },
           "read": {
             "at": "0x0102",
@@ -101,7 +102,8 @@
             "ep": 1,
             "eval": "Item.val",
             "fn": "zcl",
-            "mf": "0x115F"
+            "mf": "0x115F",
+            "state.timeout": 2
           },
           "range": [1, 200],
           "default": 30
@@ -111,11 +113,12 @@
           "refresh.interval": 3600,
           "awake": true,
           "parse": {
-            "at": "0xff07",
+            "at": "0x0152",
+            "cl": "0xFCC0",
             "ep": 1,
             "eval": "Item.val = Attr.val",
-            "fn": "xiaomi:special",
-            "idx": "0x6b"
+            "fn": "zcl",
+            "mf": "0x115F"
           },
           "read": {
             "at": "0x0152",
@@ -131,7 +134,8 @@
             "ep": 1,
             "eval": "Item.val",
             "fn": "zcl",
-            "mf": "0x115F"
+            "mf": "0x115F",
+            "state.timeout": 2
           },
           "values": [
             [true, "Device flashes on presence"],
@@ -150,11 +154,12 @@
           "refresh.interval": 3600,
           "awake": true,
           "parse": {
-            "at": "0xff07",
+            "at": "0x010C",
+            "cl": "0xFCC0",
             "ep": 1,
             "eval": "Item.val = Attr.val",
-            "fn": "xiaomi:special",
-            "idx": "0x6a"
+            "fn": "zcl",
+            "mf": "0x115F"
           },
           "read": {
             "at": "0x010C",
@@ -170,7 +175,8 @@
             "ep": 1,
             "eval": "Item.val",
             "fn": "zcl",
-            "mf": "0x115F"
+            "mf": "0x115F",
+            "state.timeout": 2
           },
           "values": [
             [1, "Low"],
@@ -272,11 +278,12 @@
           "refresh.interval": 3600,
           "awake": true,
           "parse": {
-            "at": "0xff07",
+            "at": "0x0152",
+            "cl": "0xFCC0",
             "ep": 1,
             "eval": "Item.val = Attr.val",
-            "fn": "xiaomi:special",
-            "idx": "0x6b"
+            "fn": "zcl",
+            "mf": "0x115F"
           },
           "read": {
             "at": "0x0152",
@@ -292,7 +299,8 @@
             "ep": 1,
             "eval": "Item.val",
             "fn": "zcl",
-            "mf": "0x115F"
+            "mf": "0x115F",
+            "state.timeout": 2
           },
           "values": [
             [true, "Device flashes on presence"],

--- a/devices/xiaomi/xiaomi_wrs-r02_h1_switch.json
+++ b/devices/xiaomi/xiaomi_wrs-r02_h1_switch.json
@@ -109,7 +109,8 @@
             "ep": 1,
             "eval": "if (Item.val == 'highspeed') { 1 } else if (Item.val == 'multiclick') { 2 }",
             "fn": "zcl",
-            "mf": "0x115f"
+            "mf": "0x115f",
+            "state.timeout": 2
           },
           "values": [
             ["\"highspeed\"", "Buttons emit only single click events, but fast"],
@@ -142,7 +143,8 @@
             "ep": 1,
             "eval": "if (Item.val == 'compatibility') { 1 } else if (Item.val == 'zigbee') { 2 }",
             "fn": "zcl",
-            "mf": "0x115f"
+            "mf": "0x115f",
+            "state.timeout": 2
           },
           "values": [
             ["\"compatibility\"", "Default mode for Xiaomi devices"],

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -791,11 +791,19 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                 }
                 
                 const auto &ddfItem = DDF_GetItem(item);
-                const auto stateTimeout = ddfItem.writeParameters.toMap()[QLatin1String("state.timeout")].toUInt(&ok);
                 
-                if (ok && stateTimeout > 0)
+                if (!ddfItem.writeParameters.isNull())
                 {
-                    change.setStateTimeoutMs(1000 * stateTimeout);
+                    const auto writeParam = ddfItem.writeParameters.toMap();
+                    if (writeParam.contains(QLatin1String("state.timeout"))
+                    {
+                        int stateTimeout = writeParam.value(QLatin1String("state.timeout")).toInt(&ok);
+
+                        if (ok && stateTimeout > 0)
+                        {
+                            change.setStateTimeoutMs(1000 * stateTimeout);
+                        }
+                    }
                 }
 
                 if (sensor->modelId().startsWith(QLatin1String("SPZB")) && hostFlags == 0) // Eurotronic Spirit

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -789,6 +789,14 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                                                QString("invalid value, %1, for parameter %2").arg(map[pi.key()].toString()).arg(pi.key())));
                     continue;
                 }
+                
+                const auto &ddfItem = DDF_GetItem(item);
+                const auto stateTimeout = ddfItem.writeParameters.toMap()[QLatin1String("state.timeout")].toUInt(&ok);
+                
+                if (ok && stateTimeout > 0)
+                {
+                    change.setStateTimeoutMs(1000 * stateTimeout);
+                }
 
                 if (sensor->modelId().startsWith(QLatin1String("SPZB")) && hostFlags == 0) // Eurotronic Spirit
                 {

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -795,7 +795,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                 if (!ddfItem.writeParameters.isNull())
                 {
                     const auto writeParam = ddfItem.writeParameters.toMap();
-                    if (writeParam.contains(QLatin1String("state.timeout"))
+                    if (writeParam.contains(QLatin1String("state.timeout")))
                     {
                         int stateTimeout = writeParam.value(QLatin1String("state.timeout")).toInt(&ok);
 

--- a/state_change.h
+++ b/state_change.h
@@ -114,6 +114,7 @@ public:
     const std::vector<Param> &parameters() const { return m_parameters; }
     quint8 dstEndpoint() const { return m_dstEndpoint; }
     void setChangeTimeoutMs(int timeout) { m_changeTimeoutMs = timeout; }
+    void setStateTimeoutMs(int timeout) { m_stateTimeoutMs = timeout; }
 
 private:
     State m_state = StateCallFunction;

--- a/xiaomi.cpp
+++ b/xiaomi.cpp
@@ -173,11 +173,11 @@ void DeRestPluginPrivate::handleZclAttributeReportIndicationXiaomiSpecial(const 
         Device *device = DEV_GetDevice(m_devices, ind.srcAddress().ext());
         if (device)
         {
+            enqueueEvent(Event(device->prefix(), REventAwake, 0, device->key()));
             if (device->managed())
             {
                 return;
             }
-            enqueueEvent(Event(device->prefix(), REventAwake, 0, device->key()));
         }
     }
 

--- a/xiaomi.cpp
+++ b/xiaomi.cpp
@@ -173,11 +173,11 @@ void DeRestPluginPrivate::handleZclAttributeReportIndicationXiaomiSpecial(const 
         Device *device = DEV_GetDevice(m_devices, ind.srcAddress().ext());
         if (device)
         {
-            enqueueEvent(Event(device->prefix(), REventAwake, 0, device->key()));
             if (device->managed())
             {
                 return;
             }
+            enqueueEvent(Event(device->prefix(), REventAwake, 0, device->key()));
         }
     }
 


### PR DESCRIPTION
Primarily Xiaomi sleeping enddevices with configuration options benefit from this change. However, this one might come in handy for other devices as well where timing is important.

An item write frunction can now be extended by the `state.timeout` attribute, where its value is expressed in seconds:
```
"write": {
     "at": "0x0152",
     "cl": "0xFCC0",
     "dt": "0x20",
     "ep": 1,
     "eval": "Item.val",
     "fn": "zcl",
     "mf": "0x115F",
     "state.timeout": 2
}
```

This allows to overwrite the internal timeout of a change (5 seconds). The current state flow would be: _read -> after 5 seconds write -> after 5 seconds read (to verify)_. As many Xiaomi battery powered devices are deep sleepers usually waking up roughly every 50 mins or upon button press, there's only a tiny timeframe (4 - 6 seconds) to interact with it. For the flow mentioned above, this is too less. Overwriting the timeout, the flow will be _read -> after 2 seconds write -> after 2 seconds read (to verify)_. So there's now a very high chance a state change completes at least read and write when the device is awake.