### PR TITLE
DDF: Promote woox_r7060_ts0101 Gold

### DIFF
--- a/devices/woox/woox_r7060_ts0101.json
+++ b/devices/woox/woox_r7060_ts0101.json
@@ -5,7 +5,7 @@
   "vendor": "WOOX",
   "product": "TS0101",
   "sleeper": false,
-  "status": "Bronze",
+  "status": "Gold",
   "path": "/devices/ts0101.json",
   "subdevices": [
     {


### PR DESCRIPTION
Is it possible to promote the "Woox R7060 Smart Garden Irrigation Control" DDF to Gold? 

I've got 4 of these and they have two issues with the legacy implementation. Both are solved with using the DDF for this device:

- Battery status is not present in the legacy support, but is there in de DDF
- On reboot of deconz, the device is unresponsive to on/off from deconz, and requires a push of a button on the physical device for commands from deconz to work again. With the DDF, the device on/off calls responds as it should after a reboot.

I've been reading up on https://github.com/dresden-elektronik/deconz-rest-plugin/issues/4325 for a solution to both of these problems and I've solved it by just using this DDF