### PR TITLE
Expose change timeout via optional write function attribute `change.timeout`

### DIFF
--- a/devices/xiaomi/xiaomi_jtqj-bf-01lm_gas_leak_detector.json
+++ b/devices/xiaomi/xiaomi_jtqj-bf-01lm_gas_leak_detector.json
@@ -101,6 +101,7 @@
           },
           "write": {
             "at": "0xFFF1",
+            "change.timeout": 60,
             "cl": "0x0500",
             "dt": "0x23",
             "ep": 1,
@@ -133,6 +134,7 @@
           },
           "write": {
             "at": "0xFFF1",
+            "change.timeout": 600,
             "cl": "0x0500",
             "dt": "0x23",
             "ep": 1,

--- a/devices/xiaomi/xiaomi_jtyj-gd-01lm_smoke_detector.json
+++ b/devices/xiaomi/xiaomi_jtyj-gd-01lm_smoke_detector.json
@@ -100,6 +100,7 @@
           },
           "write": {
             "at": "0xFFF1",
+            "change.timeout": 60,
             "cl": "0x0500",
             "dt": "0x23",
             "ep": 1,
@@ -132,6 +133,7 @@
           },
           "write": {
             "at": "0xFFF1",
+            "change.timeout": 600,
             "cl": "0x0500",
             "dt": "0x23",
             "ep": 1,

--- a/devices/xiaomi/xiaomi_rtcgq14lm_p1_presence_sensor.json
+++ b/devices/xiaomi/xiaomi_rtcgq14lm_p1_presence_sensor.json
@@ -97,6 +97,7 @@
           },
           "write": {
             "at": "0x0102",
+            "change.timeout": 3600,
             "cl": "0xFCC0",
             "dt": "0x20",
             "ep": 1,
@@ -129,6 +130,7 @@
           },
           "write": {
             "at": "0x0152",
+            "change.timeout": 3600,
             "cl": "0xFCC0",
             "dt": "0x20",
             "ep": 1,
@@ -170,6 +172,7 @@
           },
           "write": {
             "at": "0x010C",
+            "change.timeout": 3600,
             "cl": "0xFCC0",
             "dt": "0x20",
             "ep": 1,
@@ -294,6 +297,7 @@
           },
           "write": {
             "at": "0x0152",
+            "change.timeout": 3600,
             "cl": "0xFCC0",
             "dt": "0x20",
             "ep": 1,

--- a/devices/xiaomi/xiaomi_wrs-r02_h1_switch.json
+++ b/devices/xiaomi/xiaomi_wrs-r02_h1_switch.json
@@ -104,6 +104,7 @@
           },
           "write": {
             "at": "0x0125",
+            "change.timeout": 3600,
             "cl": "0xfcc0",
             "dt": "0x20",
             "ep": 1,
@@ -138,6 +139,7 @@
           },
           "write": {
             "at": "0x0009",
+            "change.timeout": 3600,
             "cl": "0xfcc0",
             "dt": "0x20",
             "ep": 1,

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -804,6 +804,16 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                             change.setStateTimeoutMs(1000 * stateTimeout);
                         }
                     }
+                    
+                    if (writeParam.contains(QLatin1String("change.timeout")))
+                    {
+                        int changeTimeout = writeParam.value(QLatin1String("change.timeout")).toInt(&ok);
+
+                        if (ok && changeTimeout > 0)
+                        {
+                            change.setChangeTimeoutMs(1000 * changeTimeout);
+                        }
+                    }
                 }
 
                 if (sensor->modelId().startsWith(QLatin1String("SPZB")) && hostFlags == 0) // Eurotronic Spirit
@@ -970,7 +980,6 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                     if (devManaged && rsub)
                     {
                         change.addTargetValue(rid.suffix, data.boolean);
-                        change.setChangeTimeoutMs(60000);    // 1 min
                         rsub->addStateChange(change);
                         updated = true;
                     }


### PR DESCRIPTION
This PR is intended to allow for "external" control over the state change lifetime, which might be especially relevant for deep sleeping enddevices.

The internal default settings are 180 seconds to have a state change completed. However, if you want to change the configuration on a battery Xiaomi device via API, this is not long enough if you don't want to be forced to push the button on the device to wake it up, as they're only able to receive data only once every 50 mins. With the new attribute, the lifetime can be set at will and the relevant Xiaomi DDFs will get a lifetime of 60 mins. That should be sufficient to complete the change (but does not necessarily omit the physical button press).