### PR TITLE
DeviceJS emit events for all ResourceItems where setValue() is called

### DIFF
--- a/device_js/device_js.cpp
+++ b/device_js/device_js.cpp
@@ -28,7 +28,10 @@ public:
     JsResourceItem *jsItem = nullptr;
     JsUtils *jsUtils = nullptr;
     const deCONZ::ApsDataIndication *apsInd = nullptr;
+    std::vector<ResourceItem*> itemsSet;
 };
+
+static DeviceJsPrivate *_djsPriv = nullptr; // singleton
 
 // Polyfills for older Qt versions
 static const char *PF_String_prototype_padStart = "String.prototype.padStart = String.prototype.padStart || "
@@ -40,6 +43,7 @@ DeviceJs::DeviceJs() :
 {
     Q_ASSERT(_djs == nullptr); // enforce singleton
 
+    _djsPriv = d.get();
 #if QT_VERSION > 0x050700
     d->engine.installExtensions(QJSEngine::ConsoleExtension);
 #endif
@@ -74,12 +78,34 @@ DeviceJs::DeviceJs() :
 DeviceJs::~DeviceJs()
 {
     _djs = nullptr;
+    _djsPriv = nullptr;
 }
 
 DeviceJs *DeviceJs::instance()
 {
     Q_ASSERT(_djs);
     return _djs;
+}
+
+const std::vector<ResourceItem *> &DeviceJs::itemsSet() const
+{
+    return d->itemsSet;
+}
+
+/* Keep track of all resource items which are set via:
+   Item.val = 1 and R.item('..').val = 2)
+   during JS evaluation.
+ */
+void DeviceJS_ResourceItemValueChanged(ResourceItem *item)
+{
+    Q_ASSERT(_djsPriv);
+
+    const auto i = std::find(_djsPriv->itemsSet.cbegin(), _djsPriv->itemsSet.cend(), item);
+
+    if (i == _djsPriv->itemsSet.cend())
+    {
+        _djsPriv->itemsSet.push_back(item);
+    }
 }
 
 JsEvalResult DeviceJs::evaluate(const QString &expr)
@@ -96,20 +122,18 @@ JsEvalResult DeviceJs::evaluate(const QString &expr)
 void DeviceJs::setResource(Resource *r)
 {
     d->jsResource->r = r;
-    d->jsResource->cr = r;
 }
 
 void DeviceJs::setResource(const Resource *r)
 {
-    d->jsResource->r = nullptr;
-    d->jsResource->cr = r;
+    d->jsResource->r = const_cast<Resource*>(r);
 }
 
 void DeviceJs::setApsIndication(const deCONZ::ApsDataIndication &ind)
 {
     d->apsInd = &ind;
-    d->engine.globalObject().setProperty("SrcEp", int(ind.srcEndpoint()));
-    d->engine.globalObject().setProperty("ClusterId", int(ind.clusterId()));
+    d->engine.globalObject().setProperty(QLatin1String("SrcEp"), int(ind.srcEndpoint()));
+    d->engine.globalObject().setProperty(QLatin1String("ClusterId"), int(ind.clusterId()));
 }
 
 void DeviceJs::setZclFrame(const deCONZ::ZclFrame &zclFrame)
@@ -125,13 +149,11 @@ void DeviceJs::setZclAttribute(const deCONZ::ZclAttribute &attr)
 void DeviceJs::setItem(ResourceItem *item)
 {
     d->jsItem->item = item;
-    d->jsItem->citem = item;
 }
 
 void DeviceJs::setItem(const ResourceItem *item)
 {
-    d->jsItem->item = nullptr;
-    d->jsItem->citem = item;
+    d->jsItem->item = const_cast<ResourceItem*>(item);
 }
 
 QVariant DeviceJs::result()
@@ -143,12 +165,15 @@ void DeviceJs::reset()
 {
     d->apsInd = nullptr;
     d->jsItem->item = nullptr;
-    d->jsItem->citem = nullptr;
     d->jsResource->r = nullptr;
-    d->jsResource->cr = nullptr;
     d->jsZclAttribute->attr = nullptr;
     d->jsZclFrame->zclFrame = nullptr;
     d->engine.collectGarbage();
+}
+
+void DeviceJs::clearItemsSet()
+{
+    d->itemsSet.clear();
 }
 
 QString DeviceJs::errorString() const

--- a/device_js/device_js.h
+++ b/device_js/device_js.h
@@ -102,8 +102,10 @@ public:
     void setItem(const ResourceItem *item);
     QVariant result();
     void reset();
+    void clearItemsSet();
     QString errorString() const;
     static DeviceJs *instance();
+    const std::vector<ResourceItem*> &itemsSet() const;
 
 private:
     std::unique_ptr<DeviceJsPrivate> d;

--- a/device_js/device_js_wrappers.cpp
+++ b/device_js/device_js_wrappers.cpp
@@ -46,25 +46,23 @@ QJSValue JsResource::item(const QString &suffix)
     }
 
     ResourceItem *item = r ? r->item(rid.suffix) : nullptr;
