### PR TITLE
Fix: use correct datatype for `config/mountingmode`

### DIFF
--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1738,7 +1738,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                     }
                     else if (devManaged && rsub)
                     {
-                        change.addTargetValue(rid.suffix, data.uinteger);
+                        change.addTargetValue(rid.suffix, data.boolean);
                         rsub->addStateChange(change);
                         updated = true;
                     }

--- a/utils/utils.cpp
+++ b/utils/utils.cpp
@@ -147,7 +147,7 @@ bool startsWith(QLatin1String str, QLatin1String needle)
 RestData verifyRestData(const ResourceItemDescriptor &rid, const QVariant &val)
 {
     bool ok;
-    RestData data;
+    RestData data {};
 
     if (rid.qVariantType == val.type())
     {


### PR DESCRIPTION
Datatype must be `boolean` here, otherwise the state change will never succeed and finally time out.