### PR TITLE
Preparations for further DDFs

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1459,6 +1459,10 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
                     {
                         sensorNode = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), 0x05);
                     }
+                    else if (sensorNode->modelId() == QLatin1String("RM01"))
+                    {
+                        sensorNode = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), 0x0A);
+                    }
                     else if (sensorNode->modelId() == QLatin1String("lumi.switch.l2aeu1") || sensorNode->modelId() == QLatin1String("lumi.switch.n2aeu1"))
                     {
                         sensorNode = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), 0x29);

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1206,7 +1206,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                         QByteArray tuyaData = QByteArray("\x00\x00", 2);
                         qint8 dp = DP_IDENTIFIER_THERMOSTAT_HEATSETPOINT;
 
-					    if (R_GetProductId(sensor) == QLatin1String("Tuya_THD BRT-100"))
+                        if (R_GetProductId(sensor) == QLatin1String("Tuya_THD BRT-100"))
                         {
                             data.integer = data.integer / 10;
 
@@ -1861,37 +1861,55 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                 }
                 else if (rid.suffix == RConfigPulseConfiguration) // Unsigned integer
                 {
-                    if (data.uinteger <= UINT16_MAX &&
-                        addTaskSimpleMeteringReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, METERING_ATTRID_PULSE_CONFIGURATION, deCONZ::Zcl16BitUint, data.uinteger, VENDOR_DEVELCO))
+                    if (!devManaged)
                     {
+                        if (data.uinteger <= UINT16_MAX &&
+                        addTaskSimpleMeteringReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, METERING_ATTRID_PULSE_CONFIGURATION, deCONZ::Zcl16BitUint, data.uinteger, VENDOR_DEVELCO))
+                        {
+                            updated = true;
+                        }
+                    }
+                    else if (devManaged && rsub)
+                    {
+                        change.addTargetValue(rid.suffix, data.uinteger);
+                        rsub->addStateChange(change);
                         updated = true;
                     }
                 }
                 else if (rid.suffix == RConfigInterfaceMode) // Unsigned integer
                 {
-                    if (sensor->modelId().startsWith(QLatin1String("ZHEMI101")))
+                    if (!devManaged)
                     {
-                        const auto match = matchKeyValue(data.uinteger, RConfigInterfaceModeValuesZHEMI);
-
-                        if (match.key)
+                        if (sensor->modelId().startsWith(QLatin1String("ZHEMI101")))
                         {
-                            if (addTaskSimpleMeteringReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, METERING_ATTRID_INTERFACE_MODE, deCONZ::Zcl16BitEnum, match.value, VENDOR_DEVELCO))
+                            const auto match = matchKeyValue(data.uinteger, RConfigInterfaceModeValuesZHEMI);
+
+                            if (match.key)
                             {
-                                updated = true;
+                                if (addTaskSimpleMeteringReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, METERING_ATTRID_INTERFACE_MODE, deCONZ::Zcl16BitEnum, match.value, VENDOR_DEVELCO))
+                                {
+                                    updated = true;
+                                }
+                            }
+                        }
+                        else if (sensor->modelId().startsWith(QLatin1String("EMIZB-1")))
+                        {
+                            const auto match = matchKeyValue(data.uinteger, RConfigInterfaceModeValuesEMIZB);
+
+                            if (match.key)
+                            {
+                                if (addTaskSimpleMeteringReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, METERING_ATTRID_INTERFACE_MODE, deCONZ::Zcl16BitEnum, match.value, VENDOR_DEVELCO))
+                                {
+                                    updated = true;
+                                }
                             }
                         }
                     }
-                    else if (sensor->modelId().startsWith(QLatin1String("EMIZB-1")))
+                    else if (devManaged && rsub)
                     {
-                        const auto match = matchKeyValue(data.uinteger, RConfigInterfaceModeValuesEMIZB);
-
-                        if (match.key)
-                        {
-                            if (addTaskSimpleMeteringReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, METERING_ATTRID_INTERFACE_MODE, deCONZ::Zcl16BitEnum, match.value, VENDOR_DEVELCO))
-                            {
-                                updated = true;
-                            }
-                        }
+                        change.addTargetValue(rid.suffix, data.uinteger);
+                        rsub->addStateChange(change);
+                        updated = true;
                     }
                 }
                 if (rid.suffix == RConfigWindowCoveringType) // Unsigned integer


### PR DESCRIPTION
This PR is intended to:
- Allow for a single resource BJ RM01 switch
- Allow usage of state changes for `config/pulseconfiguration` and `config/interfacemode` when setting values via API