### PR TITLE
Fix JS padStart polyfill

### DIFF
--- a/device_js/device_js.cpp
+++ b/device_js/device_js.cpp
@@ -31,7 +31,7 @@ public:
 };
 
 // Polyfills for older Qt versions
-static const char *PF_String_prototype_padStart = "String.prototype.padString = String.prototype.padString || "
+static const char *PF_String_prototype_padStart = "String.prototype.padStart = String.prototype.padStart || "
                                      "function (targetLength, padString) { return Utils.padStart(this, targetLength, padString); } ";
 static const char *PF_Math_log10 = "Math.log10 = Math.log10 || function(x) { return Utils.log10(x) };";
 


### PR DESCRIPTION
The prototype method is padStart not padString.