### PR TITLE
DDF: Linkind A60 LED Tunable White Bulb 800 lumen

### DIFF
--- a/devices/linkind/ZBT-CCTLight-D0106.json
+++ b/devices/linkind/ZBT-CCTLight-D0106.json
@@ -5,7 +5,7 @@
   "product": "Linkind A60 LED Tunable White Bulb 800 lumen",
   "sleeper": false,
   "status": "Gold",
-  "path": "/devices/Linkind_zbt-cctlight-d0106.json",
+  "path": "",
   "subdevices": [
     {
       "type": "$TYPE_COLOR_TEMPERATURE_LIGHT",

--- a/devices/linkind/ZBT-CCTLight-D0106.json
+++ b/devices/linkind/ZBT-CCTLight-D0106.json
@@ -1,0 +1,121 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "lk",
+  "modelid": "ZBT-CCTLight-D0106",
+  "product": "Linkind A60 LED Tunable White Bulb 800 lumen",
+  "sleeper": false,
+  "status": "Gold",
+  "path": "/devices/Linkind_zbt-cctlight-d0106.json",
+  "subdevices": [
+    {
+      "type": "$TYPE_COLOR_TEMPERATURE_LIGHT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/ctmax",
+          "refresh.interval": 84000
+        },
+        {
+          "name": "config/ctmin",
+          "refresh.interval": 84000
+        },
+        {
+          "name": "state/alert",
+          "default": "none"
+        },
+        {
+          "name": "state/bri",
+          "refresh.interval": 5
+        },
+        {
+          "name": "state/colormode"
+        },
+        {
+          "name": "state/ct",
+          "refresh.interval": 5
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 5
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0006",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 300
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0008",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x20",
+          "min": 1,
+          "max": 300,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0300",
+      "report": [
+        {
+          "at": "0x0007",
+          "dt": "0x21",
+          "min": 1,
+          "max": 300,
+          "change": "0x0005"
+        }
+      ]
+    }
+  ]
+}

--- a/devices/linkind/ZBT-CCTLight-D0106.json
+++ b/devices/linkind/ZBT-CCTLight-D0106.json
@@ -5,7 +5,6 @@
   "product": "Linkind A60 LED Tunable White Bulb 800 lumen",
   "sleeper": false,
   "status": "Gold",
-  "path": "",
   "subdevices": [
     {
       "type": "$TYPE_COLOR_TEMPERATURE_LIGHT",


### PR DESCRIPTION
Linkind A60 LED Tunable White Bulb 800 lumen, works here.
Available on Amazon for €10.