### PR TITLE
Update e1c-nb7.json to add pseudo power cluster for third party apps.

### DIFF
--- a/devices/sengled/e1c-nb7.json
+++ b/devices/sengled/e1c-nb7.json
@@ -4,7 +4,7 @@
   "modelid": "E1C-NB7",
   "product": "E1C-NB7",
   "sleeper": false,
-  "status": "Gold",
+  "status": "Silver",
   "path": "/devices/sengled/e1c-nb7.json",
   "subdevices": [
     {
@@ -44,10 +44,12 @@
         },
         {
           "name": "state/alert",
+          "description": "The currently active alert effect.",
           "default": "none"
         },
         {
           "name": "state/on",
+          "description": "True when device is on; false when off.",
           "refresh.interval": 5
         },
         {
@@ -99,26 +101,15 @@
         },
         {
           "name": "state/consumption",
-          "refresh.interval": 360,
-          "read": {
-            "at": "0x0000",
-            "cl": "0x0702",
-            "ep": 0,
-            "fn": "zcl"
-          },
-          "parse": {
-            "at": "0x0000",
-            "cl": "0x0702",
-            "ep": 0,
-            "eval": "if (Attr.val != -32768) { Item.val = Attr.val / 10; }"
-          }
+          "refresh.interval": 300,
+          "default": 0
         },
         {
           "name": "state/lastupdated"
         },
         {
           "name": "state/power",
-          "refresh.interval": 360,
+          "refresh.interval": 300,
           "read": {
             "at": "0x0400",
             "cl": "0x0702",
@@ -130,7 +121,72 @@
             "cl": "0x0702",
             "ep": 0,
             "eval": "if (Attr.val != -32768) { Item.val = Attr.val / 10; }"
-          }
+          },
+          "default": 0
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_POWER_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0b04"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/power",
+          "refresh.interval": 300,
+          "read": {
+            "at": "0x0400",
+            "cl": "0x0702",
+            "ep": 1,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0400",
+            "cl": "0x0702",
+            "ep": 1,
+            "eval": "if (Attr.val != -32768) { Item.val = Attr.val / 10; }"
+          },
+          "default": 0
         }
       ]
     }

--- a/devices/sengled/e1c-nb7.json
+++ b/devices/sengled/e1c-nb7.json
@@ -44,12 +44,10 @@
         },
         {
           "name": "state/alert",
-          "description": "The currently active alert effect.",
           "default": "none"
         },
         {
           "name": "state/on",
-          "description": "True when device is on; false when off.",
           "refresh.interval": 5
         },
         {
@@ -101,7 +99,7 @@
         },
         {
           "name": "state/consumption",
-          "refresh.interval": 300,
+          "refresh.interval": 360,
           "default": 0
         },
         {
@@ -109,7 +107,7 @@
         },
         {
           "name": "state/power",
-          "refresh.interval": 300,
+          "refresh.interval": 360,
           "read": {
             "at": "0x0400",
             "cl": "0x0702",
@@ -173,7 +171,7 @@
         },
         {
           "name": "state/power",
-          "refresh.interval": 300,
+          "refresh.interval": 360,
           "read": {
             "at": "0x0400",
             "cl": "0x0702",


### PR DESCRIPTION
Proposing a modification to initial json to have Instantaneous power demand as a new monitoring device in third party apps like Domoticz or HS4 (https://forums.homeseer.com/forum/hs4-products/hs4-plugins/lighting-primary-technology-plug-ins-aa/jowihue-w-vuyk-aa/1551540-sengled-e1c-nb7-power-monitoring).

It's perhaps not so clean, thus every advice will be welcome ...