### PR TITLE
Add checks for command ID and MFC to `parseZclAttribute()`

### DIFF
--- a/device_access_fn.cpp
+++ b/device_access_fn.cpp
@@ -541,6 +541,16 @@ bool parseZclAttribute(Resource *r, ResourceItem *item, const deCONZ::ApsDataInd
     {
         return result;
     }
+    
+    if (!zclParam.hasCommandId && zclFrame.commandId() != deCONZ::ZclReadAttributesResponseId && zclFrame.commandId() != deCONZ::ZclReportAttributesId)
+    {
+        return result;
+    }
+    
+    if (zclParam.manufacturerCode != zclFrame.manufacturerCode())
+    {
+        return result;
+    }
 
     if (zclParam.endpoint < BroadcastEndpoint && zclParam.endpoint != ind.srcEndpoint())
     {


### PR DESCRIPTION
The PR adds a check for the command ID and the manufacturer code to the standard zcl parsing function. Those were just used once during function assignment, but not subsequently in regular operations.