### PR TITLE
Add support for thermostatic radiator valve from MOES

### DIFF
--- a/product_match.cpp
+++ b/product_match.cpp
@@ -66,6 +66,7 @@ static const ProductMap products[] =
     {"_TYST11_yw7cahqs", "w7cahqs", "Hama", "Tuya_THD Smart radiator TRV"},
     {"_TZE200_yw7cahqs", "TS0601", "Hama", "Tuya_THD Smart radiator TRV"},
     {"_TZE200_cwnjrr72", "TS0601", "MOES", "Tuya_THD HY368 TRV"},
+    {"_TZE200_cpmgn2cf", "TS0601", "MOES", "Tuya_THD HY368 TRV"},
     {"_TZE200_b6wax7g0", "TS0601", "MOES", "Tuya_THD BRT-100"},
 
     // Tuya Covering


### PR DESCRIPTION
Another identifier, `_TZE200_cpmgn2cf`, added as a TRV of type `TS0601` to the product mapping.

Since before, I have another identical device, but that one is advertising itself as `_TZE200_cwnjrr72`.