### PR TITLE
DDF fix ROB_200-029-0 - Roller Shutter Switch

### DIFF
--- a/devices/robb_smarrt/rob_200-029-0_covering.json
+++ b/devices/robb_smarrt/rob_200-029-0_covering.json
@@ -1,0 +1,73 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "ROBB smarrt",
+  "modelid": "ROB_200-029-0",
+  "product": "ROB_200-029-0",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_WINDOW_COVERING_DEVICE",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/lift"
+        },
+        {
+          "name": "state/open"
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0102",
+      "report": [
+        {
+          "at": "0x0008",
+          "dt": "0x20",
+          "min": 1,
+          "max": 300,
+          "change": "0x00000001"
+        }
+      ]
+    }
+  ]
+}

--- a/devices/robb_smarrt/rob_200-029-0_covering.json
+++ b/devices/robb_smarrt/rob_200-029-0_covering.json
@@ -2,7 +2,7 @@
   "schema": "devcap1.schema.json",
   "manufacturername": "ROBB smarrt",
   "modelid": "ROB_200-029-0",
-  "product": "ROB_200-029-0",
+  "product": "Roller Shutter Switch",
   "sleeper": false,
   "status": "Gold",
   "subdevices": [


### PR DESCRIPTION
This device have 2 clusters set, covering and on/off/setlevel and have as type "Dimmable light"
See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/6283