### PR TITLE
Add DDF for black namron thermostat

### DIFF
--- a/devices/namron/4512737_thermostat.json
+++ b/devices/namron/4512737_thermostat.json
@@ -1,7 +1,7 @@
 {
   "schema": "devcap1.schema.json",
-  "manufacturername": "NAMRON AS",
-  "modelid": "4512737",
+  "manufacturername": ["NAMRON AS", "NAMRON AS"],
+  "modelid": ["4512737", "4512738"],
   "product": "Thermostat Touch Zigbee 16A",
   "sleeper": false,
   "status": "Gold",


### PR DESCRIPTION
This is the same thermostat as the 4512737, but the model is black and thus has another model identifier: (4512738).

Product name: Namron termostat touch ZigBee 16A
Manufacturer: Namron AS
Model identifier: 4512738
Device type : Thermostat

Note that this is the same DDF as the white model, just with the updated modelId. 