### PR TITLE
DDf, add support for doorlock EasyAccess EasyFingerTouch

### DIFF
--- a/devices/easyaccess/easyfingertouch_doorlock.json
+++ b/devices/easyaccess/easyfingertouch_doorlock.json
@@ -12,7 +12,8 @@
       "restapi": "/sensors",
       "uuid": [
         "$address.ext",
-        "0x0b"
+        "0x0b",
+        "0x0101"
       ],
       "items": [
         {

--- a/devices/easyaccess/easyfingertouch_doorlock.json
+++ b/devices/easyaccess/easyfingertouch_doorlock.json
@@ -6,7 +6,6 @@
   "product": "EasyFingerTouch",
   "sleeper": false,
   "status": "Gold",
-  "path": "/devices/easyfingertouch.json",
   "subdevices": [
     {
       "type": "ZHADoorLock",

--- a/devices/easyaccess/easyfingertouch_doorlock.json
+++ b/devices/easyaccess/easyfingertouch_doorlock.json
@@ -1,0 +1,152 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "Onesti Products AS",
+  "modelid": "EasyFingerTouch",
+  "vendor": "EasyAccess",
+  "product": "EasyFingerTouch",
+  "sleeper": false,
+  "status": "Gold",
+  "path": "/devices/easyfingertouch.json",
+  "subdevices": [
+    {
+      "type": "ZHADoorLock",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x0b"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "read": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 11,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 11,
+            "eval": "Item.val = Attr.val/2",
+            "fn": "zcl"
+          },
+          "default": 0
+        },
+        {
+          "name": "config/lock",
+          "read": {
+            "at": "0x0000",
+            "cl": "0x0101",
+            "ep": 11,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0000",
+            "cl": "0x0101",
+            "ep": 11,
+            "eval": "Item.val = Attr.val ==1",
+            "fn": "zcl"
+          }
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/lockstate",
+          "read": {
+            "at": "0x0000",
+            "cl": "0x0101",
+            "ep": 11,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0000",
+            "cl": "0x0101",
+            "ep": 11,
+            "eval": "if (Attr.val == 0) { Item.val = 'not fully locked' } else if (Attr.val == 1) { Item.val = 'locked' } else if (Attr.val == 2) { Item.val = 'unlocked' } else { Item.val = 'undefined' }",
+            "fn": "zcl"
+          }
+        },
+        {
+          "name": "state/open",
+          "read": {
+            "at": "0x0003",
+            "cl": "0x0101",
+            "ep": 11,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0003",
+            "cl": "0x0101",
+            "ep": 11,
+            "eval": "Item.val = Attr.val !=1",
+            "fn": "zcl"
+          }
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 11,
+      "cl": "0x0101",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x30",
+          "min": 1,
+          "max": 300
+        },
+        {
+          "at": "0x0003",
+          "dt": "0x30",
+          "min": 1,
+          "max": 300
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 11,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 300,
+          "max": 2700,
+          "change": "0x00000001"
+        }
+      ]
+    }
+  ]
+}

--- a/devices/generic/subdevices/door_lock.json
+++ b/devices/generic/subdevices/door_lock.json
@@ -1,10 +1,10 @@
 {
     "schema": "subdevice1.schema.json",
-    "type": "$TYPE_DOOR_LOCK",
+    "type": "ZHADoorLock",
     "name": "Door Lock",
     "restapi": "/sensors",
     "order": 11,
-    "uuid": ["$address.ext", "0x01"],
+    "uuid": ["$address.ext", "0x01", "0x0101"],
     "items": [
         "config/lock",
         "state/reachable",


### PR DESCRIPTION
See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/5870
- Product name: EasyAccess EasyFingerTouch
- Manufacturer: Onesti Products AS
- Model identifier: EasyFingerTouch

This DDF is for sensor version (ZHADoorlock) it expose :
- config/lock to unlock lock the device
- state/lockstate that can be not fully locked/locked/unlocked/undefined
- state/open that say if the door is open or not

This device don't have poll cluster.

I have added a json item corrected for ZHADoorlock.