### PR TITLE
DDF for Heiman Smart siren HS2WD-E

### DIFF
--- a/devices/heiman/HS2WD-E.json
+++ b/devices/heiman/HS2WD-E.json
@@ -1,0 +1,177 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": [
+    "Heiman",
+    "HEIMAN"
+  ],
+  "modelid": [
+    "WarningDevice",
+    "WarningDevice-EF-3.0"
+  ],
+  "vendor": "Heiman",
+  "product": "Smart siren HS2WD-E",
+  "sleeper": false,
+  "status": "Silver",
+  "subdevices": [
+    {
+      "type": "$TYPE_WARNING_DEVICE",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert",
+          "default": "none"
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "ZHAAlarm",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0500"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0403",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x0500"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/enrolled",
+          "public": false
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/pending"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/alarm"
+        },
+        {
+          "name": "state/battery",
+          "refresh.interval": 3600,
+          "parse": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "eval": "Item.val = Attr.val / 2",
+            "fn": "zcl"
+          }
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/lowbattery"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 60,
+          "max": 3600,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0500"
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0502",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x21",
+          "min": 30,
+          "max": 120
+        }
+      ]
+    }
+  ]
+}

--- a/devices/heiman/HS2WD-E.json
+++ b/devices/heiman/HS2WD-E.json
@@ -120,13 +120,13 @@
           "name": "state/alarm"
         },
         {
-          "name": "state/battery",
+          "name": "config/battery",
           "refresh.interval": 3600,
           "parse": {
             "at": "0x0021",
             "cl": "0x0001",
             "ep": 1,
-            "eval": "Item.val = Attr.val / 2",
+            "eval": "Item.val = Math.round(Attr.val / 2);",
             "fn": "zcl"
           }
         },


### PR DESCRIPTION
From issues https://forum.phoscon.de/t/heiman-hs2wd-e-siren-state-alert-always-remains-at-none/2101/22 and https://forum.phoscon.de/t/heiman-warningdevice-ef-3-0-siren-no-battery-and-tampered-status/2346