### PR TITLE
Create SR-ZG9080A.json

### DIFF
--- a/devices/sunricher/SR-ZG9080A.json
+++ b/devices/sunricher/SR-ZG9080A.json
@@ -1,0 +1,82 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "Sunricher",
+  "modelid": "Motor Controller",
+  "product": "SR-ZG9080A",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_WINDOW_COVERING_DEVICE",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/lift",
+          "refresh.interval": 60,
+          "default": 0
+        },
+        {
+          "name": "state/open",
+          "parse": {
+            "at": "0x0008",
+            "cl": "0x0102",
+            "ep": 0,
+            "eval": "Item.val = Attr.val < 100",
+            "fn": "zcl"
+          }
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0102",
+      "report": [
+        {
+          "at": "0x0008",
+          "dt": "0x20",
+          "min": 1,
+          "max": 100,
+          "change": "0x00000001"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
DDF for Sunricher SR-ZG9080A cover controller.
The current DDF is unable to parse the position to external controlling devices. Same as Philips h2l-zbph-rs cover controller.