### PR TITLE
Update smt402ad DDF to reflect correct endpoint

### DIFF
--- a/devices/stelpro/smt402ad.json
+++ b/devices/stelpro/smt402ad.json
@@ -160,7 +160,7 @@
       "restapi": "/sensors",
       "uuid": [
         "$address.ext",
-        "0x01",
+        "0x19",
         "0x0405"
       ],
       "items": [


### PR DESCRIPTION
Changing $TYPE_HUMIDITY_SENSOR uuid to respect the fact that it's on cluster 25 (0x19) and not 1 (0x01)