### PR TITLE
Remove rescaling of consumption in Develco/friend ZHEMI101 DDF

### DIFF
--- a/devices/develco/zhemi101_external_meter_interface.json
+++ b/devices/develco/zhemi101_external_meter_interface.json
@@ -144,7 +144,7 @@
             "at": "0x0000",
             "cl": "0x0702",
             "ep": 2,
-            "eval": "Item.val = Attr.val / 1000",
+            "eval": "Item.val = Attr.val",
             "fn": "zcl"
           }
         },


### PR DESCRIPTION
This commit removes the division by 1000 when extracting the consumption value for the Develco/friend external meter interface ZHEMI101. This sensor comes in different flavors that are compatible with different standards. For example the EU version is compatible with the EU standard of 1000 pulses per kWh, so the value is already correct from the sensor.