### PR TITLE
DDF add support for Tuya 1 gang wired Moes ZTS-EUB - 1

### DIFF
--- a/devices/tuya/_TZE200_amp6tsvy_wired_switch_1gang.json
+++ b/devices/tuya/_TZE200_amp6tsvy_wired_switch_1gang.json
@@ -1,0 +1,68 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "_TZE200_amp6tsvy",
+  "modelid": "TS0601",
+  "product": "Tuya 1 gang wired switch",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_ON_OFF_LIGHT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 300,
+          "read": {
+            "fn": "tuya"
+          },
+          "write": {
+            "dpid": 1,
+            "dt": "0x10",
+            "eval": "Item.val == 1 ? 1 : 0;",
+            "fn": "tuya"
+          },
+          "parse": {
+            "dpid": 1,
+            "eval": "Item.val = Attr.val;",
+            "fn": "tuya"
+          }
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- Manufacturer: _TZE200_amp6tsvy
- Model identifier: TS0601

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/5505