-    const ResourceItem *citem = cr ? cr->item(rid.suffix) : nullptr;
 
-    if (item || citem)
+    if (item)
     {
         auto *ritem = new JsResourceItem(this);
         ritem->item = item;
-        ritem->citem = citem;
         return static_cast<QJSEngine*>(parent())->newQObject(ritem);
     }
 
     return {};
 }
 
-QVariant JsResource::endpoints()
+QVariant JsResource::endpoints() const
 {
     QVariantList result;
-    if (cr)
+    if (r)
     {
-        const deCONZ::Node *node = getResourceCoreNode(cr);
+        const deCONZ::Node *node = getResourceCoreNode(r);
         if (node)
         {
             for (auto ep : node->endpoints())
@@ -85,14 +83,13 @@ JsResourceItem::JsResourceItem(QObject *parent) :
 
 JsResourceItem::~JsResourceItem()
 {
-    if (item)
-    {
-        item = nullptr;
-    }
+    item = nullptr;
 }
 
 QVariant JsResourceItem::value() const
 {
+    const ResourceItem *citem = item;
+
     if (!citem)
     {
         return {};
@@ -136,14 +133,19 @@ void JsResourceItem::setValue(const QVariant &val)
         {
             DBG_Printf(DBG_DDF, "JS failed to set Item.val for %s\n", item->descriptor().suffix);
         }
+        else
+        {
+            emit valueChanged();
+            DeviceJS_ResourceItemValueChanged(item);
+        }
     }
 }
 
 QString JsResourceItem::name() const
 {
-    if (citem)
+    if (item)
     {
-        return QLatin1String(citem->descriptor().suffix);
+        return QLatin1String(item->descriptor().suffix);
     }
 
     return {};

--- a/device_js/device_js_wrappers.h
+++ b/device_js/device_js_wrappers.h
@@ -34,13 +34,12 @@ class JsResource : public QObject
 
 public:
     Resource *r = nullptr;
-    const Resource *cr = nullptr;
 
     JsResource(QJSEngine *parent = nullptr);
 
 public Q_SLOTS:
     QJSValue item(const QString &suffix);
-    QVariant endpoints();
+    QVariant endpoints() const;
 };
 
 class JsResourceItem : public QObject
@@ -52,7 +51,6 @@ class JsResourceItem : public QObject
 
 public:
     ResourceItem *item = nullptr;
-    const ResourceItem *citem = nullptr;
 
     JsResourceItem(QObject *parent = nullptr);
     ~JsResourceItem();
@@ -115,5 +113,7 @@ public:
     Q_INVOKABLE double log10(double x) const;
     Q_INVOKABLE QString padStart(const QString &str, QJSValue targetLength, QJSValue padString);
 };
+
+void DeviceJS_ResourceItemValueChanged(ResourceItem *item);
 
 #endif // DEVICE_JS_WRAPPERS_H


### PR DESCRIPTION
Prior to this PR only the direct item emitted events after `Item.val = 123`.
The change now also emits events for indirect set items via `R.item(...).val = 456`.