### PR TITLE
Add support for _TZ3000_otvn3lne presence sensor (and other 0x0500 IAS cluster Tuya sensors).

### DIFF
--- a/devices/tuya/ts0202_presence_sensor.json
+++ b/devices/tuya/ts0202_presence_sensor.json
@@ -1,8 +1,8 @@
 {
    "schema":"devcap1.schema.json",
-   "manufacturername":"_TZ3000_msl6wxk9",
-   "modelid":"TS0202",
-   "product":"_TZ3000_MSL6wxk9 Presence sensor",
+   "manufacturername": ["_TZ3000_msl6wxk9", "_TZ3000_otvn3lne"],
+   "modelid":["TS0202", "TS0202"],
+   "product":"TS0202 Presence sensor",
    "sleeper":true,
    "status":"Gold",
    "subdevices":[
@@ -51,15 +51,13 @@
             },
             {
                "name":"config/enrolled",
-               "public":false,
-               "description":"State of IAS enrollment process."
+               "public":false
             },
             {
                "name":"config/on"
             },
             {
-               "name":"config/pending",
-               "description":"Pending tasks to configure the device."
+               "name":"config/pending"
             },
             {
                "name":"config/reachable"
@@ -68,8 +66,7 @@
                "name":"state/lastupdated"
             },
             {
-               "name":"state/lowbattery",
-               "description":"True when the device battery runs low."
+               "name":"state/lowbattery"
             },
             {
                "name":"state/presence",


### PR DESCRIPTION
Add support for the _TZ3000_otvn3lne_presence_sensor.json
This is a relatively new sensor from Tuya, but follows the style of using an IAS Zone cluster at 0x500 rather than at 0x0406.
Tested as working on two examples of the sensor using a Conbee II.
Created using the DDF tool in the deconz app, and not externally edited.
