### PR TITLE
DDF for IKEA PRAKTLYSING cellular blind

### DIFF
--- a/devices/ikea/tredansen_block-out_cellul_blind.json
+++ b/devices/ikea/tredansen_block-out_cellul_blind.json
@@ -1,8 +1,8 @@
 {
   "schema": "devcap1.schema.json",
   "manufacturername": "$MF_IKEA",
-  "modelid": "TREDANSEN block-out cellul blind",
-  "product": "TREDANSEN block-out cellul blind",
+  "modelid": ["TREDANSEN block-out cellul blind", "PRAKTLYSING cellular blind"],
+  "product": "IKEA PRAKTLYSING/TREDANSEN cellular blind",
   "sleeper": false,
   "status": "Gold",
   "subdevices": [

--- a/devices/ikea/tredansen_block-out_cellul_blind.json
+++ b/devices/ikea/tredansen_block-out_cellul_blind.json
@@ -2,7 +2,7 @@
   "schema": "devcap1.schema.json",
   "manufacturername": ["$MF_IKEA", "$MF_IKEA"],
   "modelid": ["TREDANSEN block-out cellul blind", "PRAKTLYSING cellular blind"],
-  "product": "PRAKTLYSING/TREDANSEN cellular blind"
+  "product": "PRAKTLYSING/TREDANSEN cellular blind",
   "sleeper": false,
   "status": "Gold",
   "subdevices": [

--- a/devices/ikea/tredansen_block-out_cellul_blind.json
+++ b/devices/ikea/tredansen_block-out_cellul_blind.json
@@ -1,8 +1,8 @@
 {
   "schema": "devcap1.schema.json",
-  "manufacturername": "$MF_IKEA",
+  "manufacturername": ["$MF_IKEA", "$MF_IKEA"],
   "modelid": ["TREDANSEN block-out cellul blind", "PRAKTLYSING cellular blind"],
-  "product": "IKEA PRAKTLYSING/TREDANSEN cellular blind",
+  "product": "PRAKTLYSING/TREDANSEN cellular blind"
   "sleeper": false,
   "status": "Gold",
   "subdevices": [


### PR DESCRIPTION
IKEA PRAKTLYSING is a sibling of the IKEA TREDANSEN block-out cellular blind.

Tested by duplicating the IKEA TREDANSEN Gold DDF.

#### Node Descriptor after applying DDF

<img width="262" alt="Screenshot 2022-10-03 at 22 30 59" src="https://user-images.githubusercontent.com/58368187/193687683-6477df65-e10d-45d0-b3e1-fd74dfb81827.png">

#### Basic Info
<img width="364" alt="Screenshot 2022-10-03 at 22 31 58" src="https://user-images.githubusercontent.com/58368187/193688068-dc47d74e-8b91-4855-99e1-7e1075147405.png">

