### PR TITLE
Add DDF for Aqara T1 single rocker switch (no neutral wire) SSM-U02

### DIFF
--- a/devices/xiaomi/xiaomi_ssm-u02_t1_switch.json
+++ b/devices/xiaomi/xiaomi_ssm-u02_t1_switch.json
@@ -1,0 +1,235 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "$MF_LUMI",
+  "modelid": "lumi.switch.l0agl1",
+  "vendor": "Xiaomi",
+  "product": "Aqara T1 single rocker switch (no neutral wire) SSM-U02",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_ON_OFF_LIGHT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {
+            "at": "0x00f7",
+            "ep": 1,
+            "fn": "xiaomi:special",
+            "idx": "0x08",
+            "script": "xiaomi_swversion.js"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert"
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 300
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_SWITCH",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x29",
+        "0x0012"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0100",
+        "endpoint": "0x29",
+        "in": [
+          "0x0012"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {
+            "at": "0x00f7",
+            "ep": 1,
+            "fn": "xiaomi:special",
+            "idx": "0x08",
+            "script": "xiaomi_swversion.js"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/clickmode",
+          "refresh.interval": 300,
+          "read": {
+            "at": "0x0200",
+            "cl": "0xfcc0",
+            "ep": 1,
+            "fn": "zcl",
+            "mf": "0x115f"
+          },
+          "parse": {
+            "at": "0x0200",
+            "cl": "0xfcc0",
+            "ep": 1,
+            "eval": "if (Attr.val == 0) { Item.val = 'decoupled' } else if (Attr.val == 1) { Item.val = 'coupled' } else { Item.val = 'unknown' }",
+            "fn": "zcl",
+            "mf": "0x115f"
+          },
+          "write": {
+            "at": "0x0200",
+            "cl": "0xfcc0",
+            "dt": "0x20",
+            "ep": 1,
+            "eval": "if (Item.val == 'decoupled') { 0 } else if (Item.val == 'coupled') { 1 } else { 'unknown' }",
+            "fn": "zcl",
+            "mf": "0x115f"
+          },
+          "values": [
+            ["\"decoupled\"", "Decoupled Mode"],
+            ["\"coupled\"", "Coupled Mode"] 
+          ],
+          "default": "coupled"
+        },
+        {
+          "name": "config/devicemode",
+          "refresh.interval": 300,
+          "read": {
+            "at": "0x0009",
+            "cl": "0xfcc0",
+            "ep": 1,
+            "fn": "zcl",
+            "mf": "0x115f"
+          },
+          "parse": {
+            "at": "0x0009",
+            "cl": "0xfcc0",
+            "ep": 1,
+            "eval": "if (Attr.val == 1) { Item.val = 'compatibility' } else if (Attr.val == 2) { Item.val = 'zigbee' } else { Item.val = 'unknown' }",
+            "fn": "zcl",
+            "mf": "0x115f"
+          },
+          "write": {
+            "at": "0x0009",
+            "cl": "0xfcc0",
+            "dt": "0x20",
+            "ep": 1,
+            "eval": "if (Item.val == 'compatibility') { 1 } else if (Item.val == 'zigbee') { 2 } else { 'unknown' }",
+            "fn": "zcl",
+            "mf": "0x115f"
+          },
+          "values": [
+            ["\"compatibility\"", "Default mode for Xiaomi devices"],
+            ["\"zigbee\"", "Closer to zigbee standard"] 
+          ],
+          "default": "compatibility"
+        },
+        {
+          "name": "config/ledindication",
+          "refresh.interval": 300,
+          "read": {
+            "at": "0x0203",
+            "cl": "0xfcc0",
+            "ep": 1,
+            "fn": "zcl",
+            "mf": "0x115f"
+          },
+          "parse": {
+            "at": "0x0203",
+            "cl": "0xfcc0",
+            "ep": 1,
+            "eval": "Attr.val ? Item.val = false : Item.val = true",
+            "fn": "zcl",
+            "mf": "0x115f"
+          },
+          "write": {
+            "at": "0x0203",
+            "cl": "0xfcc0",
+            "dt": "0x20",
+            "ep": 1,
+            "eval": "Item.val ? false : true",
+            "fn": "zcl",
+            "mf": "0x115f"
+          },
+          "values": [
+            [true, "Device LED always on"],
+            [false, "Device LED off from 9pm - 9am"] 
+          ],
+          "default": true
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/buttonevent"
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
PR should allow the device to be included and create a ZHASwitch resource, but there's no button map yet.

DDF is **untested**.