### PR TITLE
Add wiki link in DDFs for lumi.plug.mmeu01 and lumi.plug.maeu01

### DIFF
--- a/devices/xiaomi/xiaomi_known_issues_plugfw.md
+++ b/devices/xiaomi/xiaomi_known_issues_plugfw.md
@@ -1,0 +1,7 @@
+
+### Firmware update required
+
+This applies for Xiaomi smart plugs ZNCZ04LM (lumi.plug.mmeu01) and SP-EUC01 (lumi.plug.maeu01). It is mandatory that RaspBee/ConBee I firmware version 0x26400500 (or higher) or RaspBee/ConBeeII firmware version 0x266f0700 (or higher) is installed.
+
+Further the plugs firmware need to be updated via OTA to work well with this DDF.
+A more detailed description can be found at: [wiki/Xiaomi-smart-plugs-not-working-correctly](https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Xiaomi-smart-plugs-not-working-correctly)

--- a/devices/xiaomi/xiaomi_sp-euc01_smart_plug.json
+++ b/devices/xiaomi/xiaomi_sp-euc01_smart_plug.json
@@ -8,6 +8,7 @@
   "status": "Gold",
   "comment": "DDF for device firmwares at least above 0.0.0_0022, paired with xBee I fw 0x26400500 / xBee II fw 0x266f0700 and above",
   "matchexpr": "R.endpoints.includes(0x15) && R.endpoints.includes(0x1F)",
+  "md:known_issues": [ "xiaomi_known_issues_plugfw.md" ],
   "subdevices": [
     {
       "type": "$TYPE_SMART_PLUG",

--- a/devices/xiaomi/xiaomi_zncz04lm_smart_plug.json
+++ b/devices/xiaomi/xiaomi_zncz04lm_smart_plug.json
@@ -8,6 +8,7 @@
   "status": "Gold",
   "comment": "DDF for device firmwares equal or below 0.0.0_0022",
   "matchexpr": "R.endpoints.includes(0x15) && R.endpoints.includes(0x16)",
+  "md:known_issues": [ "xiaomi_known_issues_plugfw.md" ],
   "subdevices": [
     {
       "type": "$TYPE_SMART_PLUG",

--- a/devices/xiaomi/xiaomi_zncz04lm_smart_plug_v24.json
+++ b/devices/xiaomi/xiaomi_zncz04lm_smart_plug_v24.json
@@ -8,6 +8,7 @@
   "status": "Gold",
   "comment": "DDF for device firmwares equal or above 0.0.0_0024",
   "matchexpr": "R.endpoints.includes(0x15) && R.endpoints.includes(0x1F)",
+  "md:known_issues": [ "xiaomi_known_issues_plugfw.md" ],
   "subdevices": [
     {
       "type": "$TYPE_SMART_PLUG",


### PR DESCRIPTION
These devices need to be updated in order to work correctly with the DDFs. This PR adds the known issues section to the DDF based compatibility list:

https://dresden-elektronik.github.io/deconz-rest-doc/devices

and in there links to https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Xiaomi-smart-plugs-not-working-correctly