### PR TITLE
Re-indent general.xml

### DIFF
--- a/general.xml
+++ b/general.xml
@@ -1,641 +1,644 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zcl>
-	<datatypes>
-		<!--Null-->
-		<datatype id="0x00" name="No data" shortname="ndat" length="0" ad="-"></datatype>
-		<!--General data -->
-		<datatype id="0x08" name="8-bit data" shortname="dat8" length="1" ad="D"></datatype>
-		<datatype id="0x09" name="16-bit data" shortname="dat16" length="2" ad="D"></datatype>
-		<datatype id="0x0a" name="24-bit data" shortname="dat24" length="3" ad="D"></datatype>
-		<datatype id="0x0b" name="32-bit data" shortname="dat32" length="4" ad="D"></datatype>
-		<datatype id="0x0c" name="40-bit data" shortname="dat40" length="5" ad="D"></datatype>
-		<datatype id="0x0d" name="48-bit data" shortname="dat48" length="6" ad="D"></datatype>
-		<datatype id="0x0e" name="56-bit data" shortname="dat56" length="7" ad="D"></datatype>
-		<datatype id="0x0f" name="64-bit data" shortname="dat64" length="8" ad="D"></datatype>
-		<!-- Logical -->
-		<datatype id="0x10" name="Boolean" shortname="bool" length="1" inval="0xff" ad="D"></datatype>
-		<!-- Bitmap -->
-		<datatype id="0x18" name="8-bit bitmap" shortname="bmp8" length="1" ad="D"></datatype>
-		<datatype id="0x19" name="16-bit bitmap" shortname="bmp16" length="2" ad="D"></datatype>
-		<datatype id="0x1a" name="24-bit bitmap" shortname="bmp24" length="3" ad="D"></datatype>
-		<datatype id="0x1b" name="32-bit bitmap" shortname="bmp32" length="4" ad="D"></datatype>
-		<datatype id="0x1c" name="40-bit bitmap" shortname="bmp40" length="5" ad="D"></datatype>
-		<datatype id="0x1d" name="48-bit bitmap" shortname="bmp48" length="6" ad="D"></datatype>
-		<datatype id="0x1e" name="56-bit bitmap" shortname="bmp56" length="7" ad="D"></datatype>
-		<datatype id="0x1f" name="64-bit bitmap" shortname="bmp64" length="8" ad="D"></datatype>
-		<!-- Unsigned integer -->
-		<datatype id="0x20" name="Unsigned 8-bit integer" shortname="u8" length="1" inval="0xff" ad="A"></datatype>
-		<datatype id="0x21" name="Unsigned 16-bit integer" shortname="u16" length="2" inval="0xffff" ad="A"></datatype>
-		<datatype id="0x22" name="Unsigned 24-bit integer" shortname="u24" length="3" inval="0xffffff" ad="A"></datatype>
-		<datatype id="0x23" name="Unsigned 32-bit integer" shortname="u32" length="4" inval="0xffffffff" ad="A"></datatype>
-		<datatype id="0x24" name="Unsigned 40-bit integer" shortname="u40" length="5" inval="0xffffffffff" ad="A"></datatype>
-		<datatype id="0x25" name="Unsigned 48-bit integer" shortname="u48" length="6" inval="0xffffffffffff" ad="A"></datatype>
-		<datatype id="0x26" name="Unsigned 56-bit integer" shortname="u56" length="7" inval="0xffffffffffffff" ad="A"></datatype>
-		<datatype id="0x27" name="Unsigned 64-bit integer" shortname="u64" length="8" inval="0xffffffffffffffff" ad="A"></datatype>
-		<!-- Signed integer -->
-		<datatype id="0x28" name="Signed 8-bit integer" shortname="s8" length="1" inval="0x80" ad="A"></datatype>
-		<datatype id="0x29" name="Signed 16-bit integer" shortname="s16" length="2" inval="0x8000" ad="A"></datatype>
-		<datatype id="0x2a" name="Signed 24-bit integer" shortname="s24" length="3" inval="0x800000" ad="A"></datatype>
-		<datatype id="0x2b" name="Signed 32-bit integer" shortname="s32" length="4" inval="0x80000000" ad="A"></datatype>
-		<datatype id="0x2c" name="Signed 40-bit integer" shortname="s40" length="5" inval="0x8000000000" ad="A"></datatype>
-		<datatype id="0x2d" name="Signed 48-bit integer" shortname="s48" length="6" inval="0x800000000000" ad="A"></datatype>
-		<datatype id="0x2e" name="Signed 56-bit integer" shortname="s56" length="7" inval="0x80000000000000" ad="A"></datatype>
-		<datatype id="0x2f" name="Signed 64-bit integer" shortname="s64" length="8" inval="0x8000000000000000" ad="A"></datatype>
-		<!-- Enumeration -->
-		<datatype id="0x30" name="8-bit enumeration" shortname="enum8" length="1" inval="0xff" ad="D"></datatype>
-		<datatype id="0x31" name="16-bit enumeration" shortname="enum16" length="2" inval="0xffff" ad="D"></datatype>
-		<!-- Floating point -->
-		<datatype id="0x38" name="Semi-precision" shortname="semi" length="2" inval="nan" ad="A"></datatype>
-		<datatype id="0x39" name="Single precision" shortname="float" length="4" inval="nan" ad="A"></datatype>
-		<datatype id="0x3a" name="Double precision" shortname="double" length="8" inval="nan" ad="A"></datatype>
-		<!-- String -->
-		<!-- oN, defined in first N octets -->
-		<datatype id="0x41" name="Octed string" shortname="ostring" length="o1" inval="0xff" ad="D"></datatype>
-		<datatype id="0x42" name="Character string" shortname="cstring" length="o1" inval="0xff" ad="D"></datatype>
-		<datatype id="0x43" name="Long octed string" shortname="lostring" length="o2" inval="0xffff" ad="D"></datatype>
-		<datatype id="0x44" name="Long character string" shortname="lcstring" length="o2" inval="0xffff" ad="D"></datatype>
-		<!-- Ordered sequence -->
-		<!-- sloc, sum of length of content -->
-		<datatype id="0x48" name="Array" shortname="array" length="2+sloc" inval="0xffff" ad="D"></datatype>
-		<datatype id="0x4c" name="Structure" shortname="struct" length="2+sloc" inval="0xffff" ad="D"></datatype>
-		<!-- Collection -->
-		<datatype id="0x50" name="Set" shortname="set" length="sloc" inval="0xffff" ad="D"></datatype>
-		<datatype id="0x51" name="Bag" shortname="bag" length="sloc" inval="0xffff" ad="D"></datatype>
-		<!-- Time -->
-		<datatype id="0xe0" name="Time of day" shortname="time" length="4" inval="0xffffffff" ad="A"></datatype>
-		<datatype id="0xe1" name="Date" shortname="date" length="4" inval="0xffffffff" ad="A"></datatype>
-		<datatype id="0xe2" name="UTCTime" shortname="utc" length="4" inval="0xffffffff" ad="A"></datatype>
-		<!-- Identifier -->
-		<datatype id="0xe8" name="Cluster ID" shortname="cid" length="2" inval="0xffff" ad="D"></datatype>
-		<datatype id="0xe9" name="Attribute ID" shortname="aid" length="2" inval="0xffff" ad="D"></datatype>
-		<datatype id="0xea" name="BACnet OID" shortname="oid" length="4" inval="0xffffffff" ad="D"></datatype>
-		<!-- Miscellaneous -->
-		<datatype id="0xf0" name="IEEE address" shortname="uid" length="8" inval="0xffffffffffffffff" ad="D"></datatype>
-		<datatype id="0xf1" name="128-bit security key" shortname="seckey" length="16" ad="D"></datatype>
-	</datatypes>
-
-	<enumeration id="0x00" name="ZCL_Status">
-		<value value="0x00" name="SUCCESS"></value>
-		<value value="0x01" name="FAILURE"></value>
-		<value value="0x7e" name="NOT_AUTHORIZED"></value>
-		<value value="0x7f" name="RESERVED_FIELD_NOT_ZERO"></value>
-		<value value="0x80" name="MALFORMED_COMMAND"></value>
-		<value value="0x81" name="UNSUP_CLUSTER_COMMAND"></value>
-		<value value="0x82" name="UNSUP_GENERAL_COMMAND"></value>
-		<value value="0x83" name="UNSUP_MANUF_CLUSTER_COMMAND"></value>
-		<value value="0x84" name="UNSUP_MANUF_GENERAL_COMMAND"></value>
-		<value value="0x85" name="INVALID_FIELD"></value>
-		<value value="0x86" name="UNSUPPORTED_ATTRIBUTE"></value>
-		<value value="0x87" name="INVALID_VALUE"></value>
-		<value value="0x88" name="READ_ONLY"></value>
-		<value value="0x89" name="INSUFFICIENT_SPACE"></value>
-		<value value="0x8a" name="DUPLICATE_EXISTS"></value>
-		<value value="0x8b" name="NOT_FOUND"></value>
-		<value value="0x8c" name="UNREPORTABLE_ATTRIBUTE"></value>
-		<value value="0x8d" name="INVALID_DATA_TYPE"></value>
-		<value value="0x8e" name="INVALID_SECTOR"></value>
-		<value value="0x8f" name="WRITE_ONLY"></value>
-		<value value="0x90" name="INCONSISTENT_STARTUP_STATE"></value>
-		<value value="0x91" name="DEFINED_OUT_OF_BAND"></value>
-		<value value="0xc0" name="HARDWARE_FAILURE"></value>
-		<value value="0xc1" name="SOFTWARE_FAILURE"></value>
-		<value value="0xc2" name="CALIBRATION_ERROR"></value>
-	</enumeration>
-
-	<enumeration id="0x01" name="ZDP_Status">
-		<value value="0x00" name="SUCCESS"></value>
-		<value value="0x80" name="INV_REQUESTTYPE"></value>
-		<value value="0x81" name="DEVICE_NOT_FOUND"></value>
-		<value value="0x82" name="INVALID_EP"></value>
-		<value value="0x83" name="NOT_ACTIVE"></value>
-		<value value="0x84" name="NOT_SUPPORTED"></value>
-		<value value="0x85" name="TIMEOUT"></value>
-		<value value="0x86" name="NO_MATCH"></value>
-		<!--          0x87  reserved -->
-		<value value="0x88" name="NO_ENTRY"></value>
-		<value value="0x89" name="NO_DESCRIPTOR"></value>
-		<value value="0x8a" name="INSUFFCIENT_SPACE"></value>
-		<value value="0x8b" name="NOT_PERMITTED"></value>
-		<value value="0x8c" name="TABLE_FULL"></value>
-		<value value="0x8d" name="NOT_AUTHORIZED"></value>
-	</enumeration>
-
-	<domain name="General" useZcl="true"
-	description="The general functional domain contains clusters and information that provides generally applicable functions and attributes that are not specific to other functional domains.">
-
-	<cluster id="0x0000" name="Basic">
-		<description>Attributes for determining basic information about a device, setting user device information such as description of location, and enabling a device.</description>
-		<server>
-		<attribute-set id="0x0000" description="Basic Device Information">
-			<attribute id="0x0000" name="ZCL Version" type="u8" access="r" default="0" required="m"></attribute>
-			<attribute id="0x0001" name="Application Version" type="u8" access="r" default="0" required="o"></attribute>
-			<attribute id="0x0002" name="Stack Version" type="u8" access="r" default="0" required="o"></attribute>
-			<attribute id="0x0003" name="HW Version" type="u8" access="r" default="0" required="o"></attribute>
-			<attribute id="0x0004" name="Manufacturer Name" type="cstring" access="r" required="o" range="0,32"></attribute>
-			<attribute id="0x0005" name="Model Identifier" type="cstring" access="r" required="o" range="0,32"></attribute>
-			<attribute id="0x0006" name="Date Code" type="cstring" access="r" required="o" range="0,16"></attribute>
-			<attribute id="0x0007" name="Power Source" type="enum8" default="0" access="r" required="m">
-				<value name="Unknown" value="0"></value>
-				<value name="Mains (single phase)" value="1"></value>
-				<value name="Mains (3 phase)" value="2"></value>
-				<value name="Battery" value="3"></value>
-				<value name="DC Source" value="4"></value>
-				<value name="Emergency mains constantly powered" value="5"></value>
-				<value name="Emergency mains and transfer switch" value="6"></value>
-				<value name="Mains (single phase) with battery backup" value="0x81"></value>
-			</attribute>
-			<attribute id="0x0008" name="Generic Device Class" type="enum8" default="0xff" access="r" required="o" >
-				<description>IKEA control outlet specific.</description>
-				<value name="Lighting" value="0"></value>
-				<value name="Unspecified" value="0xff"></value>
-			</attribute>
-			<attribute id="0x0009" name="Generic Device Type" type="enum8" default="0xff" access="r" required="o" >
-				<description>IKEA control outlet specific.</description>
-				<value name="Incandescent" value="0"></value>
-				<value name="Spotlight Halogen" value="1"></value>
-				<value name="Halogen Bulb" value="2"></value>
-				<value name="CFL" value="3"></value>
-				<value name="Linear Fluorencent" value="4"></value>
-				<value name="LED Bulb" value="5"></value>
-				<value name="Spotlight LED" value="6"></value>
-				<value name="LED Strip" value="7"></value>
-				<value name="LED Tube" value="8"></value>
-				<value name="Indoor Luminaire" value="9"></value>
-				<value name="Outdoor Luminaire" value="0x0a"></value>
-				<value name="Pendant Luminaire" value="0x0b"></value>
-				<value name="Floor Standing Luminaire" value="0x0c"></value>
-				<value name="Controller" value="0xe0"></value>
-				<value name="Wall Switch" value="0xe1"></value>
-				<value name="Portable Remote Controller" value="0xe2"></value>
-				<value name="Motion or Light Sensor" value="0xe3"></value>
-				<value name="Actuator" value="0xf0"></value>
-				<value name="Wall Socket" value="0xf1"></value>
-				<value name="Gateway or Bridge" value="0xf2"></value>
-				<value name="Plug-In Unit" value="0xf3"></value>
-				<value name="Retrofit Actuator" value="0xf4"></value>
-				<value name="Unspecified" value="0xff"></value>
-			</attribute>
-			<attribute id="0x000a" name="Product code" type="ostring" access="r" required="o" >
-				<description>As printed on the product.</description>
-			</attribute>
-			<attribute id="0x4000" name="SW Build ID" type="cstring" access="r" required="o" range="0,16"></attribute>
-			<attribute id="0xff0d" name="Xiaomi Sensitivity" type="u8" access="rw" required="o" mfcode="0x115f"></attribute>
-			<attribute id="0xff22" name="Xiaomi Disconnect 1" type="u8" showas="hex" access="rw" required="o" mfcode="0x115f">
-				<description>Set to 0x12 (0xFE) to connect (disconnect) the left button to (from) the relay.</description>
-			</attribute>
-			<attribute id="0xff23" name="Xiaomi Disconnect 2" type="u8" showas="hex" access="rw" required="o" mfcode="0x115f">
-				<description>Set to 0x22 (0xFE) to connect (disconnect) the left button to (from) the relay.</description>
-			</attribute>
-			<!-- <attribute id="0xff0d" name="Xiaomi Sensitivity" type="u8" access="rw" required="o" mfcode="0x1037"></attribute> -->
-			<attribute id="0xfffd" name="Cluster Revision" type="u16" default="0" access="rw" required="o"></attribute>
-		</attribute-set>
-		<attribute-set id="0x0010" description="Basic Device Settings">
-			<attribute id="0x0010" name="Location Description" type="cstring" range="0,16" access="rw" required="o"></attribute>
-			<attribute id="0x0011" name="Physical Environment" type="enum8" default="0" access="rw" required="o">
-				<value name="Unspecified Environment" value="0"></value>
-				<!-- 0x01 - 0x7f Specified per Profile -->
-				<value name="Unknown Environment" value="0xff"></value>
-			</attribute>
-			<attribute id="0x0012" name="Device Enabled" type="bool" default="1" access="rw" required="o">
-				<value name="Disabled" value="0"></value>
-				<value name="Enabled" value="1"></value>
-			</attribute>
-			<attribute id="0x0013" name="Alarm Mask" type="bmp8" default="00000000" access="rw" required="o">
-				<value name="General Hardware Fault" value="0"></value>
-				<value name="General Software Fault" value="1"></value>
-			</attribute>
-			<attribute id="0x0014" name="Disable Local Config" type="bmp8" default="00000000" access="rw" required="o">
-				<value name="Reset (to factory defaults) disabled" value="0"></value>
-				<value name="Device configuration disabled" value="1"></value>
-			</attribute>
-		</attribute-set>
-		<attribute-set id="0x0030" description="Philips Specific" mfcode="0x100b">
-			<attribute id="0x0030" name="Sensitivity" description="Hue motion sensor related SML001" type="enum8" default="0" access="rw" required="o" mfcode="0x100b">
-				<value name="default" value="0"></value>
-				<value name="high" value="1"></value>
-				<value name="max" value="2"></value>
-			</attribute>
-			<attribute id="0x0031" name="Configuration" type="bmp16" default="0" access="rw" required="o" mfcode="0x100b" description="TODO flags are only known for hue dimmer switch">
-				<value name="Touchlink enabled 0" value="0"></value>
-				<value name="Touchlink enabled 1" value="1"></value>
-				<value name="Touchlink enabled 2" value="3"></value>
-			</attribute>
-			<attribute id="0x0032" name="Usertest" type="bool" default="0" access="rw" required="o" mfcode="0x100b"></attribute>
-			<attribute id="0x0033" name="LED Indication" type="bool" default="0" access="rw" required="o" mfcode="0x100b"></attribute>
-			<attribute id="0x0034" name="Device Mode" type="enum8" default="0" access="rw" required="o" mfcode="0x100b">
-				<value name="Single Rocker" value="0"></value>
-				<value name="Single Push Button" value="1"></value>
-				<value name="Dual Rocker" value="2"></value>
-				<value name="Dual Push Button" value="3"></value>
-			</attribute>
-		</attribute-set>
-		<attribute-set id="0x4000" description="Manufacturer specific" mfcode="0x1037">
-			<attribute id="0x4001" name="128-Bit security key" type="seckey" access="r" required="m" mfcode="0x1037"></attribute>
-			<attribute id="0x4002" name="IEEE address" type="uid" access="rw" required="m" mfcode="0x1037"></attribute>
-		</attribute-set>
-		<attribute-set id="0x4000" description="Manufacturer specific" mfcode="0x1166">
-			<attribute id="0x4001" name="128-Bit security key" type="seckey" access="r" required="m" mfcode="0x1166"></attribute>
-			<attribute id="0x4002" name="IEEE address" type="uid" access="rw" required="m" mfcode="0x1166"></attribute>
-		</attribute-set>
-		<attribute-set id="0x4000" description="Müller Licht specific" mfcode="0x121b">
-			<attribute id="0x4005" name="Scene" type="u8" access="rw" required="o" mfcode="0x121b"></attribute>
-		</attribute-set>
-		<attribute-set id="0x5000" description="ID Lock specific" mfcode="0x1337">
-			<attribute id="0x5000" name="Lock fw" type="cstring" access="r" required="m" mfcode="0x1337" />
-		</attribute-set>
-		<attribute-set id="0x8000" description="Develco specific" mfcode="0x1015">
-			<attribute id="0x8000" name="Primary SW Version" type="ostring" access="r" required="m" mfcode="0x1015"></attribute>
-			<attribute id="0x8010" name="Primary Bootloader SW Version" type="ostring" access="r" required="m" mfcode="0x1015"></attribute>
-			<attribute id="0x8020" name="Primary HW Version" type="ostring" access="r" required="m" mfcode="0x1015"></attribute>
-			<attribute id="0x8030" name="Primary HW name" type="ostring" access="r" required="m" mfcode="0x1015"></attribute>
-			<attribute id="0x8050" name="Primary SW Version 3rd Party" type="ostring" access="r" required="m" mfcode="0x1015"></attribute>
-		</attribute-set>
-		<attribute-set id="0xFF00" description="Xiaomi specific" mfcode="0x1037">
-			<attribute id="0xFF0D" name="Xiaomi Sensitivity" type="u8" access="rw" required="o" mfcode="0x115f"></attribute>
-			<attribute id="0xFF22" name="Xiaomi Disconnect 1" type="u8" showas="hex" access="rw" required="o" mfcode="0x115f">
-				<description>Set to 0x12 (0xFE) to connect (disconnect) the left button to (from) the relay.</description>
-			</attribute>
-			<attribute id="0xFF23" name="Xiaomi Disconnect 2" type="u8" showas="hex" access="rw" required="o" mfcode="0x115f">
-				<description>Set to 0x22 (0xFE) to connect (disconnect) the left button to (from) the relay.</description>
-			</attribute>
-		</attribute-set>
-		<attribute-set id="0xFF00" description="Xiaomi specific" mfcode="0x115f">
-			<attribute id="0xFF08" name="Unknown" type="u16" access="rw" required="o" mfcode="0x115f"></attribute>
-			<attribute id="0xFF51" name="Unknown" type="ostring" access="rw" required="o" mfcode="0x115f"></attribute>
-			<attribute id="0xFF52" name="Unknown" type="cstring" access="rw" required="o" mfcode="0x115f"></attribute>
-			<attribute id="0xFF53" name="Unknown" type="ostring" access="rw" required="o" mfcode="0x115f"></attribute>
-			<attribute id="0xFF54" name="Unknown" type="ostring" access="rw" required="o" mfcode="0x115f"></attribute>
-			<attribute id="0xFFF0" name="Unknown" type="ostring" access="rw" required="o" mfcode="0x115f"></attribute>
-		</attribute-set>
-		<attribute-set id="0xFF00" description="Tuya specific" mfcode="0x1002">
-			<attribute id="0xffde" name="Reporting1" type="u8" default="0" access="rw" required="o"></attribute>
-			<attribute id="0xffe2" name="Unknown1" type="u8" default="0" access="rw" required="o"></attribute>
-			<attribute id="0xffe4" name="Unknown2" type="u8" default="0" access="rw" required="o"></attribute>
-			<attribute id="0xfffe" name="Unknown3" type="enum8" default="0" access="rw" required="o"></attribute>
-		</attribute-set>
-		<command id="00" dir="recv" name="Reset to Factory Defaults" required="o"></command>
-		</server>
-		<client>
-		</client>
-	</cluster>
-	<cluster id="0x0001" name="Power Configuration">
-		<description>Attributes for determining more detailed information about a device’s power source(s), and for configuring under/over voltage alarms.</description>
-		<server>
-		<attribute-set id="0x0000" description="Mains Information">
-			<attribute id="0x0000" name="Mains Voltage" type="u16" access="r" required="o"></attribute>
-			<attribute id="0x0001" name="Mains Frequency" type="u8" access="r" required="o"></attribute>
-		</attribute-set>
-		<attribute-set id="0x0010" description="Mains Settings">
-			<attribute id="0x0010" name="Mains Alarm Mask" type="bmp8" default="00000000" access="rw" required="o">
-				<value name="Mains Voltage too low (7.2.2.2.2)" value="0"></value>
-				<value name="Mains Voltage too high (7.2.2.2.3)" value="1"></value>
-			</attribute>
-			<attribute id="0x0011" name="Mains Voltage Min Threshold" type="u16" access="rw" default="0" required="o"></attribute>
-			<attribute id="0x0012" name="Mains Voltage Max Threshold" type="u16" access="rw" default="0xffff" required="o"></attribute>
-			<attribute id="0x0013" name="Mains Voltage Dwell Trip Point" type="u16" access="rw" default="0" required="o"></attribute>
-		</attribute-set>
-		<attribute-set id="0x0020" description="Battery Information">
-			<attribute id="0x0020" name="Battery Voltage" type="u8" access="r" required="o"></attribute>
-			<attribute id="0x0021" name="Battery Percentage Remaining" type="u8" access="r" required="o"></attribute>
-		</attribute-set>
-		<attribute-set id="0x0030" description="Battery Settings">
-			<attribute id="0x0030" name="Battery Manufacturer" type="cstring" access="rw" required="o" range="0,16"></attribute>
-			<attribute id="0x0031" name="Battery Size" type="enum8" default="0xff" access="rw" required="o">
-				<value name="No Battery" value="0"></value>
-				<value name="Built in" value="1"></value>
-				<value name="Other" value="2"></value>
-				<value name="AA" value="3"></value>
-				<value name="AAA" value="4"></value>
-				<value name="C" value="5"></value>
-				<value name="D" value="6"></value>
-			</attribute>
-			<attribute id="0x0032" name="Battery AHr Rating" type="u16" access="rw" required="o"></attribute>
-			<attribute id="0x0033" name="Battery Quantity" type="u8" access="rw" required="o"></attribute>
-			<attribute id="0x0034" name="Battery Rated Voltage" type="u8" access="rw" required="o"></attribute>
-			<attribute id="0x0035" name="Battery Alarm Mask" type="bmp8" default="00000000" access="rw" required="o">
-				<value name="Battery Voltage too low" value="0"></value>
-				<value name="Battery Alarm 1" value="1"></value>
-				<value name="Battery Alarm 2" value="2"></value>
-				<value name="Battery Alarm 3" value="3"></value>
-			</attribute>
-			<attribute id="0x0036" name="Battery Voltage Min Threshold" type="u8" access="rw" default="00" required="o"></attribute>
-			<attribute id="0x003e" name="Battery Alarm State" type="bmp32" access="rw" default="0" required="o">
-
-			</attribute>
-		</attribute-set>
-		</server>
-    <client>
-    </client>
-	</cluster>
-	<cluster id="0x0002" name="Device Temperature Configuration">
-		<description>Attributes for determining information about a device’s internal temperature, and for configuring under/over temperature alarms.</description>
-		<server>
-			<attribute-set id="0x0000" description="Device Temperature Information">
-				<attribute id="0x0000" name="Current Temperature" type="s16" access="r" range="-200,200" required="m"></attribute>
-				<attribute id="0x0001" name="Min Temp Experienced" type="s16" access="r" range="-200,200" required="o"></attribute>
-				<attribute id="0x0002" name="Max Temp Experienced" type="s16" access="r" range="-200,200" required="o"></attribute>
-				<attribute id="0x0003" name="Over Temp Total Dwell" type="u16" access="r" range="0x0000,0xffff" default="0" required="o"></attribute>
-			</attribute-set>
-			<attribute-set id="0x0010" description="Device Temperature Settings">
-				<attribute id="0x0010" name="Device Temp Alarm Mask" type="bmp8" access="rw" range="00000000,00000011" default="00000000" required="o"></attribute>
-				<attribute id="0x0011" name="Low Temp Threshold" type="s16" access="rw" range="-200,200" required="o"></attribute>
-				<attribute id="0x0012" name="High Temp Threshold" type="s16" access="rw" range="-200,200" required="o"></attribute>
-				<attribute id="0x0013" name="Low Temp Dwell Trip Point" type="u24" access="rw" range="0x000000,0xffffff" required="o"></attribute>
-				<attribute id="0x0014" name="High Temp Dwell Trip Point" type="u24" access="rw" range="0x000000,0xffffff" required="o"></attribute>
-			</attribute-set>
-		</server>
-		<client>
-		</client>
-	</cluster>
-	<cluster id="0x0003" name="Identify">
-		<description>Attributes and commands for putting a device into Identification mode (e.g. flashing a light)</description>
-		<server>
-			<attribute id="0x0000" name="Identify Time" type="u16" access="rw" default="0x0000" range="0x0000,0xfff" required="m"></attribute>
-			<attribute id="0x4000" name="Identification button" type="bool" default="0x00" access="r" required="m" mfcode="0x1246"></attribute>
-			<command id="00" dir="recv" name="Identify" required="m">
-				<description>Start or stop the device identifying itself.</description>
-				<payload>
-					<attribute id="0x0000" type="u16" name="Identify Time" required="m" default="5">
-						<description>The time in seconds for which a device will stay in identify mode.</description>
-					</attribute>
-				</payload>
-			</command>
-						<command id="01" dir="recv" name="Identify Query" response="0x00" required="m">
-								<description>Allows the sending device to request the target or targets to respond if they are currently identifying themselves.</description>
-								<payload>
-								</payload>
-						</command>
-			<command id="40" dir="recv" name="Trigger Effect" required="m">
-				<description>The trigger effect command allows the support of feedback to the user, such as a certain light effect.
-</description>
-				<payload>
-					<attribute id="0x0000" type="enum8" name="Effect identifier" required="m" default="0x00">
-						<description>The effect identifier field specifies the identify effect to use.</description>
-							<value name="Blink" value="0x00"></value>
-							<value name="Breathe" value="0x01"></value>
-							<value name="Okay" value="0x02"></value>
-							<value name="Channel change" value="0x0b"></value>
-							<value name="Finish" value="0xfe"></value>
-							<value name="Stop" value="0xff"></value>
-					</attribute>
-					<attribute id="0x0001" type="enum8" name="Effect variant" required="m" default="0">
-						<description>The effect identifier field specifies the identify effect to use.</description>
-						<value name="Default" value="0x00"></value>
-					</attribute>
-				</payload>
-			</command>
-		</server>
-		<client>
-					<command id="00" dir="recv" name="Identify Query Response" required="m">
-							<description>Response of a identify query command.</description>
-							<payload>
-									<attribute id="0x0000" type="u16" name="Timeout" required="m" default="0">
-											<description>The time in seconds for which a device will stay in identify mode.</description>
-									</attribute>
-							</payload>
-					</command>
-		</client>
-	</cluster>
-	<cluster id="0x0004" name="Groups">
-	<description>Attributes and commands for group configuration and manipulation.</description>
-		<server>
-			<attribute id="0000" name="Name Support" type="bmp8" range="x0000000" access="r" required="m">
-				<value name="Name Support" value="7"></value>
-			</attribute>
-			<attribute id="0x0001" name="IKEA Scene" type="u32" access="rw" required="m" showas="hex" mfcode="0x117c">
-
-			</attribute>
-			<command id="00" dir="recv" name="Add group" required="m" response="0x00">
-				<description>Add a group to the device.</description>
-				<payload>
-					<attribute id="0x0000" type="u16" name="Group ID" showas="hex" required="m" default="0x0000"></attribute>
-					<attribute id="0x0001" type="cstring" name="Group Name" required="m"></attribute>
-				</payload>
-			</command>
-			<command id="01" dir="recv" name="View group" required="m" response="0x01">
-				<description>Get the name of a group.</description>
-				<payload>
-					<attribute id="0x0000" type="u16" name="Group ID" showas="hex" required="m" default="0x0000"></attribute>
-				</payload>
-			</command>
-			<command id="02" dir="recv" name="Get group membership" required="m" response="0x02">
-				<description>Get the group membership of the device.</description>
-				<payload>
-					<attribute id="0x0000" type="u8" name="Group count" required="m" default="0x00"></attribute>
-					<attribute id="0x0001" type="u16" name="Group list" showas="hex" listSize="@0x0000" required="m" ></attribute>
-				</payload>
-			</command>
-			<command id="03" dir="recv" name="Remove group" required="m" response="0x03">
-				<description>Remove a group from the device.</description>
-				<payload>
-					<attribute id="0x0000" type="u16" name="Group ID" showas="hex" required="m" default="0x0000"></attribute>
-				</payload>
-			</command>
-			<command id="04" dir="recv" name="Remove all groups" required="m">
-				<description>Remove all group from the device.</description>
-			</command>
-		</server>
-		<client>
-			<command id="00" dir="recv" name="Add group response" required="m">
-				<description>The Response to the add group request.</description>
-				<payload>
-					<attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status">
-					</attribute>
-					<attribute id="0x0001" type="u16" name="Group ID" showas="hex" required="m" default="0x0000"></attribute>
-				</payload>
-			</command>
-			<command id="01" dir="recv" name="View group response" required="m">
-				<description>The Response to the view group request.</description>
-				<payload>
-					<attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status">
-					</attribute>
-					<attribute id="0x0001" type="u16" name="Group ID" showas="hex" required="m" default="0x0000"></attribute>
-					<attribute id="0x0002" type="cstring" name="Group Name" required="m"></attribute>
-					<condition id="0x0000" op="!=" value="0x00">
-						<action action="ignore" id="0x0001" />
-						<action action="ignore" id="0x0002" />
-					</condition>
-				</payload>
-			</command>
-			<command id="02" dir="recv" name="Get group membership response" required="m">
-				<description>The Response to the get group membership request.</description>
-				<payload>
-					<attribute id="0x0000" type="u8" name="Capacity" required="m" default="0x00"></attribute>
-					<attribute id="0x0001" type="u8" name="Group count" required="m" default="0x00"></attribute>
-					<attribute id="0x0002" type="u16" name="Group list" showas="hex" listSize="0x0001" required="o" ></attribute>
-				</payload>
-			</command>
-			<command id="03" dir="recv" name="Remove group response" required="m">
-				<description>The Response to the remove group request.</description>
-				<payload>
-					<attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status">
-					</attribute>
-					<attribute id="0x0001" type="u16" name="Group ID" showas="hex" required="m" default="0x0000"></attribute>
-				</payload>
-			</command>
-		</client>
-	</cluster>
-	<cluster id="0x0005" name="Scenes">
-	<description>Attributes and commands for scene configuration and manipulation.</description>
-		<server>
-			<attribute id="0x0000" name="Scene Count" type="u8" range="0x00-0xff" access="r" required="m" showas="hex" default="0x00"></attribute>
-			<attribute id="0x0001" name="Current Scene" type="u8" range="0x00-0xff" access="r" required="m" showas="hex" default="0x00"></attribute>
-			<attribute id="0x0002" name="Current Group" type="u16" range="0x0000-0xfff7" access="r" required="m" showas="hex" default="0x0000"></attribute>
-			<attribute id="0x0003" name="Scene Valid" type="bool" access="r" required="m" default="0"></attribute>
-			<attribute id="0x0004" name="Name Support" type="bmp8" access="r" showas="hex" required="m" default="0"></attribute>
-			<attribute id="0x0005" name="Last ConfiguredBy" type="uid" access="r" showas="hex" required="o"></attribute>
-			<command id="0x00" dir="recv" name="Add scene" required="m" response="0x00">
-				<description>Add a scenes to the group (empty).</description>
-				<payload>
-					<attribute id="0x0000" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
-					<attribute id="0x0001" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
-					<attribute id="0x0002" type="u16" name="Transition time" required="m" showas="hex" default="0x0000"></attribute>
-					<attribute id="0x0003" type="u8" name="Name Length" required="m" showas="hex" default="0x00"></attribute>
-				</payload>
-			</command>
-			<command id="0x01" dir="recv" name="View scene" required="m" response="0x01">
-				<description>Views the scenes of a group.</description>
-				<payload>
-					<attribute id="0x0000" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
-					<attribute id="0x0001" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
-				</payload>
-			</command>
-			<command id="0x02" dir="recv" name="Remove scene" required="m" response="0x02">
-				<description>Removes a scenes of a group.</description>
-				<payload>
-					<attribute id="0x0000" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
-					<attribute id="0x0001" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
-				</payload>
-			</command>
-			<command id="0x03" dir="recv" name="Remove all scenes" required="m" response="0x03">
-				<description>Removes all scenes of a group.</description>
-				<payload>
-					<attribute id="0x0000" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
-				</payload>
-			</command>
-			<command id="0x04" dir="recv" name="Store scene" required="m" response="0x04">
-				<description>Stores a scene of a group for a device.</description>
-				<payload>
-					<attribute id="0x0000" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
-					<attribute id="0x0001" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
-				</payload>
-			</command>
-			<command id="0x05" dir="recv" name="Recall scene" required="m" response="0x05">
-				<description>Recalls a scene of a group for a device.</description>
-				<payload>
-					<attribute id="0x0000" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
-					<attribute id="0x0001" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
-				</payload>
-			</command>
-			<command id="0x06" dir="recv" name="Get scene membership" required="m" response="0x06">
-				<description>Get the scenes of a group for a device.</description>
-				<payload>
-					<attribute id="0x0000" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
-				</payload>
-			</command>
-			<command id="0x41" dir="recv" name="Enhanced view scene" required="m" response="0x41">
-				<description>Views the scenes of a group.</description>
-				<payload>
-					<attribute id="0x0000" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
-					<attribute id="0x0001" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
-				</payload>
-			</command>
-      <command id="0x07" dir="recv" name="IKEA step" required="o" vendor="0x117c">
-        <description>Command sent by TRADFRI remote control on press left or right.  Set Direction to 1 for left or leave at 0 for right.  Leave the Unknown parameters at their default values.</description>
-        <payload>
-          <attribute id="0x0000" type="u8" name="Direction" required="m" default="0x0"></attribute>
-          <attribute id="0x0001" type="u8" name="Unknown" required="m" showas="hex" default="0x01"></attribute>
-          <attribute id="0x0002" type="u16" name="Unknown" required="m" showas="hex" default="0x000d"></attribute>
-        </payload>
-      </command>
-      <command id="0x08" dir="recv" name="IKEA move" required="o" vendor="0x117c">
-        <description>Command sent by TRADFRI remote control on hold left or right.  Set Direction to 1 for left or leave at 0 for right.  Leave the Unknown parameter at its default value.</description>
-        <payload>
-          <attribute id="0x0000" type="u8" name="Direction" required="m" default="0x0"></attribute>
-          <attribute id="0x0001" type="u16" name="Unknown" required="m" showas="hex" default="0x000d"></attribute>
-        </payload>
-      </command>
-      <command id="0x09" dir="recv" name="IKEA stop" required="o" vendor="0x117c">
-        <description>Command sent by TRADFRI remote control on release (after hold).  Leave the Unknown parameter at its default value.</description>
-        <payload>
-          <attribute id="0x0000" type="u16" name="Unknown" required="m" showas="hex" default="0x0000"></attribute>
-        </payload>
-      </command>
-		<!-- TODO -->
-		</server>
-		<client>
-			<command id="0x00" dir="recv" name="Add scene response" required="m">
-				<description>Response to the add scene command.</description>
-				<payload>
-					<attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status"></attribute>
-					<attribute id="0x0001" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
-					<attribute id="0x0002" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
-				</payload>
-			</command>
-			<command id="0x01" dir="recv" name="View scene response" required="m">
-				<description>Response to the view scene command.</description>
-				<payload>
-					<attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status"></attribute>
-					<attribute id="0x0001" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
-					<attribute id="0x0002" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
-					<attribute id="0x0003" type="u16" name="Transition time" required="m" showas="hex" default="0x0000"></attribute>
-				</payload>
-			</command>
-			<command id="0x02" dir="recv" name="Remove scene response" required="m">
-				<description>Response to the remove scene command.</description>
-				<payload>
-					<attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status"></attribute>
-					<attribute id="0x0001" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
-					<attribute id="0x0002" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
-				</payload>
-			</command>
-			<command id="0x03" dir="recv" name="Remove all scenes response" required="m">
-				<description>Response to the remove all scenes command.</description>
-				<payload>
-					<attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status"></attribute>
-					<attribute id="0x0001" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
-				</payload>
-			</command>
-			<command id="0x04" dir="recv" name="Store scene response" required="m">
-				<description>Response to the store scene command.</description>
-				<payload>
-					<attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status"></attribute>
-					<attribute id="0x0001" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
-					<attribute id="0x0002" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
-				</payload>
-			</command>
-			<command id="0x06" dir="recv" name="Get scene membershio response" required="m">
-				<description>Shows details about scene membership.</description>
-				<payload>
-					<attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status"></attribute>
-					<attribute id="0x0001" type="u8" name="Capacity" required="m" showas="dec" default="0x00"></attribute>
-					<attribute id="0x0002" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
-					<attribute id="0x0003" type="u8" name="Scene count" required="m" showas="dec" default="0x00"></attribute>
-				</payload>
-			</command>
-			<command id="0x41" dir="recv" name="Enhanced view scene response" required="m">
-				<description>A scene description.</description>
-				<payload>
-					<attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status"></attribute>
-					<attribute id="0x0001" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
-					<attribute id="0x0002" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
-					<attribute id="0x0003" type="u16" name="Transition time" required="m" showas="dec" default="0x00"></attribute>
-					<attribute id="0x0004" type="cstring" name="Name" required="m"></attribute>
-				</payload>
-			</command>
-		<!-- TODO -->
-		</client>
-	</cluster>
-	<cluster id="0x0006" name="On/Off">
-		<description>Attributes and commands for switching devices between 'On' and 'Off' states.</description>
-		<server>
-        <attribute-set id="0x0000" description="OnOff state">
-            <attribute id="0000" name="OnOff" type="bool" access="r" default="0" required="m">
-                    <value name="On" value="1"></value>
-                    <value name="Off" value="0"></value>
+  <datatypes>
+    <!--Null-->
+    <datatype id="0x00" name="No data" shortname="ndat" length="0" ad="-"></datatype>
+    <!--General data -->
+    <datatype id="0x08" name="8-bit data" shortname="dat8" length="1" ad="D"></datatype>
+    <datatype id="0x09" name="16-bit data" shortname="dat16" length="2" ad="D"></datatype>
+    <datatype id="0x0a" name="24-bit data" shortname="dat24" length="3" ad="D"></datatype>
+    <datatype id="0x0b" name="32-bit data" shortname="dat32" length="4" ad="D"></datatype>
+    <datatype id="0x0c" name="40-bit data" shortname="dat40" length="5" ad="D"></datatype>
+    <datatype id="0x0d" name="48-bit data" shortname="dat48" length="6" ad="D"></datatype>
+    <datatype id="0x0e" name="56-bit data" shortname="dat56" length="7" ad="D"></datatype>
+    <datatype id="0x0f" name="64-bit data" shortname="dat64" length="8" ad="D"></datatype>
+    <!-- Logical -->
+    <datatype id="0x10" name="Boolean" shortname="bool" length="1" inval="0xff" ad="D"></datatype>
+    <!-- Bitmap -->
+    <datatype id="0x18" name="8-bit bitmap" shortname="bmp8" length="1" ad="D"></datatype>
+    <datatype id="0x19" name="16-bit bitmap" shortname="bmp16" length="2" ad="D"></datatype>
+    <datatype id="0x1a" name="24-bit bitmap" shortname="bmp24" length="3" ad="D"></datatype>
+    <datatype id="0x1b" name="32-bit bitmap" shortname="bmp32" length="4" ad="D"></datatype>
+    <datatype id="0x1c" name="40-bit bitmap" shortname="bmp40" length="5" ad="D"></datatype>
+    <datatype id="0x1d" name="48-bit bitmap" shortname="bmp48" length="6" ad="D"></datatype>
+    <datatype id="0x1e" name="56-bit bitmap" shortname="bmp56" length="7" ad="D"></datatype>
+    <datatype id="0x1f" name="64-bit bitmap" shortname="bmp64" length="8" ad="D"></datatype>
+    <!-- Unsigned integer -->
+    <datatype id="0x20" name="Unsigned 8-bit integer" shortname="u8" length="1" inval="0xff" ad="A"></datatype>
+    <datatype id="0x21" name="Unsigned 16-bit integer" shortname="u16" length="2" inval="0xffff" ad="A"></datatype>
+    <datatype id="0x22" name="Unsigned 24-bit integer" shortname="u24" length="3" inval="0xffffff" ad="A"></datatype>
+    <datatype id="0x23" name="Unsigned 32-bit integer" shortname="u32" length="4" inval="0xffffffff" ad="A"></datatype>
+    <datatype id="0x24" name="Unsigned 40-bit integer" shortname="u40" length="5" inval="0xffffffffff" ad="A"></datatype>
+    <datatype id="0x25" name="Unsigned 48-bit integer" shortname="u48" length="6" inval="0xffffffffffff" ad="A"></datatype>
+    <datatype id="0x26" name="Unsigned 56-bit integer" shortname="u56" length="7" inval="0xffffffffffffff" ad="A"></datatype>
+    <datatype id="0x27" name="Unsigned 64-bit integer" shortname="u64" length="8" inval="0xffffffffffffffff" ad="A"></datatype>
+    <!-- Signed integer -->
+    <datatype id="0x28" name="Signed 8-bit integer" shortname="s8" length="1" inval="0x80" ad="A"></datatype>
+    <datatype id="0x29" name="Signed 16-bit integer" shortname="s16" length="2" inval="0x8000" ad="A"></datatype>
+    <datatype id="0x2a" name="Signed 24-bit integer" shortname="s24" length="3" inval="0x800000" ad="A"></datatype>
+    <datatype id="0x2b" name="Signed 32-bit integer" shortname="s32" length="4" inval="0x80000000" ad="A"></datatype>
+    <datatype id="0x2c" name="Signed 40-bit integer" shortname="s40" length="5" inval="0x8000000000" ad="A"></datatype>
+    <datatype id="0x2d" name="Signed 48-bit integer" shortname="s48" length="6" inval="0x800000000000" ad="A"></datatype>
+    <datatype id="0x2e" name="Signed 56-bit integer" shortname="s56" length="7" inval="0x80000000000000" ad="A"></datatype>
+    <datatype id="0x2f" name="Signed 64-bit integer" shortname="s64" length="8" inval="0x8000000000000000" ad="A"></datatype>
+    <!-- Enumeration -->
+    <datatype id="0x30" name="8-bit enumeration" shortname="enum8" length="1" inval="0xff" ad="D"></datatype>
+    <datatype id="0x31" name="16-bit enumeration" shortname="enum16" length="2" inval="0xffff" ad="D"></datatype>
+    <!-- Floating point -->
+    <datatype id="0x38" name="Semi-precision" shortname="semi" length="2" inval="nan" ad="A"></datatype>
+    <datatype id="0x39" name="Single precision" shortname="float" length="4" inval="nan" ad="A"></datatype>
+    <datatype id="0x3a" name="Double precision" shortname="double" length="8" inval="nan" ad="A"></datatype>
+    <!-- String -->
+    <!-- oN, defined in first N octets -->
+    <datatype id="0x41" name="Octed string" shortname="ostring" length="o1" inval="0xff" ad="D"></datatype>
+    <datatype id="0x42" name="Character string" shortname="cstring" length="o1" inval="0xff" ad="D"></datatype>
+    <datatype id="0x43" name="Long octed string" shortname="lostring" length="o2" inval="0xffff" ad="D"></datatype>
+    <datatype id="0x44" name="Long character string" shortname="lcstring" length="o2" inval="0xffff" ad="D"></datatype>
+    <!-- Ordered sequence -->
+    <!-- sloc, sum of length of content -->
+    <datatype id="0x48" name="Array" shortname="array" length="2+sloc" inval="0xffff" ad="D"></datatype>
+    <datatype id="0x4c" name="Structure" shortname="struct" length="2+sloc" inval="0xffff" ad="D"></datatype>
+    <!-- Collection -->
+    <datatype id="0x50" name="Set" shortname="set" length="sloc" inval="0xffff" ad="D"></datatype>
+    <datatype id="0x51" name="Bag" shortname="bag" length="sloc" inval="0xffff" ad="D"></datatype>
+    <!-- Time -->
+    <datatype id="0xe0" name="Time of day" shortname="time" length="4" inval="0xffffffff" ad="A"></datatype>
+    <datatype id="0xe1" name="Date" shortname="date" length="4" inval="0xffffffff" ad="A"></datatype>
+    <datatype id="0xe2" name="UTCTime" shortname="utc" length="4" inval="0xffffffff" ad="A"></datatype>
+    <!-- Identifier -->
+    <datatype id="0xe8" name="Cluster ID" shortname="cid" length="2" inval="0xffff" ad="D"></datatype>
+    <datatype id="0xe9" name="Attribute ID" shortname="aid" length="2" inval="0xffff" ad="D"></datatype>
+    <datatype id="0xea" name="BACnet OID" shortname="oid" length="4" inval="0xffffffff" ad="D"></datatype>
+    <!-- Miscellaneous -->
+    <datatype id="0xf0" name="IEEE address" shortname="uid" length="8" inval="0xffffffffffffffff" ad="D"></datatype>
+    <datatype id="0xf1" name="128-bit security key" shortname="seckey" length="16" ad="D"></datatype>
+  </datatypes>
+  
+  <enumeration id="0x00" name="ZCL_Status">
+    <value value="0x00" name="SUCCESS"></value>
+    <value value="0x01" name="FAILURE"></value>
+    <value value="0x7e" name="NOT_AUTHORIZED"></value>
+    <value value="0x7f" name="RESERVED_FIELD_NOT_ZERO"></value>
+    <value value="0x80" name="MALFORMED_COMMAND"></value>
+    <value value="0x81" name="UNSUP_CLUSTER_COMMAND"></value>
+    <value value="0x82" name="UNSUP_GENERAL_COMMAND"></value>
+    <value value="0x83" name="UNSUP_MANUF_CLUSTER_COMMAND"></value>
+    <value value="0x84" name="UNSUP_MANUF_GENERAL_COMMAND"></value>
+    <value value="0x85" name="INVALID_FIELD"></value>
+    <value value="0x86" name="UNSUPPORTED_ATTRIBUTE"></value>
+    <value value="0x87" name="INVALID_VALUE"></value>
+    <value value="0x88" name="READ_ONLY"></value>
+    <value value="0x89" name="INSUFFICIENT_SPACE"></value>
+    <value value="0x8a" name="DUPLICATE_EXISTS"></value>
+    <value value="0x8b" name="NOT_FOUND"></value>
+    <value value="0x8c" name="UNREPORTABLE_ATTRIBUTE"></value>
+    <value value="0x8d" name="INVALID_DATA_TYPE"></value>
+    <value value="0x8e" name="INVALID_SECTOR"></value>
+    <value value="0x8f" name="WRITE_ONLY"></value>
+    <value value="0x90" name="INCONSISTENT_STARTUP_STATE"></value>
+    <value value="0x91" name="DEFINED_OUT_OF_BAND"></value>
+    <value value="0xc0" name="HARDWARE_FAILURE"></value>
+    <value value="0xc1" name="SOFTWARE_FAILURE"></value>
+    <value value="0xc2" name="CALIBRATION_ERROR"></value>
+  </enumeration>
+  
+  <enumeration id="0x01" name="ZDP_Status">
+    <value value="0x00" name="SUCCESS"></value>
+    <value value="0x80" name="INV_REQUESTTYPE"></value>
+    <value value="0x81" name="DEVICE_NOT_FOUND"></value>
+    <value value="0x82" name="INVALID_EP"></value>
+    <value value="0x83" name="NOT_ACTIVE"></value>
+    <value value="0x84" name="NOT_SUPPORTED"></value>
+    <value value="0x85" name="TIMEOUT"></value>
+    <value value="0x86" name="NO_MATCH"></value>
+    <!--          0x87  reserved -->
+    <value value="0x88" name="NO_ENTRY"></value>
+    <value value="0x89" name="NO_DESCRIPTOR"></value>
+    <value value="0x8a" name="INSUFFCIENT_SPACE"></value>
+    <value value="0x8b" name="NOT_PERMITTED"></value>
+    <value value="0x8c" name="TABLE_FULL"></value>
+    <value value="0x8d" name="NOT_AUTHORIZED"></value>
+  </enumeration>
+  
+  <domain name="General" useZcl="true" description="The general functional domain contains clusters and information that provides generally applicable functions and attributes that are not specific to other functional domains.">
+    <domain name="General" useZcl="true" description="The general functional domain contains clusters and information that provides generally applicable functions and attributes that are not specific to other functional domains.">
+      <cluster id="0x0000" name="Basic">
+        <description>Attributes for determining basic information about a device, setting user device information such as description of location, and enabling a device.</description>
+        <server>
+          <attribute-set id="0x0000" description="Basic Device Information">
+            <attribute id="0x0000" name="ZCL Version" type="u8" access="r" default="0" required="m"></attribute>
+            <attribute id="0x0001" name="Application Version" type="u8" access="r" default="0" required="o"></attribute>
+            <attribute id="0x0002" name="Stack Version" type="u8" access="r" default="0" required="o"></attribute>
+            <attribute id="0x0003" name="HW Version" type="u8" access="r" default="0" required="o"></attribute>
+            <attribute id="0x0004" name="Manufacturer Name" type="cstring" access="r" required="o" range="0,32"></attribute>
+            <attribute id="0x0005" name="Model Identifier" type="cstring" access="r" required="o" range="0,32"></attribute>
+            <attribute id="0x0006" name="Date Code" type="cstring" access="r" required="o" range="0,16"></attribute>
+            <attribute id="0x0007" name="Power Source" type="enum8" default="0" access="r" required="m">
+              <value name="Unknown" value="0"></value>
+              <value name="Mains (single phase)" value="1"></value>
+              <value name="Mains (3 phase)" value="2"></value>
+              <value name="Battery" value="3"></value>
+              <value name="DC Source" value="4"></value>
+              <value name="Emergency mains constantly powered" value="5"></value>
+              <value name="Emergency mains and transfer switch" value="6"></value>
+              <value name="Mains (single phase) with battery backup" value="0x81"></value>
             </attribute>
-        </attribute-set>
-        <attribute-set id="0x4000" description="ZLL extensions">
+            <attribute id="0x0008" name="Generic Device Class" type="enum8" default="0xff" access="r" required="o" >
+              <description>IKEA control outlet specific.</description>
+              <value name="Lighting" value="0"></value>
+              <value name="Unspecified" value="0xff"></value>
+            </attribute>
+            <attribute id="0x0009" name="Generic Device Type" type="enum8" default="0xff" access="r" required="o" >
+              <description>IKEA control outlet specific.</description>
+              <value name="Incandescent" value="0"></value>
+              <value name="Spotlight Halogen" value="1"></value>
+              <value name="Halogen Bulb" value="2"></value>
+              <value name="CFL" value="3"></value>
+              <value name="Linear Fluorencent" value="4"></value>
+              <value name="LED Bulb" value="5"></value>
+              <value name="Spotlight LED" value="6"></value>
+              <value name="LED Strip" value="7"></value>
+              <value name="LED Tube" value="8"></value>
+              <value name="Indoor Luminaire" value="9"></value>
+              <value name="Outdoor Luminaire" value="0x0a"></value>
+              <value name="Pendant Luminaire" value="0x0b"></value>
+              <value name="Floor Standing Luminaire" value="0x0c"></value>
+              <value name="Controller" value="0xe0"></value>
+              <value name="Wall Switch" value="0xe1"></value>
+              <value name="Portable Remote Controller" value="0xe2"></value>
+              <value name="Motion or Light Sensor" value="0xe3"></value>
+              <value name="Actuator" value="0xf0"></value>
+              <value name="Wall Socket" value="0xf1"></value>
+              <value name="Gateway or Bridge" value="0xf2"></value>
+              <value name="Plug-In Unit" value="0xf3"></value>
+              <value name="Retrofit Actuator" value="0xf4"></value>
+              <value name="Unspecified" value="0xff"></value>
+            </attribute>
+            <attribute id="0x000a" name="Product code" type="ostring" access="r" required="o" >
+              <description>As printed on the product.</description>
+            </attribute>
+            <attribute id="0x4000" name="SW Build ID" type="cstring" access="r" required="o" range="0,16"></attribute>
+            <attribute id="0xff0d" name="Xiaomi Sensitivity" type="u8" access="rw" required="o" mfcode="0x115f"></attribute>
+            <attribute id="0xff22" name="Xiaomi Disconnect 1" type="u8" showas="hex" access="rw" required="o" mfcode="0x115f">
+              <description>Set to 0x12 (0xFE) to connect (disconnect) the left button to (from) the relay.</description>
+            </attribute>
+            <attribute id="0xff23" name="Xiaomi Disconnect 2" type="u8" showas="hex" access="rw" required="o" mfcode="0x115f">
+              <description>Set to 0x22 (0xFE) to connect (disconnect) the left button to (from) the relay.</description>
+            </attribute>
+            <!-- <attribute id="0xff0d" name="Xiaomi Sensitivity" type="u8" access="rw" required="o" mfcode="0x1037"></attribute> -->
+            <attribute id="0xfffd" name="Cluster Revision" type="u16" default="0" access="rw" required="o"></attribute>
+          </attribute-set>
+          <attribute-set id="0x0010" description="Basic Device Settings">
+            <attribute id="0x0010" name="Location Description" type="cstring" range="0,16" access="rw" required="o"></attribute>
+            <attribute id="0x0011" name="Physical Environment" type="enum8" default="0" access="rw" required="o">
+              <value name="Unspecified Environment" value="0"></value>
+              <!-- 0x01 - 0x7f Specified per Profile -->
+              <value name="Unknown Environment" value="0xff"></value>
+            </attribute>
+            <attribute id="0x0012" name="Device Enabled" type="bool" default="1" access="rw" required="o">
+              <value name="Disabled" value="0"></value>
+              <value name="Enabled" value="1"></value>
+            </attribute>
+            <attribute id="0x0013" name="Alarm Mask" type="bmp8" default="00000000" access="rw" required="o">
+              <value name="General Hardware Fault" value="0"></value>
+              <value name="General Software Fault" value="1"></value>
+            </attribute>
+            <attribute id="0x0014" name="Disable Local Config" type="bmp8" default="00000000" access="rw" required="o">
+              <value name="Reset (to factory defaults) disabled" value="0"></value>
+              <value name="Device configuration disabled" value="1"></value>
+            </attribute>
+          </attribute-set>
+          <attribute-set id="0x0030" description="Philips Specific" mfcode="0x100b">
+            <attribute id="0x0030" name="Sensitivity" description="Hue motion sensor related SML001" type="enum8" default="0" access="rw" required="o" mfcode="0x100b">
+              <value name="default" value="0"></value>
+              <value name="high" value="1"></value>
+              <value name="max" value="2"></value>
+            </attribute>
+            <attribute id="0x0031" name="Configuration" type="bmp16" default="0" access="rw" required="o" mfcode="0x100b" description="TODO flags are only known for hue dimmer switch">
+              <value name="Touchlink enabled 0" value="0"></value>
+              <value name="Touchlink enabled 1" value="1"></value>
+              <value name="Touchlink enabled 2" value="3"></value>
+            </attribute>
+            <attribute id="0x0032" name="Usertest" type="bool" default="0" access="rw" required="o" mfcode="0x100b"></attribute>
+            <attribute id="0x0033" name="LED Indication" type="bool" default="0" access="rw" required="o" mfcode="0x100b"></attribute>
+            <attribute id="0x0034" name="Device Mode" type="enum8" default="0" access="rw" required="o" mfcode="0x100b">
+              <value name="Single Rocker" value="0"></value>
+              <value name="Single Push Button" value="1"></value>
+              <value name="Dual Rocker" value="2"></value>
+              <value name="Dual Push Button" value="3"></value>
+            </attribute>
+          </attribute-set>
+          <attribute-set id="0x4000" description="Manufacturer specific" mfcode="0x1037">
+            <attribute id="0x4001" name="128-Bit security key" type="seckey" access="r" required="m" mfcode="0x1037"></attribute>
+            <attribute id="0x4002" name="IEEE address" type="uid" access="rw" required="m" mfcode="0x1037"></attribute>
+          </attribute-set>
+          <attribute-set id="0x4000" description="Manufacturer specific" mfcode="0x1166">
+            <attribute id="0x4001" name="128-Bit security key" type="seckey" access="r" required="m" mfcode="0x1166"></attribute>
+            <attribute id="0x4002" name="IEEE address" type="uid" access="rw" required="m" mfcode="0x1166"></attribute>
+          </attribute-set>
+          <attribute-set id="0x4000" description="Müller Licht specific" mfcode="0x121b">
+            <attribute id="0x4005" name="Scene" type="u8" access="rw" required="o" mfcode="0x121b"></attribute>
+          </attribute-set>
+          <attribute-set id="0x5000" description="ID Lock specific" mfcode="0x1337">
+            <attribute id="0x5000" name="Lock fw" type="cstring" access="r" required="m" mfcode="0x1337" />
+          </attribute-set>
+          <attribute-set id="0x8000" description="Develco specific" mfcode="0x1015">
+            <attribute id="0x8000" name="Primary SW Version" type="ostring" access="r" required="m" mfcode="0x1015"></attribute>
+            <attribute id="0x8010" name="Primary Bootloader SW Version" type="ostring" access="r" required="m" mfcode="0x1015"></attribute>
+            <attribute id="0x8020" name="Primary HW Version" type="ostring" access="r" required="m" mfcode="0x1015"></attribute>
+            <attribute id="0x8030" name="Primary HW name" type="ostring" access="r" required="m" mfcode="0x1015"></attribute>
+            <attribute id="0x8050" name="Primary SW Version 3rd Party" type="ostring" access="r" required="m" mfcode="0x1015"></attribute>
+          </attribute-set>
+          <attribute-set id="0xFF00" description="Xiaomi specific" mfcode="0x1037">
+            <attribute id="0xFF0D" name="Xiaomi Sensitivity" type="u8" access="rw" required="o" mfcode="0x115f"></attribute>
+            <attribute id="0xFF22" name="Xiaomi Disconnect 1" type="u8" showas="hex" access="rw" required="o" mfcode="0x115f">
+              <description>Set to 0x12 (0xFE) to connect (disconnect) the left button to (from) the relay.</description>
+            </attribute>
+            <attribute id="0xFF23" name="Xiaomi Disconnect 2" type="u8" showas="hex" access="rw" required="o" mfcode="0x115f">
+              <description>Set to 0x22 (0xFE) to connect (disconnect) the left button to (from) the relay.</description>
+            </attribute>
+          </attribute-set>
+          <attribute-set id="0xFF00" description="Xiaomi specific" mfcode="0x115f">
+            <attribute id="0xFF08" name="Unknown" type="u16" access="rw" required="o" mfcode="0x115f"></attribute>
+            <attribute id="0xFF51" name="Unknown" type="ostring" access="rw" required="o" mfcode="0x115f"></attribute>
+            <attribute id="0xFF52" name="Unknown" type="cstring" access="rw" required="o" mfcode="0x115f"></attribute>
+            <attribute id="0xFF53" name="Unknown" type="ostring" access="rw" required="o" mfcode="0x115f"></attribute>
+            <attribute id="0xFF54" name="Unknown" type="ostring" access="rw" required="o" mfcode="0x115f"></attribute>
+            <attribute id="0xFFF0" name="Unknown" type="ostring" access="rw" required="o" mfcode="0x115f"></attribute>
+          </attribute-set>
+          <attribute-set id="0xFF00" description="Tuya specific" mfcode="0x1002">
+            <attribute id="0xffde" name="Reporting1" type="u8" default="0" access="rw" required="o"></attribute>
+            <attribute id="0xffe2" name="Unknown1" type="u8" default="0" access="rw" required="o"></attribute>
+            <attribute id="0xffe4" name="Unknown2" type="u8" default="0" access="rw" required="o"></attribute>
+            <attribute id="0xfffe" name="Unknown3" type="enum8" default="0" access="rw" required="o"></attribute>
+          </attribute-set>
+          <command id="00" dir="recv" name="Reset to Factory Defaults" required="o"></command>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0001" name="Power Configuration">
+        <description>Attributes for determining more detailed information about a device’s power source(s), and for configuring under/over voltage alarms.</description>
+        <server>
+          <attribute-set id="0x0000" description="Mains Information">
+            <attribute id="0x0000" name="Mains Voltage" type="u16" access="r" required="o"></attribute>
+            <attribute id="0x0001" name="Mains Frequency" type="u8" access="r" required="o"></attribute>
+          </attribute-set>
+          <attribute-set id="0x0010" description="Mains Settings">
+            <attribute id="0x0010" name="Mains Alarm Mask" type="bmp8" default="00000000" access="rw" required="o">
+              <value name="Mains Voltage too low (7.2.2.2.2)" value="0"></value>
+              <value name="Mains Voltage too high (7.2.2.2.3)" value="1"></value>
+            </attribute>
+            <attribute id="0x0011" name="Mains Voltage Min Threshold" type="u16" access="rw" default="0" required="o"></attribute>
+            <attribute id="0x0012" name="Mains Voltage Max Threshold" type="u16" access="rw" default="0xffff" required="o"></attribute>
+            <attribute id="0x0013" name="Mains Voltage Dwell Trip Point" type="u16" access="rw" default="0" required="o"></attribute>
+          </attribute-set>
+          <attribute-set id="0x0020" description="Battery Information">
+            <attribute id="0x0020" name="Battery Voltage" type="u8" access="r" required="o"></attribute>
+            <attribute id="0x0021" name="Battery Percentage Remaining" type="u8" access="r" required="o"></attribute>
+          </attribute-set>
+          <attribute-set id="0x0030" description="Battery Settings">
+            <attribute id="0x0030" name="Battery Manufacturer" type="cstring" access="rw" required="o" range="0,16"></attribute>
+            <attribute id="0x0031" name="Battery Size" type="enum8" default="0xff" access="rw" required="o">
+              <value name="No Battery" value="0"></value>
+              <value name="Built in" value="1"></value>
+              <value name="Other" value="2"></value>
+              <value name="AA" value="3"></value>
+              <value name="AAA" value="4"></value>
+              <value name="C" value="5"></value>
+              <value name="D" value="6"></value>
+            </attribute>
+            <attribute id="0x0032" name="Battery AHr Rating" type="u16" access="rw" required="o"></attribute>
+            <attribute id="0x0033" name="Battery Quantity" type="u8" access="rw" required="o"></attribute>
+            <attribute id="0x0034" name="Battery Rated Voltage" type="u8" access="rw" required="o"></attribute>
+            <attribute id="0x0035" name="Battery Alarm Mask" type="bmp8" default="00000000" access="rw" required="o">
+              <value name="Battery Voltage too low" value="0"></value>
+              <value name="Battery Alarm 1" value="1"></value>
+              <value name="Battery Alarm 2" value="2"></value>
+              <value name="Battery Alarm 3" value="3"></value>
+            </attribute>
+            <attribute id="0x0036" name="Battery Voltage Min Threshold" type="u8" access="rw" default="00" required="o"></attribute>
+            <attribute id="0x003e" name="Battery Alarm State" type="bmp32" access="rw" default="0" required="o"></attribute>
+          </attribute-set>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0002" name="Device Temperature Configuration">
+        <description>Attributes for determining information about a device’s internal temperature, and for configuring under/over temperature alarms.</description>
+        <server>
+          <attribute-set id="0x0000" description="Device Temperature Information">
+            <attribute id="0x0000" name="Current Temperature" type="s16" access="r" range="-200,200" required="m"></attribute>
+            <attribute id="0x0001" name="Min Temp Experienced" type="s16" access="r" range="-200,200" required="o"></attribute>
+            <attribute id="0x0002" name="Max Temp Experienced" type="s16" access="r" range="-200,200" required="o"></attribute>
+            <attribute id="0x0003" name="Over Temp Total Dwell" type="u16" access="r" range="0x0000,0xffff" default="0" required="o"></attribute>
+          </attribute-set>
+          <attribute-set id="0x0010" description="Device Temperature Settings">
+            <attribute id="0x0010" name="Device Temp Alarm Mask" type="bmp8" access="rw" range="00000000,00000011" default="00000000" required="o"></attribute>
+            <attribute id="0x0011" name="Low Temp Threshold" type="s16" access="rw" range="-200,200" required="o"></attribute>
+            <attribute id="0x0012" name="High Temp Threshold" type="s16" access="rw" range="-200,200" required="o"></attribute>
+            <attribute id="0x0013" name="Low Temp Dwell Trip Point" type="u24" access="rw" range="0x000000,0xffffff" required="o"></attribute>
+            <attribute id="0x0014" name="High Temp Dwell Trip Point" type="u24" access="rw" range="0x000000,0xffffff" required="o"></attribute>
+          </attribute-set>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0003" name="Identify">
+        <description>Attributes and commands for putting a device into Identification mode (e.g. flashing a light)</description>
+        <server>
+          <attribute id="0x0000" name="Identify Time" type="u16" access="rw" default="0x0000" range="0x0000,0xfff" required="m"></attribute>
+          <attribute id="0x4000" name="Identification button" type="bool" default="0x00" access="r" required="m" mfcode="0x1246"></attribute>
+          <command id="00" dir="recv" name="Identify" required="m">
+            <description>Start or stop the device identifying itself.</description>
+            <payload>
+              <attribute id="0x0000" type="u16" name="Identify Time" required="m" default="5">
+                <description>The time in seconds for which a device will stay in identify mode.</description>
+              </attribute>
+            </payload>
+          </command>
+          <command id="01" dir="recv" name="Identify Query" response="0x00" required="m">
+            <description>Allows the sending device to request the target or targets to respond if they are currently identifying themselves.</description>
+            <payload>
+            </payload>
+          </command>
+          <command id="40" dir="recv" name="Trigger Effect" required="m">
+            <description>The trigger effect command allows the support of feedback to the user, such as a certain light effect.
+            </description>
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Effect identifier" required="m" default="0x00">
+                <description>The effect identifier field specifies the identify effect to use.</description>
+                <value name="Blink" value="0x00"></value>
+                <value name="Breathe" value="0x01"></value>
+                <value name="Okay" value="0x02"></value>
+                <value name="Channel change" value="0x0b"></value>
+                <value name="Finish" value="0xfe"></value>
+                <value name="Stop" value="0xff"></value>
+              </attribute>
+              <attribute id="0x0001" type="enum8" name="Effect variant" required="m" default="0">
+                <description>The effect identifier field specifies the identify effect to use.</description>
+                <value name="Default" value="0x00"></value>
+              </attribute>
+            </payload>
+          </command>
+        </server>
+        <client>
+          <command id="00" dir="recv" name="Identify Query Response" required="m">
+            <description>Response of a identify query command.</description>
+            <payload>
+              <attribute id="0x0000" type="u16" name="Timeout" required="m" default="0">
+                <description>The time in seconds for which a device will stay in identify mode.</description>
+              </attribute>
+            </payload>
+          </command>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0004" name="Groups">
+        <description>Attributes and commands for group configuration and manipulation.</description>
+        <server>
+          <attribute id="0000" name="Name Support" type="bmp8" range="x0000000" access="r" required="m">
+            <value name="Name Support" value="7"></value>
+          </attribute>
+          <attribute id="0x0001" name="IKEA Scene" type="u32" access="rw" required="m" showas="hex" mfcode="0x117c">
+            
+          </attribute>
+          <command id="00" dir="recv" name="Add group" required="m" response="0x00">
+            <description>Add a group to the device.</description>
+            <payload>
+              <attribute id="0x0000" type="u16" name="Group ID" showas="hex" required="m" default="0x0000"></attribute>
+              <attribute id="0x0001" type="cstring" name="Group Name" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="01" dir="recv" name="View group" required="m" response="0x01">
+            <description>Get the name of a group.</description>
+            <payload>
+              <attribute id="0x0000" type="u16" name="Group ID" showas="hex" required="m" default="0x0000"></attribute>
+            </payload>
+          </command>
+          <command id="02" dir="recv" name="Get group membership" required="m" response="0x02">
+            <description>Get the group membership of the device.</description>
+            <payload>
+              <attribute id="0x0000" type="u8" name="Group count" required="m" default="0x00"></attribute>
+              <attribute id="0x0001" type="u16" name="Group list" showas="hex" listSize="@0x0000" required="m" ></attribute>
+            </payload>
+          </command>
+          <command id="03" dir="recv" name="Remove group" required="m" response="0x03">
+            <description>Remove a group from the device.</description>
+            <payload>
+              <attribute id="0x0000" type="u16" name="Group ID" showas="hex" required="m" default="0x0000"></attribute>
+            </payload>
+          </command>
+          <command id="04" dir="recv" name="Remove all groups" required="m">
+            <description>Remove all group from the device.</description>
+          </command>
+        </server>
+        <client>
+          <command id="00" dir="recv" name="Add group response" required="m">
+            <description>The Response to the add group request.</description>
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status">
+              </attribute>
+              <attribute id="0x0001" type="u16" name="Group ID" showas="hex" required="m" default="0x0000"></attribute>
+            </payload>
+          </command>
+          <command id="01" dir="recv" name="View group response" required="m">
+            <description>The Response to the view group request.</description>
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status">
+              </attribute>
+              <attribute id="0x0001" type="u16" name="Group ID" showas="hex" required="m" default="0x0000"></attribute>
+              <attribute id="0x0002" type="cstring" name="Group Name" required="m"></attribute>
+              <condition id="0x0000" op="!=" value="0x00">
+                <action action="ignore" id="0x0001" />
+                <action action="ignore" id="0x0002" />
+              </condition>
+            </payload>
+          </command>
+          <command id="02" dir="recv" name="Get group membership response" required="m">
+            <description>The Response to the get group membership request.</description>
+            <payload>
+              <attribute id="0x0000" type="u8" name="Capacity" required="m" default="0x00"></attribute>
+              <attribute id="0x0001" type="u8" name="Group count" required="m" default="0x00"></attribute>
+              <attribute id="0x0002" type="u16" name="Group list" showas="hex" listSize="0x0001" required="o" ></attribute>
+            </payload>
+          </command>
+          <command id="03" dir="recv" name="Remove group response" required="m">
+            <description>The Response to the remove group request.</description>
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status">
+              </attribute>
+              <attribute id="0x0001" type="u16" name="Group ID" showas="hex" required="m" default="0x0000"></attribute>
+            </payload>
+          </command>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0005" name="Scenes">
+        <description>Attributes and commands for scene configuration and manipulation.</description>
+        <server>
+          <attribute id="0x0000" name="Scene Count" type="u8" range="0x00-0xff" access="r" required="m" showas="hex" default="0x00"></attribute>
+          <attribute id="0x0001" name="Current Scene" type="u8" range="0x00-0xff" access="r" required="m" showas="hex" default="0x00"></attribute>
+          <attribute id="0x0002" name="Current Group" type="u16" range="0x0000-0xfff7" access="r" required="m" showas="hex" default="0x0000"></attribute>
+          <attribute id="0x0003" name="Scene Valid" type="bool" access="r" required="m" default="0"></attribute>
+          <attribute id="0x0004" name="Name Support" type="bmp8" access="r" showas="hex" required="m" default="0"></attribute>
+          <attribute id="0x0005" name="Last ConfiguredBy" type="uid" access="r" showas="hex" required="o"></attribute>
+          <command id="0x00" dir="recv" name="Add scene" required="m" response="0x00">
+            <description>Add a scenes to the group (empty).</description>
+            <payload>
+              <attribute id="0x0000" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
+              <attribute id="0x0001" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
+              <attribute id="0x0002" type="u16" name="Transition time" required="m" showas="hex" default="0x0000"></attribute>
+              <attribute id="0x0003" type="u8" name="Name Length" required="m" showas="hex" default="0x00"></attribute>
+            </payload>
+          </command>
+          <command id="0x01" dir="recv" name="View scene" required="m" response="0x01">
+            <description>Views the scenes of a group.</description>
+            <payload>
+              <attribute id="0x0000" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
+              <attribute id="0x0001" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
+            </payload>
+          </command>
+          <command id="0x02" dir="recv" name="Remove scene" required="m" response="0x02">
+            <description>Removes a scenes of a group.</description>
+            <payload>
+              <attribute id="0x0000" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
+              <attribute id="0x0001" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
+            </payload>
+          </command>
+          <command id="0x03" dir="recv" name="Remove all scenes" required="m" response="0x03">
+            <description>Removes all scenes of a group.</description>
+            <payload>
+              <attribute id="0x0000" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
+            </payload>
+          </command>
+          <command id="0x04" dir="recv" name="Store scene" required="m" response="0x04">
+            <description>Stores a scene of a group for a device.</description>
+            <payload>
+              <attribute id="0x0000" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
+              <attribute id="0x0001" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
+            </payload>
+          </command>
+          <command id="0x05" dir="recv" name="Recall scene" required="m" response="0x05">
+            <description>Recalls a scene of a group for a device.</description>
+            <payload>
+              <attribute id="0x0000" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
+              <attribute id="0x0001" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
+            </payload>
+          </command>
+          <command id="0x06" dir="recv" name="Get scene membership" required="m" response="0x06">
+            <description>Get the scenes of a group for a device.</description>
+            <payload>
+              <attribute id="0x0000" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
+            </payload>
+          </command>
+          <command id="0x41" dir="recv" name="Enhanced view scene" required="m" response="0x41">
+            <description>Views the scenes of a group.</description>
+            <payload>
+              <attribute id="0x0000" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
+              <attribute id="0x0001" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
+            </payload>
+          </command>
+          <command id="0x07" dir="recv" name="IKEA step" required="o" vendor="0x117c">
+            <description>Command sent by TRADFRI remote control on press left or right.  Set Direction to 1 for left or leave at 0 for right.  Leave the Unknown parameters at their default values.</description>
+            <payload>
+              <attribute id="0x0000" type="u8" name="Direction" required="m" default="0x0"></attribute>
+              <attribute id="0x0001" type="u8" name="Unknown" required="m" showas="hex" default="0x01"></attribute>
+              <attribute id="0x0002" type="u16" name="Unknown" required="m" showas="hex" default="0x000d"></attribute>
+            </payload>
+          </command>
+          <command id="0x08" dir="recv" name="IKEA move" required="o" vendor="0x117c">
+            <description>Command sent by TRADFRI remote control on hold left or right.  Set Direction to 1 for left or leave at 0 for right.  Leave the Unknown parameter at its default value.</description>
+            <payload>
+              <attribute id="0x0000" type="u8" name="Direction" required="m" default="0x0"></attribute>
+              <attribute id="0x0001" type="u16" name="Unknown" required="m" showas="hex" default="0x000d"></attribute>
+            </payload>
+          </command>
+          <command id="0x09" dir="recv" name="IKEA stop" required="o" vendor="0x117c">
+            <description>Command sent by TRADFRI remote control on release (after hold).  Leave the Unknown parameter at its default value.</description>
+            <payload>
+              <attribute id="0x0000" type="u16" name="Unknown" required="m" showas="hex" default="0x0000"></attribute>
+            </payload>
+          </command>
+          <!-- TODO -->
+        </server>
+        <client>
+          <command id="0x00" dir="recv" name="Add scene response" required="m">
+            <description>Response to the add scene command.</description>
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status"></attribute>
+              <attribute id="0x0001" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
+              <attribute id="0x0002" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
+            </payload>
+          </command>
+          <command id="0x01" dir="recv" name="View scene response" required="m">
+            <description>Response to the view scene command.</description>
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status"></attribute>
+              <attribute id="0x0001" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
+              <attribute id="0x0002" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
+              <attribute id="0x0003" type="u16" name="Transition time" required="m" showas="hex" default="0x0000"></attribute>
+            </payload>
+          </command>
+          <command id="0x02" dir="recv" name="Remove scene response" required="m">
+            <description>Response to the remove scene command.</description>
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status"></attribute>
+              <attribute id="0x0001" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
+              <attribute id="0x0002" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
+            </payload>
+          </command>
+          <command id="0x03" dir="recv" name="Remove all scenes response" required="m">
+            <description>Response to the remove all scenes command.</description>
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status"></attribute>
+              <attribute id="0x0001" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
+            </payload>
+          </command>
+          <command id="0x04" dir="recv" name="Store scene response" required="m">
+            <description>Response to the store scene command.</description>
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status"></attribute>
+              <attribute id="0x0001" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
+              <attribute id="0x0002" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
+            </payload>
+          </command>
+          <command id="0x06" dir="recv" name="Get scene membershio response" required="m">
+            <description>Shows details about scene membership.</description>
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status"></attribute>
+              <attribute id="0x0001" type="u8" name="Capacity" required="m" showas="dec" default="0x00"></attribute>
+              <attribute id="0x0002" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
+              <attribute id="0x0003" type="u8" name="Scene count" required="m" showas="dec" default="0x00"></attribute>
+            </payload>
+          </command>
+          <command id="0x41" dir="recv" name="Enhanced view scene response" required="m">
+            <description>A scene description.</description>
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status"></attribute>
+              <attribute id="0x0001" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
+              <attribute id="0x0002" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
+              <attribute id="0x0003" type="u16" name="Transition time" required="m" showas="dec" default="0x00"></attribute>
+              <attribute id="0x0004" type="cstring" name="Name" required="m"></attribute>
+            </payload>
+          </command>
+          <!-- TODO -->
+        </client>
+      </cluster>
+      
+      <cluster id="0x0006" name="On/Off">
+        <description>Attributes and commands for switching devices between 'On' and 'Off' states.</description>
+        <server>
+          <attribute-set id="0x0000" description="OnOff state">
+            <attribute id="0000" name="OnOff" type="bool" access="r" default="0" required="m">
+              <value name="On" value="1"></value>
+              <value name="Off" value="0"></value>
+            </attribute>
+          </attribute-set>
+          <attribute-set id="0x4000" description="ZLL extensions">
             <attribute id="0x4000" name="GlobalSceneControl" type="bool" access="r" default="0" required="o">
             </attribute>
             <attribute id="0x4001" name="OnTime" type="u16" access="r" default="0" required="o">
@@ -643,1582 +646,1600 @@
             <attribute id="0x4002" name="OffWaitTime" type="u16" access="r" default="0" required="o">
             </attribute>
             <attribute id="0x4003" name="PowerOn OnOff" type="enum8" access="rw" default="0x01" required="o">
-                <value name="Off" value="0x00"></value>
-                <value name="On" value="0x01"></value>
-                <value name="Previous" value="0xff"></value>
-				  	</attribute>
-				</attribute-set>
-        <attribute-set id="0x8000" description="Xiaomi" mfcode="0x1037">
-          <attribute id="0x8000" name="Button Press" type="u8" access="r" required="o"/>
-        </attribute-set>
-        <attribute-set id="0x8001" description="Tuya special">
+              <value name="Off" value="0x00"></value>
+              <value name="On" value="0x01"></value>
+              <value name="Previous" value="0xff"></value>
+            </attribute>
+          </attribute-set>
+          <attribute-set id="0x8000" description="Xiaomi" mfcode="0x1037">
+            <attribute id="0x8000" name="Button Press" type="u8" access="r" required="o"/>
+          </attribute-set>
+          <attribute-set id="0x8001" description="Tuya special">
             <attribute id="0x8001" name="Light mode" type="enum8" default="0" required="m" access="r">
-                <value name="Mode 1" value="0"></value>
-                <value name="Mode 2" value="1"></value>
-                <value name="Mode 3" value="2"></value>
+              <value name="Mode 1" value="0"></value>
+              <value name="Mode 2" value="1"></value>
+              <value name="Mode 3" value="2"></value>
             </attribute>
             <attribute id="0x8002" name="Power on state" type="enum8" default="0" required="m" access="rw">
-                <value name="Off" value="0"></value>
-                <value name="On" value="1"></value>
-                <value name="Last state" value="2"></value>
+              <value name="Off" value="0"></value>
+              <value name="On" value="1"></value>
+              <value name="Last state" value="2"></value>
             </attribute>
-        </attribute-set>
-
-			<command id="00" dir="recv" name="Off" required="m">
-				<description>On receipt of this command, a device shall enter its 'Off' state. This state is device dependent, but it is recommended that it is used for power off or similar functions.</description>
-			</command>
-			<command id="01" dir="recv" name="On" required="m">
-				<description>On receipt of this command, a device shall enter its 'On' state. This state is device dependent, but it is recommended that it is used for power on or similar functions.</description>
-			</command>
-			<command id="02" dir="recv" name="Toggle" required="m">
-				<description>On receipt of this command, if a device is in its ‘Off’ state it shall enter its 'On' state. Otherwise, if it is in its ‘On’ state it shall enter its 'Off' state.</description>
-			</command>
-			<command id="40" dir="recv" name="Off with effect" required="m">
-				<description></description>
-				<payload>
-					<attribute id="0x0000" type="enum8" name="Effect identifier" required="m" default="0x00">
-						<description>The effect identifier field specifies the fading effect to use.</description>
-							<value name="Delayed all off" value="0x00"></value>
-							<value name="Dying light" value="0x01"></value>
-					</attribute>
-					<attribute id="0x0001" type="enum8" name="Effect variant" required="m" default="0x00">
-						<description>The effect identifier field specifies the effect variant to use.</description>
-							<value name="Fade off in 0.8s (Delayed all off)" value="0x00"></value>
-							<value name="No fade (Delayed all off)" value="0x01"></value>
-							<value name="50% dim down in 0.8s then fade off in 12s (Delayed all off)" value="0x02"></value>
-							<value name="20% dim up in 0.5s then off in 1s (Dying light)" value="0x00"></value>
-							<value name="" value="0x01"></value>
-					</attribute>
-				</payload>
-			</command>
-			<command id="41" dir="recv" name="On with recall global scene" required="m">
-				<description>The on with recall global scene command allows the recall of the light settings when the light was turned off.</description>
-			</command>
-			<command id="42" dir="recv" name="On with timed off" required="m">
-				<description>Allows lamps to be turned on for a specific duration with a guarded off duration so that should the lamp be subsequently switched off, further on with timed off commands, received during this time, are prevented from turning the lamps back on.</description>
-				<payload>
-					<attribute id="0x0000" type="bmp8" name="On/off control" required="m" default="0x00">
-						<description>The effect identifier field specifies the fading effect to use.</description>
-							<value name="Accept only when on" value="0"></value>
-					</attribute>
-					<attribute id="0x0001" type="u16" name="On time" required="m" default="0x0000">
-						<description>Length of time (in 1/10ths second) that the lamp is to remain on.</description>
-					</attribute>
-					<attribute id="0x0002" type="u16" name="Off wait time" required="m" default="0x0000">
-						<description>Length of time (in 1/10ths second) that the lamp shall remain off.</description>
-					</attribute>
-				</payload>
-			</command>
-		</server>
-		<client>
-		</client>
-	</cluster>
-	<cluster id="0xde06" name="RGB Color">
-		<description>Attributes and commands for setting devices light color. The color is specified in the RGB range from 0 - 255.</description>
-		<server>
-			<attribute id="0000" name="CurrentColorSet" type="u32" access="r" default="0" required="m" showas="hex">
-			</attribute>
-			<attribute id="0001" name="ColorSetCount" type="u8" access="r" default="0" required="m">
-			</attribute>
-			<command id="00" dir="recv" name="Set Color" required="m">
-				<description>On receipt of this command, the color of the light shall be changed and the current index updatet.</description>
-				<payload>
-					<attribute id="0x0000" type="u8" name="Red" required="m" default="0x00" range="0x00,0xFF" showas="slider">
-</attribute>
-					<attribute id="0x0001" type="u8" name="Green" required="m" default="0x00" range="0x00,0xFF" showas="slider"></attribute>
-					<attribute id="0x0002" type="u8" name="Blue" required="m" default="0x00" range="0x00,0xFF" showas="slider"></attribute>
-					<attribute id="0x0003" type="u8" name="Set Index" required="m" default="0x00"></attribute>
-					<attribute id="0x0004" type="bmp8" name="Options" required="m" default="0x00">
-						<value name="Change colors" value="0"></value>
-						<value name="Use current preset" value="1"></value>
-					</attribute>
-				</payload>
-			</command>
-		</server>
-		<client>
-
-		</client>
-	</cluster>
-	<cluster id="0x0007" name="On/Off Switch Configuration">
-	<description>Attributes and commands for configuring On/Off switching devices</description>
-	<server>
-		<attribute-set id="0x0000" description="Switch Information">
-			<attribute id="0x0000" name="SwitchType" type="enum8" access="r" default="0" required="m">
-				<description>The SwitchType attribute specifies the basic functionality of the On/Off switching device.</description>
-				<value name="Toggle" value="0">
-					<description>A switch with two physical states. An action by the user (e.g. toggling a rocker switch) moves the switch from state 1 to state 2. The switch then remains in that state until another action from the user returns it to state 1.</description>
-				</value>
-				<value name="Momentary" value="1">
-					<description>A switch with two physical states. An action by the user (e.g. pressing a button) moves the switch from state 1 to state 2. When the user ends his action (e.g. releases the button) the switch returns to state 1.</description>
-				</value>
-			</attribute>
-		</attribute-set>
-		<attribute-set id="0x0010" description="Switch Settings">
-			<attribute id="0x0010" name="SwitchActions" type="enum8" access="rw" default="0" required="m">
-			<description>The SwitchActions attribute is 8-bits in length and specifies the commands of the On/Off cluster to be generated when the switch moves between its two states.</description>
-				<value name="On-Off" value="0"></value>
-				<value name="Off-On" value="1"></value>
-				<value name="Toggle" value="2"></value>
-			</attribute>
-		</attribute-set>
-	</server>
-	<client>
-	</client>
-	<!-- TODO -->
-	</cluster>
-	<cluster id="0x0008" name="Level Control">
-	<description>This cluster provides an interface for controlling a characteristic of a device that can be set to a level, for example the brightness of a light, the degree of closure of a door, or the power output of a heater.</description>
-		<server>
-			<attribute id = "0x0000" name="Current Level" type="u8" range="0x00,0xff" access="r" required="m" default="0x00">
-				<description>The CurrentLevel attribute represents the current level of this device. meaning of 'level' is device dependent.</description>
-			</attribute>
-			<attribute id = "0x0001" name="Remaining Time" type="u16" range="0x0000,0xffff" access="r" required="o" default="0x0000">
-				<description>The RemainingTime attribute represents the time remaining until the current command is complete - it is specified in 1/10ths of a second.</description>
-			</attribute>
-			<attribute id = "0x0010" name="OnOff Transistion Time" type="u16" range="0x0000,0xffff" access="rw" required="o" default="0x0000">
-				<description>The OnOffTransitionTime attribute represents the time taken to move to or from the target level when On of Off commands are received by an On/Off cluster on the same endpoint. It is specified in 1/10ths of a second. The actual time taken should be as close to OnOffTransitionTime as the device is able.</description>
-			</attribute>
-			<attribute id = "0x0011" name="On Level" type="u8" range="0x01,0xff" access="rw" required="o" default="0xff">
-				<description>The OnLevel attribute determines the value that the CurrentLevel attribute is set to when the OnOff attribute of an On/Off cluster on the same endpoint is set to On. If the OnLevel attribute is not implemented, or is set to 0xff, it has no effect.</description>
-			</attribute>
-			<attribute id = "0x0012" name="On Transition Time" type="u16" range="0x0000,0xfffe" access="rw" required="o" default="0">
-				<description>The OnTransitionTime attribute represents the time taken to move the current level from the minimum level to the maximum level when an On command is received by an On/Off cluster on the same endpoint. It is specified in 10ths of a second. If this command is not implemented, or contains a value of 0xffff, the On/OffTransitionTime will be used instead.</description>
-			</attribute>
-			<attribute id = "0x0013" name="Off Transition Time" type="u16" range="0x0000,0xfffe" access="rw" required="o" default="0">
-				<description>The OffTransitionTime attribute represents the time taken to move the current level from the maximum level to the minimum level when an Off command is received by an On/Off cluster on the same endpoint. It is specified in 10ths of a second. If this command is not implemented, or contains a value of 0xffff, the On/OffTransitionTime will be used instead.</description>
-			</attribute>
-			<attribute id = "0x0014" name="Default Move Rate" type="u8" range="0x00,0xfe" access="rw" required="o">
-				<description>The DefaultMoveRate attribute determines the movement rate, in units per second, when a Move command is received with a Rate parameter of 0xFF.</description>
-			</attribute>
-			<attribute id = "0x000f" name="Unknown" type="bmp8" access="rw" required="o">
-				<description>IKEA specific.</description>
-			</attribute>
-			<attribute id="0x4000" name="PowerOn Level" type="u8" access="rw" required="o">
-			</attribute>
-			<command id="0x00" dir="recv" name="Move to Level" required="m">
-				<description></description>
-				<payload>
-					<attribute id="0x0000" type="u8" name="Level" required="m" default="0x00" range="0x00,0xff"></attribute>
-					<attribute id="0x0001" type="u16" name="Transistion time" required="m" default="0x0000"></attribute>
-				</payload>
-			</command>
-			<command id="0x01" dir="recv" name="Move" required="m">
-				<description></description>
-				<payload>
-					<attribute id="0x0000" type="enum8" name="Move mode" required="m" default="0x00">
-						<value name="Up" value="0x00"></value>
-						<value name="Down" value="0x01"></value>
-					</attribute>
-					<attribute id="0x0001" type="u8" name="Rate" required="m" default="0x00"></attribute>
-				</payload>
-			</command>
-			<command id="0x02" dir="recv" name="Step" required="m">
-				<description></description>
-				<payload>
-					<attribute id="0x0000" type="enum8" name="Step mode" required="m" default="0x00">
-						<value name="Up" value="0x00"></value>
-						<value name="Down" value="0x01"></value>
-					</attribute>
-					<attribute id="0x0001" type="u8" name="Step size" required="m" default="0x00"></attribute>
-					<attribute id="0x0002" type="u16" name="Transition time" required="m" default="0x0000"></attribute>
-				</payload>
-			</command>
-			<command id="0x03" dir="recv" name="Stop" required="m">
-				<description></description>
-			</command>
-			<command id="0x04" dir="recv" name="Move to Level (with On/Off)" required="m">
-				<description></description>
-				<payload>
-					<attribute id="0x0000" type="u8" name="Level" required="m" default="0x00" range="0x00,0xff"></attribute>
-					<attribute id="0x0001" type="u16" name="Transistion time" required="m" default="0x0000"></attribute>
-				</payload>
-			</command>
-			<command id="0x05" dir="recv" name="Move (with On/Off)" required="m">
-				<description></description>
-				<payload>
-					<attribute id="0x0000" type="enum8" name="Move mode" required="m" default="0x00">
-						<value name="Up" value="0x00"></value>
-						<value name="Down" value="0x01"></value>
-					</attribute>
-					<attribute id="0x0001" type="u8" name="Rate" required="m" default="0x00"></attribute>
-				</payload>
-			</command>
-			<command id="0x06" dir="recv" name="Step (with On/Off)" required="m">
-				<description></description>
-				<payload>
-					<attribute id="0x0000" type="enum8" name="Step mode" required="m" default="0x00">
-						<value name="Up" value="0x00"></value>
-						<value name="Down" value="0x01"></value>
-					</attribute>
-					<attribute id="0x0001" type="u8" name="Step size" required="m" default="0x00"></attribute>
-					<attribute id="0x0002" type="u16" name="Transition time" required="m" default="0x0000"></attribute>
-				</payload>
-			</command>
-			<command id="0x07" dir="recv" name="Stop (with On/Off)" required="m">
-				<description></description>
-			</command>
-		</server>
-		<client>
-		<!-- TODO commands -->
-		</client>
-	<!-- TODO -->
-	</cluster>
-	<cluster id="0x0009" name="Alarms">
-	<description>Sending alarm notifications and configuring alarm functionality.</description>
-	<!-- TODO -->
-		<server>
-			<attribute-set id="0x0000" description="Alarm Information">
-				<attribute id="0x0000" name="Alarm Count" type="u16" access="rw" required="m" default="0x00"></attribute>
-			</attribute-set>
-			<command id="0x00" dir="send" name="Alarm" required="m">
-					<payload>
-						<attribute id="0x0000" type="u8" name="Alarm code" default="0x00" required="m" showas="hex">
-						</attribute>
-						<attribute id="0x0001" type="u16" name="Cluster Id" default="0x0000" required="m" showas="hex"></attribute>
-					</payload>
-				</command>
-		</server>
-		<client>
-		</client>
-	</cluster>
-	<cluster id="0x000a" name="Time">
-		<description>This cluster provides a basic interface to a real-time clock.</description>
-		<server>
-		<attribute id="0000" name="Time" type="utc" access="rw" required="m"></attribute>
-		<attribute id="0001" name="Time Status" type="bmp8" default="0b00000000" access="rw" required="m">
-				<value name="Master Clock" value="0"></value>
-				<value name="Synchronized" value="1"></value>
-				<value name="Master for Timezone and Dst" value="2"></value>
-        <value name="Superseding" value="3"></value>
-		</attribute>
-		<attribute id="0002" name="Time Zone" type="s32" range="-86400,86400" default="0" access="rw" required="o"></attribute>
-		<attribute id="0003" name="Dst Start" type="u32" range="0x00000000,0xfffffffe" access="rw" required="o"></attribute>
-		<attribute id="0004" name="Dst End" type="u32" range="0x00000000,0xfffffffe" access="rw" required="o"></attribute>
-		<attribute id="0005" name="Dst Shift" type="s32" range="-86400,86400" default="0" access="rw" required="o"></attribute>
-		<attribute id="0006" name="Standard Time" type="u32" range="0x00000000,0xfffffffe" access="r" required="o"></attribute>
-		<attribute id="0007" name="Local Time" type="u32" range="0x00000000,0xfffffffe" access="r" required="o"></attribute>
-    <attribute id="0008" name="Last Set Time" type="utc" range="0x00000000,0xfffffffe" default="0xffffffff" access="r" required="o"></attribute>
-    <attribute id="0009" name="Valid Until Time" type="utc" range="0x00000000,0xfffffffe" default="0xffffffff" access="rw" required="o"></attribute>
-		<!-- TODO -->
-		</server>
-		<client>
-		</client>
-	</cluster>
-	<cluster id="0x000b" name="Location">
-        <description>Measure distance between devices.</description>
-		<server>
-			<command id="0x40" dir="recv" name="Distance measure" required="m" response="0x40" showas="hex">
-				<description></description>
-				<payload>
-					<attribute id="0x0000" type="u16" name="Target address" required="m" default="0x0000" ></attribute>
-                    <attribute id="0x0001" type="enum8" name="Resolution" required="m" default="0x00">
-						<value name="High" value="0x00"></value>
-						<value name="Mid" value="0x01"></value>
-                        <value name="Low" value="0x02"></value>
-					</attribute>
-				</payload>
-			</command>
-		</server>
-        <client>
-				<command id="0x40" dir="recv" name="Distance measure response" required="m">
-					<description>Returns the result of a distance measure.</description>
-					<payload>
-                        <attribute id="0x0000" type="u16" name="Target address" required="m" default="0x0000" showas="hex"></attribute>
-						<attribute id="0x0001" type="u16" name="Distance (Meter)" required="m" default="0"></attribute>
-						<attribute id="0x0002" type="u16" name="Quality index" required="m" default="0"></attribute>
-					</payload>
-				</command>
-            </client>
-	<!-- TODO -->
-	</cluster>
-	<cluster id="0x000c" name="Analog Input (Basic)">
-		<description>An interface for reading the value of an analog measurement and accessing various characteristics of that measurement.</description>
-		<server>
-            <attribute id="0x001c" name="Description" type="cstring" required="o" access="rw"></attribute>
-            <attribute id="0x0041" name="Max Present Value" type="float" required="o" access="rw"></attribute>
-            <attribute id="0x0045" name="Min Present Value" type="float" required="o" access="rw"></attribute>
-			<attribute id="0x0051" name="Out of service" type="bool" required="m" access="rw" default="0"></attribute>
-			<attribute id="0x0055" name="Present value" type="float" required="m" access="rw" default="0"></attribute>
-            <attribute id="0x0067" name="Reliability" type="enum8" required="o" access="rw" default="0">
-                <value name="No fault detected" value="0"></value>
-                <value name="No sensor" value="1"></value>
-                <value name="Over range" value="2"></value>
-                <value name="Under range" value="3"></value>
-                <value name="Open loop" value="4"></value>
-                <value name="Shorted loop" value="5"></value>
-                <value name="No output" value="6"></value>
-                <value name="Unreliable other" value="7"></value>
-                <value name="Process error" value="8"></value>
-                <value name="Multi state fault" value="9"></value>
-                <value name="Configuration error" value="10"></value>
-            </attribute>
-            <attribute id="0x006a" name="Resolution" type="float" required="o" access="rw"></attribute>
-			<attribute id="0x006f" name="Status flags" type="bmp8" required="m" access="r" default="0">
-				<value name="In Alarm" value="0x01"></value>
-				<value name="Fault" value="0x02"></value>
-				<value name="Overidden" value="0x04"></value>
-				<value name="Out of Service" value="0x08"></value>
-			</attribute>
-            <attribute id="0x0075" name="Engineering Units" type="enum16" required="o" access="rw"></attribute>
-            <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
-			<attribute id="0xff05" name="Unknown" type="u16" required="o" access="r" default="0" showas="hex"></attribute>
-		</server>
+          </attribute-set>
+          <command id="00" dir="recv" name="Off" required="m">
+            <description>On receipt of this command, a device shall enter its 'Off' state. This state is device dependent, but it is recommended that it is used for power off or similar functions.</description>
+          </command>
+          <command id="01" dir="recv" name="On" required="m">
+            <description>On receipt of this command, a device shall enter its 'On' state. This state is device dependent, but it is recommended that it is used for power on or similar functions.</description>
+          </command>
+          <command id="02" dir="recv" name="Toggle" required="m">
+            <description>On receipt of this command, if a device is in its ‘Off’ state it shall enter its 'On' state. Otherwise, if it is in its ‘On’ state it shall enter its 'Off' state.</description>
+          </command>
+          <command id="40" dir="recv" name="Off with effect" required="m">
+            <description></description>
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Effect identifier" required="m" default="0x00">
+                <description>The effect identifier field specifies the fading effect to use.</description>
+                <value name="Delayed all off" value="0x00"></value>
+                <value name="Dying light" value="0x01"></value>
+              </attribute>
+              <attribute id="0x0001" type="enum8" name="Effect variant" required="m" default="0x00">
+                <description>The effect identifier field specifies the effect variant to use.</description>
+                <value name="Fade off in 0.8s (Delayed all off)" value="0x00"></value>
+                <value name="No fade (Delayed all off)" value="0x01"></value>
+                <value name="50% dim down in 0.8s then fade off in 12s (Delayed all off)" value="0x02"></value>
+                <value name="20% dim up in 0.5s then off in 1s (Dying light)" value="0x00"></value>
+                <value name="" value="0x01"></value>
+              </attribute>
+            </payload>
+          </command>
+          <command id="41" dir="recv" name="On with recall global scene" required="m">
+            <description>The on with recall global scene command allows the recall of the light settings when the light was turned off.</description>
+          </command>
+          <command id="42" dir="recv" name="On with timed off" required="m">
+            <description>Allows lamps to be turned on for a specific duration with a guarded off duration so that should the lamp be subsequently switched off, further on with timed off commands, received during this time, are prevented from turning the lamps back on.</description>
+            <payload>
+              <attribute id="0x0000" type="bmp8" name="On/off control" required="m" default="0x00">
+                <description>The effect identifier field specifies the fading effect to use.</description>
+                <value name="Accept only when on" value="0"></value>
+              </attribute>
+              <attribute id="0x0001" type="u16" name="On time" required="m" default="0x0000">
+                <description>Length of time (in 1/10ths second) that the lamp is to remain on.</description>
+              </attribute>
+              <attribute id="0x0002" type="u16" name="Off wait time" required="m" default="0x0000">
+                <description>Length of time (in 1/10ths second) that the lamp shall remain off.</description>
+              </attribute>
+            </payload>
+          </command>
+        </server>
         <client>
         </client>
-	</cluster>
-    <cluster id="0x000d" name="Analog Output (Basic)">
+      </cluster>
+      <cluster id="0xde06" name="RGB Color">
+        <description>Attributes and commands for setting devices light color. The color is specified in the RGB range from 0 - 255.</description>
+        <server>
+          <attribute id="0000" name="CurrentColorSet" type="u32" access="r" default="0" required="m" showas="hex">
+          </attribute>
+          <attribute id="0001" name="ColorSetCount" type="u8" access="r" default="0" required="m">
+          </attribute>
+          <command id="00" dir="recv" name="Set Color" required="m">
+            <description>On receipt of this command, the color of the light shall be changed and the current index updatet.</description>
+            <payload>
+              <attribute id="0x0000" type="u8" name="Red" required="m" default="0x00" range="0x00,0xFF" showas="slider">
+              </attribute>
+              <attribute id="0x0001" type="u8" name="Green" required="m" default="0x00" range="0x00,0xFF" showas="slider"></attribute>
+              <attribute id="0x0002" type="u8" name="Blue" required="m" default="0x00" range="0x00,0xFF" showas="slider"></attribute>
+              <attribute id="0x0003" type="u8" name="Set Index" required="m" default="0x00"></attribute>
+              <attribute id="0x0004" type="bmp8" name="Options" required="m" default="0x00">
+                <value name="Change colors" value="0"></value>
+                <value name="Use current preset" value="1"></value>
+              </attribute>
+            </payload>
+          </command>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      <cluster id="0x0007" name="On/Off Switch Configuration">
+        <description>Attributes and commands for configuring On/Off switching devices</description>
+        <server>
+          <attribute-set id="0x0000" description="Switch Information">
+            <attribute id="0x0000" name="SwitchType" type="enum8" access="r" default="0" required="m">
+              <description>The SwitchType attribute specifies the basic functionality of the On/Off switching device.</description>
+              <value name="Toggle" value="0">
+                <description>A switch with two physical states. An action by the user (e.g. toggling a rocker switch) moves the switch from state 1 to state 2. The switch then remains in that state until another action from the user returns it to state 1.</description>
+              </value>
+              <value name="Momentary" value="1">
+                <description>A switch with two physical states. An action by the user (e.g. pressing a button) moves the switch from state 1 to state 2. When the user ends his action (e.g. releases the button) the switch returns to state 1.</description>
+              </value>
+            </attribute>
+          </attribute-set>
+          <attribute-set id="0x0010" description="Switch Settings">
+            <attribute id="0x0010" name="SwitchActions" type="enum8" access="rw" default="0" required="m">
+              <description>The SwitchActions attribute is 8-bits in length and specifies the commands of the On/Off cluster to be generated when the switch moves between its two states.</description>
+              <value name="On-Off" value="0"></value>
+              <value name="Off-On" value="1"></value>
+              <value name="Toggle" value="2"></value>
+            </attribute>
+          </attribute-set>
+        </server>
+        <client>
+        </client>
+        <!-- TODO -->
+      </cluster>
+      
+      <cluster id="0x0008" name="Level Control">
+        <description>This cluster provides an interface for controlling a characteristic of a device that can be set to a level, for example the brightness of a light, the degree of closure of a door, or the power output of a heater.</description>
+        <server>
+          <attribute id = "0x0000" name="Current Level" type="u8" range="0x00,0xff" access="r" required="m" default="0x00">
+            <description>The CurrentLevel attribute represents the current level of this device. meaning of 'level' is device dependent.</description>
+          </attribute>
+          <attribute id = "0x0001" name="Remaining Time" type="u16" range="0x0000,0xffff" access="r" required="o" default="0x0000">
+            <description>The RemainingTime attribute represents the time remaining until the current command is complete - it is specified in 1/10ths of a second.</description>
+          </attribute>
+          <attribute id = "0x0010" name="OnOff Transistion Time" type="u16" range="0x0000,0xffff" access="rw" required="o" default="0x0000">
+            <description>The OnOffTransitionTime attribute represents the time taken to move to or from the target level when On of Off commands are received by an On/Off cluster on the same endpoint. It is specified in 1/10ths of a second. The actual time taken should be as close to OnOffTransitionTime as the device is able.</description>
+          </attribute>
+          <attribute id = "0x0011" name="On Level" type="u8" range="0x01,0xff" access="rw" required="o" default="0xff">
+            <description>The OnLevel attribute determines the value that the CurrentLevel attribute is set to when the OnOff attribute of an On/Off cluster on the same endpoint is set to On. If the OnLevel attribute is not implemented, or is set to 0xff, it has no effect.</description>
+          </attribute>
+          <attribute id = "0x0012" name="On Transition Time" type="u16" range="0x0000,0xfffe" access="rw" required="o" default="0">
+            <description>The OnTransitionTime attribute represents the time taken to move the current level from the minimum level to the maximum level when an On command is received by an On/Off cluster on the same endpoint. It is specified in 10ths of a second. If this command is not implemented, or contains a value of 0xffff, the On/OffTransitionTime will be used instead.</description>
+          </attribute>
+          <attribute id = "0x0013" name="Off Transition Time" type="u16" range="0x0000,0xfffe" access="rw" required="o" default="0">
+            <description>The OffTransitionTime attribute represents the time taken to move the current level from the maximum level to the minimum level when an Off command is received by an On/Off cluster on the same endpoint. It is specified in 10ths of a second. If this command is not implemented, or contains a value of 0xffff, the On/OffTransitionTime will be used instead.</description>
+          </attribute>
+          <attribute id = "0x0014" name="Default Move Rate" type="u8" range="0x00,0xfe" access="rw" required="o">
+            <description>The DefaultMoveRate attribute determines the movement rate, in units per second, when a Move command is received with a Rate parameter of 0xFF.</description>
+          </attribute>
+          <attribute id = "0x000f" name="Unknown" type="bmp8" access="rw" required="o">
+            <description>IKEA specific.</description>
+          </attribute>
+          <attribute id="0x4000" name="PowerOn Level" type="u8" access="rw" required="o">
+          </attribute>
+          <command id="0x00" dir="recv" name="Move to Level" required="m">
+            <description></description>
+            <payload>
+              <attribute id="0x0000" type="u8" name="Level" required="m" default="0x00" range="0x00,0xff"></attribute>
+              <attribute id="0x0001" type="u16" name="Transistion time" required="m" default="0x0000"></attribute>
+            </payload>
+          </command>
+          <command id="0x01" dir="recv" name="Move" required="m">
+            <description></description>
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Move mode" required="m" default="0x00">
+                <value name="Up" value="0x00"></value>
+                <value name="Down" value="0x01"></value>
+              </attribute>
+              <attribute id="0x0001" type="u8" name="Rate" required="m" default="0x00"></attribute>
+            </payload>
+          </command>
+          <command id="0x02" dir="recv" name="Step" required="m">
+            <description></description>
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Step mode" required="m" default="0x00">
+                <value name="Up" value="0x00"></value>
+                <value name="Down" value="0x01"></value>
+              </attribute>
+              <attribute id="0x0001" type="u8" name="Step size" required="m" default="0x00"></attribute>
+              <attribute id="0x0002" type="u16" name="Transition time" required="m" default="0x0000"></attribute>
+            </payload>
+          </command>
+          <command id="0x03" dir="recv" name="Stop" required="m">
+            <description></description>
+          </command>
+          <command id="0x04" dir="recv" name="Move to Level (with On/Off)" required="m">
+            <description></description>
+            <payload>
+              <attribute id="0x0000" type="u8" name="Level" required="m" default="0x00" range="0x00,0xff"></attribute>
+              <attribute id="0x0001" type="u16" name="Transistion time" required="m" default="0x0000"></attribute>
+            </payload>
+          </command>
+          <command id="0x05" dir="recv" name="Move (with On/Off)" required="m">
+            <description></description>
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Move mode" required="m" default="0x00">
+                <value name="Up" value="0x00"></value>
+                <value name="Down" value="0x01"></value>
+              </attribute>
+              <attribute id="0x0001" type="u8" name="Rate" required="m" default="0x00"></attribute>
+            </payload>
+          </command>
+          <command id="0x06" dir="recv" name="Step (with On/Off)" required="m">
+            <description></description>
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Step mode" required="m" default="0x00">
+                <value name="Up" value="0x00"></value>
+                <value name="Down" value="0x01"></value>
+              </attribute>
+              <attribute id="0x0001" type="u8" name="Step size" required="m" default="0x00"></attribute>
+              <attribute id="0x0002" type="u16" name="Transition time" required="m" default="0x0000"></attribute>
+            </payload>
+          </command>
+          <command id="0x07" dir="recv" name="Stop (with On/Off)" required="m">
+            <description></description>
+          </command>
+        </server>
+        <client>
+          <!-- TODO commands -->
+        </client>
+        <!-- TODO -->
+      </cluster>
+      
+      <cluster id="0x0009" name="Alarms">
+        <description>Sending alarm notifications and configuring alarm functionality.</description>
+        <!-- TODO -->
+        <server>
+          <attribute-set id="0x0000" description="Alarm Information">
+            <attribute id="0x0000" name="Alarm Count" type="u16" access="rw" required="m" default="0x00"></attribute>
+          </attribute-set>
+          <command id="0x00" dir="send" name="Alarm" required="m">
+            <payload>
+              <attribute id="0x0000" type="u8" name="Alarm code" default="0x00" required="m" showas="hex">
+              </attribute>
+              <attribute id="0x0001" type="u16" name="Cluster Id" default="0x0000" required="m" showas="hex"></attribute>
+            </payload>
+          </command>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0x000a" name="Time">
+        <description>This cluster provides a basic interface to a real-time clock.</description>
+        <server>
+          <attribute id="0000" name="Time" type="utc" access="rw" required="m"></attribute>
+          <attribute id="0001" name="Time Status" type="bmp8" default="0b00000000" access="rw" required="m">
+            <value name="Master Clock" value="0"></value>
+            <value name="Synchronized" value="1"></value>
+            <value name="Master for Timezone and Dst" value="2"></value>
+            <value name="Superseding" value="3"></value>
+          </attribute>
+          <attribute id="0002" name="Time Zone" type="s32" range="-86400,86400" default="0" access="rw" required="o"></attribute>
+          <attribute id="0003" name="Dst Start" type="u32" range="0x00000000,0xfffffffe" access="rw" required="o"></attribute>
+          <attribute id="0004" name="Dst End" type="u32" range="0x00000000,0xfffffffe" access="rw" required="o"></attribute>
+          <attribute id="0005" name="Dst Shift" type="s32" range="-86400,86400" default="0" access="rw" required="o"></attribute>
+          <attribute id="0006" name="Standard Time" type="u32" range="0x00000000,0xfffffffe" access="r" required="o"></attribute>
+          <attribute id="0007" name="Local Time" type="u32" range="0x00000000,0xfffffffe" access="r" required="o"></attribute>
+          <attribute id="0008" name="Last Set Time" type="utc" range="0x00000000,0xfffffffe" default="0xffffffff" access="r" required="o"></attribute>
+          <attribute id="0009" name="Valid Until Time" type="utc" range="0x00000000,0xfffffffe" default="0xffffffff" access="rw" required="o"></attribute>
+          <!-- TODO -->
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0x000b" name="Location">
+        <description>Measure distance between devices.</description>
+        <server>
+          <command id="0x40" dir="recv" name="Distance measure" required="m" response="0x40" showas="hex">
+            <description></description>
+            <payload>
+              <attribute id="0x0000" type="u16" name="Target address" required="m" default="0x0000" ></attribute>
+              <attribute id="0x0001" type="enum8" name="Resolution" required="m" default="0x00">
+                <value name="High" value="0x00"></value>
+                <value name="Mid" value="0x01"></value>
+                <value name="Low" value="0x02"></value>
+              </attribute>
+            </payload>
+          </command>
+        </server>
+        <client>
+          <command id="0x40" dir="recv" name="Distance measure response" required="m">
+            <description>Returns the result of a distance measure.</description>
+            <payload>
+              <attribute id="0x0000" type="u16" name="Target address" required="m" default="0x0000" showas="hex"></attribute>
+              <attribute id="0x0001" type="u16" name="Distance (Meter)" required="m" default="0"></attribute>
+              <attribute id="0x0002" type="u16" name="Quality index" required="m" default="0"></attribute>
+            </payload>
+          </command>
+        </client>
+        <!-- TODO -->
+      </cluster>
+      
+      <cluster id="0x000c" name="Analog Input (Basic)">
+        <description>An interface for reading the value of an analog measurement and accessing various characteristics of that measurement.</description>
+        <server>
+          <attribute id="0x001c" name="Description" type="cstring" required="o" access="rw"></attribute>
+          <attribute id="0x0041" name="Max Present Value" type="float" required="o" access="rw"></attribute>
+          <attribute id="0x0045" name="Min Present Value" type="float" required="o" access="rw"></attribute>
+          <attribute id="0x0051" name="Out of service" type="bool" required="m" access="rw" default="0"></attribute>
+          <attribute id="0x0055" name="Present value" type="float" required="m" access="rw" default="0"></attribute>
+          <attribute id="0x0067" name="Reliability" type="enum8" required="o" access="rw" default="0">
+            <value name="No fault detected" value="0"></value>
+            <value name="No sensor" value="1"></value>
+            <value name="Over range" value="2"></value>
+            <value name="Under range" value="3"></value>
+            <value name="Open loop" value="4"></value>
+            <value name="Shorted loop" value="5"></value>
+            <value name="No output" value="6"></value>
+            <value name="Unreliable other" value="7"></value>
+            <value name="Process error" value="8"></value>
+            <value name="Multi state fault" value="9"></value>
+            <value name="Configuration error" value="10"></value>
+          </attribute>
+          <attribute id="0x006a" name="Resolution" type="float" required="o" access="rw"></attribute>
+          <attribute id="0x006f" name="Status flags" type="bmp8" required="m" access="r" default="0">
+            <value name="In Alarm" value="0x01"></value>
+            <value name="Fault" value="0x02"></value>
+            <value name="Overidden" value="0x04"></value>
+            <value name="Out of Service" value="0x08"></value>
+          </attribute>
+          <attribute id="0x0075" name="Engineering Units" type="enum16" required="o" access="rw"></attribute>
+          <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
+          <attribute id="0xff05" name="Unknown" type="u16" required="o" access="r" default="0" showas="hex"></attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0x000d" name="Analog Output (Basic)">
         <description>The Analog Output (Basic) cluster provides an interface for setting the value of an analog output (typically to the environment) and accessing various characteristics of that value.</description>
         <server>
-            <attribute id="0x001c" name="Description" type="cstring" required="o" access="rw"></attribute>
-            <attribute id="0x0041" name="Max Present Value" type="float" required="o" access="rw"></attribute>
-            <attribute id="0x0045" name="Min Present Value" type="float" required="o" access="rw"></attribute>
-            <attribute id="0x0051" name="Out of service" type="bool" required="m" access="rw" default="0"></attribute>
-            <attribute id="0x0055" name="Present value" type="float" required="m" access="rw" default="0"></attribute>
-            <attribute id="0x0067" name="Reliability" type="enum8" required="o" access="rw" default="0">
-                <value name="No fault detected" value="0"></value>
-                <value name="No sensor" value="1"></value>
-                <value name="Over range" value="2"></value>
-                <value name="Under range" value="3"></value>
-                <value name="Open loop" value="4"></value>
-                <value name="Shorted loop" value="5"></value>
-                <value name="No output" value="6"></value>
-                <value name="Unreliable other" value="7"></value>
-                <value name="Process error" value="8"></value>
-                <value name="Multi state fault" value="9"></value>
-                <value name="Configuration error" value="10"></value>
-            </attribute>
-            <attribute id="0x0068" name="Relinquish Default" type="float" required="o" access="rw"></attribute>
-            <attribute id="0x006a" name="Resolution" type="float" required="o" access="rw"></attribute>
-            <attribute id="0x006f" name="Status flags" type="bmp8" required="m" access="r" default="0">
-                <value name="In Alarm" value="0x01"></value>
-                <value name="Fault" value="0x02"></value>
-                <value name="Overidden" value="0x04"></value>
-                <value name="Out of Service" value="0x08"></value>
-            </attribute>
-            <attribute id="0x0075" name="Engineering Units" type="enum16" required="o" access="rw"></attribute>
-            <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
-            <attribute id="0xf000" name="Xiaomi 0xf000" type="u32" required="o" access="r"></attribute>
-        </server>
-        <client>
-        </client>
-    </cluster>
-	<cluster id="0x000e" name="Analog Value (Basic)">
-	<description>An interface for setting an analog value, typically used as a control system parameter, and accessing various characteristics of that value.</description>
-        <server>
-            <attribute id="0x001c" name="Description" type="cstring" required="o" access="rw"></attribute>
-            <attribute id="0x0051" name="Out of service" type="bool" required="m" access="rw" default="0"></attribute>
-            <attribute id="0x0055" name="Present value" type="float" required="m" access="rw" default="0"></attribute>
-            <attribute id="0x0067" name="Reliability" type="enum8" required="o" access="rw" default="0">
-                <value name="No fault detected" value="0"></value>
-                <value name="No sensor" value="1"></value>
-                <value name="Over range" value="2"></value>
-                <value name="Under range" value="3"></value>
-                <value name="Open loop" value="4"></value>
-                <value name="Shorted loop" value="5"></value>
-                <value name="No output" value="6"></value>
-                <value name="Unreliable other" value="7"></value>
-                <value name="Process error" value="8"></value>
-                <value name="Multi state fault" value="9"></value>
-                <value name="Configuration error" value="10"></value>
-            </attribute>
-            <attribute id="0x0068" name="Relinquish Default" type="float" required="o" access="rw"></attribute>
-            <attribute id="0x006f" name="Status flags" type="bmp8" required="m" access="r" default="0">
-                <value name="In Alarm" value="0x01"></value>
-                <value name="Fault" value="0x02"></value>
-                <value name="Overidden" value="0x04"></value>
-                <value name="Out of Service" value="0x08"></value>
-            </attribute>
-            <attribute id="0x0075" name="Engineering Units" type="enum16" required="o" access="rw"></attribute>
-            <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
-        </server>
-        <client>
-        </client>
-	</cluster>
-	<cluster id="0x000f" name="Binary Input (Basic)">
-		<description>The Binary Input (Basic) cluster provides an interface for reading the value of a binary measurement and accessing various characteristics of that measurement. The cluster is typically used to implement a sensor that measures a two-state physical quantity.</description>
-		<server>
-			<attribute id="0x0004" name="Active Text" type="cstring" required="o" access="rw" default=""></attribute>
-            <attribute id="0x001c" name="Description" type="cstring" access="rw" required="o"></attribute>
-            <attribute id="0x002e" name="Inactive Text" type="cstring" required="o" access="rw" default=""></attribute>
-			<attribute id="0x0051" name="Out of Service" type="bool" default="0" access="rw" required="m"></attribute>
-            <attribute id="0x0054" name="Polarity" type="enum8" required="o" access="r">
-                <value name="Normal" value="0"></value>
-                <value name="Reverse" value="1"></value>
-			</attribute>
-            <attribute id="0x0055" name="Present Value" type="bool" default="0" access="rw" required="m"></attribute>
-			<attribute id="0x0067" name="Reliability" type="enum8" required="o" access="rw" default="0">
-                <value name="No fault detected" value="0"></value>
-                <value name="No sensor" value="1"></value>
-                <value name="Over range" value="2"></value>
-                <value name="Under range" value="3"></value>
-                <value name="Open loop" value="4"></value>
-                <value name="Shorted loop" value="5"></value>
-                <value name="No output" value="6"></value>
-                <value name="Unreliable other" value="7"></value>
-                <value name="Process error" value="8"></value>
-                <value name="Multi state fault" value="9"></value>
-                <value name="Configuration error" value="10"></value>
-			</attribute>
-            <attribute id="0x006F" name="Status Flags" type="bmp8" default="0" access="r" required="m">
-				<value name="In Alarm" value="0x01"></value>
-				<value name="Fault" value="0x02"></value>
-				<value name="Overidden" value="0x04"></value>
-				<value name="Out of Service" value="0x08"></value>
-			</attribute>
-            <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
-            <attribute-set id="0x8000" description="Develco specific" mfcode="0x1015">
-                <attribute id="0x8000" name="IAS Activation" type="u16" access="rw" required="m" mfcode="0x1015"></attribute>
-            </attribute-set>
-		</server>
-		<client>
-            <attribute-set id="0x8000" description="Develco specific" mfcode="0x1015">
-                <attribute id="0x8000" name="OnWithTimeOff_OnTime" type="u16" access="rw" required="m" mfcode="0x1015"></attribute>
-                <attribute id="0x8001" name="OnWithTimeOff_OffWaitTime" type="u16" access="rw" required="m" mfcode="0x1015"></attribute>
-            </attribute-set>
-		</client>
-	</cluster>
-	<cluster id="0x0010" name="Binary Output (Basic)">
-	<description>The Binary Output (Basic) cluster provides an interface for setting the value of a binary output, and accessing various characteristics of that value.</description>
-        <server>
-            <attribute id="0x0004" name="Active Text" type="cstring" required="o" access="rw" default=""></attribute>
-            <attribute id="0x001c" name="Description" type="cstring" required="o" access="rw" default=""></attribute>
-            <attribute id="0x002e" name="Inactive Text" type="cstring" required="o" access="rw" default=""></attribute>
-            <attribute id="0x0042" name="Min Off Time" type="u32" required="o" access="rw" default="0xffffffff"></attribute>
-            <attribute id="0x0043" name="Min On Time" type="u32" required="o" access="rw" default="0xffffffff"></attribute>
-            <attribute id="0x0051" name="Out of service" type="bool" required="m" access="rw" default="0"></attribute>
-            <attribute id="0x0054" name="Polarity" type="enum8" required="o" access="r">
-                <value name="Normal" value="0"></value>
-                <value name="Reverse" value="1"></value>
-            </attribute>
-            <attribute id="0x0055" name="Present value" type="bool" required="m" access="rw"></attribute>
-            <attribute id="0x0067" name="Reliability" type="enum8" required="o" access="rw" default="0">
-                <value name="No fault detected" value="0"></value>
-                <value name="No sensor" value="1"></value>
-                <value name="Over range" value="2"></value>
-                <value name="Under range" value="3"></value>
-                <value name="Open loop" value="4"></value>
-                <value name="Shorted loop" value="5"></value>
-                <value name="No output" value="6"></value>
-                <value name="Unreliable other" value="7"></value>
-                <value name="Process error" value="8"></value>
-                <value name="Multi state fault" value="9"></value>
-                <value name="Configuration error" value="10"></value>
-            </attribute>
-            <attribute id="0x0068" name="Relinquish Default" type="bool" required="o" access="rw"></attribute>
-            <attribute id="0x006f" name="Status flags" type="bmp8" required="m" access="r" default="0">
-                <value name="In Alarm" value="0x01"></value>
-                <value name="Fault" value="0x02"></value>
-                <value name="Overidden" value="0x04"></value>
-                <value name="Out of Service" value="0x08"></value>
-            </attribute>
-            <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
-            <attribute-set id="0xff00" description="Xiaomi Specific" mfcode="0x1037">
-                <attribute id="0xff06" name="Interlock" type="bool" access="rw" required="m" mfcode="0x1037"></attribute>
-            </attribute-set>
-        </server>
-        <client>
-        </client>
-	</cluster>
-	<cluster id="0x0011" name="Binary Value (Basic)">
-	<description>The Binary Value (Basic) cluster provides an interface for setting a binary value, typically used as a control system parameter, and accessing various characteristics of that value.</description>
-        <server>
-            <attribute id="0x0004" name="Active Text" type="cstring" required="o" access="rw" default=""></attribute>
-            <attribute id="0x001c" name="Description" type="cstring" required="o" access="rw" default=""></attribute>
-            <attribute id="0x002e" name="Inactive Text" type="cstring" required="o" access="rw" default=""></attribute>
-            <attribute id="0x0042" name="Min Off Time" type="u32" required="o" access="rw" default="0xffffffff"></attribute>
-            <attribute id="0x0043" name="Min On Time" type="u32" required="o" access="rw" default="0xffffffff"></attribute>
-            <attribute id="0x0051" name="Out of service" type="bool" required="m" access="rw" default="0"></attribute>
-            <attribute id="0x0055" name="Present value" type="bool" required="m" access="rw"></attribute>
-            <attribute id="0x0067" name="Reliability" type="enum8" required="o" access="rw" default="0">
-                <value name="No fault detected" value="0"></value>
-                <value name="No sensor" value="1"></value>
-                <value name="Over range" value="2"></value>
-                <value name="Under range" value="3"></value>
-                <value name="Open loop" value="4"></value>
-                <value name="Shorted loop" value="5"></value>
-                <value name="No output" value="6"></value>
-                <value name="Unreliable other" value="7"></value>
-                <value name="Process error" value="8"></value>
-                <value name="Multi state fault" value="9"></value>
-                <value name="Configuration error" value="10"></value>
-            </attribute>
-            <attribute id="0x0068" name="Relinquish Default" type="bool" required="o" access="rw"></attribute>
-            <attribute id="0x006f" name="Status flags" type="bmp8" required="m" access="r" default="0">
-                <value name="In Alarm" value="0x01"></value>
-                <value name="Fault" value="0x02"></value>
-                <value name="Overidden" value="0x04"></value>
-                <value name="Out of Service" value="0x08"></value>
-            </attribute>
-            <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
-        </server>
-        <client>
-        </client>
-	</cluster>
-	<cluster id="0x0012" name="Multistate Input (Basic)">
-		<description>Provides an interface for reading the value of a multistate measurement and accessing various characteristics of that measurement. The cluster is typically used to implement a sensor that measures a physical quantity that can take on one of a number of discrete states.</description>
-		<server>
-			<attribute id="0x001c" name="Description" type="cstring" required="o" access="rw" default=""></attribute>
-            <attribute id="0x004a" type="u16" name="Number of states" required="m" access="rw" default="0"></attribute>
-			<attribute id="0x0051" type="bool" name="Out of service" required="m" access="rw" default="0"></attribute>
-			<attribute id="0x0055" type="u16" name="Present value" required="m" access="rw" default="0"></attribute>
-            <attribute id="0x0067" name="Reliability" type="enum8" required="o" access="rw" default="0">
-                <value name="No fault detected" value="0"></value>
-                <value name="No sensor" value="1"></value>
-                <value name="Over range" value="2"></value>
-                <value name="Under range" value="3"></value>
-                <value name="Open loop" value="4"></value>
-                <value name="Shorted loop" value="5"></value>
-                <value name="No output" value="6"></value>
-                <value name="Unreliable other" value="7"></value>
-                <value name="Process error" value="8"></value>
-                <value name="Multi state fault" value="9"></value>
-                <value name="Configuration error" value="10"></value>
-            </attribute>
-			<attribute id="0x006f" type="bmp8" name="Status flags" required="m" access="r" default="0">
-				<value name="In Alarm" value="0x01"></value>
-				<value name="Fault" value="0x02"></value>
-				<value name="Overidden" value="0x04"></value>
-				<value name="Out of Service" value="0x08"></value>
-			</attribute>
-            <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
-		</server>
-        <client>
-        </client>
-	</cluster>
-	<cluster id="0x0013" name="Multistate Output (Basic)">
-  	<description>The Multistate Output (Basic) cluster provides an interface for setting the value of an output that can take one of a number of discrete values, and accessing characteristics of that value.</description>
-        <server>
-            <attribute id="0x001c" name="Description" type="cstring" required="o" access="rw" default=""></attribute>
-            <attribute id="0x004a" type="u16" name="Number of states" required="m" access="rw" default="0"></attribute>
-            <attribute id="0x0051" type="bool" name="Out of service" required="m" access="rw" default="0"></attribute>
-            <attribute id="0x0055" type="u16" name="Present value" required="m" access="rw" default="0"></attribute>
-            <attribute id="0x0067" name="Reliability" type="enum8" required="o" access="rw" default="0">
-                <value name="No fault detected" value="0"></value>
-                <value name="No sensor" value="1"></value>
-                <value name="Over range" value="2"></value>
-                <value name="Under range" value="3"></value>
-                <value name="Open loop" value="4"></value>
-                <value name="Shorted loop" value="5"></value>
-                <value name="No output" value="6"></value>
-                <value name="Unreliable other" value="7"></value>
-                <value name="Process error" value="8"></value>
-                <value name="Multi state fault" value="9"></value>
-                <value name="Configuration error" value="10"></value>
-            </attribute>
-            <attribute id="0x0068" name="Relinquish Default" type="u16" required="o" access="rw"></attribute>
-            <attribute id="0x006f" type="bmp8" name="Status flags" required="m" access="r" default="0">
-                <value name="In Alarm" value="0x01"></value>
-                <value name="Fault" value="0x02"></value>
-                <value name="Overidden" value="0x04"></value>
-                <value name="Out of Service" value="0x08"></value>
-            </attribute>
-            <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
-            <attribute id="0xf000" name="Xiaomi 0xf000" type="u32" required="o" access="r"></attribute>
-        </server>
-        <client>
-        </client>
-	</cluster>
-	<cluster id="0x0014" name="Multistate Value (Basic)">
-	<description>The Multistate Value (Basic) cluster provides an interface for setting a multistate value, typically used as a control system parameter, and accessing characteristics of that value.</description>
-        <server>
-            <attribute id="0x001c" name="Description" type="cstring" required="o" access="rw" default=""></attribute>
-            <attribute id="0x004a" type="u16" name="Number of states" required="m" access="rw" default="0"></attribute>
-            <attribute id="0x0051" type="bool" name="Out of service" required="m" access="rw" default="0"></attribute>
-            <attribute id="0x0055" type="u16" name="Present value" required="m" access="rw" default="0"></attribute>
-            <attribute id="0x0067" name="Reliability" type="enum8" required="o" access="rw" default="0">
-                <value name="No fault detected" value="0"></value>
-                <value name="No sensor" value="1"></value>
-                <value name="Over range" value="2"></value>
-                <value name="Under range" value="3"></value>
-                <value name="Open loop" value="4"></value>
-                <value name="Shorted loop" value="5"></value>
-                <value name="No output" value="6"></value>
-                <value name="Unreliable other" value="7"></value>
-                <value name="Process error" value="8"></value>
-                <value name="Multi state fault" value="9"></value>
-                <value name="Configuration error" value="10"></value>
-            </attribute>
-            <attribute id="0x0068" name="Relinquish Default" type="u16" required="o" access="rw"></attribute>
-            <attribute id="0x006f" type="bmp8" name="Status flags" required="m" access="r" default="0">
-                <value name="In Alarm" value="0x01"></value>
-                <value name="Fault" value="0x02"></value>
-                <value name="Overidden" value="0x04"></value>
-                <value name="Out of Service" value="0x08"></value>
-            </attribute>
-            <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
-        </server>
-        <client>
-        </client>
-	</cluster>
-	<cluster id="0x0015" name="Commissioning">
-	<description>Attributes and commands for commissioning and managing a ZigBee device.</description>
-		<server>
-			<!-- TODO -->
-			<attribute-set id="0x0000" description="Startup Parameters I">
-				<attribute id="0x0000" name="Short Address" type="u16" access="rw" range="0x0000,0xfff7" showas="hex" required="m"></attribute>
-				<attribute id="0x0001" name="Extended PAN ID" type="uid" access="rw" range="0x0000000000000000,0xfffffffffffffff7" required="m"></attribute>
-				<attribute id="0x0002" name="PAN ID" type="u16" access="rw" range="0x0000,0xffff" showas="hex" required="m"></attribute>
-				<attribute id="0x0003" name="Channel Mask" type="bmp32" access="rw" required="m">
-					<value name="CH 11" value="11"></value>
-					<value name="CH 12" value="12"></value>
-					<value name="CH 13" value="13"></value>
-					<value name="CH 14" value="14"></value>
-					<value name="CH 15" value="15"></value>
-					<value name="CH 16" value="16"></value>
-					<value name="CH 17" value="17"></value>
-					<value name="CH 18" value="18"></value>
-					<value name="CH 19" value="19"></value>
-					<value name="CH 20" value="20"></value>
-					<value name="CH 21" value="21"></value>
-					<value name="CH 22" value="22"></value>
-					<value name="CH 23" value="23"></value>
-					<value name="CH 24" value="24"></value>
-					<value name="CH 25" value="25"></value>
-					<value name="CH 26" value="26"></value>
-				</attribute>
-				<attribute id="0x0004" name="Protocol Version" type="u8" access="rw" default="0x02" required="m"></attribute>
-				<attribute id="0x0005" name="Stack Profile" type="u8" access="rw" range="0x01,0x02" required="m"></attribute>
-				<attribute id="0x0006" name="Startup Control" type="enum8" access="rw" required="m">
-					<value name="Part of the network" value="0x00"></value>
-					<value name="Form a network" value="0x01"></value>
-					<value name="Rejoin the network" value="0x02"></value>
-					<value name="Start from scratch" value="0x03"></value>
-				</attribute>
-			</attribute-set>
-			<attribute-set id="0x0010" description="Startup Parameters II">
-				<attribute id="0x0010" name="Trust Center Address" type="uid" access="rw" required="m"></attribute>
-				<attribute id="0x0011" name="Trust Center Master Key" type="seckey" access="rw" required="m"></attribute>
-				<attribute id="0x0012" name="Network Key" type="seckey" access="rw" required="m"></attribute>
-				<attribute id="0x0013" name="Use Insecure Join" type="bool" access="rw" required="m"></attribute>
-				<attribute id="0x0014" name="Preconfigured Link Key" type="seckey" access="rw" required="m"></attribute>
-				<attribute id="0x0015" name="Network Key Seq Num" type="u8" access="rw" range="0x00,0xff" required="m"></attribute>
-				<attribute id="0x0016" name="Network Key Type" type="enum8" access="rw" required="m">
-					<value name="Standard" value="0x01"></value>
-					<value name="High Security" value="0x05"></value>
-				</attribute>
-				<attribute id="0x0017" name="Network Manager Address" type="u16" access="rw" required="m"></attribute>
-			</attribute-set>
-			<attribute-set id="0x0020" description="Join Parameters">
-				<attribute id="0x0020" name="Scan Attemps" type="u8" access="rw" range="0x01,0xff" required="m"></attribute>
-				<attribute id="0x0021" name="Time Between Scans" type="u16" access="rw" range="0x0001,0xffff" required="m"></attribute>
-				<attribute id="0x0022" name="Rejoin Interval" type="u16" access="rw" range="0x0001,0xffff" required="m"></attribute>
-				<attribute id="0x0023" name="Max Rejoin Interval" type="u16" access="rw" range="0x0001,0xffff" required="m"></attribute>
-			</attribute-set>
-			<attribute-set id="0x0030" description="End Device Parameters">
-				<attribute id="0x0030" name="Indirect Poll Rate" type="u16" access="rw" range="0x0000,0xffff" required="m"></attribute>
-				<attribute id="0x0030" name="Parent Retry Threshold" type="u8" access="rw" range="0x00,0xff" required="m"></attribute>
-			</attribute-set>
-			<attribute-set id="0x0040" description="Concentrator Parameters">
-				<attribute id="0x0040" name="Concentrator Flag" type="bool" access="rw" required="m"></attribute>
-				<attribute id="0x0041" name="Concentrator Radius" type="u8" access="rw" range="0x00,0xff" required="m"></attribute>
-				<attribute id="0x0042" name="Concentrator Discovery Time" type="u8" access="rw" range="0x00,0xff" required="m"></attribute>
-			</attribute-set>
-			<attribute-set id="0xde00" description="DE Setup Parameters">
-			<attribute id="0xde01" name="MAC Address" type="uid" access="rw" required="m"></attribute>
-			</attribute-set>
-			<command id="00" dir="recv" name="Restart Device" required="m" response="0x00">
-				<description>The Restart Device command is used to optionally install a set of startup parameters in a device and run the startup procedure so as to put the new values into effect. The new values may take effect immediately or after an optional delay with optional jitter. The server will send a Restart Device Response command back to the client device before executing the procedure or starting the countdown timer required to time the delay.</description>
-				<payload>
-					<attribute id="0x0000" name="Options" type="bmp8" default="00000000" access="rw" required="m">
-						<value name="Don't replace attributes on restart" value="0"></value>
-						<value name="Immediate" value="1"></value>
-					</attribute>
-					<attribute id="0x0001" type="u8" name="Delay" required="m"></attribute>
-					<attribute id="0x0002" type="u8" name="Jitter" required="m"></attribute>
-				</payload>
-			</command>
-			<command id="01" dir="recv" name="Save Startup Parameters" required="o" response="0x01">
-				<description>The Save Startup Parameters Request command allows for the current attribute set to be stored under a given index.</description>
-				<payload>
-					<attribute id="0x0000" name="Options" type="bmp8" default="00000000" access="rw" required="m">
-					</attribute>
-					<attribute id="0x0001" type="u8" name="Index" required="m"></attribute>
-				</payload>
-			</command>
-			<command id="02" dir="recv" name="Restore Startup Parameters" required="o" response="0x02">
-				<description>This command allows a saved startup parameters attribute set to be restored to current status overwriting whatever was there previously.</description>
-				<payload>
-					<attribute id="0x0000" name="Options" type="bmp8" default="00000000" access="rw" required="m">
-					</attribute>
-					<attribute id="0x0001" type="u8" name="Index" required="m"></attribute>
-				</payload>
-			</command>
-			<command id="03" dir="recv" name="Reset Startup Parameters" required="m" response="0x03">
-				<description>This command allows current startup parameters attribute set and one or all of the saved attribute sets to be set to default values. There is also an option for erasing the index under which an attribute set is saved thereby freeing up storage capacity.</description>
-				<payload>
-					<attribute id="0x0000" name="Options" type="bmp8" default="00000000" access="rw" required="m">
-					<value name="Reset Current" value="0"></value>
-					<value name="Reset All" value="1"></value>
-					<value name="Erase Index" value="2"></value>
-					</attribute>
-					<attribute id="0x0001" type="u8" name="Index" required="m"></attribute>
-				</payload>
-			</command>
-		</server>
-		<client>
-			<command id="00" dir="recv" name="Restart Device Response" required="m">
-				<description>On receipt of this command the client is made aware that the server has received the corresponding request and is informed of the status of the request.</description>
-				<payload>
-					<attribute id="0x0000" name="Status" type="enum8" access="rw" required="m" enumeration="ZCL_Status">
-					</attribute>
-				</payload>
-			</command>
-			<command id="01" dir="recv" name="Save Startup Parameters Response" required="m">
-				<description>On receipt of this command the client is made aware that the server has received the corresponding request and is informed of the status of the request.</description>
-				<payload>
-					<attribute id="0x0000" name="Status" type="enum8" access="rw" required="m" enumeration="ZCL_Status">
-					</attribute>
-				</payload>
-			</command>
-			<command id="02" dir="recv" name="Restore Startup Parameters Response" required="m">
-				<description>On receipt of this command the client is made aware that the server has received the corresponding request and is informed of the status of the request.</description>
-				<payload>
-					<attribute id="0x0000" name="Status" type="enum8" access="rw" required="m" enumeration="ZCL_Status">
-					</attribute>
-				</payload>
-			</command>
-			<command id="03" dir="recv" name="Reset Startup Parameters Response" required="m">
-				<description>On receipt of this command the client is made aware that the server has received the corresponding request and is informed of the status of the request.</description>
-				<payload>
-					<attribute id="0x0000" name="Status" type="enum8" access="rw" required="m" enumeration="ZCL_Status">
-					</attribute>
-				</payload>
-			</command>
-		</client>
-		</cluster>
-		<cluster id="0x0019" name="OTAU">
-			<description>Over the air upgrade.</description>
-			<client>
-				<attribute id="0x0000" name="Upgrade server" type="uid" default="0" access="rw" required="m"></attribute>
-				<attribute id="0x0001" name="File Offset" type="u32" default="0xffffffff" access="r" required="o" showas="hex"></attribute>
-				<attribute id="0x0002" name="Current File Version" type="u32" default="0xffffffff" access="r" required="o" showas="hex"></attribute>
-				<attribute id="0x0003" name="Current ZigBee Stack Version" type="u16" default="0xffff" access="r" required="o" showas="hex"></attribute>
-				<attribute id="0x0004" name="Downloaded File Version" type="u32" default="0xffffffff" access="r" required="o" showas="hex"></attribute>
-				<attribute id="0x0005" name="Downloaded ZigBee Stack Version" type="u16" default="0xffff" access="r" required="o" showas="hex"></attribute>
-				<attribute id="0x0006" name="Image upgrade status" type="enum8" default="0x04" access="rw" required="m">
-					<value name="Normal" value="0"></value>
-					<value name="Download in progress" value="1"></value>
-					<value name="Download complete" value="2"></value>
-					<value name="Waiting to upgrade" value="3"></value>
-					<value name="Count down" value="4"></value>
-					<value name="Wait for more" value="5"></value>
-				</attribute>
-				<attribute id="0x0007" name="Manufacturer ID" type="u16" access="r" required="o" showas="hex"></attribute>
-				<attribute id="0x0008" name="Image Type ID" type="u16" access="r" required="o" showas="hex"></attribute>
-				<attribute id="0x0009" name="Min block request delay" type="u16" default="0" access="r" required="m"></attribute>
-				<command id="0x01" dir="send" name="Query next image" required="m">
-					<description></description>
-					<payload>
-						<attribute id="0x0000" type="bmp8" name="Control field" required="m" default="0x00">
-							<value name="Hardware version present" value="0x01"></value>
-						</attribute>
-						<attribute id="0x0001" type="u16" showas="hex" name="Manufacturer ID" required="m"></attribute>
-						<attribute id="0x0002" type="enum16" name="Image type" required="m" default="0x0000">
-							<value name="Specific image" value="0x0000"></value>
-							<value name="Security credential" value="0xFFC0"></value>
-							<value name="Configuration" value="0xFFC1"></value>
-							<value name="Log" value="0xFFC2"></value>
-							<value name="Wild card" value="0xFFFF"></value>
-						</attribute>
-						<!--  Firmware Version -->
-						<attribute id="0x0003" type="u8" showas="hex" name="Application Release" required="m"></attribute>
-						<attribute id="0x0004" type="u8" showas="hex" name="Application Build" required="m"></attribute>
-						<attribute id="0x0005" type="u8" showas="hex" name="Stack Release" required="m"></attribute>
-						<attribute id="0x0006" type="u8" showas="hex" name="Stack Build" required="m"></attribute>
-					</payload>
-				</command>
-
-				<command id="0x07" dir="recv" name="Upgrade end response" required="m">
-					<description></description>
-					<payload>
-						<attribute id="0x0000" type="u16" showas="hex" name="Manufacturer ID" required="m"></attribute>
-						<attribute id="0x0001" type="u16" showas="hex" name="Image type" required="m"></attribute>
-						<attribute id="0x0002" type="u32" showas="hex" name="File version" required="m"></attribute>
-						<attribute id="0x0003" type="u32" showas="hex" name="Current time" required="m"></attribute>
-						<attribute id="0x0004" type="u32" showas="hex" name="Upgrade time" required="m"></attribute>
-					</payload>
-				</command>
-			</client>
-			<server>
-			</server>
-		</cluster>
-		<cluster id="0x0020" name="Poll Control">
-			<description>Provides a mechanism for the management of an end device’s MAC
-Data Request rate.</description>
-			<client>
-			</client>
-			<server>
-				<attribute id="0x0000" name="Check-in Interval" type="u32" default="0x3840" access="rw" required="m" range="0x0,0x6e0000"></attribute>
-				<attribute id="0x0001" name="Long Poll Interval" type="u32" default="0x14" access="r" required="m" range="0x04,0x6e0000"></attribute>
-				<attribute id="0x0002" name="Short Poll Interval" type="u16" default="0x02" access="r" required="m" range="0x01,0xffff"></attribute>
-				<attribute id="0x0003" name="Fast Poll Timeout" type="u16" default="0x028" access="rw" required="m" range="0x01,0xffff"></attribute>
-				<attribute id="0x0004" name="Check-in Interval Min" type="u32" default="0" access="r" required="o"></attribute>
-				<attribute id="0x0005" name="Long Poll Interval Min" type="u32" default="0" access="r" required="o"></attribute>
-				<attribute id="0x0006" name="Fast Poll Timeout Max" type="u16" default="0" access="r" required="o"></attribute>
-
-				<command id="0x00" dir="send" name="Check-in" required="m">
-					<description>The Poll Control Cluster server sends out a Check-in command to the devices to which it is paired based on
-the server‘s Check-inInterval attribute. It does this to find out if any of the Poll Control Cluster Clients with
-which it is paired are interested in having it enter fast poll mode so that it can be managed. This request is sent
-out based on either the Check-inInterval, or the next Check-in value in the Fast Poll Stop Request generated
-by the Poll Control Cluster Client.</description>
-					<payload></payload>
-				</command>
-				<command id="0x01" dir="send" name="Stop" required="m">
-				    <description>send Fast Poll Stop</description>
-					<payload></payload>
-				</command>
-				<command id="0x02" dir="recv" name="Set Long Poll Interval" required="o">
-					<description>Sets the Read Only LongPollInterval attribute.</description>
-					<payload>
-						<attribute id="0x0000" type="u32" showas="hex" name="New Long Poll Interval" required="m"></attribute>
-					</payload>
-				</command>
-				<command id="0x03" dir="recv" name="Set Short Poll Interval" required="o">
-					<description>Sets the Read Only ShortPollInterval attribute.</description>
-					<payload>
-						<attribute id="0x0000" type="u16" showas="hex" name="New Short Poll Interval" required="m"></attribute>
-					</payload>
-				</command>
-			</server>
-		</cluster>
-		<cluster id="0x0800" name="Key Establishment">
-			<description></description>
-			<client></client>
-			<server></server>
-			<!-- TODO -->
-		</cluster>
-	</domain>
-	<domain name="Closures" low_bound="0100" high_bound="01ff" description="The closures functional domain contains clusters and information to build devices in the closure domain, e.g. shade controllers.">
-		<cluster id="0x0100" name="Shade Configuration">
-			<description></description>
-			<!-- TODO -->
-		</cluster>
-    <cluster id="0x0100" name="Shade Configuration">
-      <description>The shade configuration cluster provides an interface for reading information about a shade, and configuring its open and closed limits.</description>
-      <client>
-      </client>
-      <server>
-        <attribute-set id="0x0000" description="Shade Information Attribute Set">
-          <attribute id="0x0000" name="Physical Closed Limit" type="u16" access="r" required="o"></attribute>
-          <attribute id="0x0001" name="MotorStepSize" type="u8" access="r" required="o"></attribute>
-          <attribute id="0x0002" name="Status" type="bmp8" access="rw" required="m">
-            <value name="Shade operational" value="0"></value>
-            <value name="Shade adjusting" value="1"></value>
-            <value name="Shade direction" value="2"></value>
-            <value name="Direction Reversed" value="3"></value>
+          <attribute id="0x001c" name="Description" type="cstring" required="o" access="rw"></attribute>
+          <attribute id="0x0041" name="Max Present Value" type="float" required="o" access="rw"></attribute>
+          <attribute id="0x0045" name="Min Present Value" type="float" required="o" access="rw"></attribute>
+          <attribute id="0x0051" name="Out of service" type="bool" required="m" access="rw" default="0"></attribute>
+          <attribute id="0x0055" name="Present value" type="float" required="m" access="rw" default="0"></attribute>
+          <attribute id="0x0067" name="Reliability" type="enum8" required="o" access="rw" default="0">
+            <value name="No fault detected" value="0"></value>
+            <value name="No sensor" value="1"></value>
+            <value name="Over range" value="2"></value>
+            <value name="Under range" value="3"></value>
+            <value name="Open loop" value="4"></value>
+            <value name="Shorted loop" value="5"></value>
+            <value name="No output" value="6"></value>
+            <value name="Unreliable other" value="7"></value>
+            <value name="Process error" value="8"></value>
+            <value name="Multi state fault" value="9"></value>
+            <value name="Configuration error" value="10"></value>
           </attribute>
-        </attribute-set>
-        <attribute-set id="0x0010" description="Shade Settings Attribute Set">
-          <attribute id="0x0010" name="Closed Limit" type="u16" access="rw" range="0x0001,0xfffe" default="0x0001" required="m"></attribute>
-          <attribute id="0x0011" name="Mode" type="enum8" access="rw" default="0x00" required="m">
-            <value name="Normal" value="0x00"></value>
-            <value name="Configure" value="0x01"></value>
-            <value name="Invalid" value="0xff"></value>
+          <attribute id="0x0068" name="Relinquish Default" type="float" required="o" access="rw"></attribute>
+          <attribute id="0x006a" name="Resolution" type="float" required="o" access="rw"></attribute>
+          <attribute id="0x006f" name="Status flags" type="bmp8" required="m" access="r" default="0">
+            <value name="In Alarm" value="0x01"></value>
+            <value name="Fault" value="0x02"></value>
+            <value name="Overidden" value="0x04"></value>
+            <value name="Out of Service" value="0x08"></value>
           </attribute>
-        </attribute-set>
-      </server>
-    </cluster>
-    <cluster id="0x0101" name="Door Lock">
-      <description>The door lock cluster provides an interface to a generic way to secure a door.</description>
-      <client>
-      </client>
-      <server>
-        <attribute-set id="0x0000" description="Basic Information Attribute Set">
-          <attribute id="0x0000" name="Lock State" type="enum8" access="r" required="m">
-            <value name="Not fully locked" value="0x00"></value>
-            <value name="Locked" value="0x01"></value>
-            <value name="Unlocked" value="0x02"></value>
-            <value name="Undefined" value="0xff"></value>
+          <attribute id="0x0075" name="Engineering Units" type="enum16" required="o" access="rw"></attribute>
+          <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
+          <attribute id="0xf000" name="Xiaomi 0xf000" type="u32" required="o" access="r"></attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0x000e" name="Analog Value (Basic)">
+        <description>An interface for setting an analog value, typically used as a control system parameter, and accessing various characteristics of that value.</description>
+        <server>
+          <attribute id="0x001c" name="Description" type="cstring" required="o" access="rw"></attribute>
+          <attribute id="0x0051" name="Out of service" type="bool" required="m" access="rw" default="0"></attribute>
+          <attribute id="0x0055" name="Present value" type="float" required="m" access="rw" default="0"></attribute>
+          <attribute id="0x0067" name="Reliability" type="enum8" required="o" access="rw" default="0">
+            <value name="No fault detected" value="0"></value>
+            <value name="No sensor" value="1"></value>
+            <value name="Over range" value="2"></value>
+            <value name="Under range" value="3"></value>
+            <value name="Open loop" value="4"></value>
+            <value name="Shorted loop" value="5"></value>
+            <value name="No output" value="6"></value>
+            <value name="Unreliable other" value="7"></value>
+            <value name="Process error" value="8"></value>
+            <value name="Multi state fault" value="9"></value>
+            <value name="Configuration error" value="10"></value>
           </attribute>
-          <attribute id="0x0001" name="Lock Type" type="enum8" access="r" required="m">
-            <value name="Dead bolt" value="0x00"></value>
-            <value name="Magnetic" value="0x01"></value>
-            <value name="Other" value="0x02"></value>
-            <value name="Mortise" value="0x03"></value>
-            <value name="Rim" value="0x04"></value>
-            <value name="Latch Bolt" value="0x05"></value>
-            <value name="Cylindrical Lock" value="0x06"></value>
-            <value name="Tubular Lock" value="0x07"></value>
-            <value name="Interconnected Lock" value="0x08"></value>
-            <value name="Dead Latch" value="0x09"></value>
-            <value name="Door Furniture" value="0x0A"></value>
+          <attribute id="0x0068" name="Relinquish Default" type="float" required="o" access="rw"></attribute>
+          <attribute id="0x006f" name="Status flags" type="bmp8" required="m" access="r" default="0">
+            <value name="In Alarm" value="0x01"></value>
+            <value name="Fault" value="0x02"></value>
+            <value name="Overidden" value="0x04"></value>
+            <value name="Out of Service" value="0x08"></value>
           </attribute>
-          <attribute id="0x0002" name="Actuator enabled" type="bool" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Door state" type="enum8" access="r" required="m">
-            <value name="Open" value="0x00"/>
-            <value name="Closed" value="0x01"/>
-            <value name="Error jammed" value="0x02"/>
-            <value name="Error forced open" value="0x03"/>
-            <value name="Error unspecified" value="0x04"/>
-            <value name="Undefined" value="0xff"/>
+          <attribute id="0x0075" name="Engineering Units" type="enum16" required="o" access="rw"></attribute>
+          <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0x000f" name="Binary Input (Basic)">
+        <description>The Binary Input (Basic) cluster provides an interface for reading the value of a binary measurement and accessing various characteristics of that measurement. The cluster is typically used to implement a sensor that measures a two-state physical quantity.</description>
+        <server>
+          <attribute id="0x0004" name="Active Text" type="cstring" required="o" access="rw" default=""></attribute>
+          <attribute id="0x001c" name="Description" type="cstring" access="rw" required="o"></attribute>
+          <attribute id="0x002e" name="Inactive Text" type="cstring" required="o" access="rw" default=""></attribute>
+          <attribute id="0x0051" name="Out of Service" type="bool" default="0" access="rw" required="m"></attribute>
+          <attribute id="0x0054" name="Polarity" type="enum8" required="o" access="r">
+            <value name="Normal" value="0"></value>
+            <value name="Reverse" value="1"></value>
           </attribute>
-        </attribute-set>
-        <attribute-set id="0x0010" description="User, PIN, Schedule Information Attribute Set">
-          <attribute id="0x0010" name="Number Of Log Records Supported" type="u16" default="0" access="r" required="o"></attribute>
-          <attribute id="0x0011" name="Number Of Total Users Supported" type="u16" default="0" access="r" required="o"></attribute>
-          <attribute id="0x0012" name="Number Of PIN Users Supported" type="u16" default="0" access="r" required="o"></attribute>
-          <attribute id="0x0013" name="Number Of RFID Users Supported" type="u16" default="0" access="r" required="o"></attribute>
-          <attribute id="0x0014" name="Number Of WeekDay Schedules Supported Per User" type="u8" default="0" access="r" required="o"></attribute>
-          <attribute id="0x0015" name="Number Of Year Day Schedules Supported Per User" type="u8" default="0" access="r" required="o"></attribute>
-          <attribute id="0x0016" name="Number Of Holiday Schedules Supported" type="u8" default="0" access="r" required="o"></attribute>
-          <attribute id="0x0017" name="Max PIN length" type="u8" access="r" required="o"/>
-          <attribute id="0x0018" name="Min PIN length" type="u8" access="r" required="o"/>
-        </attribute-set>
-        <attribute-set id="0x0020" description="Operational Settings Attribute Set">
-          <attribute id="0x0020" name="Enable Logging" type="bool" default="0" access="rw" required="o"></attribute>
-          <attribute id="0x0021" name="Language" type="cstring" access="rw" required="o"></attribute>
-          <attribute id="0x0022" name="Led Setting" type="u8" default="0" access="rw" required="o">
+          <attribute id="0x0055" name="Present Value" type="bool" default="0" access="rw" required="m"></attribute>
+          <attribute id="0x0067" name="Reliability" type="enum8" required="o" access="rw" default="0">
+            <value name="No fault detected" value="0"></value>
+            <value name="No sensor" value="1"></value>
+            <value name="Over range" value="2"></value>
+            <value name="Under range" value="3"></value>
+            <value name="Open loop" value="4"></value>
+            <value name="Shorted loop" value="5"></value>
+            <value name="No output" value="6"></value>
+            <value name="Unreliable other" value="7"></value>
+            <value name="Process error" value="8"></value>
+            <value name="Multi state fault" value="9"></value>
+            <value name="Configuration error" value="10"></value>
+          </attribute>
+          <attribute id="0x006F" name="Status Flags" type="bmp8" default="0" access="r" required="m">
+            <value name="In Alarm" value="0x01"></value>
+            <value name="Fault" value="0x02"></value>
+            <value name="Overidden" value="0x04"></value>
+            <value name="Out of Service" value="0x08"></value>
+          </attribute>
+          <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
+          <attribute-set id="0x8000" description="Develco specific" mfcode="0x1015">
+            <attribute id="0x8000" name="IAS Activation" type="u16" access="rw" required="m" mfcode="0x1015"></attribute>
+          </attribute-set>
+        </server>
+        <client>
+          <attribute-set id="0x8000" description="Develco specific" mfcode="0x1015">
+            <attribute id="0x8000" name="OnWithTimeOff_OnTime" type="u16" access="rw" required="m" mfcode="0x1015"></attribute>
+            <attribute id="0x8001" name="OnWithTimeOff_OffWaitTime" type="u16" access="rw" required="m" mfcode="0x1015"></attribute>
+          </attribute-set>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0010" name="Binary Output (Basic)">
+        <description>The Binary Output (Basic) cluster provides an interface for setting the value of a binary output, and accessing various characteristics of that value.</description>
+        <server>
+          <attribute id="0x0004" name="Active Text" type="cstring" required="o" access="rw" default=""></attribute>
+          <attribute id="0x001c" name="Description" type="cstring" required="o" access="rw" default=""></attribute>
+          <attribute id="0x002e" name="Inactive Text" type="cstring" required="o" access="rw" default=""></attribute>
+          <attribute id="0x0042" name="Min Off Time" type="u32" required="o" access="rw" default="0xffffffff"></attribute>
+          <attribute id="0x0043" name="Min On Time" type="u32" required="o" access="rw" default="0xffffffff"></attribute>
+          <attribute id="0x0051" name="Out of service" type="bool" required="m" access="rw" default="0"></attribute>
+          <attribute id="0x0054" name="Polarity" type="enum8" required="o" access="r">
+            <value name="Normal" value="0"></value>
+            <value name="Reverse" value="1"></value>
+          </attribute>
+          <attribute id="0x0055" name="Present value" type="bool" required="m" access="rw"></attribute>
+          <attribute id="0x0067" name="Reliability" type="enum8" required="o" access="rw" default="0">
+            <value name="No fault detected" value="0"></value>
+            <value name="No sensor" value="1"></value>
+            <value name="Over range" value="2"></value>
+            <value name="Under range" value="3"></value>
+            <value name="Open loop" value="4"></value>
+            <value name="Shorted loop" value="5"></value>
+            <value name="No output" value="6"></value>
+            <value name="Unreliable other" value="7"></value>
+            <value name="Process error" value="8"></value>
+            <value name="Multi state fault" value="9"></value>
+            <value name="Configuration error" value="10"></value>
+          </attribute>
+          <attribute id="0x0068" name="Relinquish Default" type="bool" required="o" access="rw"></attribute>
+          <attribute id="0x006f" name="Status flags" type="bmp8" required="m" access="r" default="0">
+            <value name="In Alarm" value="0x01"></value>
+            <value name="Fault" value="0x02"></value>
+            <value name="Overidden" value="0x04"></value>
+            <value name="Out of Service" value="0x08"></value>
+          </attribute>
+          <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
+          <attribute-set id="0xff00" description="Xiaomi Specific" mfcode="0x1037">
+            <attribute id="0xff06" name="Interlock" type="bool" access="rw" required="m" mfcode="0x1037"></attribute>
+          </attribute-set>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0011" name="Binary Value (Basic)">
+        <description>The Binary Value (Basic) cluster provides an interface for setting a binary value, typically used as a control system parameter, and accessing various characteristics of that value.</description>
+        <server>
+          <attribute id="0x0004" name="Active Text" type="cstring" required="o" access="rw" default=""></attribute>
+          <attribute id="0x001c" name="Description" type="cstring" required="o" access="rw" default=""></attribute>
+          <attribute id="0x002e" name="Inactive Text" type="cstring" required="o" access="rw" default=""></attribute>
+          <attribute id="0x0042" name="Min Off Time" type="u32" required="o" access="rw" default="0xffffffff"></attribute>
+          <attribute id="0x0043" name="Min On Time" type="u32" required="o" access="rw" default="0xffffffff"></attribute>
+          <attribute id="0x0051" name="Out of service" type="bool" required="m" access="rw" default="0"></attribute>
+          <attribute id="0x0055" name="Present value" type="bool" required="m" access="rw"></attribute>
+          <attribute id="0x0067" name="Reliability" type="enum8" required="o" access="rw" default="0">
+            <value name="No fault detected" value="0"></value>
+            <value name="No sensor" value="1"></value>
+            <value name="Over range" value="2"></value>
+            <value name="Under range" value="3"></value>
+            <value name="Open loop" value="4"></value>
+            <value name="Shorted loop" value="5"></value>
+            <value name="No output" value="6"></value>
+            <value name="Unreliable other" value="7"></value>
+            <value name="Process error" value="8"></value>
+            <value name="Multi state fault" value="9"></value>
+            <value name="Configuration error" value="10"></value>
+          </attribute>
+          <attribute id="0x0068" name="Relinquish Default" type="bool" required="o" access="rw"></attribute>
+          <attribute id="0x006f" name="Status flags" type="bmp8" required="m" access="r" default="0">
+            <value name="In Alarm" value="0x01"></value>
+            <value name="Fault" value="0x02"></value>
+            <value name="Overidden" value="0x04"></value>
+            <value name="Out of Service" value="0x08"></value>
+          </attribute>
+          <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0012" name="Multistate Input (Basic)">
+        <description>Provides an interface for reading the value of a multistate measurement and accessing various characteristics of that measurement. The cluster is typically used to implement a sensor that measures a physical quantity that can take on one of a number of discrete states.</description>
+        <server>
+          <attribute id="0x001c" name="Description" type="cstring" required="o" access="rw" default=""></attribute>
+          <attribute id="0x004a" type="u16" name="Number of states" required="m" access="rw" default="0"></attribute>
+          <attribute id="0x0051" type="bool" name="Out of service" required="m" access="rw" default="0"></attribute>
+          <attribute id="0x0055" type="u16" name="Present value" required="m" access="rw" default="0"></attribute>
+          <attribute id="0x0067" name="Reliability" type="enum8" required="o" access="rw" default="0">
+            <value name="No fault detected" value="0"></value>
+            <value name="No sensor" value="1"></value>
+            <value name="Over range" value="2"></value>
+            <value name="Under range" value="3"></value>
+            <value name="Open loop" value="4"></value>
+            <value name="Shorted loop" value="5"></value>
+            <value name="No output" value="6"></value>
+            <value name="Unreliable other" value="7"></value>
+            <value name="Process error" value="8"></value>
+            <value name="Multi state fault" value="9"></value>
+            <value name="Configuration error" value="10"></value>
+          </attribute>
+          <attribute id="0x006f" type="bmp8" name="Status flags" required="m" access="r" default="0">
+            <value name="In Alarm" value="0x01"></value>
+            <value name="Fault" value="0x02"></value>
+            <value name="Overidden" value="0x04"></value>
+            <value name="Out of Service" value="0x08"></value>
+          </attribute>
+          <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0013" name="Multistate Output (Basic)">
+        <description>The Multistate Output (Basic) cluster provides an interface for setting the value of an output that can take one of a number of discrete values, and accessing characteristics of that value.</description>
+        <server>
+          <attribute id="0x001c" name="Description" type="cstring" required="o" access="rw" default=""></attribute>
+          <attribute id="0x004a" type="u16" name="Number of states" required="m" access="rw" default="0"></attribute>
+          <attribute id="0x0051" type="bool" name="Out of service" required="m" access="rw" default="0"></attribute>
+          <attribute id="0x0055" type="u16" name="Present value" required="m" access="rw" default="0"></attribute>
+          <attribute id="0x0067" name="Reliability" type="enum8" required="o" access="rw" default="0">
+            <value name="No fault detected" value="0"></value>
+            <value name="No sensor" value="1"></value>
+            <value name="Over range" value="2"></value>
+            <value name="Under range" value="3"></value>
+            <value name="Open loop" value="4"></value>
+            <value name="Shorted loop" value="5"></value>
+            <value name="No output" value="6"></value>
+            <value name="Unreliable other" value="7"></value>
+            <value name="Process error" value="8"></value>
+            <value name="Multi state fault" value="9"></value>
+            <value name="Configuration error" value="10"></value>
+          </attribute>
+          <attribute id="0x0068" name="Relinquish Default" type="u16" required="o" access="rw"></attribute>
+          <attribute id="0x006f" type="bmp8" name="Status flags" required="m" access="r" default="0">
+            <value name="In Alarm" value="0x01"></value>
+            <value name="Fault" value="0x02"></value>
+            <value name="Overidden" value="0x04"></value>
+            <value name="Out of Service" value="0x08"></value>
+          </attribute>
+          <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
+          <attribute id="0xf000" name="Xiaomi 0xf000" type="u32" required="o" access="r"></attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0014" name="Multistate Value (Basic)">
+        <description>The Multistate Value (Basic) cluster provides an interface for setting a multistate value, typically used as a control system parameter, and accessing characteristics of that value.</description>
+        <server>
+          <attribute id="0x001c" name="Description" type="cstring" required="o" access="rw" default=""></attribute>
+          <attribute id="0x004a" type="u16" name="Number of states" required="m" access="rw" default="0"></attribute>
+          <attribute id="0x0051" type="bool" name="Out of service" required="m" access="rw" default="0"></attribute>
+          <attribute id="0x0055" type="u16" name="Present value" required="m" access="rw" default="0"></attribute>
+          <attribute id="0x0067" name="Reliability" type="enum8" required="o" access="rw" default="0">
+            <value name="No fault detected" value="0"></value>
+            <value name="No sensor" value="1"></value>
+            <value name="Over range" value="2"></value>
+            <value name="Under range" value="3"></value>
+            <value name="Open loop" value="4"></value>
+            <value name="Shorted loop" value="5"></value>
+            <value name="No output" value="6"></value>
+            <value name="Unreliable other" value="7"></value>
+            <value name="Process error" value="8"></value>
+            <value name="Multi state fault" value="9"></value>
+            <value name="Configuration error" value="10"></value>
+          </attribute>
+          <attribute id="0x0068" name="Relinquish Default" type="u16" required="o" access="rw"></attribute>
+          <attribute id="0x006f" type="bmp8" name="Status flags" required="m" access="r" default="0">
+            <value name="In Alarm" value="0x01"></value>
+            <value name="Fault" value="0x02"></value>
+            <value name="Overidden" value="0x04"></value>
+            <value name="Out of Service" value="0x08"></value>
+          </attribute>
+          <attribute id="0x0100" name="Application Type" type="u32" required="o" access="r"></attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0015" name="Commissioning">
+        <description>Attributes and commands for commissioning and managing a ZigBee device.</description>
+        <server>
+          <!-- TODO -->
+          <attribute-set id="0x0000" description="Startup Parameters I">
+            <attribute id="0x0000" name="Short Address" type="u16" access="rw" range="0x0000,0xfff7" showas="hex" required="m"></attribute>
+            <attribute id="0x0001" name="Extended PAN ID" type="uid" access="rw" range="0x0000000000000000,0xfffffffffffffff7" required="m"></attribute>
+            <attribute id="0x0002" name="PAN ID" type="u16" access="rw" range="0x0000,0xffff" showas="hex" required="m"></attribute>
+            <attribute id="0x0003" name="Channel Mask" type="bmp32" access="rw" required="m">
+              <value name="CH 11" value="11"></value>
+              <value name="CH 12" value="12"></value>
+              <value name="CH 13" value="13"></value>
+              <value name="CH 14" value="14"></value>
+              <value name="CH 15" value="15"></value>
+              <value name="CH 16" value="16"></value>
+              <value name="CH 17" value="17"></value>
+              <value name="CH 18" value="18"></value>
+              <value name="CH 19" value="19"></value>
+              <value name="CH 20" value="20"></value>
+              <value name="CH 21" value="21"></value>
+              <value name="CH 22" value="22"></value>
+              <value name="CH 23" value="23"></value>
+              <value name="CH 24" value="24"></value>
+              <value name="CH 25" value="25"></value>
+              <value name="CH 26" value="26"></value>
+            </attribute>
+            <attribute id="0x0004" name="Protocol Version" type="u8" access="rw" default="0x02" required="m"></attribute>
+            <attribute id="0x0005" name="Stack Profile" type="u8" access="rw" range="0x01,0x02" required="m"></attribute>
+            <attribute id="0x0006" name="Startup Control" type="enum8" access="rw" required="m">
+              <value name="Part of the network" value="0x00"></value>
+              <value name="Form a network" value="0x01"></value>
+              <value name="Rejoin the network" value="0x02"></value>
+              <value name="Start from scratch" value="0x03"></value>
+            </attribute>
+          </attribute-set>
+          <attribute-set id="0x0010" description="Startup Parameters II">
+            <attribute id="0x0010" name="Trust Center Address" type="uid" access="rw" required="m"></attribute>
+            <attribute id="0x0011" name="Trust Center Master Key" type="seckey" access="rw" required="m"></attribute>
+            <attribute id="0x0012" name="Network Key" type="seckey" access="rw" required="m"></attribute>
+            <attribute id="0x0013" name="Use Insecure Join" type="bool" access="rw" required="m"></attribute>
+            <attribute id="0x0014" name="Preconfigured Link Key" type="seckey" access="rw" required="m"></attribute>
+            <attribute id="0x0015" name="Network Key Seq Num" type="u8" access="rw" range="0x00,0xff" required="m"></attribute>
+            <attribute id="0x0016" name="Network Key Type" type="enum8" access="rw" required="m">
+              <value name="Standard" value="0x01"></value>
+              <value name="High Security" value="0x05"></value>
+            </attribute>
+            <attribute id="0x0017" name="Network Manager Address" type="u16" access="rw" required="m"></attribute>
+          </attribute-set>
+          <attribute-set id="0x0020" description="Join Parameters">
+            <attribute id="0x0020" name="Scan Attemps" type="u8" access="rw" range="0x01,0xff" required="m"></attribute>
+            <attribute id="0x0021" name="Time Between Scans" type="u16" access="rw" range="0x0001,0xffff" required="m"></attribute>
+            <attribute id="0x0022" name="Rejoin Interval" type="u16" access="rw" range="0x0001,0xffff" required="m"></attribute>
+            <attribute id="0x0023" name="Max Rejoin Interval" type="u16" access="rw" range="0x0001,0xffff" required="m"></attribute>
+          </attribute-set>
+          <attribute-set id="0x0030" description="End Device Parameters">
+            <attribute id="0x0030" name="Indirect Poll Rate" type="u16" access="rw" range="0x0000,0xffff" required="m"></attribute>
+            <attribute id="0x0030" name="Parent Retry Threshold" type="u8" access="rw" range="0x00,0xff" required="m"></attribute>
+          </attribute-set>
+          <attribute-set id="0x0040" description="Concentrator Parameters">
+            <attribute id="0x0040" name="Concentrator Flag" type="bool" access="rw" required="m"></attribute>
+            <attribute id="0x0041" name="Concentrator Radius" type="u8" access="rw" range="0x00,0xff" required="m"></attribute>
+            <attribute id="0x0042" name="Concentrator Discovery Time" type="u8" access="rw" range="0x00,0xff" required="m"></attribute>
+          </attribute-set>
+          <attribute-set id="0xde00" description="DE Setup Parameters">
+            <attribute id="0xde01" name="MAC Address" type="uid" access="rw" required="m"></attribute>
+          </attribute-set>
+          <command id="00" dir="recv" name="Restart Device" required="m" response="0x00">
+            <description>The Restart Device command is used to optionally install a set of startup parameters in a device and run the startup procedure so as to put the new values into effect. The new values may take effect immediately or after an optional delay with optional jitter. The server will send a Restart Device Response command back to the client device before executing the procedure or starting the countdown timer required to time the delay.</description>
+            <payload>
+              <attribute id="0x0000" name="Options" type="bmp8" default="00000000" access="rw" required="m">
+                <value name="Don't replace attributes on restart" value="0"></value>
+                <value name="Immediate" value="1"></value>
+              </attribute>
+              <attribute id="0x0001" type="u8" name="Delay" required="m"></attribute>
+              <attribute id="0x0002" type="u8" name="Jitter" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="01" dir="recv" name="Save Startup Parameters" required="o" response="0x01">
+            <description>The Save Startup Parameters Request command allows for the current attribute set to be stored under a given index.</description>
+            <payload>
+              <attribute id="0x0000" name="Options" type="bmp8" default="00000000" access="rw" required="m">
+              </attribute>
+              <attribute id="0x0001" type="u8" name="Index" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="02" dir="recv" name="Restore Startup Parameters" required="o" response="0x02">
+            <description>This command allows a saved startup parameters attribute set to be restored to current status overwriting whatever was there previously.</description>
+            <payload>
+              <attribute id="0x0000" name="Options" type="bmp8" default="00000000" access="rw" required="m">
+              </attribute>
+              <attribute id="0x0001" type="u8" name="Index" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="03" dir="recv" name="Reset Startup Parameters" required="m" response="0x03">
+            <description>This command allows current startup parameters attribute set and one or all of the saved attribute sets to be set to default values. There is also an option for erasing the index under which an attribute set is saved thereby freeing up storage capacity.</description>
+            <payload>
+              <attribute id="0x0000" name="Options" type="bmp8" default="00000000" access="rw" required="m">
+                <value name="Reset Current" value="0"></value>
+                <value name="Reset All" value="1"></value>
+                <value name="Erase Index" value="2"></value>
+              </attribute>
+              <attribute id="0x0001" type="u8" name="Index" required="m"></attribute>
+            </payload>
+          </command>
+        </server>
+        <client>
+          <command id="00" dir="recv" name="Restart Device Response" required="m">
+            <description>On receipt of this command the client is made aware that the server has received the corresponding request and is informed of the status of the request.</description>
+            <payload>
+              <attribute id="0x0000" name="Status" type="enum8" access="rw" required="m" enumeration="ZCL_Status">
+              </attribute>
+            </payload>
+          </command>
+          <command id="01" dir="recv" name="Save Startup Parameters Response" required="m">
+            <description>On receipt of this command the client is made aware that the server has received the corresponding request and is informed of the status of the request.</description>
+            <payload>
+              <attribute id="0x0000" name="Status" type="enum8" access="rw" required="m" enumeration="ZCL_Status">
+              </attribute>
+            </payload>
+          </command>
+          <command id="02" dir="recv" name="Restore Startup Parameters Response" required="m">
+            <description>On receipt of this command the client is made aware that the server has received the corresponding request and is informed of the status of the request.</description>
+            <payload>
+              <attribute id="0x0000" name="Status" type="enum8" access="rw" required="m" enumeration="ZCL_Status">
+              </attribute>
+            </payload>
+          </command>
+          <command id="03" dir="recv" name="Reset Startup Parameters Response" required="m">
+            <description>On receipt of this command the client is made aware that the server has received the corresponding request and is informed of the status of the request.</description>
+            <payload>
+              <attribute id="0x0000" name="Status" type="enum8" access="rw" required="m" enumeration="ZCL_Status">
+              </attribute>
+            </payload>
+          </command>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0019" name="OTAU">
+        <description>Over the air upgrade.</description>
+        <client>
+          <attribute id="0x0000" name="Upgrade server" type="uid" default="0" access="rw" required="m"></attribute>
+          <attribute id="0x0001" name="File Offset" type="u32" default="0xffffffff" access="r" required="o" showas="hex"></attribute>
+          <attribute id="0x0002" name="Current File Version" type="u32" default="0xffffffff" access="r" required="o" showas="hex"></attribute>
+          <attribute id="0x0003" name="Current ZigBee Stack Version" type="u16" default="0xffff" access="r" required="o" showas="hex"></attribute>
+          <attribute id="0x0004" name="Downloaded File Version" type="u32" default="0xffffffff" access="r" required="o" showas="hex"></attribute>
+          <attribute id="0x0005" name="Downloaded ZigBee Stack Version" type="u16" default="0xffff" access="r" required="o" showas="hex"></attribute>
+          <attribute id="0x0006" name="Image upgrade status" type="enum8" default="0x04" access="rw" required="m">
+            <value name="Normal" value="0"></value>
+            <value name="Download in progress" value="1"></value>
+            <value name="Download complete" value="2"></value>
+            <value name="Waiting to upgrade" value="3"></value>
+            <value name="Count down" value="4"></value>
+            <value name="Wait for more" value="5"></value>
+          </attribute>
+          <attribute id="0x0007" name="Manufacturer ID" type="u16" access="r" required="o" showas="hex"></attribute>
+          <attribute id="0x0008" name="Image Type ID" type="u16" access="r" required="o" showas="hex"></attribute>
+          <attribute id="0x0009" name="Min block request delay" type="u16" default="0" access="r" required="m"></attribute>
+          <command id="0x01" dir="send" name="Query next image" required="m">
+            <description></description>
+            <payload>
+              <attribute id="0x0000" type="bmp8" name="Control field" required="m" default="0x00">
+                <value name="Hardware version present" value="0x01"></value>
+              </attribute>
+              <attribute id="0x0001" type="u16" showas="hex" name="Manufacturer ID" required="m"></attribute>
+              <attribute id="0x0002" type="enum16" name="Image type" required="m" default="0x0000">
+                <value name="Specific image" value="0x0000"></value>
+                <value name="Security credential" value="0xFFC0"></value>
+                <value name="Configuration" value="0xFFC1"></value>
+                <value name="Log" value="0xFFC2"></value>
+                <value name="Wild card" value="0xFFFF"></value>
+              </attribute>
+              <!--  Firmware Version -->
+              <attribute id="0x0003" type="u8" showas="hex" name="Application Release" required="m"></attribute>
+              <attribute id="0x0004" type="u8" showas="hex" name="Application Build" required="m"></attribute>
+              <attribute id="0x0005" type="u8" showas="hex" name="Stack Release" required="m"></attribute>
+              <attribute id="0x0006" type="u8" showas="hex" name="Stack Build" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="0x07" dir="recv" name="Upgrade end response" required="m">
+            <description></description>
+            <payload>
+              <attribute id="0x0000" type="u16" showas="hex" name="Manufacturer ID" required="m"></attribute>
+              <attribute id="0x0001" type="u16" showas="hex" name="Image type" required="m"></attribute>
+              <attribute id="0x0002" type="u32" showas="hex" name="File version" required="m"></attribute>
+              <attribute id="0x0003" type="u32" showas="hex" name="Current time" required="m"></attribute>
+              <attribute id="0x0004" type="u32" showas="hex" name="Upgrade time" required="m"></attribute>
+            </payload>
+          </command>
+        </client>
+        <server>
+        </server>
+      </cluster>
+      
+      <cluster id="0x0020" name="Poll Control">
+        <description>Provides a mechanism for the management of an end device’s MAC
+          Data Request rate.</description>
+        <client>
+        </client>
+        <server>
+          <attribute id="0x0000" name="Check-in Interval" type="u32" default="0x3840" access="rw" required="m" range="0x0,0x6e0000"></attribute>
+          <attribute id="0x0001" name="Long Poll Interval" type="u32" default="0x14" access="r" required="m" range="0x04,0x6e0000"></attribute>
+          <attribute id="0x0002" name="Short Poll Interval" type="u16" default="0x02" access="r" required="m" range="0x01,0xffff"></attribute>
+          <attribute id="0x0003" name="Fast Poll Timeout" type="u16" default="0x028" access="rw" required="m" range="0x01,0xffff"></attribute>
+          <attribute id="0x0004" name="Check-in Interval Min" type="u32" default="0" access="r" required="o"></attribute>
+          <attribute id="0x0005" name="Long Poll Interval Min" type="u32" default="0" access="r" required="o"></attribute>
+          <attribute id="0x0006" name="Fast Poll Timeout Max" type="u16" default="0" access="r" required="o"></attribute>
+          <command id="0x00" dir="send" name="Check-in" required="m">
+            <description>The Poll Control Cluster server sends out a Check-in command to the devices to which it is paired based on
+              the server‘s Check-inInterval attribute. It does this to find out if any of the Poll Control Cluster Clients with
+              which it is paired are interested in having it enter fast poll mode so that it can be managed. This request is sent
+              out based on either the Check-inInterval, or the next Check-in value in the Fast Poll Stop Request generated
+              by the Poll Control Cluster Client.</description>
+            <payload></payload>
+          </command>
+          <command id="0x01" dir="send" name="Stop" required="m">
+            <description>send Fast Poll Stop</description>
+            <payload></payload>
+          </command>
+          <command id="0x02" dir="recv" name="Set Long Poll Interval" required="o">
+            <description>Sets the Read Only LongPollInterval attribute.</description>
+            <payload>
+              <attribute id="0x0000" type="u32" showas="hex" name="New Long Poll Interval" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="0x03" dir="recv" name="Set Short Poll Interval" required="o">
+            <description>Sets the Read Only ShortPollInterval attribute.</description>
+            <payload>
+              <attribute id="0x0000" type="u16" showas="hex" name="New Short Poll Interval" required="m"></attribute>
+            </payload>
+          </command>
+        </server>
+      </cluster>
+      <cluster id="0x0800" name="Key Establishment">
+        <description></description>
+        <client></client>
+        <server></server>
+        <!-- TODO -->
+      </cluster>
+    </domain>
+    
+    <domain name="Closures" low_bound="0100" high_bound="01ff" description="The closures functional domain contains clusters and information to build devices in the closure domain, e.g. shade controllers.">
+      <cluster id="0x0100" name="Shade Configuration">
+        <description></description>
+        <!-- TODO -->
+      </cluster>
+      
+      <cluster id="0x0100" name="Shade Configuration">
+        <description>The shade configuration cluster provides an interface for reading information about a shade, and configuring its open and closed limits.</description>
+        <client>
+        </client>
+        <server>
+          <attribute-set id="0x0000" description="Shade Information Attribute Set">
+            <attribute id="0x0000" name="Physical Closed Limit" type="u16" access="r" required="o"></attribute>
+            <attribute id="0x0001" name="MotorStepSize" type="u8" access="r" required="o"></attribute>
+            <attribute id="0x0002" name="Status" type="bmp8" access="rw" required="m">
+              <value name="Shade operational" value="0"></value>
+              <value name="Shade adjusting" value="1"></value>
+              <value name="Shade direction" value="2"></value>
+              <value name="Direction Reversed" value="3"></value>
+            </attribute>
+          </attribute-set>
+          <attribute-set id="0x0010" description="Shade Settings Attribute Set">
+            <attribute id="0x0010" name="Closed Limit" type="u16" access="rw" range="0x0001,0xfffe" default="0x0001" required="m"></attribute>
+            <attribute id="0x0011" name="Mode" type="enum8" access="rw" default="0x00" required="m">
+              <value name="Normal" value="0x00"></value>
+              <value name="Configure" value="0x01"></value>
+              <value name="Invalid" value="0xff"></value>
+            </attribute>
+          </attribute-set>
+        </server>
+      </cluster>
+      
+      <cluster id="0x0101" name="Door Lock">
+        <description>The door lock cluster provides an interface to a generic way to secure a door.</description>
+        <client>
+        </client>
+        <server>
+          <attribute-set id="0x0000" description="Basic Information Attribute Set">
+            <attribute id="0x0000" name="Lock State" type="enum8" access="r" required="m">
+              <value name="Not fully locked" value="0x00"></value>
+              <value name="Locked" value="0x01"></value>
+              <value name="Unlocked" value="0x02"></value>
+              <value name="Undefined" value="0xff"></value>
+            </attribute>
+            <attribute id="0x0001" name="Lock Type" type="enum8" access="r" required="m">
+              <value name="Dead bolt" value="0x00"></value>
+              <value name="Magnetic" value="0x01"></value>
+              <value name="Other" value="0x02"></value>
+              <value name="Mortise" value="0x03"></value>
+              <value name="Rim" value="0x04"></value>
+              <value name="Latch Bolt" value="0x05"></value>
+              <value name="Cylindrical Lock" value="0x06"></value>
+              <value name="Tubular Lock" value="0x07"></value>
+              <value name="Interconnected Lock" value="0x08"></value>
+              <value name="Dead Latch" value="0x09"></value>
+              <value name="Door Furniture" value="0x0A"></value>
+            </attribute>
+            <attribute id="0x0002" name="Actuator enabled" type="bool" access="r" required="m"></attribute>
+            <attribute id="0x0003" name="Door state" type="enum8" access="r" required="m">
+              <value name="Open" value="0x00"/>
+              <value name="Closed" value="0x01"/>
+              <value name="Error jammed" value="0x02"/>
+              <value name="Error forced open" value="0x03"/>
+              <value name="Error unspecified" value="0x04"/>
+              <value name="Undefined" value="0xff"/>
+            </attribute>
+          </attribute-set>
+          <attribute-set id="0x0010" description="User, PIN, Schedule Information Attribute Set">
+            <attribute id="0x0010" name="Number Of Log Records Supported" type="u16" default="0" access="r" required="o"></attribute>
+            <attribute id="0x0011" name="Number Of Total Users Supported" type="u16" default="0" access="r" required="o"></attribute>
+            <attribute id="0x0012" name="Number Of PIN Users Supported" type="u16" default="0" access="r" required="o"></attribute>
+            <attribute id="0x0013" name="Number Of RFID Users Supported" type="u16" default="0" access="r" required="o"></attribute>
+            <attribute id="0x0014" name="Number Of WeekDay Schedules Supported Per User" type="u8" default="0" access="r" required="o"></attribute>
+            <attribute id="0x0015" name="Number Of Year Day Schedules Supported Per User" type="u8" default="0" access="r" required="o"></attribute>
+            <attribute id="0x0016" name="Number Of Holiday Schedules Supported" type="u8" default="0" access="r" required="o"></attribute>
+            <attribute id="0x0017" name="Max PIN length" type="u8" access="r" required="o"/>
+            <attribute id="0x0018" name="Min PIN length" type="u8" access="r" required="o"/>
+          </attribute-set>
+          <attribute-set id="0x0020" description="Operational Settings Attribute Set">
+            <attribute id="0x0020" name="Enable Logging" type="bool" default="0" access="rw" required="o"></attribute>
+            <attribute id="0x0021" name="Language" type="cstring" access="rw" required="o"></attribute>
+            <attribute id="0x0022" name="Led Setting" type="u8" default="0" access="rw" required="o">
               <value name="Never use LED for signalization" value="0x00"></value>
               <value name="Use LED signalization except for access allowed events" value="0x01"></value>
               <value name="Use LED signalization for all events" value="0x02"></value>
-          </attribute>
-          <attribute id="0x0023" name="Auto Relock Time" type="u32" default="0" access="rw" required="o"></attribute>
-          <attribute id="0x0024" name="Sound Volume" type="u8" default="0" access="rw" required="o">
+            </attribute>
+            <attribute id="0x0023" name="Auto Relock Time" type="u32" default="0" access="rw" required="o"></attribute>
+            <attribute id="0x0024" name="Sound Volume" type="u8" default="0" access="rw" required="o">
               <value name="Silent Mode" value="0x00"></value>
               <value name="Low Volume" value="0x01"></value>
               <value name="Hight Volume" value="0x02"></value>
-          </attribute>
-          <attribute id="0x0025" name="Operating mode" type="enum8" default="0" access="rw" required="o">
+            </attribute>
+            <attribute id="0x0025" name="Operating mode" type="enum8" default="0" access="rw" required="o">
               <value name="Normal" value="0x00"></value>
               <value name="Vacation" value="0x01"></value>
               <value name="Privacy" value="0x02"></value>
               <value name="No RF Lock/Unlock" value="0x03"></value>
               <value name="Passage" value="0x04"></value>
-          </attribute>
-          <attribute id="0x0026" name="Supported operating mode" type="bmp16" default="0x0000" access="r" required="o">
+            </attribute>
+            <attribute id="0x0026" name="Supported operating mode" type="bmp16" default="0x0000" access="r" required="o">
               <value name="Normal Mode Supported" value="0"></value>
               <value name="Vacation Mode Supported" value="1"></value>
               <value name="Privacy Mode Supported" value="2"></value>
               <value name="No RF Lock or Unlock Mode Supported" value="3"></value>
               <value name="Passage Mode Supported" value="4"></value>
-          </attribute>
-          <attribute id="0x0027" name="Default Configuration Register" type="bmp16" default="0x0000" access="r" required="o">
+            </attribute>
+            <attribute id="0x0027" name="Default Configuration Register" type="bmp16" default="0x0000" access="r" required="o">
               <value name="Enable Local Programming" value="0"></value>
               <value name="Keypad Interface" value="1"></value>
               <value name="RF Interface" value="2"></value>
               <value name="Sound Volume attribute" value="5"></value>
               <value name="Auto Relock Time attribute" value="6"></value>
               <value name="Led Settings attribute" value="7"></value>
-          </attribute>
-          <attribute id="0x0028" name="Enable Local Programming" type="bool" default="0" access="rw" required="o"></attribute>
-          <attribute id="0x0029" name="Enable One TouchLocking" type="bool" default="0" access="rw" required="o"></attribute>
-          <attribute id="0x002A" name="Enable Inside Status LED" type="bool" default="0" access="rw" required="o"></attribute>
-          <attribute id="0x002B" name="Enable Privacy ModeButton" type="bool" default="0" access="rw" required="o"></attribute>
-        </attribute-set>
-        <attribute-set id="0x0030" description="Security Settings Attribute Set">
-          <attribute id="0x0030" name="Wrong Code Entry Limit" type="u8" default="0" access="r" required="o"></attribute>
-          <attribute id="0x0031" name="User Code Temporary Disable Time" type="u8" default="0" access="r" required="o"></attribute>
-          <attribute id="0x0032" name="Send PIN Over The Air" type="bool" default="0" access="rw" required="o"></attribute>
-          <attribute id="0x0033" name="Require PIN for RF Operation" type="bool" default="0" access="rw" required="o"></attribute>
-          <attribute id="0x0034" name="Zigbee Security Level" type="enum8" default="0" access="r" required="o">
-            <value name="Network Security" value="0x00"></value>
-            <value name="APS Security" value="0x01"></value>
-          </attribute>
-        </attribute-set>
-        <attribute-set id="0x0040" description="Alarm and Event Masks Attribute Set">
-          <attribute id="0x0040" name="Alarm Mask" type="bmp16" default="0x0000" access="rw" required="o">
-            <value name="Deadbolt Jammed" value="0"></value>
-            <value name="Lock Reset to Factory Defaults" value="1"></value>
-            <value name="Reserved" value="2"></value>
-            <value name="RF Module Power Cycled" value="3"></value>
-            <value name="Tamper Alarm – wrong code entry limit" value="4"></value>
-            <value name="Tamper Alarm - front escutcheon removed from main" value="5"></value>
-            <value name="Forced Door Open under Door Locked Condition" value="6"></value>
-          </attribute>
-          <attribute id="0x0042" name="RF Operation Event Mask" type="bmp16" default="0x0000" access="rw" required="o">
-            <value name="Unknown or manufacturer-specific RF operation event" value="0"></value>
-            <value name="Lock, source: RF" value="1"></value>
-            <value name="Unlock, source: RF" value="2"></value>
-            <value name="Lock, source: RF, error: invalid code" value="3"></value>
-            <value name="Lock, source: RF, error: invalid schedule" value="4"></value>
-            <value name="Unlock, source: RF, error: invalid code" value="5"></value>
-            <value name="Unlock, source: RF, error: invalid schedule" value="6"></value>
-          </attribute>
-          <attribute id="0x0043" name="Manual Operation Event Mask" type="bmp16" default="0x0000" access="rw" required="o">
-            <value name="Unknown or manufacturer-specific manual operation event" value="0"></value>
-            <value name="Thumbturn Lock" value="1"></value>
-            <value name="Thumbturn Unlock" value="2"></value>
-            <value name="One touch lock" value="3"></value>
-            <value name="Key Lock" value="4"></value>
-            <value name="Key Unlock" value="5"></value>
-            <value name="Auto lock" value="6"></value>
-            <value name="Schedule Lock" value="7"></value>
-            <value name="Schedule Unlock" value="8"></value>
-            <value name="Manual Lock (Key or Thumbturn)" value="9"></value>
-            <value name="Manual Unlock (Key or Thumbturn)" value="10"></value>
-          </attribute>
-        </attribute-set>
-        <attribute-set id="0x0050" description="Xiaomi Special" mfcode="0x1037">
-          <attribute id="0x0055" name="Event Type" type="u16" access="r" required="o"></attribute>
-          <attribute id="0x0503" name="Tilt Angle" type="u16" access="r" required="o"></attribute>
-          <attribute id="0x0505" name="Vibration Strength" type="u32" showas="hex" access="r" required="o"></attribute>
-          <attribute id="0x0508" name="Orientation" type="u48" showas="hex" access="r" required="o"></attribute>
-        </attribute-set>
-        <attribute-set id="0x4000" description="ID Lock special" mfcode="0x1337">
-          <attribute id="0x4000" name="Master PIN mode" type="bool" access="rw" required="m" mfcode="0x1337"/>
-          <attribute id="0x4001" name="RFID Enabled" type="bool" access="rw" required="m" mfcode="0x1337"/>
-          <attribute id="0x4002" name="Hinge mode" type="bool" access="rw" required="m" mfcode="0x1337"/>
-          <attribute id="0x4003" name="Service PIN mode" type="u8" access="rw" required="m" mfcode="0x1337">
-            <value name="Deactivated" value="0x00"/>
-            <value name="1x use" value="0x01"/>
-            <value name="2x uses" value="0x02"/>
-            <value name="5x uses" value="0x03"/>
-            <value name="10x uses" value="0x04"/>
-            <value name="Random PIN 1x use" value="0x05"/>
-            <value name="Random PIN 24 hours" value="0x06"/>
-            <value name="Always valid" value="0x07"/>
-            <value name="12 hours" value="0x08"/>
-            <value name="24 hours" value="0x09"/>
-          </attribute>
-          <attribute id="0x4004" name="Lock mode" type="u8" access="rw" required="m" mfcode="0x1337">
-            <value name="Auto lock OFF/Away mode OFF" value="0x00"/>
-            <value name="Auto lock ON/Away mode OFF" value="0x01"/>
-            <value name="Auto lock OFF/Away mode ON" value="0x02"/>
-            <value name="Auto lock ON/Away mode ON" value="0x03"/>
-          </attribute>
-          <attribute id="0x4005" name="Relock enabled" type="bool" access="rw" required="m" mfcode="0x1337"/>
-          <attribute id="0x4006" name="Audio volume" type="u8" access="rw" required="m" mfcode="0x1337">
-            <value name="Volume off" value="0x00"/>
-            <value name="1" value="0x01"/>
-            <value name="2" value="0x02"/>
-            <value name="3" value="0x03"/>
-            <value name="4" value="0x04"/>
-            <value name="5" value="0x05"/>
-          </attribute>
-        </attribute-set>
-        <command id="0x00" dir="recv" name="Lock Door" required="m">
-          <description>This command causes the lock device to lock the door.</description>
-          <payload></payload>
-        </command>
-        <command id="0x01" dir="recv" name="Unlock Door" required="m">
-          <description>This command causes the lock device to unlock the door.</description>
-          <payload></payload>
-        </command>
-        <command id="0x02" dir="recv" name="Toggle Door" required="o">
-          <description>This command toggle the lock device.</description>
-          <payload></payload>
-        </command>
-        <command id="0x03" dir="recv" name="Unlock with timer" required="o">
-          <description>This command Unlock the lock device but with a timer.</description>
-          <payload>
+            </attribute>
+            <attribute id="0x0028" name="Enable Local Programming" type="bool" default="0" access="rw" required="o"></attribute>
+            <attribute id="0x0029" name="Enable One TouchLocking" type="bool" default="0" access="rw" required="o"></attribute>
+            <attribute id="0x002A" name="Enable Inside Status LED" type="bool" default="0" access="rw" required="o"></attribute>
+            <attribute id="0x002B" name="Enable Privacy ModeButton" type="bool" default="0" access="rw" required="o"></attribute>
+          </attribute-set>
+          <attribute-set id="0x0030" description="Security Settings Attribute Set">
+            <attribute id="0x0030" name="Wrong Code Entry Limit" type="u8" default="0" access="r" required="o"></attribute>
+            <attribute id="0x0031" name="User Code Temporary Disable Time" type="u8" default="0" access="r" required="o"></attribute>
+            <attribute id="0x0032" name="Send PIN Over The Air" type="bool" default="0" access="rw" required="o"></attribute>
+            <attribute id="0x0033" name="Require PIN for RF Operation" type="bool" default="0" access="rw" required="o"></attribute>
+            <attribute id="0x0034" name="Zigbee Security Level" type="enum8" default="0" access="r" required="o">
+              <value name="Network Security" value="0x00"></value>
+              <value name="APS Security" value="0x01"></value>
+            </attribute>
+          </attribute-set>
+          <attribute-set id="0x0040" description="Alarm and Event Masks Attribute Set">
+            <attribute id="0x0040" name="Alarm Mask" type="bmp16" default="0x0000" access="rw" required="o">
+              <value name="Deadbolt Jammed" value="0"></value>
+              <value name="Lock Reset to Factory Defaults" value="1"></value>
+              <value name="Reserved" value="2"></value>
+              <value name="RF Module Power Cycled" value="3"></value>
+              <value name="Tamper Alarm – wrong code entry limit" value="4"></value>
+              <value name="Tamper Alarm - front escutcheon removed from main" value="5"></value>
+              <value name="Forced Door Open under Door Locked Condition" value="6"></value>
+            </attribute>
+            <attribute id="0x0042" name="RF Operation Event Mask" type="bmp16" default="0x0000" access="rw" required="o">
+              <value name="Unknown or manufacturer-specific RF operation event" value="0"></value>
+              <value name="Lock, source: RF" value="1"></value>
+              <value name="Unlock, source: RF" value="2"></value>
+              <value name="Lock, source: RF, error: invalid code" value="3"></value>
+              <value name="Lock, source: RF, error: invalid schedule" value="4"></value>
+              <value name="Unlock, source: RF, error: invalid code" value="5"></value>
+              <value name="Unlock, source: RF, error: invalid schedule" value="6"></value>
+            </attribute>
+            <attribute id="0x0043" name="Manual Operation Event Mask" type="bmp16" default="0x0000" access="rw" required="o">
+              <value name="Unknown or manufacturer-specific manual operation event" value="0"></value>
+              <value name="Thumbturn Lock" value="1"></value>
+              <value name="Thumbturn Unlock" value="2"></value>
+              <value name="One touch lock" value="3"></value>
+              <value name="Key Lock" value="4"></value>
+              <value name="Key Unlock" value="5"></value>
+              <value name="Auto lock" value="6"></value>
+              <value name="Schedule Lock" value="7"></value>
+              <value name="Schedule Unlock" value="8"></value>
+              <value name="Manual Lock (Key or Thumbturn)" value="9"></value>
+              <value name="Manual Unlock (Key or Thumbturn)" value="10"></value>
+            </attribute>
+          </attribute-set>
+          <attribute-set id="0x0050" description="Xiaomi Special" mfcode="0x1037">
+            <attribute id="0x0055" name="Event Type" type="u16" access="r" required="o"></attribute>
+            <attribute id="0x0503" name="Tilt Angle" type="u16" access="r" required="o"></attribute>
+            <attribute id="0x0505" name="Vibration Strength" type="u32" showas="hex" access="r" required="o"></attribute>
+            <attribute id="0x0508" name="Orientation" type="u48" showas="hex" access="r" required="o"></attribute>
+          </attribute-set>
+          <attribute-set id="0x4000" description="ID Lock special" mfcode="0x1337">
+            <attribute id="0x4000" name="Master PIN mode" type="bool" access="rw" required="m" mfcode="0x1337"/>
+            <attribute id="0x4001" name="RFID Enabled" type="bool" access="rw" required="m" mfcode="0x1337"/>
+            <attribute id="0x4002" name="Hinge mode" type="bool" access="rw" required="m" mfcode="0x1337"/>
+            <attribute id="0x4003" name="Service PIN mode" type="u8" access="rw" required="m" mfcode="0x1337">
+              <value name="Deactivated" value="0x00"/>
+              <value name="1x use" value="0x01"/>
+              <value name="2x uses" value="0x02"/>
+              <value name="5x uses" value="0x03"/>
+              <value name="10x uses" value="0x04"/>
+              <value name="Random PIN 1x use" value="0x05"/>
+              <value name="Random PIN 24 hours" value="0x06"/>
+              <value name="Always valid" value="0x07"/>
+              <value name="12 hours" value="0x08"/>
+              <value name="24 hours" value="0x09"/>
+            </attribute>
+            <attribute id="0x4004" name="Lock mode" type="u8" access="rw" required="m" mfcode="0x1337">
+              <value name="Auto lock OFF/Away mode OFF" value="0x00"/>
+              <value name="Auto lock ON/Away mode OFF" value="0x01"/>
+              <value name="Auto lock OFF/Away mode ON" value="0x02"/>
+              <value name="Auto lock ON/Away mode ON" value="0x03"/>
+            </attribute>
+            <attribute id="0x4005" name="Relock enabled" type="bool" access="rw" required="m" mfcode="0x1337"/>
+            <attribute id="0x4006" name="Audio volume" type="u8" access="rw" required="m" mfcode="0x1337">
+              <value name="Volume off" value="0x00"/>
+              <value name="1" value="0x01"/>
+              <value name="2" value="0x02"/>
+              <value name="3" value="0x03"/>
+              <value name="4" value="0x04"/>
+              <value name="5" value="0x05"/>
+            </attribute>
+          </attribute-set>
+          <command id="0x00" dir="recv" name="Lock Door" required="m">
+            <description>This command causes the lock device to lock the door.</description>
+            <payload></payload>
+          </command>
+          <command id="0x01" dir="recv" name="Unlock Door" required="m">
+            <description>This command causes the lock device to unlock the door.</description>
+            <payload></payload>
+          </command>
+          <command id="0x02" dir="recv" name="Toggle Door" required="o">
+            <description>This command toggle the lock device.</description>
+            <payload></payload>
+          </command>
+          <command id="0x03" dir="recv" name="Unlock with timer" required="o">
+            <description>This command Unlock the lock device but with a timer.</description>
+            <payload>
               <attribute id="0x0000" type="u16" name="Timeout" required="m"></attribute>
-          </payload>
-        </command>
-        <command id="0x04" dir="recv" name="Get Log Record" required="o">
-          <description>Request a log record.</description>
-          <payload>
-            <attribute id="0x0000" type="u16" name="Log Index" required="m" default="0x0000"></attribute>
-          </payload>
-        </command>
-        <command id="0x04" dir="send" name="Get Log Record Response" required="m">
-          <description>Returns the specified log record.</description>
-          <payload>
-          <attribute id="0x0000" type="u16" name="Log Entry ID" required="m"></attribute>
-          <attribute id="0x0001" type="u32" name="Timestamp" required="m"></attribute>
-          <attribute id="0x0002" type="enum8" name="Event Type" required="m">
-            <value name="Operation" value="0"></value>
-            <value name="Programming" value="1"></value>
-            <value name="Alarm" value="2"></value>
-          </attribute>
-          <attribute id="0x0003" type="u8" name="Source" required="m"></attribute>
-          <attribute id="0x0004" type="u8" name="Event ID/Alarm Code" required="m"></attribute>
-          <attribute id="0x0005" type="u16" name="User ID" required="m"></attribute>
-          <attribute id="0x0006" type="cstring" name="PIN" required="m"></attribute>
-          </payload>
-        </command>
-        <command id="0x05" dir="recv" name="Set PIN code" required="o">
-          <description>Set PIN-code for user. User ID is between 0 and [# of PIN Users Supported Attribute]</description>
-          <payload>
-            <attribute id="0x0000" type="u16" name="User ID" required="m"></attribute>
-            <attribute id="0x0001" type="u8" name="User Status" required="o">
-              <value name="Occupied/Enabled" value="1" />
-              <value name="Occupied/Disabled" value="3" />
+            </payload>
+          </command>
+          <command id="0x04" dir="recv" name="Get Log Record" required="o">
+            <description>Request a log record.</description>
+            <payload>
+              <attribute id="0x0000" type="u16" name="Log Index" required="m" default="0x0000"></attribute>
+            </payload>
+          </command>
+          <command id="0x04" dir="send" name="Get Log Record Response" required="m">
+            <description>Returns the specified log record.</description>
+            <payload>
+              <attribute id="0x0000" type="u16" name="Log Entry ID" required="m"></attribute>
+              <attribute id="0x0001" type="u32" name="Timestamp" required="m"></attribute>
+              <attribute id="0x0002" type="enum8" name="Event Type" required="m">
+                <value name="Operation" value="0"></value>
+                <value name="Programming" value="1"></value>
+                <value name="Alarm" value="2"></value>
+              </attribute>
+              <attribute id="0x0003" type="u8" name="Source" required="m"></attribute>
+              <attribute id="0x0004" type="u8" name="Event ID/Alarm Code" required="m"></attribute>
+              <attribute id="0x0005" type="u16" name="User ID" required="m"></attribute>
+              <attribute id="0x0006" type="cstring" name="PIN" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="0x05" dir="recv" name="Set PIN code" required="o">
+            <description>Set PIN-code for user. User ID is between 0 and [# of PIN Users Supported Attribute]</description>
+            <payload>
+              <attribute id="0x0000" type="u16" name="User ID" required="m"></attribute>
+              <attribute id="0x0001" type="u8" name="User Status" required="o">
+                <value name="Occupied/Enabled" value="1" />
+                <value name="Occupied/Disabled" value="3" />
+              </attribute>
+              <attribute id="0x0002" type="enum8" name="User Type" required="o">
+                <value name="Unrestricted" value="0"/>
+                <value name="Year Day Schedule User" value="1"/>
+                <value name="Week Day Schedule User" value="2"/>
+                <value name="Master User" value="3"/>
+                <value name="Non Access User" value="4"/>
+                <value name="Not Supported" value="0xff"/>
+              </attribute>
+              <attribute id="0x0003" type="ostring" name="Code" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="0x05" dir="send" name="Set PIN code response" required="o">
+            <description>Status</description>
+            <payload>
+              <attribute id="0x0000" type="u8" name="Status" required="m">
+                <value name="Success" value="0" />
+                <value name="Fail" value="1" />
+                <value name="Memory full" value="2" />
+                <value name="Duplicate code error" value="3" />
+              </attribute>
+            </payload>
+          </command>
+          <command id="0x06" dir="recv" name="Get PIN code" required="o">
+            <description>Get PIN code for user. User ID is between 0 and [# of PIN Users Supported Attribute]</description>
+            <payload>
+              <attribute id="0x0000" type="u16" name="User ID" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="0x06" dir="send" name="Get PIN code response" required="o">
+            <description>Returns PIN-code for user.</description>
+            <payload>
+              <attribute id="0x0000" type="u16" name="User ID" required="m"></attribute>
+              <attribute id="0x0001" type="u8" name="User Status" required="o"></attribute>
+              <attribute id="0x0002" type="enum8" name="User Type" required="o">
+                <value name="Unrestricted" value="0"/>
+                <value name="Year Day Schedule User" value="1"/>
+                <value name="Week Day Schedule User" value="2"/>
+                <value name="Master User" value="3"/>
+                <value name="Non Access User" value="4"/>
+                <value name="Not Supported" value="0xff"/>
+              </attribute>
+              <attribute id="0x0003" type="ostring" name="Code" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="0x07" dir="recv" name="Clear PIN code" required="o">
+            <description>Clear PIN code for user. User ID is between 0 and [# of PIN Users Supported Attribute]</description>
+            <payload>
+              <attribute id="0x0000" type="u16" name="User ID" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="0x07" dir="send" name="Clear PIN code response" required="o">
+            <description>Status</description>
+            <payload>
+              <attribute id="0x0000" type="u8" name="Status" required="m">
+                <value name="Success" value="0" />
+                <value name="General failure" value="1" />
+              </attribute>
+            </payload>
+          </command>
+          <command id="0x08" dir="recv" name="Clear all PIN codes" required="o">
+            <description>Clear all registred PIN codes.</description>
+          </command>
+          <command id="0x08" dir="send" name="Clear all PIN codes response" required="o">
+            <description>Status</description>
+            <payload>
+              <attribute id="0x0000" type="u8" name="Status" required="m">
+                <value name="Success" value="0" />
+                <value name="General failure" value="1" />
+              </attribute>
+            </payload>
+          </command>
+          <command id="0x20" dir="send" name="Operationg Event Notification" required="o">
+            <description>The door lock server sends out operation event notification when the event is triggered by the various event sources.</description>
+            <payload>
+              <attribute id="0x0000" type="u8" name="Operation Event Source" required="m"></attribute>
+              <attribute id="0x0001" type="u8" name="Operation Event Code" required="m"></attribute>
+              <attribute id="0x0002" type="u16" name="User ID" required="m"></attribute>
+              <attribute id="0x0003" type="u8" name="PIN" required="m" default="0x0000"></attribute>
+              <attribute id="0x0004" type="u32" name="ZigBee Local Time" required="m"></attribute>
+              <attribute id="0x0005" type="cstring" name="Data" required="m"></attribute>
+            </payload>
+          </command>
+        </server>
+      </cluster>
+      
+      <cluster id="0x0102" name="Window Covering">
+        <description>The window covering cluster provides an interface for controlling and adjusting automatic window coverings such as drapery motors, automatic shades, and blinds.</description>
+        <server>
+          <attribute-set id="0x0000" description="Window Covering Information">
+            <attribute id="0x0000" name="Window Covering Type" type="enum8" default="0x00" access="r" required="m">
+              <value name="Rollershade" value="0"></value>
+              <value name="Rollershade - 2 Motor" value="1"></value>
+              <value name="Rollershade – Exterior" value="2"></value>
+              <value name="Rollershade - Exterior - 2 Motor" value="3"></value>
+              <value name="Drapery" value="4"></value>
+              <value name="Awning" value="5"></value>
+              <value name="Shutter" value="6"></value>
+              <value name="Tilt Blind - Tilt Only" value="7"></value>
+              <value name="Tilt Blind - Lift and Tilt" value="8"></value>
+              <value name="Projector Screen" value="9"></value>
             </attribute>
-            <attribute id="0x0002" type="enum8" name="User Type" required="o">
-              <value name="Unrestricted" value="0"/>
-              <value name="Year Day Schedule User" value="1"/>
-              <value name="Week Day Schedule User" value="2"/>
-              <value name="Master User" value="3"/>
-              <value name="Non Access User" value="4"/>
-              <value name="Not Supported" value="0xff"/>
+            <attribute id="0x0001" name="Physical Closed Limit – Lift" type="u16" default="0x0000" access="r" required="o"></attribute>
+            <attribute id="0x0002" name="Physical Closed Limit – Tilt" type="u16" default="0x0000" access="r" required="o"></attribute>
+            <attribute id="0x0003" name="Current Position – Lift" type="u16" default="0x0000" access="r" required="o"></attribute>
+            <attribute id="0x0004" name="Current Position – Tilt" type="u16" default="0x0000" access="r" required="o"></attribute>
+            <attribute id="0x0005" name="Number of Actuations – Lift" type="u16" default="0x0000" access="r" required="o"></attribute>
+            <attribute id="0x0006" name="Number of Actuations – Tilt" type="u16" default="0x0000" access="r" required="o"></attribute>
+            <attribute id="0x0007" name="Config / Status" type="bmp8" default="0x03" access="r" required="o">
+              <value name="Operational" value="0"></value>
+              <value name="Online" value="1"></value>
+              <value name="Commands Reversed" value="2"></value>
+              <value name="Lift control is Closed Loop" value="3"></value>
+              <value name="Tilt control is Closed Loop" value="4"></value>
+              <value name="Lift: Encoder Controlled" value="5"></value>
+              <value name="Tilt: Encoder Controlled" value="6"></value>
             </attribute>
-            <attribute id="0x0003" type="ostring" name="Code" required="m"></attribute>
-          </payload>
-        </command>
-        <command id="0x05" dir="send" name="Set PIN code response" required="o">
-          <description>Status</description>
-          <payload>
-            <attribute id="0x0000" type="u8" name="Status" required="m">
-              <value name="Success" value="0" />
-              <value name="Fail" value="1" />
-              <value name="Memory full" value="2" />
-              <value name="Duplicate code error" value="3" />
+            <attribute id="0x0008" name="Current Position Lift Percentage" type="u8" default="0x00" access="r" required="o" range="0,0x64"></attribute>
+            <attribute id="0x0009" name="Current Position Tilt Percentage" type="u8" default="0x00" access="r" required="o" range="0,0x64"></attribute>
+          </attribute-set>
+          <attribute-set id="0x0010" description="Window Covering Settings">
+            <attribute id="0x0010" name="Installed Open Limit – Lift" type="u16" default="0x0000" access="r" required="o"></attribute>
+            <attribute id="0x0011" name="Installed Closed Limit – Lift" type="u16" default="0xffff" access="r" required="o"></attribute>
+            <attribute id="0x0012" name="Installed Open Limit – Tilt" type="u16" default="0x0000" access="r" required="o"></attribute>
+            <attribute id="0x0013" name="Installed Open Limit – Tilt" type="u16" default="0xffff" access="r" required="o"></attribute>
+            <attribute id="0x0014" name="Velocity – Lift" type="u16" default="0x0000" access="rw" required="o"></attribute>
+            <attribute id="0x0015" name="Acceleration Time – Lift" type="u16" default="0x0000" access="rw" required="o"></attribute>
+            <attribute id="0x0016" name="Deceleration Time – Lift" type="u16" default="0x0000" access="rw" required="o"></attribute>
+            <attribute id="0x0017" name="Mode" type="bmp8" default="0x0000" access="rw" required="o">
+              <value name="Reversed" value="0"></value>
+              <value name="Calibration Mode" value="1"></value>
+              <value name="Maintenance Mode" value="2"></value>
+              <value name="LED feedback" value="3"></value>
             </attribute>
-          </payload>
-        </command>
-        <command id="0x06" dir="recv" name="Get PIN code" required="o">
-          <description>Get PIN code for user. User ID is between 0 and [# of PIN Users Supported Attribute]</description>
-          <payload>
-            <attribute id="0x0000" type="u16" name="User ID" required="m"></attribute>
-          </payload>
-        </command>
-        <command id="0x06" dir="send" name="Get PIN code response" required="o">
-          <description>Returns PIN-code for user.</description>
-          <payload>
-            <attribute id="0x0000" type="u16" name="User ID" required="m"></attribute>
-            <attribute id="0x0001" type="u8" name="User Status" required="o"></attribute>
-            <attribute id="0x0002" type="enum8" name="User Type" required="o">
-              <value name="Unrestricted" value="0"/>
-              <value name="Year Day Schedule User" value="1"/>
-              <value name="Week Day Schedule User" value="2"/>
-              <value name="Master User" value="3"/>
-              <value name="Non Access User" value="4"/>
-              <value name="Not Supported" value="0xff"/>
+            <attribute id="0x0018" name="Intermediate Setpoints – Lift" type="ostring" default="1,0x0000" access="rw" required="o"></attribute>
+            <attribute id="0x0019" name="Intermediate Setpoints – Tilt" type="ostring" default="1,0x0000" access="rw" required="o"></attribute>
+          </attribute-set>
+          <attribute-set id="0xf001" description="Tuya Window Covering Setting">
+            <attribute id="0xf001" name="Calibration" type="enum8" default="0" required="m" access="rw">
+              <value name="Start" value="0"></value>
+              <value name="End" value="1"></value>
             </attribute>
-            <attribute id="0x0003" type="ostring" name="Code" required="m"></attribute>
-          </payload>
-        </command>
-        <command id="0x07" dir="recv" name="Clear PIN code" required="o">
-          <description>Clear PIN code for user. User ID is between 0 and [# of PIN Users Supported Attribute]</description>
-          <payload>
-            <attribute id="0x0000" type="u16" name="User ID" required="m"></attribute>
-          </payload>
-        </command>
-        <command id="0x07" dir="send" name="Clear PIN code response" required="o">
-          <description>Status</description>
-          <payload>
-            <attribute id="0x0000" type="u8" name="Status" required="m">
-              <value name="Success" value="0" />
-              <value name="General failure" value="1" />
+            <attribute id="0xf002" name="Motor Reversal" type="enum8" default="0" required="m" access="rw">
+              <value name="Off" value="0"></value>
+              <value name="On" value="1"></value>
             </attribute>
-          </payload>
-        </command>
-        <command id="0x08" dir="recv" name="Clear all PIN codes" required="o">
-          <description>Clear all registred PIN codes.</description>
-        </command>
-        <command id="0x08" dir="send" name="Clear all PIN codes response" required="o">
-          <description>Status</description>
-          <payload>
-            <attribute id="0x0000" type="u8" name="Status" required="m">
-              <value name="Success" value="0" />
-              <value name="General failure" value="1" />
+            <attribute id="0xf003" name="Calibration time (tenth of a second)" type="u16" default="0x0000" required="m" access="rw"></attribute>
+          </attribute-set>
+          
+          <attribute-set id="0xe000" description="Merten specific" mfcode="0x105e">
+            <attribute id="0xe000" name="Cover run time" type="u16" default="0" required="m" access="rw" mfcode="0x105e"> </attribute>
+            <attribute id="0xe010" name="Unknown" type="bmp8" required="m" access="r" mfcode="0x105e">
+              <value name="Unknown" value="0"></value>
+              <value name="Unknown" value="1"></value>
+              <value name="Unknown" value="2"></value>
+              <value name="Unknown" value="3"></value>
+              <value name="Unknown" value="4"></value>
+              <value name="Unknown" value="5"></value>
+              <value name="Unknown" value="6"></value>
+              <value name="Unknown" value="7"></value>
             </attribute>
-          </payload>
-        </command>
-        <command id="0x20" dir="send" name="Operationg Event Notification" required="o">
-          <description>The door lock server sends out operation event notification when the event is triggered by the various event sources.</description>
-          <payload>
-            <attribute id="0x0000" type="u8" name="Operation Event Source" required="m"></attribute>
-            <attribute id="0x0001" type="u8" name="Operation Event Code" required="m"></attribute>
-            <attribute id="0x0002" type="u16" name="User ID" required="m"></attribute>
-            <attribute id="0x0003" type="u8" name="PIN" required="m" default="0x0000"></attribute>
-            <attribute id="0x0004" type="u32" name="ZigBee Local Time" required="m"></attribute>
-            <attribute id="0x0005" type="cstring" name="Data" required="m"></attribute>
-          </payload>
-        </command>
-      </server>
-    </cluster>
-    <cluster id="0x0102" name="Window Covering">
-      <description>The window covering cluster provides an interface for controlling and adjusting automatic window coverings such as drapery motors, automatic shades, and blinds.</description>
-      <server>
-        <attribute-set id="0x0000" description="Window Covering Information">
-          <attribute id="0x0000" name="Window Covering Type" type="enum8" default="0x00" access="r" required="m">
-            <value name="Rollershade" value="0"></value>
-            <value name="Rollershade - 2 Motor" value="1"></value>
-            <value name="Rollershade – Exterior" value="2"></value>
-            <value name="Rollershade - Exterior - 2 Motor" value="3"></value>
-            <value name="Drapery" value="4"></value>
-            <value name="Awning" value="5"></value>
-            <value name="Shutter" value="6"></value>
-            <value name="Tilt Blind - Tilt Only" value="7"></value>
-            <value name="Tilt Blind - Lift and Tilt" value="8"></value>
-            <value name="Projector Screen" value="9"></value>
-          </attribute>
-          <attribute id="0x0001" name="Physical Closed Limit – Lift" type="u16" default="0x0000" access="r" required="o"></attribute>
-          <attribute id="0x0002" name="Physical Closed Limit – Tilt" type="u16" default="0x0000" access="r" required="o"></attribute>
-          <attribute id="0x0003" name="Current Position – Lift" type="u16" default="0x0000" access="r" required="o"></attribute>
-          <attribute id="0x0004" name="Current Position – Tilt" type="u16" default="0x0000" access="r" required="o"></attribute>
-          <attribute id="0x0005" name="Number of Actuations – Lift" type="u16" default="0x0000" access="r" required="o"></attribute>
-          <attribute id="0x0006" name="Number of Actuations – Tilt" type="u16" default="0x0000" access="r" required="o"></attribute>
-          <attribute id="0x0007" name="Config / Status" type="bmp8" default="0x03" access="r" required="o">
-            <value name="Operational" value="0"></value>
-            <value name="Online" value="1"></value>
-            <value name="Commands Reversed" value="2"></value>
-            <value name="Lift control is Closed Loop" value="3"></value>
-            <value name="Tilt control is Closed Loop" value="4"></value>
-            <value name="Lift: Encoder Controlled" value="5"></value>
-            <value name="Tilt: Encoder Controlled" value="6"></value>
-          </attribute>
-          <attribute id="0x0008" name="Current Position Lift Percentage" type="u8" default="0x00" access="r" required="o" range="0,0x64"></attribute>
-          <attribute id="0x0009" name="Current Position Tilt Percentage" type="u8" default="0x00" access="r" required="o" range="0,0x64"></attribute>
-        </attribute-set>
-        <attribute-set id="0x0010" description="Window Covering Settings">
-          <attribute id="0x0010" name="Installed Open Limit – Lift" type="u16" default="0x0000" access="r" required="o"></attribute>
-          <attribute id="0x0011" name="Installed Closed Limit – Lift" type="u16" default="0xffff" access="r" required="o"></attribute>
-          <attribute id="0x0012" name="Installed Open Limit – Tilt" type="u16" default="0x0000" access="r" required="o"></attribute>
-          <attribute id="0x0013" name="Installed Open Limit – Tilt" type="u16" default="0xffff" access="r" required="o"></attribute>
-          <attribute id="0x0014" name="Velocity – Lift" type="u16" default="0x0000" access="rw" required="o"></attribute>
-          <attribute id="0x0015" name="Acceleration Time – Lift" type="u16" default="0x0000" access="rw" required="o"></attribute>
-          <attribute id="0x0016" name="Deceleration Time – Lift" type="u16" default="0x0000" access="rw" required="o"></attribute>
-          <attribute id="0x0017" name="Mode" type="bmp8" default="0x0000" access="rw" required="o">
-            <value name="Reversed" value="0"></value>
-            <value name="Calibration Mode" value="1"></value>
-            <value name="Maintenance Mode" value="2"></value>
-            <value name="LED feedback" value="3"></value>
-          </attribute>
-          <attribute id="0x0018" name="Intermediate Setpoints – Lift" type="ostring" default="1,0x0000" access="rw" required="o"></attribute>
-          <attribute id="0x0019" name="Intermediate Setpoints – Tilt" type="ostring" default="1,0x0000" access="rw" required="o"></attribute>
-        </attribute-set>
-        <attribute-set id="0xf001" description="Tuya Window Covering Setting">
-			<attribute id="0xf001" name="Calibration" type="enum8" default="0" required="m" access="rw">
-				<value name="Start" value="0"></value>
-				<value name="End" value="1"></value>
-			</attribute>
-			<attribute id="0xf002" name="Motor Reversal" type="enum8" default="0" required="m" access="rw">
-				<value name="Off" value="0"></value>
-				<value name="On" value="1"></value>
-			</attribute>
-			<attribute id="0xf003" name="Calibration time (tenth of a second)" type="u16" default="0x0000" required="m" access="rw"></attribute>
-		</attribute-set>
-
-		<attribute-set id="0xe000" description="Merten specific" mfcode="0x105e">
-			<attribute id="0xe000" name="Cover run time" type="u16" default="0" required="m" access="rw" mfcode="0x105e"> </attribute>
-			<attribute id="0xe010" name="Unknown" type="bmp8" required="m" access="r" mfcode="0x105e">
-				<value name="Unknown" value="0"></value>
-				<value name="Unknown" value="1"></value>
-				<value name="Unknown" value="2"></value>
-				<value name="Unknown" value="3"></value>
-				<value name="Unknown" value="4"></value>
-				<value name="Unknown" value="5"></value>
-				<value name="Unknown" value="6"></value>
-				<value name="Unknown" value="7"></value>
-			</attribute>
-			<attribute id="0xe012" name="Unknown" type="u16" default="0" required="m" access="rw" mfcode="0x105e"> </attribute>
-			<attribute id="0xe013" name="Unknown" type="bmp8" required="m" access="r" mfcode="0x105e">
-				<value name="Unknown" value="0"></value>
-				<value name="Unknown" value="1"></value>
-				<value name="Unknown" value="2"></value>
-				<value name="Unknown" value="3"></value>
-				<value name="Unknown" value="4"></value>
-				<value name="Unknown" value="5"></value>
-				<value name="Unknown" value="6"></value>
-				<value name="Unknown" value="7"></value>
-			</attribute>
-		</attribute-set>
-
-        <command id="0x00" dir="recv" name="Up / Open" required="m"></command>
-        <command id="0x01" dir="recv" name="Down / Close" required="m"></command>
-        <command id="0x02" dir="recv" name="Stop" required="m"></command>
-        <command id="0x04" dir="recv" name="Go To Lift Value" required="o">
-          <payload>
-            <attribute id="0x0000" type="u16" name="Lift Value" required="m" default="0x0000"></attribute>
-          </payload>
-        </command>
-        <command id="0x05" dir="recv" name="Go to Lift Percentage" required="o">
-          <payload>
-            <attribute id="0x0000" type="u8" name="Lift Percentage" required="m" default="0x00" range="0,0x64"></attribute>
-          </payload>
-        </command>
-        <command id="0x07" dir="recv" name="Go to Tilt Value" required="o">
-          <payload>
-            <attribute id="0x0000" type="u16" name="Tilt Value" required="m" default="0x0000"></attribute>
-          </payload>
-        </command>
-        <command id="0x08" dir="recv" name="Go to Tilt Percentage" required="o">
-          <payload>
-            <attribute id="0x0000" type="u8" name="Tilt Percentage" required="m" default="0x00" range="0,0x64"></attribute>
-          </payload>
-        </command>
-      </server>
-      <client>
-      </client>
-    </cluster>
-	</domain>
-	<domain name="HVAC" low_bound="0200" high_bound="02ff" description="The HVAC functional domain contains clusters and information to build devices in the HVAC domain, e.g. pumps.">
-		<cluster id="0x0200" name="Pump Configuration and Control">
-			<description>An interface for configuring and controlling pumps.</description>
-			<!-- TODO -->
-		</cluster>
-		<cluster id="0x0201" name="Thermostat">
-			<description>Thermostat control cluster attributes and commands.</description>
-			<server>
-				<attribute-set id="0x0000" description="Thermostat Information">
-					<attribute id="0x0000" name="Local Temperature" type="s16" range="0x954d,0x7fff" access="r" required="m"></attribute>
-					<attribute id="0x0001" name="Outdoor Temperature" type="s16" range="0x954d,0x7fff" access="r" required="o"></attribute>
-					<attribute id="0x0002" name="Occupancy" type="bmp8" access="r" required="o" default="0"></attribute>
-					<attribute id="0x0003" name="Abs Min Heat Setpoint Limit" type="s16" range="0x954d,0x7fff" access="r" required="o" default="0x02bc"></attribute>
-					<attribute id="0x0004" name="Abs Max Heat Setpoint Limit" type="s16" range="0x954d,0x7fff" access="r" required="o" default="0x0bb8"></attribute>
-					<attribute id="0x0005" name="Abs Min Cool Setpoint Limit" type="s16" range="0x954d,0x7fff" access="r" required="o" default="0x0640"></attribute>
-					<attribute id="0x0006" name="Abs Max Cool Setpoint Limit" type="s16" range="0x954d,0x7fff" access="r" required="o" default="0x0c80"></attribute>
-					<attribute id="0x0007" name="PI Cooling Demand" type="u8" range="0x00,0x64" access="r" required="o"></attribute>
-					<attribute id="0x0008" name="PI Heating Demand" type="u8" range="0x00,0x64" access="r" required="o"></attribute>
-					<attribute id="0x0009" name="HVAC System Type Configuration" type="bmp8" access="rw" required="o" default="0"></attribute>
-				</attribute-set>
-				<attribute-set id="0x0010" description="Thermostat Settings">
-					<attribute id="0x0010" name="Local Temperature Calibration" type="s8" default="0x00" range="0xe7,0x19" access="rw" required="o"></attribute>
-					<attribute id="0x0011" name="Occupied Cooling Setpoint" type="s16" default="0x0a28" range="0x954d,0x7fff" access="rw" required="m"></attribute>
-					<attribute id="0x0012" name="Occupied Heating Setpoint" type="s16" default="0x07d0" range="0x954d,0x7fff" access="rw" required="m"></attribute>
-					<attribute id="0x0013" name="Unoccupied Cooling Setpoint" type="s16" default="0x0a28" access="rw" required="o"></attribute>
-					<attribute id="0x0014" name="Unoccupied Heating Setpoint" type="s16" default="0x07d0" access="rw" required="o"></attribute>
-					<attribute id="0x0015" name="Min Heat Setpoint Limit" type="s16" default="0x02bc" range="0x954d,0x7fff" access="rw" required="o"></attribute>
-					<attribute id="0x0016" name="Max Heat Setpoint Limit" type="s16" default="0x0bb8" range="0x954d,0x7fff" access="rw" required="o"></attribute>
-					<attribute id="0x0017" name="Min Cool Setpoint Limit" type="s16" default="0x0640" range="0x954d,0x7fff" access="rw" required="o"></attribute>
-					<attribute id="0x0018" name="Max Cool Setpoint Limit" type="s16" default="0x0c80" range="0x954d,0x7fff" access="rw" required="o"></attribute>
-					<attribute id="0x0019" name="Min Setpoint Dead Band" type="s8" default="0x19" range="0x0a,0x19" access="rw" required="o"></attribute>
-					<attribute id="0x001a" name="Remote Sensing" type="bmp8" default="0" access="rw" required="o">
-						<value name="Local temperature sensed remotely" value="0"></value>
-						<value name="Outdoor temperature sensed remotely" value="1"></value>
-						<value name="Occupancy sensed remotely" value="2"></value>
-					</attribute>
-					<attribute id="0x001b" name="Control Sequence Of Operation" type="enum8" default="0x04" access="rw" required="m">
-						<value name="Cooling Only" value="0"></value>
-						<value name="Cooling With Reheat" value="1"></value>
-						<value name="Heating Only" value="2"></value>
-						<value name="Heating With Reheat" value="3"></value>
-						<value name="Cooling and Heating 4-pipes" value="4"></value>
-						<value name="Cooling and Heating 4-pipes with Reheat" value="5"></value>
-					</attribute>
-					<attribute id="0x001c" name="System Mode" type="enum8" default="0x01" access="rw" required="m">
-						<value name="Off" value="0x00"></value>
-						<value name="Auto" value="0x01"></value>
-						<value name="Cool" value="0x03"></value>
-						<value name="Heat" value="0x04"></value>
-						<value name="Emergency heating" value="0x05"></value>
-						<value name="Precooling" value="0x06"></value>
-						<value name="Fan only" value="0x07"></value>
-						<value name="Dry" value="0x08"></value>
-						<value name="Sleep" value="0x09"></value>
-					</attribute>
-					<attribute id="0x001d" name="Alarm Mask" type="bmp8" default="0" access="r" required="o">
-						<value name="Initialization failure" value="0"></value>
-						<value name="Hardware failure" value="1"></value>
-						<value name="Self-calibration failure" value="2"></value>
-					</attribute>
-					<attribute id="0x001e" name="Thermostat Running Mode" type="enum8" default="0x00" access="r" required="o">
-						<value name="Off" value="0"></value>
-						<value name="Cool" value="3"></value>
-						<value name="Heat" value="4"></value>
-					</attribute>
-				</attribute-set>
-				<attribute-set id="0x0020" description="Thermostat Schedule and HVAC Relay">
-					<attribute id="0x0020" name="Start of Week" type="enum8" default="0x00" access="r" required="o">
-						<value name="Sunday" value="0"></value>
-						<value name="Monday" value="1"></value>
-						<value name="Tuesday" value="2"></value>
-						<value name="Wednesday" value="3"></value>
-						<value name="Thursday" value="4"></value>
-						<value name="Friday" value="5"></value>
-						<value name="Saturday" value="6"></value>
-					</attribute>
-					<attribute id="0x0021" name="Number of Weekly Transitions" type="u8" range="0x00,0xff" access="r" required="o"></attribute>
-					<attribute id="0x0022" name="Number of Daily Transitions" type="u8" range="0x00,0xff" access="r" required="o"></attribute>
-					<attribute id="0x0023" name="Temperature Setpoint Hold" type="enum8" default="0x00" access="rw" required="o">
-						<value name="Setpoint Hold Off" value="0"></value>
-						<value name="Setpoint Hold On" value="1"></value>
-					</attribute>
-					<attribute id="0x0024" name="Temperature Setpoint Hold Duration" type="u16" range="0x05a0,0xffff" default="0xffff" access="rw" required="o"></attribute>
-					<attribute id="0x0025" name="Thermostat Programming Operation Mode" type="bmp8" default="0" access="rw" required="o">
-						<value name="Simple/setpoint mode" value="0">
-							<description>0 – This mode means the thermostat setpoint is altered only by manual
-up/down changes at the thermostat or remotely, not by internal schedule programming.
-1 – Schedule programming mode. This enables or disables any programmed weekly schedule con-
-figurations.
-Note: It does not clear or delete previous weekly schedule programming configurations.</description></value>
-						<value name="Auto/recovery mode" value="1"></value>
-						<value name="Economy/EnergyStar mode" value="2"></value>
-					</attribute>
-				</attribute-set>
-				<attribute-set id="0x0029" description="HVAC Relay">
-					<attribute id="0x0029" name="Thermostat Running State" type="bmp16" access="r" required="o">
-						<value name="Heat State On" value="0"></value>
-						<value name="Cool State On" value="1"></value>
-						<value name="Fan State On" value="2"></value>
-						<value name="Heat 2nd Stage State On" value="3"></value>
-						<value name="Cool 2nd Stage State On" value="4"></value>
-						<value name="Fan 2nd Stage State On" value="5"></value>
-						<value name="Fan 3rd Stage State On" value="6"></value>
-					</attribute>
-				</attribute-set>
-				<attribute-set id="0x0030" description="Thermostat Setpoint Change Tracking">
-					<attribute id="0x0030" name="Setpoint Change Source" type="enum8" access="r" required="o">
-						<value name="Manual" value="0"></value>
-						<value name="Schedule" value="1"></value>
-						<value name="Zigbee" value="2"></value>
-					</attribute>
-					<attribute id="0x0031" name="Setpoint Change Amount" type="s16" access="r" required="o" default="0x8000"/>
-					<attribute id="0x0032" name="Setpoint Change Timestamp" type="utc" access="r" required="o" default="0"/>
-				</attribute-set>
-
-				<attribute-set id="0x0040" description="AC Information">
-					<attribute id="0x0040" name="AC Type" type="enum8" access="rw" required="o">
-						<value name="Cooling and Fixed Speed" value="1"></value>
-						<value name="Heat Pump and Fixed Speed" value="2"></value>
-						<value name="Cooling and Inverter" value="3"></value>
-						<value name="Heat Pump and Inverter" value="4"></value>
-					</attribute>
-					<attribute id="0x0041" name="AC Capacity" type="u16" access="rw" required="o" default="0x00"/>
-					<attribute id="0x0042" name="AC Refrigerant Type" type="enum8" access="rw" required="o" default="0x00">
-						<value name="R22" value="1"></value>
-						<value name="R410a" value="2"></value>
-						<value name="R407c" value="3"></value>
-					</attribute>
-					<attribute id="0x0043" name="AC Compressor Type" type="enum8" access="rw" required="o" default="0x00">
-						<value name="T1, Max working ambient 43 oC" value="1"></value>
-						<value name="T2, Max working ambient 35 oC" value="2"></value>
-						<value name="T3, Max working ambient 52 oC" value="3"></value>
-					</attribute>
-					<attribute id="0x0044" name="AC Error Code" type="bmp32" access="rw" required="o" default="0x00000000">
-						<value name="Compressor Failure or Refrigerant Leakage" value="0"></value>
-						<value name="Room Temperature Sensor Failure" value="1"></value>
-						<value name="Outdoor Temperature Sensor Failure" value="2"></value>
-						<value name="Indoor Coil Temperature Sensor Failure" value="3"></value>
-						<value name="Fan Failure" value="4"></value>
-					</attribute>
-					<attribute id="0x0045" name="AC Louver Position" type="enum8" access="rw" required="o" default="0x00">
-						<value name="Fully Closed" value="1"></value>
-						<value name="Fully Open" value="2"></value>
-						<value name="Quarter Open" value="3"></value>
-						<value name="Half Open" value="4"></value>
-						<value name="Three Quarters Open" value="5"></value>
-					</attribute>
-					<attribute id="0x0046" name="AC Coil Temperature" type="s16" access="r" required="o"/>
-					<attribute id="0x0047" name="AC Capacity Format" type="enum8" access="rw" required="o" default="0x00">
-						<value name="BTUh" value="0"></value>
-					</attribute>
-				</attribute-set>
-
-				<attribute-set id="0x0080" description="eCozy" mfcode="0x1014">
-					<attribute id="0x0080" name="Unknown" type="s16" access="r" required="o"/>
-					<attribute id="0x0081" name="Unknown" type="s16" access="r" required="o"/>
-					<attribute id="0x0082" name="Unknown (Heat Setpoint?)" type="s16" access="r" required="o"/>
-				</attribute-set>
-
-		<!-- ELKO specific -->
-		<attribute-set id="0x0400" description="ELKO specific" mfcode="0x1002">
-			<attribute id="0x0401" name="Unknown" type="u16" access="rw" required="m"></attribute>
-			<attribute id="0x0402" name="Unknown name field" type="cstring" access="rw" required="m"></attribute>
-			<attribute id="0x0403" name="Temperature measurement" type="enum8" access="rw" required="m">
-				<value name="Air sensor" value="0x00"></value>
-				<value name="Floor sensor" value="0x01"></value>
-				<value name="Floor protection" value="0x03"></value>
-			</attribute>
-			<attribute id="0x0404" name="Unknown" type="u8" access="rw" required="m"></attribute>
-			<attribute id="0x0405" name="Regulator mode" type="bool" access="rw" required="m"></attribute>
-			<attribute id="0x0406" name="Device on" type="bool" access="rw" required="m"></attribute>
-			<attribute id="0x0407" name="Unknown" type="ostring" access="rw" required="m"></attribute>
-			<attribute id="0x0408" name="Unknown" type="u16" access="rw" required="m"></attribute>
-			<attribute id="0x0409" name="Floor temperature sensor" type="s16" access="rw" required="m"></attribute>
-			<attribute id="0x0411" name="Night lowering" type="bool" access="rw" required="m"></attribute>
-			<attribute id="0x0412" name="Unknown" type="bool" access="r" required="m"></attribute>
-			<attribute id="0x0413" name="Child lock" type="bool" access="rw" required="m"></attribute>
-			<attribute id="0x0414" name="Unknown" type="u8" access="rw" required="m"></attribute>
-			<attribute id="0x0415" name="Heating active/inactive" type="bool" access="rw" required="m"></attribute>
-			<attribute id="0x0416" name="Unknown" type="ostring" access="rw" required="m"></attribute>
-			<attribute id="0x0417" name="Unknown" type="s8" access="rw" required="m"></attribute>
-			<attribute id="0x0418" name="Unknown" type="u8" access="rw" required="m"></attribute>
-			<attribute id="0x0419" name="Unknown" type="u8" access="rw" required="m"></attribute>
-		</attribute-set>
-
-		<!-- Eurotronic manufacturer specific -->
-		<attribute-set id="0x4000" description="Eurotronic" mfcode="0x1037">
-			<attribute id="0x4000" name="TRV Mode" type="enum8" default="0x02" access="rw" required="m" mfcode="0x1037">
-				<value name="Unknown 1" value="0"></value>
-				<value name="Unknown 2" value="1"></value>
-				<value name="manual" value="2"></value>
-			</attribute>
-			<attribute id="0x4001" name="Set Valve Position" type="u8" default="0x00" access="rw" required="m" mfcode="0x1037"></attribute>
-			<attribute id="0x4002" name="Errors" type="u8" default="0x00" access="r" required="m" mfcode="0x1037">
-				<value name="Reserved" value="0"></value>
-				<value name="Reserved" value="1"></value>
-				<value name="Reserved" value="2"></value>
-				<value name="Valve Adaption Failed (E1)" value="3"></value>
-				<value name="Valve Movement too slow (E2)" value="4"></value>
-				<value name="Valve not Moving (E3)" value="5"></value>
-				<value name="Reserved" value="6"></value>
-				<value name="Reserved" value="7"></value>
-			</attribute>
-			<attribute id="0x4003" name="Current Temperature Setpoint" type="s16" default="0x07d0" access="rw" required="m" mfcode="0x1037"></attribute>
-			<attribute id="0x4008" name="Host Flags" type="u24" default="0x000000" showas="hex" access="rw" required="m" mfcode="0x1037"></attribute>
-		</attribute-set>
-
-		<!-- Danfoss manufacturer specific -->
-		<attribute-set id="0x4000" description="Danfoss specific" mfcode="0x1246">
-			<attribute id="0x4000" name="eTRV Open Window Detection" type="enum8" default="0x00" access="r" required="o" mfcode="0x1246">
-				<value name="Quarantine" value="0x00"></value>
-				<value name="Closed" value="0x01"></value>
-				<value name="Hold" value="0x02"></value>
-				<value name="Open" value="0x03"></value>
-				<value name="Windows open from external, but detected closed" value="0x04"></value>
-			</attribute>
-			<attribute id="0x4003" name="External Open Window Detected" type="bool" default="0x00" access="rw" required="o" mfcode="0x1246"></attribute>
-			<attribute id="0x4010" name="Exercise day of week" type="enum8" default="0x04" access="rw" required="o" mfcode="0x1246">
-				<value name="Sunday" value="0x00"></value>
-				<value name="Monday" value="0x01"></value>
-				<value name="Tuesday" value="0x02"></value>
-				<value name="Wednesday" value="0x03"></value>
-				<value name="Thursday" value="0x04"></value>
-				<value name="Friday" value="0x05"></value>
-				<value name="Saturday" value="0x06"></value>
-				<value name="Undefined" value="0x07"></value>
-			</attribute>
-			<attribute id="0x4011" name="Exercise trigger time" type="u16" default="660" access="rw" required="o" mfcode="0x1246"></attribute>
-			<attribute id="0x4012" name="Mounting mode active" type="bool" default="0x01" access="r" required="o" mfcode="0x1246"></attribute>
-			<attribute id="0x4013" name="Mounting mode control" type="bool" access="rw" required="o" mfcode="0x1246"></attribute>
-			<attribute id="0x4014" name="eTRV Orientation" type="bool" default="0x00" access="rw" required="o" mfcode="0x1246"></attribute>
-			<attribute id="0x4015" name="External Measured Room Sensor" type="s16" access="rw" required="o" mfcode="0x1246"></attribute>
-			<attribute id="0x4016" name="Radiator Covered" type="bool" access="w" required="o" mfcode="0x1246"></attribute>
-			<attribute id="0x4020" name="Control Algorithm Scale Factor" type="u8" default="1" access="rw" required="o" mfcode="0x1246"></attribute>
-			<attribute id="0x4030" name="Heat Available" type="bool" default="0x00" access="rw" required="o" mfcode="0x1246"></attribute>
-			<attribute id="0x4031" name="Heat Supply Request " type="bool" default="0x00" access="r" required="o" mfcode="0x1246"></attribute>
-			<attribute id="0x4032" name="Load Balancing Enabled" type="bool" default="0x01" access="rw" required="o" mfcode="0x1246"></attribute>
-			<attribute id="0x4040" name="Load Radiator Room Mean" type="s16" access="rw" required="o" mfcode="0x1246"></attribute>
-			<attribute id="0x404A" name="Load Estimate (Radiator)" type="s16" access="r" required="o" mfcode="0x1246"></attribute>
-			<attribute id="0x404B" name="Regulation SetPoint Offset" type="s8" default="0x00" access="rw" required="o" mfcode="0x1246"></attribute>
-			<attribute id="0x404C" name="Adaptation Run Control" type="enum8" default="0x00" access="rw" required="o" mfcode="0x1246">
-				<value name="Idle" value="0x00"></value>
-				<value name="Initiate Adaptation Run" value="0x01"></value>
-				<value name="Cancel Adaptation Run" value="0x02"></value>
-			</attribute>
-			<attribute id="0x404D" name="Adaptation Run Status" type="bmp8" default="0x00" access="r" required="o" mfcode="0x1246">
-				<value name="Adaptation Run in Progress" value="0"></value>
-				<value name="OP Found" value="1"></value>
-				<value name="OP Lost" value="2"></value>
-			</attribute>
-			<attribute id="0x404E" name="Adaptation Run Settings" type="bmp8" default="0x00" access="rw" required="o" mfcode="0x1246">
-				<value name="Default" value="0"></value>
-				<value name="Automatic Adaptation Run Enabled" value="1"></value>
-			</attribute>
-			<attribute id="0x404F" name="Preheat Status" type="bool" default="0x00" access="r" required="o" mfcode="0x1246"></attribute>
-			<attribute id="0x4050" name="Preheat Time" type="u32" access="r" required="o" mfcode="0x1246"></attribute>
-			<attribute id="0x4051" name="Window Open Feature On" type="bool" default="0x01" access="rw" required="o" mfcode="0x1246"></attribute>
-		</attribute-set>
-
-		<!-- Sinope manufacturer specific -->
-		<attribute-set id="0x0400" description="Sinope specific" mfcode="0x119c">
-			<attribute id="0x0400" name="Occupancy" type="enum8" access="rw" required="m" mfcode="0x119c">
-				<value name="Unoccupied" value="0x00"></value>
-				<value name="Occupied" value="0x01"></value>
-			</attribute>
-			<attribute id="0x0402" name="Backlight" type="enum8" access="rw" required="m" mfcode="0x119c">
-				<value name="On demand" value="0x00"></value>
-				<value name="Sensing" value="0x01"></value>
-			</attribute>
-		</attribute-set>
-
-		<!-- Stelpro manufacturer specific -->
-		<attribute-set id="0x4000" description="Stelpro specific" mfcode="0x1185">
-			<attribute id="0x4001" name="Outdoor temp" type="s16" access="rw" required="m" mfcode="0x1185"></attribute>
-			<attribute id="0x401c" name="System Mode" type="enum8" default="0x04" access="rw" required="m" mfcode="0x1185">
-				<value name="Off" value="0x00"/>
-				<value name="Heat" value="0x04"/>
-				<value name="Eco" value="0x05"/>
-				<description>States only supportedb by Stelpro thermostats (useless for Maestro).</description>
-			</attribute>
-		</attribute-set>
-
-        <!-- Sunrichee manufacturer specific -->
-        <attribute-set id="0x1000" description="Sunricher Specific Attributes" mfcode="0x1224">
+            <attribute id="0xe012" name="Unknown" type="u16" default="0" required="m" access="rw" mfcode="0x105e"> </attribute>
+            <attribute id="0xe013" name="Unknown" type="bmp8" required="m" access="r" mfcode="0x105e">
+              <value name="Unknown" value="0"></value>
+              <value name="Unknown" value="1"></value>
+              <value name="Unknown" value="2"></value>
+              <value name="Unknown" value="3"></value>
+              <value name="Unknown" value="4"></value>
+              <value name="Unknown" value="5"></value>
+              <value name="Unknown" value="6"></value>
+              <value name="Unknown" value="7"></value>
+            </attribute>
+          </attribute-set>
+          
+          <command id="0x00" dir="recv" name="Up / Open" required="m"></command>
+          <command id="0x01" dir="recv" name="Down / Close" required="m"></command>
+          <command id="0x02" dir="recv" name="Stop" required="m"></command>
+          <command id="0x04" dir="recv" name="Go To Lift Value" required="o">
+            <payload>
+              <attribute id="0x0000" type="u16" name="Lift Value" required="m" default="0x0000"></attribute>
+            </payload>
+          </command>
+          <command id="0x05" dir="recv" name="Go to Lift Percentage" required="o">
+            <payload>
+              <attribute id="0x0000" type="u8" name="Lift Percentage" required="m" default="0x00" range="0,0x64"></attribute>
+            </payload>
+          </command>
+          <command id="0x07" dir="recv" name="Go to Tilt Value" required="o">
+            <payload>
+              <attribute id="0x0000" type="u16" name="Tilt Value" required="m" default="0x0000"></attribute>
+            </payload>
+          </command>
+          <command id="0x08" dir="recv" name="Go to Tilt Percentage" required="o">
+            <payload>
+              <attribute id="0x0000" type="u8" name="Tilt Percentage" required="m" default="0x00" range="0,0x64"></attribute>
+            </payload>
+          </command>
+        </server>
+        <client>
+        </client>
+      </cluster>
+    </domain>
+    
+    <domain name="HVAC" low_bound="0200" high_bound="02ff" description="The HVAC functional domain contains clusters and information to build devices in the HVAC domain, e.g. pumps.">
+      <cluster id="0x0200" name="Pump Configuration and Control">
+        <description>An interface for configuring and controlling pumps.</description>
+        <!-- TODO -->
+      </cluster>
+      
+      <cluster id="0x0201" name="Thermostat">
+        <description>Thermostat control cluster attributes and commands.</description>
+        <server>
+          <attribute-set id="0x0000" description="Thermostat Information">
+            <attribute id="0x0000" name="Local Temperature" type="s16" range="0x954d,0x7fff" access="r" required="m"></attribute>
+            <attribute id="0x0001" name="Outdoor Temperature" type="s16" range="0x954d,0x7fff" access="r" required="o"></attribute>
+            <attribute id="0x0002" name="Occupancy" type="bmp8" access="r" required="o" default="0"></attribute>
+            <attribute id="0x0003" name="Abs Min Heat Setpoint Limit" type="s16" range="0x954d,0x7fff" access="r" required="o" default="0x02bc"></attribute>
+            <attribute id="0x0004" name="Abs Max Heat Setpoint Limit" type="s16" range="0x954d,0x7fff" access="r" required="o" default="0x0bb8"></attribute>
+            <attribute id="0x0005" name="Abs Min Cool Setpoint Limit" type="s16" range="0x954d,0x7fff" access="r" required="o" default="0x0640"></attribute>
+            <attribute id="0x0006" name="Abs Max Cool Setpoint Limit" type="s16" range="0x954d,0x7fff" access="r" required="o" default="0x0c80"></attribute>
+            <attribute id="0x0007" name="PI Cooling Demand" type="u8" range="0x00,0x64" access="r" required="o"></attribute>
+            <attribute id="0x0008" name="PI Heating Demand" type="u8" range="0x00,0x64" access="r" required="o"></attribute>
+            <attribute id="0x0009" name="HVAC System Type Configuration" type="bmp8" access="rw" required="o" default="0"></attribute>
+          </attribute-set>
+          <attribute-set id="0x0010" description="Thermostat Settings">
+            <attribute id="0x0010" name="Local Temperature Calibration" type="s8" default="0x00" range="0xe7,0x19" access="rw" required="o"></attribute>
+            <attribute id="0x0011" name="Occupied Cooling Setpoint" type="s16" default="0x0a28" range="0x954d,0x7fff" access="rw" required="m"></attribute>
+            <attribute id="0x0012" name="Occupied Heating Setpoint" type="s16" default="0x07d0" range="0x954d,0x7fff" access="rw" required="m"></attribute>
+            <attribute id="0x0013" name="Unoccupied Cooling Setpoint" type="s16" default="0x0a28" access="rw" required="o"></attribute>
+            <attribute id="0x0014" name="Unoccupied Heating Setpoint" type="s16" default="0x07d0" access="rw" required="o"></attribute>
+            <attribute id="0x0015" name="Min Heat Setpoint Limit" type="s16" default="0x02bc" range="0x954d,0x7fff" access="rw" required="o"></attribute>
+            <attribute id="0x0016" name="Max Heat Setpoint Limit" type="s16" default="0x0bb8" range="0x954d,0x7fff" access="rw" required="o"></attribute>
+            <attribute id="0x0017" name="Min Cool Setpoint Limit" type="s16" default="0x0640" range="0x954d,0x7fff" access="rw" required="o"></attribute>
+            <attribute id="0x0018" name="Max Cool Setpoint Limit" type="s16" default="0x0c80" range="0x954d,0x7fff" access="rw" required="o"></attribute>
+            <attribute id="0x0019" name="Min Setpoint Dead Band" type="s8" default="0x19" range="0x0a,0x19" access="rw" required="o"></attribute>
+            <attribute id="0x001a" name="Remote Sensing" type="bmp8" default="0" access="rw" required="o">
+              <value name="Local temperature sensed remotely" value="0"></value>
+              <value name="Outdoor temperature sensed remotely" value="1"></value>
+              <value name="Occupancy sensed remotely" value="2"></value>
+            </attribute>
+            <attribute id="0x001b" name="Control Sequence Of Operation" type="enum8" default="0x04" access="rw" required="m">
+              <value name="Cooling Only" value="0"></value>
+              <value name="Cooling With Reheat" value="1"></value>
+              <value name="Heating Only" value="2"></value>
+              <value name="Heating With Reheat" value="3"></value>
+              <value name="Cooling and Heating 4-pipes" value="4"></value>
+              <value name="Cooling and Heating 4-pipes with Reheat" value="5"></value>
+            </attribute>
+            <attribute id="0x001c" name="System Mode" type="enum8" default="0x01" access="rw" required="m">
+              <value name="Off" value="0x00"></value>
+              <value name="Auto" value="0x01"></value>
+              <value name="Cool" value="0x03"></value>
+              <value name="Heat" value="0x04"></value>
+              <value name="Emergency heating" value="0x05"></value>
+              <value name="Precooling" value="0x06"></value>
+              <value name="Fan only" value="0x07"></value>
+              <value name="Dry" value="0x08"></value>
+              <value name="Sleep" value="0x09"></value>
+            </attribute>
+            <attribute id="0x001d" name="Alarm Mask" type="bmp8" default="0" access="r" required="o">
+              <value name="Initialization failure" value="0"></value>
+              <value name="Hardware failure" value="1"></value>
+              <value name="Self-calibration failure" value="2"></value>
+            </attribute>
+            <attribute id="0x001e" name="Thermostat Running Mode" type="enum8" default="0x00" access="r" required="o">
+              <value name="Off" value="0"></value>
+              <value name="Cool" value="3"></value>
+              <value name="Heat" value="4"></value>
+            </attribute>
+          </attribute-set>
+          <attribute-set id="0x0020" description="Thermostat Schedule and HVAC Relay">
+            <attribute id="0x0020" name="Start of Week" type="enum8" default="0x00" access="r" required="o">
+              <value name="Sunday" value="0"></value>
+              <value name="Monday" value="1"></value>
+              <value name="Tuesday" value="2"></value>
+              <value name="Wednesday" value="3"></value>
+              <value name="Thursday" value="4"></value>
+              <value name="Friday" value="5"></value>
+              <value name="Saturday" value="6"></value>
+            </attribute>
+            <attribute id="0x0021" name="Number of Weekly Transitions" type="u8" range="0x00,0xff" access="r" required="o"></attribute>
+            <attribute id="0x0022" name="Number of Daily Transitions" type="u8" range="0x00,0xff" access="r" required="o"></attribute>
+            <attribute id="0x0023" name="Temperature Setpoint Hold" type="enum8" default="0x00" access="rw" required="o">
+              <value name="Setpoint Hold Off" value="0"></value>
+              <value name="Setpoint Hold On" value="1"></value>
+            </attribute>
+            <attribute id="0x0024" name="Temperature Setpoint Hold Duration" type="u16" range="0x05a0,0xffff" default="0xffff" access="rw" required="o"></attribute>
+            <attribute id="0x0025" name="Thermostat Programming Operation Mode" type="bmp8" default="0" access="rw" required="o">
+              <value name="Simple/setpoint mode" value="0">
+                <description>0 – This mode means the thermostat setpoint is altered only by manual
+                  up/down changes at the thermostat or remotely, not by internal schedule programming.
+                  1 – Schedule programming mode. This enables or disables any programmed weekly schedule con-
+                  figurations.
+                  Note: It does not clear or delete previous weekly schedule programming configurations.</description></value>
+              <value name="Auto/recovery mode" value="1"></value>
+              <value name="Economy/EnergyStar mode" value="2"></value>
+            </attribute>
+          </attribute-set>
+          <attribute-set id="0x0029" description="HVAC Relay">
+            <attribute id="0x0029" name="Thermostat Running State" type="bmp16" access="r" required="o">
+              <value name="Heat State On" value="0"></value>
+              <value name="Cool State On" value="1"></value>
+              <value name="Fan State On" value="2"></value>
+              <value name="Heat 2nd Stage State On" value="3"></value>
+              <value name="Cool 2nd Stage State On" value="4"></value>
+              <value name="Fan 2nd Stage State On" value="5"></value>
+              <value name="Fan 3rd Stage State On" value="6"></value>
+            </attribute>
+          </attribute-set>
+          <attribute-set id="0x0030" description="Thermostat Setpoint Change Tracking">
+            <attribute id="0x0030" name="Setpoint Change Source" type="enum8" access="r" required="o">
+              <value name="Manual" value="0"></value>
+              <value name="Schedule" value="1"></value>
+              <value name="Zigbee" value="2"></value>
+            </attribute>
+            <attribute id="0x0031" name="Setpoint Change Amount" type="s16" access="r" required="o" default="0x8000"/>
+            <attribute id="0x0032" name="Setpoint Change Timestamp" type="utc" access="r" required="o" default="0"/>
+          </attribute-set>
+          
+          <attribute-set id="0x0040" description="AC Information">
+            <attribute id="0x0040" name="AC Type" type="enum8" access="rw" required="o">
+              <value name="Cooling and Fixed Speed" value="1"></value>
+              <value name="Heat Pump and Fixed Speed" value="2"></value>
+              <value name="Cooling and Inverter" value="3"></value>
+              <value name="Heat Pump and Inverter" value="4"></value>
+            </attribute>
+            <attribute id="0x0041" name="AC Capacity" type="u16" access="rw" required="o" default="0x00"/>
+            <attribute id="0x0042" name="AC Refrigerant Type" type="enum8" access="rw" required="o" default="0x00">
+              <value name="R22" value="1"></value>
+              <value name="R410a" value="2"></value>
+              <value name="R407c" value="3"></value>
+            </attribute>
+            <attribute id="0x0043" name="AC Compressor Type" type="enum8" access="rw" required="o" default="0x00">
+              <value name="T1, Max working ambient 43 oC" value="1"></value>
+              <value name="T2, Max working ambient 35 oC" value="2"></value>
+              <value name="T3, Max working ambient 52 oC" value="3"></value>
+            </attribute>
+            <attribute id="0x0044" name="AC Error Code" type="bmp32" access="rw" required="o" default="0x00000000">
+              <value name="Compressor Failure or Refrigerant Leakage" value="0"></value>
+              <value name="Room Temperature Sensor Failure" value="1"></value>
+              <value name="Outdoor Temperature Sensor Failure" value="2"></value>
+              <value name="Indoor Coil Temperature Sensor Failure" value="3"></value>
+              <value name="Fan Failure" value="4"></value>
+            </attribute>
+            <attribute id="0x0045" name="AC Louver Position" type="enum8" access="rw" required="o" default="0x00">
+              <value name="Fully Closed" value="1"></value>
+              <value name="Fully Open" value="2"></value>
+              <value name="Quarter Open" value="3"></value>
+              <value name="Half Open" value="4"></value>
+              <value name="Three Quarters Open" value="5"></value>
+            </attribute>
+            <attribute id="0x0046" name="AC Coil Temperature" type="s16" access="r" required="o"/>
+            <attribute id="0x0047" name="AC Capacity Format" type="enum8" access="rw" required="o" default="0x00">
+              <value name="BTUh" value="0"></value>
+            </attribute>
+          </attribute-set>
+          
+          <attribute-set id="0x0080" description="eCozy" mfcode="0x1014">
+            <attribute id="0x0080" name="Unknown" type="s16" access="r" required="o"/>
+            <attribute id="0x0081" name="Unknown" type="s16" access="r" required="o"/>
+            <attribute id="0x0082" name="Unknown (Heat Setpoint?)" type="s16" access="r" required="o"/>
+          </attribute-set>
+          
+          <!-- ELKO specific -->
+          <attribute-set id="0x0400" description="ELKO specific" mfcode="0x1002">
+            <attribute id="0x0401" name="Unknown" type="u16" access="rw" required="m"></attribute>
+            <attribute id="0x0402" name="Unknown name field" type="cstring" access="rw" required="m"></attribute>
+            <attribute id="0x0403" name="Temperature measurement" type="enum8" access="rw" required="m">
+              <value name="Air sensor" value="0x00"></value>
+              <value name="Floor sensor" value="0x01"></value>
+              <value name="Floor protection" value="0x03"></value>
+            </attribute>
+            <attribute id="0x0404" name="Unknown" type="u8" access="rw" required="m"></attribute>
+            <attribute id="0x0405" name="Regulator mode" type="bool" access="rw" required="m"></attribute>
+            <attribute id="0x0406" name="Device on" type="bool" access="rw" required="m"></attribute>
+            <attribute id="0x0407" name="Unknown" type="ostring" access="rw" required="m"></attribute>
+            <attribute id="0x0408" name="Unknown" type="u16" access="rw" required="m"></attribute>
+            <attribute id="0x0409" name="Floor temperature sensor" type="s16" access="rw" required="m"></attribute>
+            <attribute id="0x0411" name="Night lowering" type="bool" access="rw" required="m"></attribute>
+            <attribute id="0x0412" name="Unknown" type="bool" access="r" required="m"></attribute>
+            <attribute id="0x0413" name="Child lock" type="bool" access="rw" required="m"></attribute>
+            <attribute id="0x0414" name="Unknown" type="u8" access="rw" required="m"></attribute>
+            <attribute id="0x0415" name="Heating active/inactive" type="bool" access="rw" required="m"></attribute>
+            <attribute id="0x0416" name="Unknown" type="ostring" access="rw" required="m"></attribute>
+            <attribute id="0x0417" name="Unknown" type="s8" access="rw" required="m"></attribute>
+            <attribute id="0x0418" name="Unknown" type="u8" access="rw" required="m"></attribute>
+            <attribute id="0x0419" name="Unknown" type="u8" access="rw" required="m"></attribute>
+          </attribute-set>
+          
+          <!-- Eurotronic manufacturer specific -->
+          <attribute-set id="0x4000" description="Eurotronic" mfcode="0x1037">
+            <attribute id="0x4000" name="TRV Mode" type="enum8" default="0x02" access="rw" required="m" mfcode="0x1037">
+              <value name="Unknown 1" value="0"></value>
+              <value name="Unknown 2" value="1"></value>
+              <value name="manual" value="2"></value>
+            </attribute>
+            <attribute id="0x4001" name="Set Valve Position" type="u8" default="0x00" access="rw" required="m" mfcode="0x1037"></attribute>
+            <attribute id="0x4002" name="Errors" type="u8" default="0x00" access="r" required="m" mfcode="0x1037">
+              <value name="Reserved" value="0"></value>
+              <value name="Reserved" value="1"></value>
+              <value name="Reserved" value="2"></value>
+              <value name="Valve Adaption Failed (E1)" value="3"></value>
+              <value name="Valve Movement too slow (E2)" value="4"></value>
+              <value name="Valve not Moving (E3)" value="5"></value>
+              <value name="Reserved" value="6"></value>
+              <value name="Reserved" value="7"></value>
+            </attribute>
+            <attribute id="0x4003" name="Current Temperature Setpoint" type="s16" default="0x07d0" access="rw" required="m" mfcode="0x1037"></attribute>
+            <attribute id="0x4008" name="Host Flags" type="u24" default="0x000000" showas="hex" access="rw" required="m" mfcode="0x1037"></attribute>
+          </attribute-set>
+          
+          <!-- Danfoss manufacturer specific -->
+          <attribute-set id="0x4000" description="Danfoss specific" mfcode="0x1246">
+            <attribute id="0x4000" name="eTRV Open Window Detection" type="enum8" default="0x00" access="r" required="o" mfcode="0x1246">
+              <value name="Quarantine" value="0x00"></value>
+              <value name="Closed" value="0x01"></value>
+              <value name="Hold" value="0x02"></value>
+              <value name="Open" value="0x03"></value>
+              <value name="Windows open from external, but detected closed" value="0x04"></value>
+            </attribute>
+            <attribute id="0x4003" name="External Open Window Detected" type="bool" default="0x00" access="rw" required="o" mfcode="0x1246"></attribute>
+            <attribute id="0x4010" name="Exercise day of week" type="enum8" default="0x04" access="rw" required="o" mfcode="0x1246">
+              <value name="Sunday" value="0x00"></value>
+              <value name="Monday" value="0x01"></value>
+              <value name="Tuesday" value="0x02"></value>
+              <value name="Wednesday" value="0x03"></value>
+              <value name="Thursday" value="0x04"></value>
+              <value name="Friday" value="0x05"></value>
+              <value name="Saturday" value="0x06"></value>
+              <value name="Undefined" value="0x07"></value>
+            </attribute>
+            <attribute id="0x4011" name="Exercise trigger time" type="u16" default="660" access="rw" required="o" mfcode="0x1246"></attribute>
+            <attribute id="0x4012" name="Mounting mode active" type="bool" default="0x01" access="r" required="o" mfcode="0x1246"></attribute>
+            <attribute id="0x4013" name="Mounting mode control" type="bool" access="rw" required="o" mfcode="0x1246"></attribute>
+            <attribute id="0x4014" name="eTRV Orientation" type="bool" default="0x00" access="rw" required="o" mfcode="0x1246"></attribute>
+            <attribute id="0x4015" name="External Measured Room Sensor" type="s16" access="rw" required="o" mfcode="0x1246"></attribute>
+            <attribute id="0x4016" name="Radiator Covered" type="bool" access="w" required="o" mfcode="0x1246"></attribute>
+            <attribute id="0x4020" name="Control Algorithm Scale Factor" type="u8" default="1" access="rw" required="o" mfcode="0x1246"></attribute>
+            <attribute id="0x4030" name="Heat Available" type="bool" default="0x00" access="rw" required="o" mfcode="0x1246"></attribute>
+            <attribute id="0x4031" name="Heat Supply Request " type="bool" default="0x00" access="r" required="o" mfcode="0x1246"></attribute>
+            <attribute id="0x4032" name="Load Balancing Enabled" type="bool" default="0x01" access="rw" required="o" mfcode="0x1246"></attribute>
+            <attribute id="0x4040" name="Load Radiator Room Mean" type="s16" access="rw" required="o" mfcode="0x1246"></attribute>
+            <attribute id="0x404A" name="Load Estimate (Radiator)" type="s16" access="r" required="o" mfcode="0x1246"></attribute>
+            <attribute id="0x404B" name="Regulation SetPoint Offset" type="s8" default="0x00" access="rw" required="o" mfcode="0x1246"></attribute>
+            <attribute id="0x404C" name="Adaptation Run Control" type="enum8" default="0x00" access="rw" required="o" mfcode="0x1246">
+              <value name="Idle" value="0x00"></value>
+              <value name="Initiate Adaptation Run" value="0x01"></value>
+              <value name="Cancel Adaptation Run" value="0x02"></value>
+            </attribute>
+            <attribute id="0x404D" name="Adaptation Run Status" type="bmp8" default="0x00" access="r" required="o" mfcode="0x1246">
+              <value name="Adaptation Run in Progress" value="0"></value>
+              <value name="OP Found" value="1"></value>
+              <value name="OP Lost" value="2"></value>
+            </attribute>
+            <attribute id="0x404E" name="Adaptation Run Settings" type="bmp8" default="0x00" access="rw" required="o" mfcode="0x1246">
+              <value name="Default" value="0"></value>
+              <value name="Automatic Adaptation Run Enabled" value="1"></value>
+            </attribute>
+            <attribute id="0x404F" name="Preheat Status" type="bool" default="0x00" access="r" required="o" mfcode="0x1246"></attribute>
+            <attribute id="0x4050" name="Preheat Time" type="u32" access="r" required="o" mfcode="0x1246"></attribute>
+            <attribute id="0x4051" name="Window Open Feature On" type="bool" default="0x01" access="rw" required="o" mfcode="0x1246"></attribute>
+          </attribute-set>
+          
+          <!-- Sinope manufacturer specific -->
+          <attribute-set id="0x0400" description="Sinope specific" mfcode="0x119c">
+            <attribute id="0x0400" name="Occupancy" type="enum8" access="rw" required="m" mfcode="0x119c">
+              <value name="Unoccupied" value="0x00"></value>
+              <value name="Occupied" value="0x01"></value>
+            </attribute>
+            <attribute id="0x0402" name="Backlight" type="enum8" access="rw" required="m" mfcode="0x119c">
+              <value name="On demand" value="0x00"></value>
+              <value name="Sensing" value="0x01"></value>
+            </attribute>
+          </attribute-set>
+          
+          <!-- Stelpro manufacturer specific -->
+          <attribute-set id="0x4000" description="Stelpro specific" mfcode="0x1185">
+            <attribute id="0x4001" name="Outdoor temp" type="s16" access="rw" required="m" mfcode="0x1185"></attribute>
+            <attribute id="0x401c" name="System Mode" type="enum8" default="0x04" access="rw" required="m" mfcode="0x1185">
+              <value name="Off" value="0x00"/>
+              <value name="Heat" value="0x04"/>
+              <value name="Eco" value="0x05"/>
+              <description>States only supportedb by Stelpro thermostats (useless for Maestro).</description>
+            </attribute>
+          </attribute-set>
+          
+          <!-- Sunrichee manufacturer specific -->
+          <attribute-set id="0x1000" description="Sunricher Specific Attributes" mfcode="0x1224">
             <attribute id="0x1000" name="Display LED Brightness" type="enum8" access="rw" default="0x01" required="m" mfcode="0x1224">
               <description>OLED brightness when operating the buttons.  Default: Medium.</description>
               <value name="Low" value="0x00"></value>
@@ -2282,2654 +2303,2678 @@ Note: It does not clear or delete previous weekly schedule programming configura
               <value name="Home" value="0x00"></value>
               <value name="Away" value="0x01"></value>
             </attribute>
-        </attribute-set>
-        <!-- Danfoss manufacturer specific -->
-        <attribute-set id="0x4100" description="Danfoss specific" mfcode="0x1246">
+          </attribute-set>
+          <!-- Danfoss manufacturer specific -->
+          <attribute-set id="0x4100" description="Danfoss specific" mfcode="0x1246">
             <attribute id="0x4100" name="Room Status Code" type="enum16" default="0x0000" access="r" required="o" mfcode="0x1246">
-                <value name="No Error" value="0x0000"></value>
-                <value name="Missing RT" value="0x0101"></value>
-                <value name="RT Touch Error" value="0x0201"></value>
-                <value name="Floor Sensor Short Circuit" value="0x0401"></value>
-                <value name="Floor Sensor Disconnected" value="0x0801"></value>
+              <value name="No Error" value="0x0000"></value>
+              <value name="Missing RT" value="0x0101"></value>
+              <value name="RT Touch Error" value="0x0201"></value>
+              <value name="Floor Sensor Short Circuit" value="0x0401"></value>
+              <value name="Floor Sensor Disconnected" value="0x0801"></value>
             </attribute>
             <attribute id="0x4110" name="Output Status" type="enum8" default="0x00" access="r" required="o" mfcode="0x1246">
-                <value name="Inactive" value="0x00"></value>
-                <value name="Active" value="0x01"></value>
+              <value name="Inactive" value="0x00"></value>
+              <value name="Active" value="0x01"></value>
             </attribute>
             <attribute id="0x4120" name="Room Floor Sensor Mode" type="enum8" default="0x00" access="r" required="o" mfcode="0x1246">
-                <value name="Comfort Mode" value="0x00"></value>
-                <value name="Floor Sensor Mode" value="0x01"></value>
-                <value name="Dual Mode" value="0x02"></value>
+              <value name="Comfort Mode" value="0x00"></value>
+              <value name="Floor Sensor Mode" value="0x01"></value>
+              <value name="Dual Mode" value="0x02"></value>
             </attribute>
             <attribute id="0x4121" name="Floor Minimum Setpoint" type="s16" default="0x0708" access="rw" required="o" mfcode="0x1246"></attribute>
             <attribute id="0x4121" name="Floor Maximum Setpoint" type="s16" default="0x0DAC" access="rw" required="o" mfcode="0x1246"></attribute>
             <attribute id="0x4130" name="Schedule Type Used" type="enum8" default="0x00" access="rw" required="o" mfcode="0x1246">
-                <value name="Regular Schedule" value="0x00"></value>
-                <value name="Vacation Schedule" value="0x01"></value>
+              <value name="Regular Schedule" value="0x00"></value>
+              <value name="Vacation Schedule" value="0x01"></value>
             </attribute>
-        </attribute-set>
-
-		<command id="0x00" dir="recv" name="Setpoint Raise/Lower" required="m">
-			<description>This command increases (or decreases) the setpoint(s) by amount, in steps of 0.1°C.</description>
-			<payload>
-				<attribute id="0x0000" type="enum8" name="Mode" required="m">
-					<value name="Heat (adjust Heat Setpoint)" value="0x00"></value>
-					<value name="Cool (adjust Cool Setpoint)" value="0x01"></value>
-					<value name="Both (adjust Heat Setpoint and Cool Setpoint)" value="0x02"></value>
-				</attribute>
-				<attribute id="0x0001" type="s8" name="Amount" required="m">
-					<description>The amount field is a signed 8-bit integer that specifies the amount the setpoint(s) are to be a increased (or decreased) by, in steps of 0.1°C.</description>
-				</attribute>
-			</payload>
-		</command>
-        <command id="0x01" dir="recv" name="Set Weekly Schedule" required="o">
+          </attribute-set>
+          
+          <command id="0x00" dir="recv" name="Setpoint Raise/Lower" required="m">
+            <description>This command increases (or decreases) the setpoint(s) by amount, in steps of 0.1°C.</description>
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Mode" required="m">
+                <value name="Heat (adjust Heat Setpoint)" value="0x00"></value>
+                <value name="Cool (adjust Cool Setpoint)" value="0x01"></value>
+                <value name="Both (adjust Heat Setpoint and Cool Setpoint)" value="0x02"></value>
+              </attribute>
+              <attribute id="0x0001" type="s8" name="Amount" required="m">
+                <description>The amount field is a signed 8-bit integer that specifies the amount the setpoint(s) are to be a increased (or decreased) by, in steps of 0.1°C.</description>
+              </attribute>
+            </payload>
+          </command>
+          <command id="0x01" dir="recv" name="Set Weekly Schedule" required="o">
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Number of Transtions for Sequence" required="m">
+                <value name="0" value="0"></value>
+                <value name="1" value="1"></value>
+                <value name="2" value="2"></value>
+                <value name="3" value="3"></value>
+                <value name="4" value="4"></value>
+                <value name="5" value="5"></value>
+                <value name="6" value="6"></value>
+                <value name="7" value="7"></value>
+                <value name="8" value="8"></value>
+                <value name="9" value="9"></value>
+                <value name="10" value="10"></value>
+              </attribute>
+              <attribute id="0x0001" type="bmp8" name="Day of Week for Sequence" required="m">
+                <value name="Sunday" value="0"></value>
+                <value name="Monday" value="1"></value>
+                <value name="Tuesday" value="2"></value>
+                <value name="Wednesday" value="3"></value>
+                <value name="Thursday" value="4"></value>
+                <value name="Friday" value="5"></value>
+                <value name="Saturday" value="6"></value>
+                <value name="Vacation or Away" value="7"></value>
+              </attribute>
+              <attribute id="0x0002" type="bmp8" name="Mode for Sequence" required="m">
+                <value name="Heat Setpoint Field Present in Payload" value="0"></value>
+                <value name="Cool Setpoint Field Present in Payload" value="1"></value>
+              </attribute>
+              <attribute id="0x0003" type="u16" name="Transition Time 1" required="o"/>
+              <attribute id="0x0004" type="s16" name="Heat Set Point 1" required="o"/>
+              <attribute id="0x0005" type="u16" name="Transition Time 2" required="o"/>
+              <attribute id="0x0006" type="s16" name="Heat Set Point 2" required="o"/>
+              <attribute id="0x0007" type="u16" name="Transition Time 3" required="o"/>
+              <attribute id="0x0008" type="s16" name="Heat Set Point 3" required="o"/>
+              <attribute id="0x0009" type="u16" name="Transition Time 4" required="o"/>
+              <attribute id="0x000A" type="s16" name="Heat Set Point 4" required="o"/>
+              <attribute id="0x000B" type="u16" name="Transition Time 5" required="o"/>
+              <attribute id="0x000C" type="s16" name="Heat Set Point 5" required="o"/>
+              <attribute id="0x000D" type="u16" name="Transition Time 6" required="o"/>
+              <attribute id="0x000E" type="s16" name="Heat Set Point 6" required="o"/>
+              <attribute id="0x000F" type="u16" name="Transition Time 7" required="o"/>
+              <attribute id="0x0010" type="s16" name="Heat Set Point 7" required="o"/>
+              <attribute id="0x0011" type="u16" name="Transition Time 8" required="o"/>
+              <attribute id="0x0012" type="s16" name="Heat Set Point 8" required="o"/>
+              <attribute id="0x0013" type="u16" name="Transition Time 9" required="o"/>
+              <attribute id="0x0014" type="s16" name="Heat Set Point 9" required="o"/>
+              <attribute id="0x0015" type="u16" name="Transition Time 10" required="o"/>
+              <attribute id="0x0016" type="s16" name="Heat Set Point 10" required="o"/>
+            </payload>
+          </command>
+          <command id="0x02" dir="recv" name="Get Weekly Schedule" required="o" response="0x00">
+            <payload>
+              <attribute id="0x0000" type="bmp8" name="Days to Return" required="m">
+                <value name="Sunday" value="0"></value>
+                <value name="Monday" value="1"></value>
+                <value name="Tuesday" value="2"></value>
+                <value name="Wednesday" value="3"></value>
+                <value name="Thursday" value="4"></value>
+                <value name="Friday" value="5"></value>
+                <value name="Saturday" value="6"></value>
+                <value name="Vacation or Away" value="7"></value>
+              </attribute>
+              <attribute id="0x0001" type="bmp8" name="Mode to Return" required="m">
+                <value name="Heat Setpoint Field Present in Payload" value="0"></value>
+                <value name="Cool Setpoint Field Present in Payload" value="1"></value>
+              </attribute>
+            </payload>
+          </command>
+          <command id="0x03" dir="recv" name="Clear Weekly Schedule" required="o">
+          </command>
+          <command id="0x04" dir="recv" name="Get Relay Status Log" required="o">
+          </command>
+        </server>
+        <client>
+          <command id="0x00" dir="recv" name="Get Weekly Schedule Response" required="o">
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Number of Transtions for Sequence" required="m">
+                <value name="0" value="0"></value>
+                <value name="1" value="1"></value>
+                <value name="2" value="2"></value>
+                <value name="3" value="3"></value>
+                <value name="4" value="4"></value>
+                <value name="5" value="5"></value>
+                <value name="6" value="6"></value>
+                <value name="7" value="7"></value>
+                <value name="8" value="8"></value>
+                <value name="9" value="9"></value>
+                <value name="10" value="10"></value>
+              </attribute>
+              <attribute id="0x0001" type="bmp8" name="Day of Week for Sequence" required="m">
+                <value name="Sunday" value="0"></value>
+                <value name="Monday" value="1"></value>
+                <value name="Tuesday" value="2"></value>
+                <value name="Wednesday" value="3"></value>
+                <value name="Thursday" value="4"></value>
+                <value name="Friday" value="5"></value>
+                <value name="Saturday" value="6"></value>
+                <value name="Vacation or Away" value="7"></value>
+              </attribute>
+              <attribute id="0x0002" type="bmp8" name="Mode for Sequence" required="m">
+                <value name="Heat Setpoint Field Present in Payload" value="0"></value>
+                <value name="Cool Setpoint Field Present in Payload" value="1"></value>
+              </attribute>
+              <attribute id="0x0003" type="u16" name="Transition Time 1" required="o"/>
+              <attribute id="0x0004" type="s16" name="Heat Set Point 1" required="o"/>
+              <attribute id="0x0005" type="u16" name="Transition Time 2" required="o"/>
+              <attribute id="0x0006" type="s16" name="Heat Set Point 2" required="o"/>
+              <attribute id="0x0007" type="u16" name="Transition Time 3" required="o"/>
+              <attribute id="0x0008" type="s16" name="Heat Set Point 3" required="o"/>
+              <attribute id="0x0009" type="u16" name="Transition Time 4" required="o"/>
+              <attribute id="0x000A" type="s16" name="Heat Set Point 4" required="o"/>
+              <attribute id="0x000B" type="u16" name="Transition Time 5" required="o"/>
+              <attribute id="0x000C" type="s16" name="Heat Set Point 5" required="o"/>
+              <attribute id="0x000D" type="u16" name="Transition Time 6" required="o"/>
+              <attribute id="0x000E" type="s16" name="Heat Set Point 6" required="o"/>
+              <attribute id="0x000F" type="u16" name="Transition Time 7" required="o"/>
+              <attribute id="0x0010" type="s16" name="Heat Set Point 7" required="o"/>
+              <attribute id="0x0011" type="u16" name="Transition Time 8" required="o"/>
+              <attribute id="0x0012" type="s16" name="Heat Set Point 8" required="o"/>
+              <attribute id="0x0013" type="u16" name="Transition Time 9" required="o"/>
+              <attribute id="0x0014" type="s16" name="Heat Set Point 9" required="o"/>
+              <attribute id="0x0015" type="u16" name="Transition Time 10" required="o"/>
+              <attribute id="0x0016" type="s16" name="Heat Set Point 10" required="o"/>
+            </payload>
+          </command>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0202" name="Fan Control">
+        <description>This cluster specifies an interface to control the speed of a fan as part of a heating / cooling system.</description>
+        <server>
+          <attribute id="0x0000" name="Fan Mode" type="enum8" access="rw" default="0x05" required="m">
+            <value name="Off" value="0x00"></value>
+            <value name="Low" value="0x01"></value>
+            <value name="Medium" value="0x02"></value>
+            <value name="High" value="0x03"></value>
+            <value name="On" value="0x04"></value>
+            <value name="Auto" value="0x05"></value>
+            <value name="Smart" value="0x06"></value>
+          </attribute>
+          <attribute id="0x0001" name="Fan Mode Sequence" type="enum8" access="rw" default="0x02" required="m">
+            <value name="Low/Med/High" value="0x00"></value>
+            <value name="Low/High" value="0x01"></value>
+            <value name="Low/Med/High/Auto" value="0x02"></value>
+            <value name="Low/High/Auto" value="0x03"></value>
+            <value name="On/Auto" value="0x04"></value>
+          </attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0203" name="Dehumidification Control">
+        <description>dfdf</description>
+        <!-- TODO -->
+      </cluster>
+      
+      <cluster id="0x0204" name="Thermostat User Interface Configuration">
+        <description>This cluster provides an interface to allow configuration of the user interface for a thermostat, or a thermostat
+          controller device, that supports a keypad and LCD screen.</description>
+        <server>
+          <attribute id="0x0000" name="Temperature Display Mode" type="enum8" access="rw" range="0x00,0x01" default="0x00" required="m">
+            <value name="Temperature in °C" value="0x00"></value>
+            <value name="Temperature in °F" value="0x01"></value>
+          </attribute>
+          <attribute id="0x0001" name="Keypad Lockout" type="enum8" access="rw" range="0x00,0x05" default="0x00" required="m">
+            <value name="No lockout" value="0x00"></value>
+            <value name="Level 1 lockout" value="0x01"></value>
+            <value name="Level 2 lockout" value="0x02"></value>
+            <value name="Level 3 lockout" value="0x03"></value>
+            <value name="Level 4 lockout" value="0x04"></value>
+            <value name="Level 5 lockout" value="0x05"></value>
+          </attribute>
+          <attribute id="0x0002" name="Schedule Programming Visibility" type="enum8" access="rw"  range="0x00,0x01" default="0x00" required="o">
+            <value name="Local schedule programming enabled" value="0x00"></value>
+            <value name="Local schedule programming disabled" value="0x01"></value>
+          </attribute>
+          <attribute id="0x4000" name="Viewing Direction" type="enum8" access="rw" range="0x00,0x01" default="0x00" required="o" mfcode="0x1246">
+            <value name="Viewing direction 1" value="0x00"></value>
+            <value name="Viewing direction 2" value="0x01"></value>
+          </attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0xde42" name="DE Debug">
+        <description>Attributes and commands for debugging purposes.</description>
+        <server>
+          <attribute id="0x0000" name="Debug enabled" type="bool" access="rw" default="0x00" required="m"></attribute>
+          <attribute id="0x0001" name="Debug destination" type="u16" access="rw" default="0x0000" showas="hex" required="m"></attribute>
+        </server>
+        <client>
+          <!-- TODO -->
+        </client>
+      </cluster>
+    </domain>
+    
+    <domain name="Lighting" low_bound="0300" high_bound="03ff" description="The lighting functional domain contains clusters and information to build devices in the lighting domain, e.g. ballast units.">
+      <cluster id="0x0300" name="Color control">
+        <description>Attributes and commands for controlling the color properties of a color-capable light.</description>
+        <server>
+          <attribute-set id="0x0000" description="Color Information">
+            <attribute id="0x0000" name="Current hue" type="u8" access="r" range="0x00,0xfe" default="0x00" required="o"></attribute>
+            <attribute id="0x0001" name="Current saturation" type="u8" access="r" range="0x00,0xfe" default="0x00" required="o"></attribute>
+            <attribute id="0x0002" name="Remaining time" type="u16" access="r" range="0x0000,0xfffe" default="0x0000" required="o"></attribute>
+            <attribute id="0x0003" name="Current x" type="u16" access="r" range="0x0000,0xfeff" default="0x61eb" required="m"></attribute>
+            <attribute id="0x0004" name="Current y" type="u16" access="r" range="0x0000,0xfeff" default="0x607b" required="m"></attribute>
+            <attribute id="0x0007" name="Color temperature" type="u16" access="r" range="0x0000,0xfeff" default="0" required="m"></attribute>
+            <!-- TODO -->
+            <attribute id="0x0008" name="Color Mode" type="enum8" access="r" range="0x00,0x02" default="0x01" required="o">
+              <value name="Current hue and current saturation" value="0x00"></value>
+              <value name="Current x and current y" value="0x01"></value>
+              <value name="Color temperature" value="0x02"></value>
+            </attribute>
+          </attribute-set>
+          <attribute-set id="0x0010" description="Defined Primaries Information">
+            <attribute id="0x0010" name="Number of primaries" type="u8" access="r" range="0x00,0x06" required="o"></attribute>
+            <attribute id="0x0011" name="Primary1 x" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+            <attribute id="0x0012" name="Primary1 y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+            <attribute id="0x0013" name="Primary1 intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
+            <attribute id="0x0015" name="Primary2 x" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+            <attribute id="0x0016" name="Primary2 y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+            <attribute id="0x0017" name="Primary2 intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
+            <attribute id="0x0019" name="Primary3 x" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+            <attribute id="0x001a" name="Primary3 y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+            <attribute id="0x001b" name="Primary3 intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
+          </attribute-set>
+          <attribute-set id="0x0020" description="Additional Defined Primaries Information">
+            <attribute id="0x0020" name="Primary4 x" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+            <attribute id="0x0021" name="Primary4 y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+            <attribute id="0x0022" name="Primary4 intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
+            <attribute id="0x0024" name="Primary5 x" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+            <attribute id="0x0025" name="Primary5 y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+            <attribute id="0x0026" name="Primary5 intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
+            <attribute id="0x0028" name="Primary6 x" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+            <attribute id="0x0029" name="Primary6 y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+            <attribute id="0x002a" name="Primary6 intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
+          </attribute-set>
+          <attribute-set id="0x0030" description="Defined Color Points Settings">
+            <attribute id="0x0030" name="WhitePoint x" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
+            <attribute id="0x0031" name="WhitePoint y" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
+            <attribute id="0x0032" name="ColorPoint r x" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
+            <attribute id="0x0033" name="ColorPoint r y" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
+            <attribute id="0x0034" name="ColorPoint r intensity" type="u8" access="rw" range="0x00,0xff" required="o"></attribute>
+            <attribute id="0x0036" name="ColorPoint g x" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
+            <attribute id="0x0037" name="ColorPoint g y" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
+            <attribute id="0x0038" name="ColorPoint g intensity" type="u8" access="rw" range="0x00,0xff" required="o"></attribute>
+            <attribute id="0x003a" name="ColorPoint b x" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
+            <attribute id="0x003b" name="ColorPoint b y" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
+            <attribute id="0x003c" name="ColorPoint b intensity" type="u8" access="rw" range="0x00,0xff" required="o"></attribute>
+          </attribute-set>
+          <attribute-set id="0x4000" description="ZLL extensions">
+            <attribute id="0x4000" name="Enhanced current hue" type="u16" access="r" range="0x0000,0xffff" default="0x0000" required="m"></attribute>
+            <attribute id="0x4001" name="Enhanced color mode" type="enum8" access="r" range="0x00,0xff" default="0x00" required="m">
+              <value name="Current hue and current saturation" value="0x00"></value>
+              <value name="Current x and current y" value="0x01"></value>
+              <value name="Color temperature" value="0x02"></value>
+              <value name="Enhanced current hue and current saturation" value="0x03"></value>
+            </attribute>
+            <attribute id="0x4002" name="Color loop active" type="u8" access="r" range="0x00,0xff" default="0x00" required="m"></attribute>
+            <attribute id="0x4003" name="Color loop direction" type="u8" access="r" range="0x00,0xff" default="0x00" required="m"></attribute>
+            <attribute id="0x4004" name="Color loop time" type="u16" access="r" range="0x00,0xff" default="0x0019" required="m"></attribute>
+            <attribute id="0x4005" name="Color loop start - enhanced hue" type="u16" access="r" range="0x00,0xff" default="0x2300" required="m"></attribute>
+            <attribute id="0x4006" name="Color loop stored - enhanced hue" type="u16" access="r" range="0x00,0xff" default="0x0000" required="m"></attribute>
+            <attribute id="0x400a" type="bmp16" name="Color capabilities" access="r" required="m" default="0x0000">
+              <value name="Hue saturation" value="0"></value>
+              <value name="Enhanced Hue saturation" value="1"></value>
+              <value name="Color loop" value="2"></value>
+              <value name="CIE 1931 XY" value="3"></value>
+              <value name="Color temperature" value="4"></value>
+            </attribute>
+            <attribute id="0x400b" name="Color temperature min" type="u16" access="r" range="0x0000,0xfeff" default="0" required="m"></attribute>
+            <attribute id="0x400c" name="Color temperature max" type="u16" access="r" range="0x0000,0xfeff" default="0xfeff" required="m"></attribute>
+            <attribute id="0x4010" name="PowerOn Color Temperature" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
+            <!--
+            <attribute id="0x0003" mfcode="0x100b" name="PowerOn X" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
+            <attribute id="0x0004" mfcode="0x100b" name="PowerOn Y" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
+            -->
+          </attribute-set>
+          <attribute-set id="0xde00" description="FLS extensions" mfcode="0x1135">
+            <attribute id="0xde01" name="Active channels" type="u8" access="r" range="0x00,0xff" default="0x00" required="m"></attribute>
+          </attribute-set>
+          <command id="0x00" dir="recv" name="Move to hue" required="o">
+            <payload>
+              <attribute id="0x0000" type="u8" name="Hue" required="m"></attribute>
+              <attribute id="0x0001" type="enum8" name="Direction" required="m">
+                <value name="Shortest distance" value="0x00"></value>
+                <value name="Longest Distance" value="0x01"></value>
+                <value name="Up" value="0x02"></value>
+                <value name="Down" value="0x03"></value>
+              </attribute>
+              <attribute id="0x0002" type="u16" name="Transition time" required="m">
+                <description>The transition time in 1/10ths of a second.</description>
+              </attribute>
+            </payload>
+          </command>
+          <command id="0x01" dir="recv" name="Move hue" required="o">
+            <payload>
+              <attribute id="0x0001" type="enum8" name="Move mode" required="m">
+                <value name="Stop" value="0x00"></value>
+                <value name="Up" value="0x01"></value>
+                <value name="Down" value="0x03"></value>
+              </attribute>
+              <attribute id="0x0002" type="u8" name="Steps/second" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="0x02" dir="recv" name="Step hue" required="o">
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Step mode" required="m">
+                <value name="Up" value="0x01"></value>
+                <value name="Down" value="0x03"></value>
+              </attribute>
+              <attribute id="0x0001" type="u8" name="Step size" required="m"></attribute>
+              <attribute id="0x0002" type="u8" name="Transition time" required="m">
+                <description>The transitiontime in 1/10 seconds.</description>
+              </attribute>
+            </payload>
+          </command>
+          <command id="0x03" dir="recv" name="Move to saturation" required="o">
+            <payload>
+              <attribute id="0x0000" type="u8" name="Saturation" required="m"></attribute>
+              <attribute id="0x0001" type="u16" name="Transition time" required="m">
+                <description>The transitiontime in 1/10 seconds.</description>
+              </attribute>
+            </payload>
+          </command>
+          <command id="0x04" dir="recv" name="Move saturation" required="o">
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Move mode" required="m">
+                <value name="Stop" value="0x00"></value>
+                <value name="Up" value="0x01"></value>
+                <value name="Down" value="0x03"></value>
+              </attribute>
+              <attribute id="0x0001" type="u8" name="Rate" required="m">
+                <description>The steps per second.</description>
+              </attribute>
+            </payload>
+          </command>
+          <command id="0x05" dir="recv" name="Step saturation" required="o">
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Step mode" required="m">
+                <value name="Up" value="0x01"></value>
+                <value name="Down" value="0x03"></value>
+              </attribute>
+              <attribute id="0x0001" type="u8" name="Step size" required="m"></attribute>
+              <attribute id="0x0002" type="u8" name="Transition time" required="m">
+                <description>The transitiontime in 1/10 seconds.</description>
+              </attribute>
+            </payload>
+          </command>
+          <command id="0x06" dir="recv" name="Move to hue and saturation" required="o">
+            <payload>
+              <attribute id="0x0000" type="u8" name="Hue" required="m"></attribute>
+              <attribute id="0x0001" type="u8" name="Saturation" required="m"></attribute>
+              <attribute id="0x0002" type="u16" name="Transition time" required="m">
+                <description>The transitiontime in 1/10 seconds.</description>
+              </attribute>
+            </payload>
+          </command>
+          <command id="0x07" dir="recv" name="Move to color" required="m">
+            <payload>
+              <attribute id="0x0000" type="u16" name="ColorX" required="m"></attribute>
+              <attribute id="0x0001" type="u16" name="ColorY" required="m"></attribute>
+              <attribute id="0x0002" type="u16" name="Transition time" required="m">
+                <description>The transitiontime in 1/10 seconds.</description>
+              </attribute>
+            </payload>
+          </command>
+          <command id="0x08" dir="recv" name="Move color" required="o">
+            <payload>
+              <attribute id="0x0000" type="s16" name="Rate X" required="m">
+                <description>The steps per second.</description>
+              </attribute>
+              <attribute id="0x0001" type="s16" name="Rate Y" required="m">
+                <description>The steps per second.</description>
+              </attribute>
+            </payload>
+          </command>
+          <command id="0x09" dir="recv" name="Step color" required="o">
+            <payload>
+              <attribute id="0x0000" type="s16" name="Step X" required="m"></attribute>
+              <attribute id="0x0001" type="s16" name="Step Y" required="m"></attribute>
+              <attribute id="0x0002" type="u16" name="Transition time" required="m">
+                <description>The transitiontime in 1/10 seconds.</description>
+              </attribute>
+            </payload>
+          </command>
+          <command id="0x0a" dir="recv" name="Move to color temperature" required="o">
+            <payload>
+              <attribute id="0x0000" type="u16" name="Color temperature" required="m"></attribute>
+              <attribute id="0x0001" type="u16" name="Transition time" required="m">
+                <description>The transitiontime in 1/10 seconds.</description>
+              </attribute>
+            </payload>
+          </command>
+          <command id="0x40" dir="recv" name="Enhanced move to hue" required="m">
+            <payload>
+              <attribute id="0x0000" type="u16" name="Enhanced hue" required="m"></attribute>
+              <attribute id="0x0001" type="enum8" name="Direction" required="m">
+                <value name="Shortest distance" value="0x00"></value>
+                <value name="Longest Distance" value="0x01"></value>
+                <value name="Up" value="0x02"></value>
+                <value name="Down" value="0x03"></value>
+              </attribute>
+              <attribute id="0x0002" type="u16" name="Transition time" required="m">
+                <description>The transitiontime in 1/10 seconds.</description>
+              </attribute>
+            </payload>
+          </command>
+          <command id="0x41" dir="recv" name="Enhanced move hue" required="m">
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Move mode" required="m">
+                <value name="Stop" value="0x00"></value>
+                <value name="Up" value="0x01"></value>
+                <value name="Down" value="0x03"></value>
+              </attribute>
+              <attribute id="0x0001" type="u16" name="Rate" required="m">
+                <description>Steps per second.</description>
+              </attribute>
+            </payload>
+          </command>
+          <command id="0x42" dir="recv" name="Enhanced step hue" required="m">
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Step mode" required="m">
+                <value name="Up" value="0x01"></value>
+                <value name="Down" value="0x03"></value>
+              </attribute>
+              <attribute id="0x0001" type="u16" name="Step size" required="m"></attribute>
+              <attribute id="0x0002" type="u16" name="Transition time" required="m">
+                <description>The transitiontime in 1/10 seconds.</description>
+              </attribute>
+            </payload>
+          </command>
+          <command id="0x43" dir="recv" name="Enhanced move to hue and saturation" required="m">
+            <payload>
+              <attribute id="0x0000" type="u16" name="Enhanced hue" required="m"></attribute>
+              <attribute id="0x0001" type="u8" name="Saturation" required="m"></attribute>
+              <attribute id="0x0002" type="u16" name="Transition time" required="m">
+                <description>The transitiontime in 1/10 seconds.</description>
+              </attribute>
+            </payload>
+          </command>
+          <command id="0x44" dir="recv" name="Color loop set" required="m">
+            <payload>
+              <attribute id="0x0000" type="bmp8" name="Update flags" required="m">
+                <value name="Update action" value="0"></value>
+                <value name="Update direction" value="1"></value>
+                <value name="Update time" value="2"></value>
+                <value name="Update start hue" value="3"></value>
+              </attribute>
+              <attribute id="0x0001" type="enum8" name="Action" required="m">
+                <value name="De-activate color loop" value="0x00"></value>
+                <value name="Activate from ColorLoopStartEnhancedHue" value="0x01"></value>
+                <value name="Activate from EnhancedCurrentHue" value="0x02"></value>
+              </attribute>
+              <attribute id="0x0002" type="enum8" name="Direction" required="m">
+                <value name="Decrement hue" value="0x00"></value>
+                <value name="Increment hue" value="0x01"></value>
+              </attribute>
+              <attribute id="0x0003" type="u16" name="Time" required="m">
+                <description>Time in seconds used for a whole color loop.</description>
+              </attribute>
+              <attribute id="0x0004" type="u16" name="Start enhanced hue" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="0x47" dir="recv" name="Stop move step" required="m">
+            <description>Stops move to and step commands. It has no effect on a active color loop.</description>
+            <payload>
+            </payload>
+          </command>
+          <command id="0x4b" dir="recv" name="Move color temperature" required="m">
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Move mode" required="m">
+                <value name="Stop" value="0x00"></value>
+                <value name="Up" value="0x01"></value>
+                <value name="Down" value="0x03"></value>
+              </attribute>
+              <attribute id="0x0001" type="u16" name="Rate" required="m">
+                <description>Steps per second.</description>
+              </attribute>
+              <attribute id="0x0002" type="u16" name="Color temperature min" required="m">
+                <description>Specifies a lower bound on the color temperature for the current move operation.</description>
+              </attribute>
+              <attribute id="0x0003" type="u16" name="Color temperature max" required="m">
+                <description>Specifies a upper bound on the color temperature for the current move operation.</description>
+              </attribute>
+            </payload>
+          </command>
+          <command id="0x4c" dir="recv" name="Step color temperature" required="m">
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Step mode" required="m">
+                <value name="Up" value="0x01"></value>
+                <value name="Down" value="0x03"></value>
+              </attribute>
+              <attribute id="0x0001" type="u16" name="Step size" required="m"></attribute>
+              <attribute id="0x0002" type="u16" name="Transition time" required="m">
+                <description>The transitiontime in 1/10 seconds.</description>
+              </attribute>
+              <attribute id="0x0003" type="u16" name="Color temperature min" required="m">
+                <description>Specifies a lower bound on the color temperature for the current step operation.</description>
+              </attribute>
+              <attribute id="0x0004" type="u16" name="Color temperature max" required="m">
+                <description>Specifies a upper bound on the color temperature for the current step operation.</description>
+              </attribute>
+            </payload>
+          </command>
+          <command id="0xd0" dir="recv" name="Set active channels" required="m">
+            <payload>
+              <attribute id="0x00" type="u8" name="Channels" required="m"></attribute>
+            </payload>
+          </command>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0301" name="Ballast Configuration">
+        <description>Attributes and commands to configure a ballast.</description>
+        <server>
+          <attribute-set id="0x0000" description="Ballast Information">
+            <attribute id="0x0000" name="Physical Min Level" type="u8" access="r" range="0x01,0xfe" default="0x01" required="o"></attribute>
+            <attribute id="0x0001" name="Physical Max Level" type="u8" access="r" range="0x01,0xfe" default="0xfe" required="o"></attribute>
+            <attribute id="0x0002" name="Ballast Status" type="bmp8" access="r" default="0x00" required="m">
+              <value name="Non-operational" value="0"></value>
+              <value name="Lamp not in socket" value="1"></value>
+            </attribute>
+          </attribute-set>
+          
+          <attribute-set id="0x0010" description="Ballast Settings">
+            <attribute id="0x0010" name="Min Level" type="u8" access="rw" range="0x01,0xfe" default="0x01" required="o"></attribute>
+            <attribute id="0x0011" name="Max Level" type="u8" access="rw" range="0x01,0xfe" default="0xfe" required="o"></attribute>
+            <attribute id="0x0012" name="Power On Level" type="u8" access="rw" range="0x01,0xfe" default="0xfe" required="o"></attribute>
+            <attribute id="0x0013" name="Power On Fade Time" type="u16" access="rw" range="0x0000,0xfffe" default="0x0000" required="o"></attribute>
+            <attribute id="0x0014" name="Intrinsic Ballast Factor" type="u8" access="rw" range="0x00,0xfe" default="0x00" required="o"></attribute>
+            <attribute id="0x0015" name="Ballast Factor Adjustment" type="u8" access="rw" range="0x64,0xff" default="0xff" required="o"></attribute>
+          </attribute-set>
+          
+          <attribute-set id="0x0020" description="Lamp Information">
+            <attribute id="0x0020" name="Lamp Quantity" type="u8" access="r" range="0x00,0xfe" default="0x00" required="o"></attribute>
+          </attribute-set>
+          
+          <attribute-set id="0x0030" description="Lamp Settings">
+            <attribute id="0x0030" name="Lamp Type" type="cstring" access="rw" required="o"></attribute>
+            <attribute id="0x0031" name="Lamp Manufacturer" type="cstring" access="rw" required="o"></attribute>
+            <attribute id="0x0032" name="Lamp Rated Hours" type="u24" access="rw" range="0x000000,0xfffffe" default="0xffffff" required="o"></attribute>
+            <attribute id="0x0033" name="Lamp Burn Hours" type="u24" access="rw" range="0x000000,0xfffffe" default="0x000000" required="o"></attribute>
+            <attribute id="0x0034" name="Lamp Alarm Mode" type="bmp8" access="rw" default="0x00" required="m">
+              <value name="Lamp Burn Hours" value="0"></value>
+            </attribute>
+            <attribute id="0x0035" name="Lamp Burn Hours Trip Point" type="u24" access="rw" range="0x000000,0xfffffe" default="0x000000" required="o"></attribute>
+          </attribute-set>
+        </server>
+        <client>
+        </client>
+      </cluster>
+    </domain>
+    
+    <domain name="Measurement and sensing" low_bound="0400" high_bound="04ff" description="The measurement and sensing functional domain contains clusters and information to build devices in the measurement and sensing domain, e.g. a temperature sensor or an occupancy sensor.">
+      <cluster id="0x0400" name="Illuminance measurement">
+        <description>The server cluster provides an interface to illuminance measurement functionality, including configuration and provision of notifications of illuminance measurements.</description>
+        <!-- TODO -->
+        <server>
+          <attribute-set id="0x0000" description="Illuminance Measurement Information">
+            <attribute id="0x0000" name="Measured Value" type="u16" access="r" default="0" required="m"></attribute>
+            <attribute id="0x0001" name="Min Measured Value" type="u16" access="r" required="m" range="0x0002,0xfffd"></attribute>
+            <attribute id="0x0002" name="Max Measured Value" type="u16" access="r" required="m" range="0x0001,0x7ffe"></attribute>
+            <attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o" range="0x0000,0x0800"></attribute>
+            <attribute id="0x0004" name="Light Sensor Type" type="enum8" range="0x00,0xff" access="r" required="o">
+              <value name="Photodiode" value="0x00"></value>
+              <value name="CMOS" value="0x01"></value>
+              <value name="Unknown" value="0xff"></value>
+            </attribute>
+          </attribute-set>
+        </server>
+        <client>
+          <attribute-set id="0xf000" description="Illuminance Adjustement Configuration">
+            <attribute id="0xf000" name="Hysteresis" type="u16" access="rw" required="o"></attribute>
+            <attribute id="0xf001" name="Max Up Speed" type="u16" access="rw" required="o"><description>Maximum up adjustment speed in 1/10 seconds.</description></attribute>
+            <attribute id="0xf002" name="Max Down Speed" type="u16" access="rw" required="o"><description>Maximum down adjustment speed in 1/10 seconds.</description></attribute>
+            <attribute id="0xf003" name="Target Value" type="u16" access="rw" required="o"><description>Target value in Lux which should be kept.</description></attribute>
+            <attribute id="0xf004" name="Startup Type" type="enum8" access="rw" required="o">
+              <description>Brightness control startup type.</description>
+              <value name="Default Level" value="0x00"></value>
+              <value name="Zero Level" value="0x01"></value>
+            </attribute>
+          </attribute-set>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0401" name="Illuminance level sensing">
+        <description></description>
+        <!-- TODO -->
+      </cluster>
+      
+      <cluster id="0x0402" name="Temperature measurement">
+        <description>The server cluster provides an interface to temperature measurement functionality, including configuration and provision  of notifications of temperature measurements.</description>
+        <!-- TODO -->
+        <server>
+          <attribute-set id="0x0000" description="Temperature Measurement Information">
+            <attribute id="0x0000" name="Measured Value" type="s16" access="r" default="0" required="m"></attribute>
+            <attribute id="0x0001" name="Min Measured Value" type="s16" access="r" required="m" range="0x954d,0x7ffe"></attribute>
+            <attribute id="0x0002" name="Max Measured Value" type="s16" access="r" required="m" range="0x954e,0x7ffe"></attribute>
+            <attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o" range="0x0000,0x0800"></attribute>
+          </attribute-set>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0403" name="Pressure measurement">
+        <description>The server cluster provides an interface to air pressure measurement functionality, including configuration and provision of notifications of air pressure measurements.</description>
+        <server>
+          <attribute-set id="0x0000" description="Pressure Measurement Information">
+            <attribute id="0x0000" name="Measured Value" type="s16" access="r" default="0" required="m"></attribute>
+            <attribute id="0x0010" name="Scaled Value" type="s16" access="r" default="0" required="o"></attribute>
+            <attribute id="0x0014" name="Scale" type="s8" access="r" required="o"></attribute>
+          </attribute-set>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0404" name="Flow measurement">
+        <description></description>
+        <!-- TODO -->
+        <server>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0405" name="Relative humidity measurement">
+        <description></description>
+        <server>
+          <attribute-set id="0x0000" description="Relative Humidity Measurement Information">
+            <attribute id="0x0000" name="Measured Value" type="u16" access="r" default="0" required="m"></attribute>
+            <attribute id="0x0001" name="Min Measured Value" type="u16" access="r" required="m" range="0x954d,0x7ffe"></attribute>
+            <attribute id="0x0002" name="Max Measured Value" type="u16" access="r" required="m" range="0x954e,0x7ffe"></attribute>
+            <attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o" range="0x0000,0x0800"></attribute>
+          </attribute-set>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0406" name="Occupancy sensing">
+        <description><!-- TODO --></description>
+        <server>
+          <attribute-set id="0x0000" description="Occupancy sensor information">
+            <attribute id="0x0000" name="Occupancy" type="bmp8" range="0000000x" access="r" required="m"></attribute>
+            <attribute id="0x0001" name="Occupancy Sensor Type" type="enum8" range="0x00,0xfe" access="r" required="m">
+              <value name="PIR" value="0x00"></value>
+              <value name="Ultrasonic" value="0x01"></value>
+              <value name="PIR and ultrasonic" value="0x02"></value>
+            </attribute>
+          </attribute-set>
+          <attribute-set id="0x0010" description="PIR configuration">
+            <attribute id="0x0010" name="PIR Occupied To Unoccupied Delay" type="u16" range="0x00,0xfffe" access="rw" required="o" default="0x00">
+              <description>The PIROccupiedToUnoccupiedDelay attribute is 16-bits in length and specifies the time delay, in seconds, before the PIR sensor changes to its occupied state when the sensed area becomes unoccupied. This attribute, along with PIRUnoccupiedToOccupiedTime, may be used to reduce sensor 'chatter' when used in an area where occupation changes frequently.</description>
+            </attribute>
+            <attribute id="0x0011" name="PIR Unoccupied To Occupied Delay" type="u16" range="0x00,0xfffe" access="rw" required="o" default="0x00">
+              <description>The PIRUnoccupiedToOccupiedDelay attribute is 16-bits in length and specifies the time delay, in seconds, before the PIR sensor changes to its unoccupied state when the sensed area becomes occupied.</description>
+            </attribute>
+            <attribute id="0x0012" name="PIR Unoccupied To Occupied Threshold" type="u8" range="0x01,0xfe" access="rw" required="o" default="0x01">
+              <description>The PIRUnoccupiedToOccupiedThreshold attribute is 8 bits in length and specifies the number of movement detection events that must occur in the period PIRUnoccupiedToOccupiedDelay, before the PIR sensor changes to its occupied state.</description>
+            </attribute>
+          </attribute-set>
+          <attribute-set id="0x0020" description="Ultrasonic configuration">
+            <attribute id="0x0020" name="Ultrasonic Occupied To Unoccupied Delay" type="u8" range="0x00,0xfe" access="rw" required="o" default="0x00">
+              <description>The UltraSonicOccupiedToUnoccupiedTime attribute specifies the time delay, in seconds, before the ultrasonic sensor changes to its occupied state when the sensed area becomes unoccupied. This attribute, along with UltraSonicUnoccupiedToOccupiedTime, may be used to reduce sensor 'chatter' when used in an area where occupation changes frequently.</description>
+            </attribute>
+            <attribute id="0x0021" name="Ultrasonic Unoccupied To Occupied Delay" type="u8" range="0x00,0xfe" access="rw" required="o" default="0x00">
+              <description>The UltraSonicUnoccupiedToOccupiedTime attribute specifies the time delay, in seconds, before the ultrasonic sensor changes to its unoccupied state when the sensed area becomes occupied.</description>
+            </attribute>
+          </attribute-set>
+          <attribute-set id="0x0030" description="Philips Specific" mfcode="0x100b">
+            <attribute id="0x0030" name="Sensitivity" type="u8" default="0" access="rw" required="o" mfcode="0x100b"></attribute>
+            <attribute id="0x0031" name="Sensitivity max." type="u8" default="0" access="rw" required="o" mfcode="0x100b"></attribute>
+          </attribute-set>
+          <attribute-set id="0xfc00" description="Develco Specific" mfcode="0x1015">
+            <attribute id="0xfc00" name="ArmThreshold_MinTemperature" type="s16" access="rw" range="0x954d,0x7ffe" required="m" mfcode="0x1015"></attribute>
+            <attribute id="0xfc01" name="ArmThreshold_MaxTemperature" type="s16" access="rw" range="0x954d,0x7ffe" required="m" mfcode="0x1015"></attribute>
+            <attribute id="0xfc02" name="Target Level" type="u16" access="rw" range="0x0002,0xfffd" required="m" mfcode="0x1015"></attribute>
+          </attribute-set>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0408" name="Soil Moisture">
+        <description></description>
+        <server>
+          <attribute-set id="0x0000" description="Soil Moisture Information">
+            <attribute id="0x0000" name="Measured Value" type="u16" access="r" default="0" required="m"></attribute>
+            <attribute id="0x0001" name="Min Measured Value" type="u16" access="r" required="m" range="0x954d,0x7ffe"></attribute>
+            <attribute id="0x0002" name="Max Measured Value" type="u16" access="r" required="m" range="0x954e,0x7ffe"></attribute>
+            <attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o" range="0x0000,0x0800"></attribute>
+          </attribute-set>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0b04" name="Electrical Measurement">
+        <description>Provides a mechanism for querying data about the electrical properties as measured by the device.</description>
+        <server>
+          <attribute-set id="0x0000" description="Basic Information">
+            <attribute id="0x0000" name="Measurement Type" type="bmp32" access="r" required="m" default="0x00000000">
+              <value name="Active measurement (AC)" value="0"></value>
+              <value name="Reactive measurement (AC)" value="1"></value>
+              <value name="Apparent measurement (AC)" value="2"></value>
+              <value name="Phase A measurement" value="3"></value>
+              <value name="Phase B measurement" value="4"></value>
+              <value name="Phase C measurement" value="5"></value>
+              <value name="DC measurement" value="6"></value>
+              <value name="Harmonics measurement" value="7"></value>
+              <value name="Power quality measurement" value="8"></value>
+            </attribute>
+          </attribute-set>
+          <attribute-set id="0x0300" description="AC (Non-phase Specific) Measurements">
+            <attribute id="0x0300" name="AC Frequency" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+            <attribute id="0x0304" name="Total Active Power" type="u32" access="r" required="o"></attribute>
+            <attribute id="0x0305" name="Total Reactive Power" type="u32" access="r" required="o"></attribute>
+            <attribute id="0x0306" name="Total Apparent Power" type="s32" access="r" required="o"></attribute>
+          </attribute-set>
+          <attribute-set id="0x0400" description="AC (Non-phase Specific) Formatting">
+            <attribute id="0x0402" name="Power Multiplier" type="u32" access="r" required="o" default="0x000001"></attribute>
+            <attribute id="0x0403" name="Power Divisor" type="u32" access="r" required="o" default="0x000001"></attribute>
+          </attribute-set>
+          <attribute-set id="0x0500" description="AC (Single Phase or Phase A) Measurements">
+            <attribute id="0x0505" name="RMS Voltage" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+            <attribute id="0x0508" name="RMS Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+            <attribute id="0x050a" name="Max Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+            <attribute id="0x050b" name="Active Power" type="s16" access="r" required="o" default="0x8000">
+              <description>Represents the single phase or Phase A, current demand of active power delivered or received at the premises, in Watts (W). Positive values indicate power delivered to the premises where negative values indicate power received from the premises.</description>
+            </attribute>
+            <attribute id="0x050e" name="Reactive Power" type="s16" access="r" required="o" default="0x8000"></attribute>
+            <attribute id="0x050f" name="Apparent Power" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+            <attribute id="0x0510" name="Power Factor" type="s8" access="r" required="o" default="0x00"></attribute>
+          </attribute-set>
+          <attribute-set id="0x0600" description="AC Formatting">
+            <attribute id="0x0600" name="AC Voltage Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
+            <attribute id="0x0601" name="AC Voltage Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
+            <attribute id="0x0602" name="AC Current Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
+            <attribute id="0x0603" name="AC Current Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
+            <attribute id="0x0604" name="AC Power Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
+            <attribute id="0x0605" name="AC Power Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
+          </attribute-set>
+          <attribute-set id="0x0900" description="AC (Phase B) Measurements">
+            <attribute id="0x0905" name="RMS Voltage" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+            <attribute id="0x0908" name="RMS Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+            <attribute id="0x090a" name="Max Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+            <attribute id="0x090f" name="RMS Power" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+          </attribute-set>
+          <attribute-set id="0x0a00" description="AC (Phase C) Measurements">
+            <attribute id="0x0a05" name="RMS Voltage" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+            <attribute id="0x0a08" name="RMS Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+            <attribute id="0x0a0a" name="Max Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+            <attribute id="0x0a0f" name="RMS Power" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+          </attribute-set>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0b05" name="Diagnostics">
+        <description>The diagnostics cluster provides access to information regarding the operation of the ZigBee stack over time.</description>
+        <server>
+          <attribute-set id="0x0000" description="Hardware Information">
+            <attribute id="0x0000" name="Number of Resets" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x0001" name="Persistens Memory Writes" type="u16" access="r" required="o" default="0x0000"></attribute>
+          </attribute-set>
+          <attribute-set id="0x0100" description="Stack/Network Information">
+            <attribute id="0x0100" name="Mac Rx Bcast" type="u32" access="r" required="o" default="0x00000000"></attribute>
+            <attribute id="0x0101" name="Mac Tx Bcast" type="u32" access="r" required="o" default="0x00000000"></attribute>
+            <attribute id="0x0102" name="Mac Rx Ucast" type="u32" access="r" required="o" default="0x00000000"></attribute>
+            <attribute id="0x0103" name="Mac Tx Ucast" type="u32" access="r" required="o" default="0x00000000"></attribute>
+            <attribute id="0x0104" name="Mac Tx Ucast Retry" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x0105" name="Mac Tx Ucast Fail" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x0106" name="APS Rx Bcast" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x0107" name="APS Tx Bcast" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x0108" name="APS Rx Ucast" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x0109" name="APS Tx Ucast Success" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x010a" name="APS Tx Ucast Retry" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x010b" name="APS Tx Ucast Fail" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x010c" name="Route Disc Initiated" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x010d" name="Neighbor Added" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x010e" name="Neighbor Removed" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x010f" name="Neighbor Stale" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x0110" name="Join Indication" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x0111" name="Child Moved" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x0112" name="NWK FC Failure" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x0113" name="APS FC Failure" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x0114" name="APS Unauthorized Key" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x0115" name="NWK Decrypt Failures" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x0116" name="APS Decrypt Failures" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x0117" name="Packet Buffer Alloc Failures" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x0118" name="Relayed Ucast" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x0119" name="Phy to MAC queue limit reached" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x011a" name="Packet Validate Dropcount" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x011b" name="Avg MAC Retry per APS Msg Sent" type="u16" access="r" required="o" default="0x0000"></attribute>
+            <attribute id="0x011c" name="Last Message LQI" type="u8" access="r" required="o" default="0x00"></attribute>
+            <attribute id="0x011d" name="Last Message RSSI" type="s8" access="r" required="o" default="0x00"></attribute>
+          </attribute-set>
+          <attribute-set id="0x4000" description="Vendor specific attributes">
+            <attribute id="0x4000" name="SW error code" type="bmp16" access="rw" default="0" required="o" mfcode="0x1246"></attribute>
+          </attribute-set>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0500" name="IAS Zone">
+        <description>The IAS Zone cluster defines an interface to the functionality of an IAS security zone device. IAS Zone supports up totwo alarm types per zone, low battery reports and supervision of the IAS network.</description>
+        <server>
+          <attribute-set id="0x0000" description="Zone information">
+            <attribute id="0x0000" name="Zone State" type="enum8" range="0x00,0x01" access="r" required="m">
+              <value name="Not enrolled" value="0x00"></value>
+              <value name="Enrolled" value="0x01"><description>The client will react to Zone
+                State Change Notification commands from the server.</description></value>
+            </attribute>
+            <attribute id="0x0001" name="Zone Type" type="enum16" range="0x0000,0xffff" access="r" required="m">
+              <value name="Standard CIE" value="0x0000"></value>
+              <value name="Motion sensor" value="0x000d"></value>
+              <value name="Contact switch" value="0x0015"></value>
+              <value name="Fire sensor" value="0x0028"></value>
+              <value name="Water sensor" value="0x002a"></value>
+              <value name="Carbon Monoxide (CO) sensor" value="0x002b"></value>
+              <value name="Personal emergency device" value="0x002c"></value>
+              <value name="Vibration / Movement sensor" value="0x002d"></value>
+              <value name="Remote Control" value="0x010f"></value>
+              <value name="Key fob" value="0x0115"></value>
+              <value name="Keypad" value="0x021d"></value>
+              <value name="Standard Warning Device" value="0x0225"></value>
+              <value name="Glass break sensor" value="0x0226"></value>
+              <value name="Security repeater" value="0x0229"></value>
+              <value name="Manufacturer specific" value="0x8000"></value>
+              <value name="Invalid Zone Type" value="0xffff"></value>
+            </attribute>
+            <attribute id="0x0002" type="bmp16" name="Zone Status" access="r" required="m">
+              <value name="Alarm 1" value="0"></value>
+              <value name="Alarm 2" value="1"></value>
+              <value name="Tamper" value="2"></value>
+              <value name="Battery" value="3"></value>
+              <value name="Supervision reports" value="4"></value>
+              <value name="Restore reports" value="5"></value>
+              <value name="Trouble" value="6"></value>
+              <value name="AC (mains)" value="7"></value>
+              <value name="Test" value="8"></value>
+              <value name="Battery defect" value="9"></value>
+            </attribute>
+          </attribute-set>
+          <attribute-set id="0x0010" description="Zone settings">
+            <attribute id="0x0010" name="IAS_CIE_Address" type="uid" access="rw" required="o" default="0"></attribute>
+            <attribute id="0x0011" name="Zone ID" type="u8" range="0x00,0xff" access="r" required="m"></attribute>
+          </attribute-set>
+          <attribute-set id="0x8000" description="Develco specific" mfcode="0x1015">
+            <attribute id="0x8000" name="Zone Status Interval" type="u16" access="rw" required="o" mfcode="0x1015"></attribute>
+            <attribute id="0x8001" name="Alarm Off Delay" type="u16" access="rw" required="o" mfcode="0x1015"></attribute>
+          </attribute-set>
+          <attribute-set id="0xf000" description="Xiaomi specific" mfcode="0x1037">
+            <attribute id="0xfff0" name="Device config" type="u64" access="r" required="o" mfcode="0x115f"></attribute>
+          </attribute-set>
+          <command id="0x00" dir="recv" name="Zone Enroll Response" required="m">
+            <payload>
+              <attribute id="0x00" type="enum8" name="Enroll response code" required="m">
+                <value name="Success" value="0x00"></value>
+                <value name="Not supported" value="0x01"></value>
+                <value name="No enroll permit" value="0x02"></value>
+                <value name="Too many zones" value="0x03"></value>
+              </attribute>
+              <attribute id="0x01" type="u8" name="Zone ID" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="0x01" dir="recv" name="Initiate Normal Operation Mode" required="o">
+            <payload>
+            </payload>
+          </command>
+          <command id="0x00" dir="send" name="Zone Status Change Notification" required="m">
+            <payload>
+              <attribute id="0x00" type="bmp16" name="Zone Status" required="m">
+                <value name="Alarm 1" value="0"></value>
+                <value name="Alarm 2" value="1"></value>
+                <value name="Tamper" value="2"></value>
+                <value name="Battery" value="3"></value>
+                <value name="Supervision reports" value="4"></value>
+                <value name="Restore reports" value="5"></value>
+                <value name="Trouble" value="6"></value>
+                <value name="AC (mains)" value="7"></value>
+                <value name="Test" value="8"></value>
+                <value name="Battery defect" value="9"></value>
+              </attribute>
+              <attribute id="0x01" type="bmp8" name="Extended Status" default="0x00" required="m"></attribute>
+              <attribute id="0x02" type="u8" name="Zone ID" required="m"></attribute>
+              <attribute id="0x03" type="u16" name="Delay" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="0x01" dir="send" name="Zone Enroll request" required="m">
+            <payload>
+              <attribute id="0x00" type="enum16" name="Zone Status" required="m">
+                <value name="Standard CIE" value="0x0000"></value>
+                <value name="Motion sensor" value="0x000d"></value>
+                <value name="Contact switch" value="0x0015"></value>
+                <value name="Fire sensor" value="0x0028"></value>
+                <value name="Water sensor" value="0x002a"></value>
+                <value name="Gas sensor" value="0x002b"></value>
+                <value name="Personal emergency device" value="0x002c"></value>
+                <value name="Vibration / Movement sensor" value="0x002d"></value>
+                <value name="Remote Control" value="0x010f"></value>
+                <value name="Key fob" value="0x0115"></value>
+                <value name="Keypad" value="0x021d"></value>
+                <value name="Standard Warning Device" value="0x0225"></value>
+                <value name="Invalid Zone Type" value="0xffff"></value>
+              </attribute>
+              <attribute id="0x01" type="u16" name="Manufacturer Code" required="m"></attribute>
+            </payload>
+          </command>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0501" name="IAS ACE">
+        <description>The IAS ACE cluster defines an interface to the functionality of any Ancillary Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE device can access a IAS CIE device and manipulate the IAS system, on behalf of a level-2 user.</description>
+        <server>
+          <attribute></attribute>
+          <command id="0x00" dir="recv" name="Arm" required="m">
+            <payload>
+              <attribute id="0x00" type="enum8" name="Arm Mode" required="m">
+                <value name="Disarm" value="0x00"></value>
+                <value name="Arm Day/Home Zones Only" value="0x01"></value>
+                <value name="Arm Night/Sleep Zones Only" value="0x02"></value>
+                <value name="Arm All Zones" value="0x03"></value>
+              </attribute>
+              <attribute id="0x01" type="cstring" name="Arm/Disarm Code" required="m"></attribute>
+              <attribute id="0x02" type="u8" name="Zone ID" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="0x01" dir="recv" name="Bypass" required="m">
+            <payload>
+              <attribute id="0x00" type="u8" name="Number of Zones" required="m"></attribute>
+              <attribute id="0x01" type="u8" name="Zone ID" required="m"></attribute>
+              <attribute id="0x02" type="cstring" name="Arm/Disarm Code" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="0x02" dir="recv" name="Emergency" required="m">
+          </command>
+          <command id="0x03" dir="recv" name="Fire" required="m">
+          </command>
+          <command id="0x04" dir="recv" name="Panic" required="m">
+          </command>
+          <command id="0x05" dir="recv" name="Get Zone ID Map" required="m">
+          </command>
+          <command id="0x06" dir="recv" name="Get Zone Information" required="m">
+            <payload>
+              <attribute id="0x00" type="u8" name="Zone ID" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="0x07" dir="recv" name="Get Panel Status" required="m">
+          </command>
+          <command id="0x08" dir="recv" name="Get Bypassed Zone List" required="m">
+          </command>
+          <command id="0x09" dir="recv" name="Get Zone Status" required="m">
+            <payload>
+              <attribute id="0x00" type="u8" name="Starting Zone ID" required="m"></attribute>
+              <attribute id="0x01" type="u8" name="Max Number of Zone IDs" required="m"></attribute>
+              <attribute id="0x02" type="bool" name="Zone Status Mask Flag" required="m"></attribute>
+              <attribute id="0x03" type="bmp16" name="Zone Status Mask" required="m"></attribute>
+              <!--More to do here!!!-->
+            </payload>
+          </command>
+        </server>
+        <client>
+          <command id="0x00" dir="recv" name="Arm Response" required="m">
+            <payload>
+              <attribute id="0x00" type="enum8" name="Arm Notification" required="m">
+                <value name="All Zones Disarmed" value="0x00"></value>
+                <value name="Only Day/Home Zones Armed" value="0x01"></value>
+                <value name="Only Night/Sleep Zones Armed" value="0x02"></value>
+                <value name="All Zones Armed" value="0x03"></value>
+                <value name="Invalid Arm/Disarm Code" value="0x04"></value>
+                <value name="Not ready to arm" value="0x05"></value>
+                <value name="Already disarmed" value="0x06"></value>
+              </attribute>
+              <attribute id="0x01" type="cstring" name="Arm/Disarm Code" required="m"></attribute>
+              <attribute id="0x02" type="u8" name="Zone ID" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="0x01" dir="recv" name="Get Zone ID Map Response" required="m">
+            <payload>
+              <attribute id="0x00" type="bmp16" name="Zone ID Map section 0" required="m"></attribute>
+              <!--More to do here!!!-->
+            </payload>
+          </command>
+          <command id="0x02" dir="recv" name="Get Zone Information Response" required="m">
+            <payload>
+              <attribute id="0x00" type="u8" name="Zone ID" required="m"></attribute>
+              <attribute id="0x01" type="enum16" name="Zone Type" required="m">
+                <value name="All Zones Disarmed" value="0x00"></value>
+                <value name="Only Day/Home Zones Armed" value="0x01"></value>
+                <value name="Only Night/Sleep Zones Armed" value="0x02"></value>
+                <value name="All Zones Armed" value="0x03"></value>
+                <value name="Invalid Arm/Disarm Code" value="0x04"></value>
+                <value name="Not ready to arm" value="0x05"></value>
+                <value name="Already disarmed" value="0x06"></value>
+              </attribute>
+              <attribute id="0x02" type="uid" name="IEEE address" required="m"></attribute>
+              <attribute id="0x03" type="cstring" name="Zone Label" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="0x03" dir="recv" name="Zone Status Changed" required="m">
+            <payload>
+              <attribute id="0x00" type="u8" name="Zone ID" required="m"></attribute>
+              <attribute id="0x01" type="enum16" name="Zone Status" required="m">
+                <!--More to do here!!!-->
+                <value name="All Zones Disarmed" value="0x00"></value>
+                <value name="Only Day/Home Zones Armed" value="0x01"></value>
+                <value name="Only Night/Sleep Zones Armed" value="0x02"></value>
+                <value name="All Zones Armed" value="0x03"></value>
+                <value name="Invalid Arm/Disarm Code" value="0x04"></value>
+                <value name="Not ready to arm" value="0x05"></value>
+                <value name="Already disarmed" value="0x06"></value>
+              </attribute>
+              <attribute id="0x02" type="enum8" name="Audible Notification" default="0x01" required="m">
+                <value name="Mute" value="0x00"></value>
+                <value name="Default sound" value="0x01"></value>
+              </attribute>
+              <attribute id="0x03" type="cstring" name="Zone Label" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="0x04" dir="recv" name="Panel Status Changed" required="m">
+            <payload>
+              <attribute id="0x00" type="enum8" name="Panel Status" required="m">
+                <value name="Panel disarmed (all zones disarmed) and ready to arm" value="0x00"></value>
+                <value name="Armed stay" value="0x01"></value>
+                <value name="Armed night" value="0x02"></value>
+                <value name="Armed away" value="0x03"></value>
+                <value name="Exit delay" value="0x04"></value>
+                <value name="Entry delay" value="0x05"></value>
+                <value name="Not ready to arm" value="0x06"></value>
+                <value name="In alarm" value="0x07"></value>
+                <value name="Arming stay" value="0x08"></value>
+                <value name="Arming night" value="0x09"></value>
+                <value name="Arming away" value="0x0a"></value>
+              </attribute>
+              <attribute id="0x01" type="u8" name="Seconds Remaining" default="0x00" required="m"></attribute>
+              <attribute id="0x02" type="enum8" name="Audible Notification" default="0x01" required="m">
+                <value name="Mute" value="0x00"></value>
+                <value name="Default sound" value="0x01"></value>
+              </attribute>
+              <attribute id="0x03" type="enum8" name="Alarm Status" default="0x00" required="m">
+                <value name="No alarm" value="0x00"></value>
+                <value name="Burglar" value="0x01"></value>
+                <value name="Fire" value="0x02"></value>
+                <value name="Emergency" value="0x03"></value>
+                <value name="Police Panic" value="0x04"></value>
+                <value name="Fire Panic" value="0x05"></value>
+                <value name="Emergency Panic (i.e., medical issue)" value="0x06"></value>
+              </attribute>
+              <attribute id="0x04" type="cstring" name="Zone Label" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="0x05" dir="recv" name="Get Panel Status Response" required="m">
+            <payload>
+              <attribute id="0x00" type="enum8" name="Panel Status" required="m">
+                <value name="Panel disarmed (all zones disarmed) and ready to arm" value="0x00"></value>
+                <value name="Armed stay" value="0x01"></value>
+                <value name="Armed night" value="0x02"></value>
+                <value name="Armed away" value="0x03"></value>
+                <value name="Exit delay" value="0x04"></value>
+                <value name="Entry delay" value="0x05"></value>
+                <value name="Not ready to arm" value="0x06"></value>
+                <value name="In alarm" value="0x07"></value>
+                <value name="Arming stay" value="0x08"></value>
+                <value name="Arming night" value="0x09"></value>
+                <value name="Arming away" value="0x0a"></value>
+              </attribute>
+              <attribute id="0x01" type="u8" name="Seconds Remaining" default="0x00" required="m"></attribute>
+              <attribute id="0x02" type="enum8" name="Audible Notification" default="0x01" required="m">
+                <value name="Mute" value="0x00"></value>
+                <value name="Default sound" value="0x01"></value>
+              </attribute>
+              <attribute id="0x03" type="enum8" name="Alarm Status" default="0x00" required="m">
+                <value name="No alarm" value="0x00"></value>
+                <value name="Burglar" value="0x01"></value>
+                <value name="Fire" value="0x02"></value>
+                <value name="Emergency" value="0x03"></value>
+                <value name="Police Panic" value="0x04"></value>
+                <value name="Fire Panic" value="0x05"></value>
+                <value name="Emergency Panic (i.e., medical issue)" value="0x06"></value>
+              </attribute>
+              <attribute id="0x04" type="cstring" name="Zone Label" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="0x06" dir="recv" name="Set Bypassed Zone List" required="m">
+            <payload>
+              <attribute id="0x00" type="u8" name="Number of Zones" required="m"></attribute>
+              <attribute id="0x01" type="u8" name="Zone ID 1" required="m"></attribute>
+              <attribute id="0x02" type="u8" name="Zone ID 2" required="m"></attribute>
+              <attribute id="0x03" type="u8" name="Zone ID 3" required="m"></attribute>
+              <attribute id="0x04" type="u8" name="Zone ID 4" required="m"></attribute>
+              <attribute id="0x05" type="u8" name="Zone ID 5" required="m"></attribute>
+              <attribute id="0x06" type="u8" name="Zone ID 6" required="m"></attribute>
+              <attribute id="0x07" type="u8" name="Zone ID 7" required="m"></attribute>
+              <attribute id="0x08" type="u8" name="Zone ID 8" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="0x07" dir="recv" name="Bypass Response" required="m">
+            <payload>
+              <attribute id="0x00" type="u8" name="Number of Zones" required="m"></attribute>
+              <attribute id="0x01" type="u8" name="Bypass Result for Zone ID 1" required="m"></attribute>
+              <attribute id="0x02" type="u8" name="Bypass Result for Zone ID 2" required="m"></attribute>
+              <attribute id="0x03" type="u8" name="Bypass Result for Zone ID 3" required="m"></attribute>
+              <attribute id="0x04" type="u8" name="Bypass Result for Zone ID 4" required="m"></attribute>
+              <attribute id="0x05" type="u8" name="Bypass Result for Zone ID 5" required="m"></attribute>
+              <attribute id="0x06" type="u8" name="Bypass Result for Zone ID 6" required="m"></attribute>
+              <attribute id="0x07" type="u8" name="Bypass Result for Zone ID 7" required="m"></attribute>
+              <attribute id="0x08" type="u8" name="Bypass Result for Zone ID 8" required="m"></attribute>
+              <!--<value name="Zone bypassed" value="0x00"></value>
+              <value name="Zone not bypassed" value="0x01"></value>
+              <value name="Not allowed" value="0x02"></value>
+              <value name="Invalid Zone ID" value="0x03"></value>
+              <value name="Unknown Zone ID" value="0x04"></value>
+              <value name="Invalid Arm/Disarm Code" value="0x05"></value>-->
+            </payload>
+          </command>
+          <command id="0x08" dir="recv" name="Get Zone Status Response" required="m">
+            <payload>
+              <attribute id="0x00" type="bool" name="Zone Status Complete" required="m"></attribute>
+              <attribute id="0x01" type="u8" name="Number of Zones" required="m"></attribute>
+              <attribute id="0x02" type="u8" name="Zone ID 1" required="m"></attribute>
+              <attribute id="0x03" type="bmp16" name="Zone ID 1 Zone Status" required="m"></attribute>
+              <attribute id="0x04" type="u8" name="Zone ID 2" required="m"></attribute>
+              <attribute id="0x05" type="bmp16" name="Zone ID 2 Zone Status" required="m"></attribute>
+              <attribute id="0x06" type="u8" name="Zone ID 3" required="m"></attribute>
+              <attribute id="0x07" type="bmp16" name="Zone ID 3 Zone Status" required="m"></attribute>
+              <attribute id="0x08" type="u8" name="Zone ID 4" required="m"></attribute>
+              <attribute id="0x09" type="bmp16" name="Zone ID 4 Zone Status" required="m"></attribute>
+            </payload>
+          </command>
+        </client>
+      </cluster>
+      
+      <cluster id="0x0502" name="IAS WD">
+        <description>The IAS WD cluster provides an interface to the functionality of any Warning Device equipment of the IAS system. Using this cluster, a ZigBee enabled CIE device can access a ZigBee enabled IAS WD device and issue alarm warning indications (siren, strobe lighting, etc.) when a system alarm condition is detected.</description>
+        <server>
+          <attribute id="0x0000" name="Max Duration" type="u16" range="0x0000,0xfffe" access="rw" required="m" default="240"></attribute>
+          <command id="0x00" dir="recv" name="Start warning" required="m">
+            <payload>
+              <attribute id="0x00" type="bmp8" name="Options" required="m">
+                <value name="Siren level 0" value="0"></value>
+                <value name="Siren level 1" value="1"></value>
+                <value name="Strobe" value="2"></value>
+                <value name="Warning mode 0" value="4"></value>
+                <value name="Warning mode 1" value="5"></value>
+                <value name="Warning mode 2" value="6"></value>
+                <value name="Warning mode 3" value="7"></value>
+              </attribute>
+              <attribute id="0x01" type="u16" name="Warning duration" required="m"></attribute>
+              <attribute id="0x02" type="u8" name="Strobe duty cycle" required="m" default="0x00"></attribute>
+              <attribute id="0x00" type="enum8" name="Strobe level" required="m">
+                <value name="Low" value="0x00"></value>
+                <value name="Medium" value="0x01"></value>
+                <value name="High" value="0x02"></value>
+                <value name="Very high" value="0x03"></value>
+              </attribute>
+            </payload>
+          </command>
+          <command id="0x01" dir="recv" name="Squawk" required="m">
+            <payload>
+              <attribute id="0x00" type="bmp8" name="Options" required="m">
+                <value name="Sqawk level 0" value="0"></value>
+                <value name="Sqawk level 1" value="1"></value>
+                <value name="Strobe" value="3"></value>
+                <value name="Sound for disarmed" value="4"></value>
+              </attribute>
+            </payload>
+          </command>
+        </server>
+        <client>
+        </client>
+      </cluster>
+    </domain>
+    
+    <domain name="Security and safety" low_bound="0500" high_bound="05ff" description="The security and safety functional domain contains clusters and information to build devices in the security and safety domain, e.g. alarm units.">
+    </domain>
+    
+    <domain name="Protocol interfaces" low_bound="0600" high_bound="06ff" description="The protocol interfaces functional domain contains clusters and information to build devices to interface to other protocols, e.g. BACnet.">
+    </domain>
+    
+    <domain name="Smart energy" low_bound="0700" high_bound="07ff" description="TODO Smart Energy Description">
+      <cluster id="0x0700" name="Price">
+        <description>The Price Cluster provides the mechanism for communicating Gas, Energy, or Water pricing information within the premise. This pricing information is distributed to the ESP from either the utilities or from regional energy providers.</description>
+        <server>
+          <attribute id="0000" name="Tier1 Price Label" type="ostring" access="rw" required="o" range="0,12" default="Tier1"></attribute>
+          <attribute id="0001" name="Tier2 Price Label" type="ostring" access="rw" required="o" range="0,12" default="Tier2"></attribute>
+          <attribute id="0002" name="Tier3 Price Label" type="ostring" access="rw" required="o" range="0,12" default="Tier3"></attribute>
+          <attribute id="0003" name="Tier4 Price Label" type="ostring" access="rw" required="o" range="0,12" default="Tier4"></attribute>
+          <attribute id="0004" name="Tier5 Price Label" type="ostring" access="rw" required="o" range="0,12" default="Tier5"></attribute>
+          <attribute id="0005" name="Tier6 Price Label" type="ostring" access="rw" required="o" range="0,12" default="Tier6"></attribute>
+          <command id="00" dir="recv" name="Get Current Price" required="m">
+            <payload>
+              <attribute id="0x0000" type="bmp8" name="Command Options" required="m">
+                <value name="Requestor Rx On When Idle" value="0x00"/>
+              </attribute>
+            </payload>
+          </command>
+          <command id="01" dir="recv" name="Get Scheduled Prices" required="o">
+            <payload>
+              <attribute id="0x0000" type="utc" name="Start Time" required="m"></attribute>
+              <attribute id="0x0001" type="u8" name="Number of Events" required="m"></attribute>
+            </payload>
+          </command>
+        </server>
+        <client>
+          <!-- TODO -->
+        </client>
+      </cluster>
+      
+      <cluster id="0x0701" name="Demand Response and Load Control">
+        <description>This cluster provides an interface to the functionality of Smart Energy Demand Response and Load Control. Devices targeted by this cluster include thermostats and devices that support load control.</description>
+        <client>
+          <attribute id="0000" name="Utility Enrolment Group" type="u8" access="rw" default="0" range="0x00,0xff" required="m"></attribute>
+          <attribute id="0001" name="Start Randomize Minutes" type="u8" access="rw" default="0x1e" range="0x00,0x3c" required="m"></attribute>
+          <attribute id="0002" name="Stop Randomize Minutes" type="u8" access="rw" default="0x1e" range="0x00,0x3c" required="m"></attribute>
+          <attribute id="0003" name="Device Class Value" type="u16" access="r" default="0x1e" range="0x00,0xff" required="m"></attribute>
+        </client>
+        <server>
+          <!-- TODO -->
+        </server>
+      </cluster>
+      
+      <cluster id="0x0702" name="Simple Metering">
+        <description>The Simple Metering Cluster provides a mechanism to retrieve usage information from Electric, Gas, Water, and potentially Thermal metering devices. These
+          devices can operate on either battery or mains power, and can have a wide variety of sophistication.</description>
+        <server>
+          <attribute-set id="0x0000" description="Reading Information Set">
+            <attribute id="0x0000" name="Current Summation Delivered" type="u48" access="r" required="m"></attribute>
+            <attribute id="0x0001" name="Current Summation Received" type="u48" access="r" required="o"></attribute>
+            <attribute id="0x041b" name="Unknown" type="u64" access="rw" required="o" mfcode="0x1037"></attribute>
+            <!-- TODO -->
+          </attribute-set>
+          <attribute-set id="0x0100" description="TOU Information Set">
+            <attribute id="0x0100" name="Index HCHC/EJPHN/BBRHCJB, Current Summation Delivered (1)" type="u48" access="r" required="m"></attribute>
+            <attribute id="0x0102" name="Index HCHP/EJPHPM/BBRHPJB, Current Summation Delivered(2)" type="u48" access="r" required="m"></attribute>
+            <!-- TODO -->
+          </attribute-set>
+          <attribute-set id="0x0200" description="Meter Status">
+            <attribute id="0x0200" name="Status" type="bmp8" default="00000000" access="r" required="m">
+              <value name="Check Meter" value="0"></value>
+              <value name="Low Battery" value="1"></value>
+              <value name="Tamper Detect" value="2"></value>
+              <value name="Power Failure" value="3"></value>
+              <value name="Power Quality" value="4"></value>
+              <value name="Leak Detect" value="5"></value>
+              <value name="Service Disconnect Open" value="6"></value>
+            </attribute>
+          </attribute-set>
+          <attribute-set id="0x0300" description="Formatting">
+            <attribute id="0x0300" name="Unit of Measure" type="enum8" default="0" access="r" required="m">
+              <value name="kW &amp; kWh binary" value="0"></value>
+              <value name="m³ &amp; m³/h binary" value="1"></value>
+              <value name="ft³ &amp; ft³/h binary" value="2"></value>
+              <value name="ccf &amp; ccf/h binary" value="3"></value>
+              <value name="US gl &amp; Us gl/h binary" value="4"></value>
+              <value name="IMP gl &amp; IMP gl/h binary" value="5"></value>
+              <value name="BTUs &amp; BTU/h binary" value="6"></value>
+              <value name="Liters &amp; l/h binary" value="7"></value>
+              <value name="kPA(gauge) binary" value="8"></value>
+              <value name="kPA(absolute) binary" value="9"></value>
+              
+              <value name="kW &amp; kWh BCD" value="80"></value>
+              <value name="m³ &amp; m³/h BCD" value="81"></value>
+              <value name="ft³ &amp; ft³/h BCD" value="82"></value>
+              <value name="ccf &amp; ccf/h BCD" value="83"></value>
+              <value name="US gl &amp; Us gl/h BCD" value="84"></value>
+              <value name="IMP gl &amp; IMP gl/h BCD" value="85"></value>
+              <value name="BTUs &amp; BTU/h BCD" value="86"></value>
+              <value name="Liters &amp; l/h BCD" value="87"></value>
+              <value name="kPA(gauge) BCD" value="88"></value>
+              <value name="kPA(absolute) BCD" value="89"></value>
+            </attribute>
+            <attribute id="0x0301" name="Multiplier" type="u24" access="r" required="o"></attribute>
+            <attribute id="0x0302" name="Divisor" type="u24" access="r" required="o"></attribute>
+            <attribute id="0x0303" name="Summation Formatting" type="bmp8" access="r" required="m">
+              <value name="Number Digits Right" description="Number of Digets to the right of the Decimal Point" value="0,2"></value>
+              <value name="Number Digits Left" description="Number of Digets to the left of the Decimal Point" value="3,6"></value>
+              <value name="Suppress Leading Zeros" value="7"></value>
+            </attribute>
+            <attribute id="0x0304" name="Demand Formatting" type="bmp8" access="r" required="o">
+              <value name="Number Digits Right" description="Number of Digets to the right of the Decimal Point" value="0,2"></value>
+              <value name="Number Digits Left" description="Number of Digets to the left of the Decimal Point" value="3,6"></value>
+              <value name="Suppress Leading Zeros" value="7"></value>
+            </attribute>
+            <!-- TODO -->
+            <attribute id="0x0306" name="Metering Device Type" type="enum8" access="r" required="m">
+              <value name="Electric Metering" value="0"></value>
+              <value name="Gas Metering" value="1"></value>
+              <value name="Water Metering" value="2"></value>
+              <value name="Thermal Metering" value="3"></value>
+              <value name="Pressure Metering" value="4"></value>
+              <value name="Heat Metering" value="5"></value>
+              <value name="Cooling Metering" value="6"></value>
+              
+              <value name="Mirrored Gas Metering" value="128"></value>
+              <value name="Mirrored Water Metering" value="129"></value>
+              <value name="Mirrored Thermal Metering" value="130"></value>
+              <value name="Mirrored Pressure Metering" value="131"></value>
+              <value name="Mirrored Heat Metering" value="132"></value>
+              <value name="Mirrored Cooling Metering" value="133"></value>
+            </attribute>
+            <attribute id="0x0308" name="Meter Serial Number" type="ostring" range="0,24" access="r" required="o"></attribute>
+            <!-- TODO -->
+          </attribute-set>
+          <attribute-set id="0x0300" description="Develco specific" mfcode="0x1015">
+            <attribute id="0x0300" name="Pulse Configuration" type="u16" access="rw" required="o" mfcode="0x1015"></attribute>
+            <attribute id="0x0301" name="Current Summation" type="u48" access="w" required="o" mfcode="0x1015"></attribute>
+            <attribute id="0x0302" name="Interface Mode" type="enum16" access="rw" required="o" mfcode="0x1015">
+              <value name="Pulse Counting on an Electricity Meter – Unit KWh" value="0x0000"></value>
+              <value name="Pulse Counting on a Gas Meter – Unit m3" value="0x0001"></value>
+              <value name="Pulse Counting on a Water Meter – Unit m3" value="0x0002"></value>
+              <value name="Kamstrup KMP Protocol" value="0x0100"></value>
+              <value name="Not Supported - Linky Protocol" value="0x0101"></value>
+              <value name="DLMS-COSEM - IEC62056-21 mod A" value="0x0102"></value>
+              <value name="P1 Dutch Standard – DSMR 2.3 Version" value="0x0103"></value>
+              <value name="P1 Dutch Standard – DSMR 4.0 Version" value="0x0104"></value>
+            </attribute>
+          </attribute-set>
+          <attribute-set id="0x0400" description="ESP Historical Consumption">
+            <attribute id="0x0400" name="Instantaneous Demand" type="s24" access="r" required="o"></attribute>
+          </attribute-set>
+          <attribute-set id="0x0500" description="Load Profile Configuration">
+          </attribute-set>
+          <attribute-set id="0x0600" description="Supply Limit">
+          </attribute-set>
+          <!-- TODO -->
+          <!-- dont support generated commands yet
+          <command id="01" dir="send" name="Get Profile Response" required="o">
           <payload>
-            <attribute id="0x0000" type="enum8" name="Number of Transtions for Sequence" required="m">
-              <value name="0" value="0"></value>
-              <value name="1" value="1"></value>
-              <value name="2" value="2"></value>
-              <value name="3" value="3"></value>
-              <value name="4" value="4"></value>
-              <value name="5" value="5"></value>
-              <value name="6" value="6"></value>
-              <value name="7" value="7"></value>
-              <value name="8" value="8"></value>
-              <value name="9" value="9"></value>
-              <value name="10" value="10"></value>
-            </attribute>
-            <attribute id="0x0001" type="bmp8" name="Day of Week for Sequence" required="m">
-              <value name="Sunday" value="0"></value>
-              <value name="Monday" value="1"></value>
-              <value name="Tuesday" value="2"></value>
-              <value name="Wednesday" value="3"></value>
-              <value name="Thursday" value="4"></value>
-              <value name="Friday" value="5"></value>
-              <value name="Saturday" value="6"></value>
-              <value name="Vacation or Away" value="7"></value>
-            </attribute>
-            <attribute id="0x0002" type="bmp8" name="Mode for Sequence" required="m">
-              <value name="Heat Setpoint Field Present in Payload" value="0"></value>
-              <value name="Cool Setpoint Field Present in Payload" value="1"></value>
-            </attribute>
-            <attribute id="0x0003" type="u16" name="Transition Time 1" required="o"/>
-            <attribute id="0x0004" type="s16" name="Heat Set Point 1" required="o"/>
-            <attribute id="0x0005" type="u16" name="Transition Time 2" required="o"/>
-            <attribute id="0x0006" type="s16" name="Heat Set Point 2" required="o"/>
-            <attribute id="0x0007" type="u16" name="Transition Time 3" required="o"/>
-            <attribute id="0x0008" type="s16" name="Heat Set Point 3" required="o"/>
-            <attribute id="0x0009" type="u16" name="Transition Time 4" required="o"/>
-            <attribute id="0x000A" type="s16" name="Heat Set Point 4" required="o"/>
-            <attribute id="0x000B" type="u16" name="Transition Time 5" required="o"/>
-            <attribute id="0x000C" type="s16" name="Heat Set Point 5" required="o"/>
-            <attribute id="0x000D" type="u16" name="Transition Time 6" required="o"/>
-            <attribute id="0x000E" type="s16" name="Heat Set Point 6" required="o"/>
-            <attribute id="0x000F" type="u16" name="Transition Time 7" required="o"/>
-            <attribute id="0x0010" type="s16" name="Heat Set Point 7" required="o"/>
-            <attribute id="0x0011" type="u16" name="Transition Time 8" required="o"/>
-            <attribute id="0x0012" type="s16" name="Heat Set Point 8" required="o"/>
-            <attribute id="0x0013" type="u16" name="Transition Time 9" required="o"/>
-            <attribute id="0x0014" type="s16" name="Heat Set Point 9" required="o"/>
-            <attribute id="0x0015" type="u16" name="Transition Time 10" required="o"/>
-            <attribute id="0x0016" type="s16" name="Heat Set Point 10" required="o"/>
+          <field type="utc" name="End Time">
+          </field>
+          <field type="enum8" name="Status">
+          <value name="Success" value="0x00"/>
+          <value name="Undefined Interval Channel requested" value="0x01"/>
+          <value name="Interval Channel not supported" value="0x02"/>
+          <value name="Invalid End Time" value="0x03"/>
+          <value name="More periods requested then can be returned" value="0x04"/>
+          <value name="No intervals available for the requested time" value="0x05"/>
+          </field>
+          <field type="enum8" name="Profile Interval Period">
+          <value name="Daily" value="0"/>
+          <value name="60 minutes" value="1"/>
+          <value name="30 minutes" value="2"/>
+          <value name="15 minutes" value="3"/>
+          <value name="10 minutes" value="4"/>
+          <value name="7.5 minutes" value="5"/>
+          <value name="5 minutes" value="6"/>
+          <value name="2.5 minutes" value="7"/>
+          </field>
+          <field type="u8" name="Number Of Periods Delivered">
+          </field>
+          <field type="u24" name="Intervals" list="true">
+          </field>
           </payload>
-        </command>
-        <command id="0x02" dir="recv" name="Get Weekly Schedule" required="o" response="0x00">
-          <payload>
-            <attribute id="0x0000" type="bmp8" name="Days to Return" required="m">
-              <value name="Sunday" value="0"></value>
-              <value name="Monday" value="1"></value>
-              <value name="Tuesday" value="2"></value>
-              <value name="Wednesday" value="3"></value>
-              <value name="Thursday" value="4"></value>
-              <value name="Friday" value="5"></value>
-              <value name="Saturday" value="6"></value>
-              <value name="Vacation or Away" value="7"></value>
-            </attribute>
-            <attribute id="0x0001" type="bmp8" name="Mode to Return" required="m">
-              <value name="Heat Setpoint Field Present in Payload" value="0"></value>
-              <value name="Cool Setpoint Field Present in Payload" value="1"></value>
-            </attribute>
-          </payload>
-        </command>
-        <command id="0x03" dir="recv" name="Clear Weekly Schedule" required="o">
-        </command>
-        <command id="0x04" dir="recv" name="Get Relay Status Log" required="o">
-        </command>
-      </server>
-      <client>
-        <command id="0x00" dir="recv" name="Get Weekly Schedule Response" required="o">
-          <payload>
-            <attribute id="0x0000" type="enum8" name="Number of Transtions for Sequence" required="m">
-              <value name="0" value="0"></value>
-              <value name="1" value="1"></value>
-              <value name="2" value="2"></value>
-              <value name="3" value="3"></value>
-              <value name="4" value="4"></value>
-              <value name="5" value="5"></value>
-              <value name="6" value="6"></value>
-              <value name="7" value="7"></value>
-              <value name="8" value="8"></value>
-              <value name="9" value="9"></value>
-              <value name="10" value="10"></value>
-            </attribute>
-            <attribute id="0x0001" type="bmp8" name="Day of Week for Sequence" required="m">
-              <value name="Sunday" value="0"></value>
-              <value name="Monday" value="1"></value>
-              <value name="Tuesday" value="2"></value>
-              <value name="Wednesday" value="3"></value>
-              <value name="Thursday" value="4"></value>
-              <value name="Friday" value="5"></value>
-              <value name="Saturday" value="6"></value>
-              <value name="Vacation or Away" value="7"></value>
-            </attribute>
-            <attribute id="0x0002" type="bmp8" name="Mode for Sequence" required="m">
-              <value name="Heat Setpoint Field Present in Payload" value="0"></value>
-              <value name="Cool Setpoint Field Present in Payload" value="1"></value>
-            </attribute>
-            <attribute id="0x0003" type="u16" name="Transition Time 1" required="o"/>
-            <attribute id="0x0004" type="s16" name="Heat Set Point 1" required="o"/>
-            <attribute id="0x0005" type="u16" name="Transition Time 2" required="o"/>
-            <attribute id="0x0006" type="s16" name="Heat Set Point 2" required="o"/>
-            <attribute id="0x0007" type="u16" name="Transition Time 3" required="o"/>
-            <attribute id="0x0008" type="s16" name="Heat Set Point 3" required="o"/>
-            <attribute id="0x0009" type="u16" name="Transition Time 4" required="o"/>
-            <attribute id="0x000A" type="s16" name="Heat Set Point 4" required="o"/>
-            <attribute id="0x000B" type="u16" name="Transition Time 5" required="o"/>
-            <attribute id="0x000C" type="s16" name="Heat Set Point 5" required="o"/>
-            <attribute id="0x000D" type="u16" name="Transition Time 6" required="o"/>
-            <attribute id="0x000E" type="s16" name="Heat Set Point 6" required="o"/>
-            <attribute id="0x000F" type="u16" name="Transition Time 7" required="o"/>
-            <attribute id="0x0010" type="s16" name="Heat Set Point 7" required="o"/>
-            <attribute id="0x0011" type="u16" name="Transition Time 8" required="o"/>
-            <attribute id="0x0012" type="s16" name="Heat Set Point 8" required="o"/>
-            <attribute id="0x0013" type="u16" name="Transition Time 9" required="o"/>
-            <attribute id="0x0014" type="s16" name="Heat Set Point 9" required="o"/>
-            <attribute id="0x0015" type="u16" name="Transition Time 10" required="o"/>
-            <attribute id="0x0016" type="s16" name="Heat Set Point 10" required="o"/>
-          </payload>
-        </command>
-			</client>
-		</cluster>
-		<cluster id="0x0202" name="Fan Control">
-			<description>This cluster specifies an interface to control the speed of a fan as part of a heating / cooling system.</description>
-			<server>
-				<attribute id="0x0000" name="Fan Mode" type="enum8" access="rw" default="0x05" required="m">
-					<value name="Off" value="0x00"></value>
-					<value name="Low" value="0x01"></value>
-					<value name="Medium" value="0x02"></value>
-					<value name="High" value="0x03"></value>
-					<value name="On" value="0x04"></value>
-					<value name="Auto" value="0x05"></value>
-					<value name="Smart" value="0x06"></value>
-				</attribute>
-				<attribute id="0x0001" name="Fan Mode Sequence" type="enum8" access="rw" default="0x02" required="m">
-					<value name="Low/Med/High" value="0x00"></value>
-					<value name="Low/High" value="0x01"></value>
-					<value name="Low/Med/High/Auto" value="0x02"></value>
-					<value name="Low/High/Auto" value="0x03"></value>
-					<value name="On/Auto" value="0x04"></value>
-				</attribute>
-			</server>
-			<client>
-			</client>
-		</cluster>
-		<cluster id="0x0203" name="Dehumidification Control">
-			<description>dfdf</description>
-			<!-- TODO -->
-		</cluster>
-		<cluster id="0x0204" name="Thermostat User Interface Configuration">
-			<description>This cluster provides an interface to allow configuration of the user interface for a thermostat, or a thermostat
-controller device, that supports a keypad and LCD screen.</description>
-			<server>
-				<attribute id="0x0000" name="Temperature Display Mode" type="enum8" access="rw" range="0x00,0x01" default="0x00" required="m">
-					<value name="Temperature in °C" value="0x00"></value>
-					<value name="Temperature in °F" value="0x01"></value>
-				</attribute>
-				<attribute id="0x0001" name="Keypad Lockout" type="enum8" access="rw" range="0x00,0x05" default="0x00" required="m">
-					<value name="No lockout" value="0x00"></value>
-					<value name="Level 1 lockout" value="0x01"></value>
-					<value name="Level 2 lockout" value="0x02"></value>
-					<value name="Level 3 lockout" value="0x03"></value>
-					<value name="Level 4 lockout" value="0x04"></value>
-					<value name="Level 5 lockout" value="0x05"></value>
-				</attribute>
-				<attribute id="0x0002" name="Schedule Programming Visibility" type="enum8" access="rw"  range="0x00,0x01" default="0x00" required="o">
-					<value name="Local schedule programming enabled" value="0x00"></value>
-					<value name="Local schedule programming disabled" value="0x01"></value>
-				</attribute>
-                <attribute id="0x4000" name="Viewing Direction" type="enum8" access="rw" range="0x00,0x01" default="0x00" required="o" mfcode="0x1246">
-					<value name="Viewing direction 1" value="0x00"></value>
-					<value name="Viewing direction 2" value="0x01"></value>
-				</attribute>
-			</server>
-			<client>
-			</client>
-		</cluster>
-		<cluster id="0xde42" name="DE Debug">
-		<description>Attributes and commands for debugging purposes.</description>
-		<server>
-			<attribute id="0x0000" name="Debug enabled" type="bool" access="rw" default="0x00" required="m"></attribute>
-			<attribute id="0x0001" name="Debug destination" type="u16" access="rw" default="0x0000" showas="hex" required="m"></attribute>
-		</server>
-		<client>
-		<!-- TODO -->
-		</client>
-	</cluster>
-	</domain>
-	<domain name="Lighting" low_bound="0300" high_bound="03ff" description="The lighting functional domain contains clusters and information to build devices in the lighting domain, e.g. ballast units.">
-	<cluster id="0x0300" name="Color control">
-		<description>Attributes and commands for controlling the color properties of a color-capable light.</description>
-		<server>
-			<attribute-set id="0x0000" description="Color Information">
-				<attribute id="0x0000" name="Current hue" type="u8" access="r" range="0x00,0xfe" default="0x00" required="o"></attribute>
-				<attribute id="0x0001" name="Current saturation" type="u8" access="r" range="0x00,0xfe" default="0x00" required="o"></attribute>
-				<attribute id="0x0002" name="Remaining time" type="u16" access="r" range="0x0000,0xfffe" default="0x0000" required="o"></attribute>
-				<attribute id="0x0003" name="Current x" type="u16" access="r" range="0x0000,0xfeff" default="0x61eb" required="m"></attribute>
-				<attribute id="0x0004" name="Current y" type="u16" access="r" range="0x0000,0xfeff" default="0x607b" required="m"></attribute>
-				<attribute id="0x0007" name="Color temperature" type="u16" access="r" range="0x0000,0xfeff" default="0" required="m"></attribute>
-				<!-- TODO -->
-				<attribute id="0x0008" name="Color Mode" type="enum8" access="r" range="0x00,0x02" default="0x01" required="o">
-					<value name="Current hue and current saturation" value="0x00"></value>
-					<value name="Current x and current y" value="0x01"></value>
-					<value name="Color temperature" value="0x02"></value>
-				</attribute>
-			</attribute-set>
-			<attribute-set id="0x0010" description="Defined Primaries Information">
-				<attribute id="0x0010" name="Number of primaries" type="u8" access="r" range="0x00,0x06" required="o"></attribute>
-				<attribute id="0x0011" name="Primary1 x" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-				<attribute id="0x0012" name="Primary1 y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-				<attribute id="0x0013" name="Primary1 intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
-				<attribute id="0x0015" name="Primary2 x" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-				<attribute id="0x0016" name="Primary2 y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-				<attribute id="0x0017" name="Primary2 intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
-				<attribute id="0x0019" name="Primary3 x" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-				<attribute id="0x001a" name="Primary3 y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-				<attribute id="0x001b" name="Primary3 intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
-      </attribute-set>
-      <attribute-set id="0x0020" description="Additional Defined Primaries Information">
-        <attribute id="0x0020" name="Primary4 x" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-				<attribute id="0x0021" name="Primary4 y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-				<attribute id="0x0022" name="Primary4 intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
-				<attribute id="0x0024" name="Primary5 x" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-				<attribute id="0x0025" name="Primary5 y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-				<attribute id="0x0026" name="Primary5 intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
-				<attribute id="0x0028" name="Primary6 x" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-				<attribute id="0x0029" name="Primary6 y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-				<attribute id="0x002a" name="Primary6 intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
-			</attribute-set>
-      <attribute-set id="0x0030" description="Defined Color Points Settings">
-        <attribute id="0x0030" name="WhitePoint x" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
-        <attribute id="0x0031" name="WhitePoint y" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
-        <attribute id="0x0032" name="ColorPoint r x" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
-        <attribute id="0x0033" name="ColorPoint r y" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
-        <attribute id="0x0034" name="ColorPoint r intensity" type="u8" access="rw" range="0x00,0xff" required="o"></attribute>
-        <attribute id="0x0036" name="ColorPoint g x" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
-        <attribute id="0x0037" name="ColorPoint g y" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
-        <attribute id="0x0038" name="ColorPoint g intensity" type="u8" access="rw" range="0x00,0xff" required="o"></attribute>
-        <attribute id="0x003a" name="ColorPoint b x" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
-        <attribute id="0x003b" name="ColorPoint b y" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
-        <attribute id="0x003c" name="ColorPoint b intensity" type="u8" access="rw" range="0x00,0xff" required="o"></attribute>
-			</attribute-set>
-			<attribute-set id="0x4000" description="ZLL extensions">
-				<attribute id="0x4000" name="Enhanced current hue" type="u16" access="r" range="0x0000,0xffff" default="0x0000" required="m"></attribute>
-				<attribute id="0x4001" name="Enhanced color mode" type="enum8" access="r" range="0x00,0xff" default="0x00" required="m">
-					<value name="Current hue and current saturation" value="0x00"></value>
-					<value name="Current x and current y" value="0x01"></value>
-					<value name="Color temperature" value="0x02"></value>
-					<value name="Enhanced current hue and current saturation" value="0x03"></value>
-				</attribute>
-				<attribute id="0x4002" name="Color loop active" type="u8" access="r" range="0x00,0xff" default="0x00" required="m"></attribute>
-				<attribute id="0x4003" name="Color loop direction" type="u8" access="r" range="0x00,0xff" default="0x00" required="m"></attribute>
-				<attribute id="0x4004" name="Color loop time" type="u16" access="r" range="0x00,0xff" default="0x0019" required="m"></attribute>
-				<attribute id="0x4005" name="Color loop start - enhanced hue" type="u16" access="r" range="0x00,0xff" default="0x2300" required="m"></attribute>
-				<attribute id="0x4006" name="Color loop stored - enhanced hue" type="u16" access="r" range="0x00,0xff" default="0x0000" required="m"></attribute>
-				<attribute id="0x400a" type="bmp16" name="Color capabilities" access="r" required="m" default="0x0000">
-					<value name="Hue saturation" value="0"></value>
-					<value name="Enhanced Hue saturation" value="1"></value>
-					<value name="Color loop" value="2"></value>
-					<value name="CIE 1931 XY" value="3"></value>
-					<value name="Color temperature" value="4"></value>
-				</attribute>
-				<attribute id="0x400b" name="Color temperature min" type="u16" access="r" range="0x0000,0xfeff" default="0" required="m"></attribute>
-				<attribute id="0x400c" name="Color temperature max" type="u16" access="r" range="0x0000,0xfeff" default="0xfeff" required="m"></attribute>
-				<attribute id="0x4010" name="PowerOn Color Temperature" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
-        <!--
-        <attribute id="0x0003" mfcode="0x100b" name="PowerOn X" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
-        <attribute id="0x0004" mfcode="0x100b" name="PowerOn Y" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
-        -->
-			</attribute-set>
-			<attribute-set id="0xde00" description="FLS extensions" mfcode="0x1135">
-				<attribute id="0xde01" name="Active channels" type="u8" access="r" range="0x00,0xff" default="0x00" required="m"></attribute>
-			</attribute-set>
-			<command id="0x00" dir="recv" name="Move to hue" required="o">
-				<payload>
-					<attribute id="0x0000" type="u8" name="Hue" required="m"></attribute>
-					<attribute id="0x0001" type="enum8" name="Direction" required="m">
-						<value name="Shortest distance" value="0x00"></value>
-						<value name="Longest Distance" value="0x01"></value>
-						<value name="Up" value="0x02"></value>
-						<value name="Down" value="0x03"></value>
-					</attribute>
-					<attribute id="0x0002" type="u16" name="Transition time" required="m">
-						<description>The transition time in 1/10ths of a second.</description>
-					</attribute>
-				</payload>
-			</command>
-			<command id="0x01" dir="recv" name="Move hue" required="o">
-				<payload>
-					<attribute id="0x0001" type="enum8" name="Move mode" required="m">
-						<value name="Stop" value="0x00"></value>
-						<value name="Up" value="0x01"></value>
-						<value name="Down" value="0x03"></value>
-					</attribute>
-					<attribute id="0x0002" type="u8" name="Steps/second" required="m"></attribute>
-				</payload>
-			</command>
-			<command id="0x02" dir="recv" name="Step hue" required="o">
-				<payload>
-					<attribute id="0x0000" type="enum8" name="Step mode" required="m">
-						<value name="Up" value="0x01"></value>
-						<value name="Down" value="0x03"></value>
-					</attribute>
-					<attribute id="0x0001" type="u8" name="Step size" required="m"></attribute>
-					<attribute id="0x0002" type="u8" name="Transition time" required="m">
-						<description>The transitiontime in 1/10 seconds.</description>
-					</attribute>
-				</payload>
-			</command>
-			<command id="0x03" dir="recv" name="Move to saturation" required="o">
-				<payload>
-					<attribute id="0x0000" type="u8" name="Saturation" required="m"></attribute>
-					<attribute id="0x0001" type="u16" name="Transition time" required="m">
-						<description>The transitiontime in 1/10 seconds.</description>
-					</attribute>
-				</payload>
-			</command>
-			<command id="0x04" dir="recv" name="Move saturation" required="o">
-				<payload>
-					<attribute id="0x0000" type="enum8" name="Move mode" required="m">
-						<value name="Stop" value="0x00"></value>
-						<value name="Up" value="0x01"></value>
-						<value name="Down" value="0x03"></value>
-					</attribute>
-					<attribute id="0x0001" type="u8" name="Rate" required="m">
-						<description>The steps per second.</description>
-					</attribute>
-				</payload>
-			</command>
-			<command id="0x05" dir="recv" name="Step saturation" required="o">
-				<payload>
-					<attribute id="0x0000" type="enum8" name="Step mode" required="m">
-						<value name="Up" value="0x01"></value>
-						<value name="Down" value="0x03"></value>
-					</attribute>
-					<attribute id="0x0001" type="u8" name="Step size" required="m"></attribute>
-					<attribute id="0x0002" type="u8" name="Transition time" required="m">
-						<description>The transitiontime in 1/10 seconds.</description>
-					</attribute>
-				</payload>
-			</command>
-			<command id="0x06" dir="recv" name="Move to hue and saturation" required="o">
-				<payload>
-					<attribute id="0x0000" type="u8" name="Hue" required="m"></attribute>
-					<attribute id="0x0001" type="u8" name="Saturation" required="m"></attribute>
-					<attribute id="0x0002" type="u16" name="Transition time" required="m">
-						<description>The transitiontime in 1/10 seconds.</description>
-					</attribute>
-				</payload>
-			</command>
-			<command id="0x07" dir="recv" name="Move to color" required="m">
-				<payload>
-					<attribute id="0x0000" type="u16" name="ColorX" required="m"></attribute>
-					<attribute id="0x0001" type="u16" name="ColorY" required="m"></attribute>
-					<attribute id="0x0002" type="u16" name="Transition time" required="m">
-						<description>The transitiontime in 1/10 seconds.</description>
-					</attribute>
-				</payload>
-			</command>
-			<command id="0x08" dir="recv" name="Move color" required="o">
-				<payload>
-					<attribute id="0x0000" type="s16" name="Rate X" required="m">
-						<description>The steps per second.</description>
-					</attribute>
-					<attribute id="0x0001" type="s16" name="Rate Y" required="m">
-						<description>The steps per second.</description>
-					</attribute>
-				</payload>
-			</command>
-			<command id="0x09" dir="recv" name="Step color" required="o">
-				<payload>
-					<attribute id="0x0000" type="s16" name="Step X" required="m"></attribute>
-					<attribute id="0x0001" type="s16" name="Step Y" required="m"></attribute>
-					<attribute id="0x0002" type="u16" name="Transition time" required="m">
-						<description>The transitiontime in 1/10 seconds.</description>
-					</attribute>
-				</payload>
-			</command>
-			<command id="0x0a" dir="recv" name="Move to color temperature" required="o">
-				<payload>
-					<attribute id="0x0000" type="u16" name="Color temperature" required="m"></attribute>
-					<attribute id="0x0001" type="u16" name="Transition time" required="m">
-						<description>The transitiontime in 1/10 seconds.</description>
-					</attribute>
-				</payload>
-			</command>
-			<command id="0x40" dir="recv" name="Enhanced move to hue" required="m">
-				<payload>
-					<attribute id="0x0000" type="u16" name="Enhanced hue" required="m"></attribute>
-					<attribute id="0x0001" type="enum8" name="Direction" required="m">
-						<value name="Shortest distance" value="0x00"></value>
-						<value name="Longest Distance" value="0x01"></value>
-						<value name="Up" value="0x02"></value>
-						<value name="Down" value="0x03"></value>
-					</attribute>
-					<attribute id="0x0002" type="u16" name="Transition time" required="m">
-						<description>The transitiontime in 1/10 seconds.</description>
-					</attribute>
-				</payload>
-			</command>
-			<command id="0x41" dir="recv" name="Enhanced move hue" required="m">
-				<payload>
-					<attribute id="0x0000" type="enum8" name="Move mode" required="m">
-						<value name="Stop" value="0x00"></value>
-						<value name="Up" value="0x01"></value>
-						<value name="Down" value="0x03"></value>
-					</attribute>
-					<attribute id="0x0001" type="u16" name="Rate" required="m">
-						<description>Steps per second.</description>
-					</attribute>
-				</payload>
-			</command>
-			<command id="0x42" dir="recv" name="Enhanced step hue" required="m">
-				<payload>
-					<attribute id="0x0000" type="enum8" name="Step mode" required="m">
-						<value name="Up" value="0x01"></value>
-						<value name="Down" value="0x03"></value>
-					</attribute>
-					<attribute id="0x0001" type="u16" name="Step size" required="m"></attribute>
-					<attribute id="0x0002" type="u16" name="Transition time" required="m">
-						<description>The transitiontime in 1/10 seconds.</description>
-					</attribute>
-				</payload>
-			</command>
-			<command id="0x43" dir="recv" name="Enhanced move to hue and saturation" required="m">
-				<payload>
-					<attribute id="0x0000" type="u16" name="Enhanced hue" required="m"></attribute>
-					<attribute id="0x0001" type="u8" name="Saturation" required="m"></attribute>
-					<attribute id="0x0002" type="u16" name="Transition time" required="m">
-						<description>The transitiontime in 1/10 seconds.</description>
-					</attribute>
-				</payload>
-			</command>
-			<command id="0x44" dir="recv" name="Color loop set" required="m">
-				<payload>
-					<attribute id="0x0000" type="bmp8" name="Update flags" required="m">
-						<value name="Update action" value="0"></value>
-						<value name="Update direction" value="1"></value>
-						<value name="Update time" value="2"></value>
-						<value name="Update start hue" value="3"></value>
-					</attribute>
-					<attribute id="0x0001" type="enum8" name="Action" required="m">
-						<value name="De-activate color loop" value="0x00"></value>
-						<value name="Activate from ColorLoopStartEnhancedHue" value="0x01"></value>
-						<value name="Activate from EnhancedCurrentHue" value="0x02"></value>
-					</attribute>
-					<attribute id="0x0002" type="enum8" name="Direction" required="m">
-						<value name="Decrement hue" value="0x00"></value>
-						<value name="Increment hue" value="0x01"></value>
-					</attribute>
-					<attribute id="0x0003" type="u16" name="Time" required="m">
-						<description>Time in seconds used for a whole color loop.</description>
-					</attribute>
-					<attribute id="0x0004" type="u16" name="Start enhanced hue" required="m"></attribute>
-				</payload>
-			</command>
-			<command id="0x47" dir="recv" name="Stop move step" required="m">
-				<description>Stops move to and step commands. It has no effect on a active color loop.</description>
-				<payload>
-				</payload>
-			</command>
-			<command id="0x4b" dir="recv" name="Move color temperature" required="m">
-				<payload>
-					<attribute id="0x0000" type="enum8" name="Move mode" required="m">
-						<value name="Stop" value="0x00"></value>
-						<value name="Up" value="0x01"></value>
-						<value name="Down" value="0x03"></value>
-					</attribute>
-					<attribute id="0x0001" type="u16" name="Rate" required="m">
-						<description>Steps per second.</description>
-					</attribute>
-					<attribute id="0x0002" type="u16" name="Color temperature min" required="m">
-						<description>Specifies a lower bound on the color temperature for the current move operation.</description>
-					</attribute>
-					<attribute id="0x0003" type="u16" name="Color temperature max" required="m">
-						<description>Specifies a upper bound on the color temperature for the current move operation.</description>
-					</attribute>
-				</payload>
-			</command>
-			<command id="0x4c" dir="recv" name="Step color temperature" required="m">
-				<payload>
-					<attribute id="0x0000" type="enum8" name="Step mode" required="m">
-						<value name="Up" value="0x01"></value>
-						<value name="Down" value="0x03"></value>
-					</attribute>
-					<attribute id="0x0001" type="u16" name="Step size" required="m"></attribute>
-					<attribute id="0x0002" type="u16" name="Transition time" required="m">
-						<description>The transitiontime in 1/10 seconds.</description>
-					</attribute>
-					<attribute id="0x0003" type="u16" name="Color temperature min" required="m">
-						<description>Specifies a lower bound on the color temperature for the current step operation.</description>
-					</attribute>
-					<attribute id="0x0004" type="u16" name="Color temperature max" required="m">
-						<description>Specifies a upper bound on the color temperature for the current step operation.</description>
-					</attribute>
-				</payload>
-			</command>
-			<command id="0xd0" dir="recv" name="Set active channels" required="m">
-				<payload>
-					<attribute id="0x00" type="u8" name="Channels" required="m"></attribute>
-				</payload>
-			</command>
-		</server>
-		<client>
-		</client>
-	</cluster>
-	<cluster id="0x0301" name="Ballast Configuration">
-		<description>Attributes and commands to configure a ballast.</description>
-		<server>
-			<attribute-set id="0x0000" description="Ballast Information">
-				<attribute id="0x0000" name="Physical Min Level" type="u8" access="r" range="0x01,0xfe" default="0x01" required="o"></attribute>
-				<attribute id="0x0001" name="Physical Max Level" type="u8" access="r" range="0x01,0xfe" default="0xfe" required="o"></attribute>
-				<attribute id="0x0002" name="Ballast Status" type="bmp8" access="r" default="0x00" required="m">
-					<value name="Non-operational" value="0"></value>
-					<value name="Lamp not in socket" value="1"></value>
-				</attribute>
-			</attribute-set>
-
-			<attribute-set id="0x0010" description="Ballast Settings">
-				<attribute id="0x0010" name="Min Level" type="u8" access="rw" range="0x01,0xfe" default="0x01" required="o"></attribute>
-				<attribute id="0x0011" name="Max Level" type="u8" access="rw" range="0x01,0xfe" default="0xfe" required="o"></attribute>
-				<attribute id="0x0012" name="Power On Level" type="u8" access="rw" range="0x01,0xfe" default="0xfe" required="o"></attribute>
-				<attribute id="0x0013" name="Power On Fade Time" type="u16" access="rw" range="0x0000,0xfffe" default="0x0000" required="o"></attribute>
-				<attribute id="0x0014" name="Intrinsic Ballast Factor" type="u8" access="rw" range="0x00,0xfe" default="0x00" required="o"></attribute>
-				<attribute id="0x0015" name="Ballast Factor Adjustment" type="u8" access="rw" range="0x64,0xff" default="0xff" required="o"></attribute>
-			</attribute-set>
-
-			<attribute-set id="0x0020" description="Lamp Information">
-				<attribute id="0x0020" name="Lamp Quantity" type="u8" access="r" range="0x00,0xfe" default="0x00" required="o"></attribute>
-			</attribute-set>
-
-			<attribute-set id="0x0030" description="Lamp Settings">
-				<attribute id="0x0030" name="Lamp Type" type="cstring" access="rw" required="o"></attribute>
-				<attribute id="0x0031" name="Lamp Manufacturer" type="cstring" access="rw" required="o"></attribute>
-				<attribute id="0x0032" name="Lamp Rated Hours" type="u24" access="rw" range="0x000000,0xfffffe" default="0xffffff" required="o"></attribute>
-				<attribute id="0x0033" name="Lamp Burn Hours" type="u24" access="rw" range="0x000000,0xfffffe" default="0x000000" required="o"></attribute>
-				<attribute id="0x0034" name="Lamp Alarm Mode" type="bmp8" access="rw" default="0x00" required="m">
-					<value name="Lamp Burn Hours" value="0"></value>
-				</attribute>
-				<attribute id="0x0035" name="Lamp Burn Hours Trip Point" type="u24" access="rw" range="0x000000,0xfffffe" default="0x000000" required="o"></attribute>
-			</attribute-set>
-		</server>
-		<client>
-		</client>
-	</cluster>
-	</domain>
-	<domain name="Measurement and sensing" low_bound="0400" high_bound="04ff" description="The measurement and sensing functional domain contains clusters and information to build devices in the measurement and sensing domain, e.g. a temperature sensor or an occupancy sensor.">
-		<cluster id="0x0400" name="Illuminance measurement">
-			<description>The server cluster provides an interface to illuminance measurement functionality, including configuration and provision of notifications of illuminance measurements.</description>
-			<!-- TODO -->
-			<server>
-				<attribute-set id="0x0000" description="Illuminance Measurement Information">
-					<attribute id="0x0000" name="Measured Value" type="u16" access="r" default="0" required="m"></attribute>
-					<attribute id="0x0001" name="Min Measured Value" type="u16" access="r" required="m" range="0x0002,0xfffd"></attribute>
-					<attribute id="0x0002" name="Max Measured Value" type="u16" access="r" required="m" range="0x0001,0x7ffe"></attribute>
-					<attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o" range="0x0000,0x0800"></attribute>
-					<attribute id="0x0004" name="Light Sensor Type" type="enum8" range="0x00,0xff" access="r" required="o">
-						<value name="Photodiode" value="0x00"></value>
-						<value name="CMOS" value="0x01"></value>
-						<value name="Unknown" value="0xff"></value>
-					</attribute>
-				</attribute-set>
-			</server>
-			<client>
-				<attribute-set id="0xf000" description="Illuminance Adjustement Configuration">
-					<attribute id="0xf000" name="Hysteresis" type="u16" access="rw" required="o"></attribute>
-					<attribute id="0xf001" name="Max Up Speed" type="u16" access="rw" required="o"><description>Maximum up adjustment speed in 1/10 seconds.</description></attribute>
-					<attribute id="0xf002" name="Max Down Speed" type="u16" access="rw" required="o"><description>Maximum down adjustment speed in 1/10 seconds.</description></attribute>
-					<attribute id="0xf003" name="Target Value" type="u16" access="rw" required="o"><description>Target value in Lux which should be kept.</description></attribute>
-					<attribute id="0xf004" name="Startup Type" type="enum8" access="rw" required="o">
-						<description>Brightness control startup type.</description>
-						<value name="Default Level" value="0x00"></value>
-						<value name="Zero Level" value="0x01"></value>
-					</attribute>
-				</attribute-set>
-			</client>
-		</cluster>
-		<cluster id="0x0401" name="Illuminance level sensing">
-			<description></description>
-			<!-- TODO -->
-		</cluster>
-		<cluster id="0x0402" name="Temperature measurement">
-			<description>The server cluster provides an interface to temperature measurement functionality, including configuration and provision  of notifications of temperature measurements.</description>
-			<!-- TODO -->
-			<server>
-				<attribute-set id="0x0000" description="Temperature Measurement Information">
-					<attribute id="0x0000" name="Measured Value" type="s16" access="r" default="0" required="m"></attribute>
-					<attribute id="0x0001" name="Min Measured Value" type="s16" access="r" required="m" range="0x954d,0x7ffe"></attribute>
-					<attribute id="0x0002" name="Max Measured Value" type="s16" access="r" required="m" range="0x954e,0x7ffe"></attribute>
-					<attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o" range="0x0000,0x0800"></attribute>
-				</attribute-set>
-			</server>
-			<client>
-			</client>
-		</cluster>
-		<cluster id="0x0403" name="Pressure measurement">
-			<description>The server cluster provides an interface to air pressure measurement functionality, including configuration and provision of notifications of air pressure measurements.</description>
-			<server>
-				<attribute-set id="0x0000" description="Pressure Measurement Information">
-					<attribute id="0x0000" name="Measured Value" type="s16" access="r" default="0" required="m"></attribute>
-					<attribute id="0x0010" name="Scaled Value" type="s16" access="r" default="0" required="o"></attribute>
-					<attribute id="0x0014" name="Scale" type="s8" access="r" required="o"></attribute>
-				</attribute-set>
-			</server>
-			<client>
-			</client>
-		</cluster>
-		<cluster id="0x0404" name="Flow measurement">
-			<description></description>
-			<!-- TODO -->
-			<server>
-			</server>
-			<client>
-			</client>
-		</cluster>
-		<cluster id="0x0405" name="Relative humidity measurement">
-			<description></description>
-			<server>
-				<attribute-set id="0x0000" description="Relative Humidity Measurement Information">
-					<attribute id="0x0000" name="Measured Value" type="u16" access="r" default="0" required="m"></attribute>
-					<attribute id="0x0001" name="Min Measured Value" type="u16" access="r" required="m" range="0x954d,0x7ffe"></attribute>
-					<attribute id="0x0002" name="Max Measured Value" type="u16" access="r" required="m" range="0x954e,0x7ffe"></attribute>
-					<attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o" range="0x0000,0x0800"></attribute>
-				</attribute-set>
-			</server>
-			<client>
-			</client>
-		</cluster>
-		<cluster id="0x0406" name="Occupancy sensing">
-			<description><!-- TODO --></description>
-			<server>
-				<attribute-set id="0x0000" description="Occupancy sensor information">
-					<attribute id="0x0000" name="Occupancy" type="bmp8" range="0000000x" access="r" required="m"></attribute>
-					<attribute id="0x0001" name="Occupancy Sensor Type" type="enum8" range="0x00,0xfe" access="r" required="m">
-						<value name="PIR" value="0x00"></value>
-						<value name="Ultrasonic" value="0x01"></value>
-						<value name="PIR and ultrasonic" value="0x02"></value>
-					</attribute>
-				</attribute-set>
-				<attribute-set id="0x0010" description="PIR configuration">
-					<attribute id="0x0010" name="PIR Occupied To Unoccupied Delay" type="u16" range="0x00,0xfffe" access="rw" required="o" default="0x00">
-						<description>The PIROccupiedToUnoccupiedDelay attribute is 16-bits in length and specifies the time delay, in seconds, before the PIR sensor changes to its occupied state when the sensed area becomes unoccupied. This attribute, along with PIRUnoccupiedToOccupiedTime, may be used to reduce sensor 'chatter' when used in an area where occupation changes frequently.</description>
-					</attribute>
-					<attribute id="0x0011" name="PIR Unoccupied To Occupied Delay" type="u16" range="0x00,0xfffe" access="rw" required="o" default="0x00">
-						<description>The PIRUnoccupiedToOccupiedDelay attribute is 16-bits in length and specifies the time delay, in seconds, before the PIR sensor changes to its unoccupied state when the sensed area becomes occupied.</description>
-					</attribute>
-					<attribute id="0x0012" name="PIR Unoccupied To Occupied Threshold" type="u8" range="0x01,0xfe" access="rw" required="o" default="0x01">
-						<description>The PIRUnoccupiedToOccupiedThreshold attribute is 8 bits in length and specifies the number of movement detection events that must occur in the period PIRUnoccupiedToOccupiedDelay, before the PIR sensor changes to its occupied state.</description>
-					</attribute>
-				</attribute-set>
-				<attribute-set id="0x0020" description="Ultrasonic configuration">
-					<attribute id="0x0020" name="Ultrasonic Occupied To Unoccupied Delay" type="u8" range="0x00,0xfe" access="rw" required="o" default="0x00">
-						<description>The UltraSonicOccupiedToUnoccupiedTime attribute specifies the time delay, in seconds, before the ultrasonic sensor changes to its occupied state when the sensed area becomes unoccupied. This attribute, along with UltraSonicUnoccupiedToOccupiedTime, may be used to reduce sensor 'chatter' when used in an area where occupation changes frequently.</description>
-					</attribute>
-					<attribute id="0x0021" name="Ultrasonic Unoccupied To Occupied Delay" type="u8" range="0x00,0xfe" access="rw" required="o" default="0x00">
-						<description>The UltraSonicUnoccupiedToOccupiedTime attribute specifies the time delay, in seconds, before the ultrasonic sensor changes to its unoccupied state when the sensed area becomes occupied.</description>
-					</attribute>
-				</attribute-set>
-				<attribute-set id="0x0030" description="Philips Specific" mfcode="0x100b">
-					<attribute id="0x0030" name="Sensitivity" type="u8" default="0" access="rw" required="o" mfcode="0x100b"></attribute>
-					<attribute id="0x0031" name="Sensitivity max." type="u8" default="0" access="rw" required="o" mfcode="0x100b"></attribute>
-				</attribute-set>
-				<attribute-set id="0xfc00" description="Develco Specific" mfcode="0x1015">
-					<attribute id="0xfc00" name="ArmThreshold_MinTemperature" type="s16" access="rw" range="0x954d,0x7ffe" required="m" mfcode="0x1015"></attribute>
-					<attribute id="0xfc01" name="ArmThreshold_MaxTemperature" type="s16" access="rw" range="0x954d,0x7ffe" required="m" mfcode="0x1015"></attribute>
-					<attribute id="0xfc02" name="Target Level" type="u16" access="rw" range="0x0002,0xfffd" required="m" mfcode="0x1015"></attribute>
-				</attribute-set>
-			</server>
-			<client>
-			</client>
-		</cluster>
-		<cluster id="0x0408" name="Soil Moisture">
-			<description></description>
-			<server>
-				<attribute-set id="0x0000" description="Soil Moisture Information">
-					<attribute id="0x0000" name="Measured Value" type="u16" access="r" default="0" required="m"></attribute>
-					<attribute id="0x0001" name="Min Measured Value" type="u16" access="r" required="m" range="0x954d,0x7ffe"></attribute>
-					<attribute id="0x0002" name="Max Measured Value" type="u16" access="r" required="m" range="0x954e,0x7ffe"></attribute>
-					<attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o" range="0x0000,0x0800"></attribute>
-				</attribute-set>
-			</server>
-			<client>
-			</client>
-		</cluster>
-	<cluster id="0x0b04" name="Electrical Measurement">
-		<description>Provides a mechanism for querying data about the electrical properties as measured by the device.</description>
-		<server>
-			<attribute-set id="0x0000" description="Basic Information">
-				<attribute id="0x0000" name="Measurement Type" type="bmp32" access="r" required="m" default="0x00000000">
-						<value name="Active measurement (AC)" value="0"></value>
-						<value name="Reactive measurement (AC)" value="1"></value>
-						<value name="Apparent measurement (AC)" value="2"></value>
-						<value name="Phase A measurement" value="3"></value>
-						<value name="Phase B measurement" value="4"></value>
-						<value name="Phase C measurement" value="5"></value>
-						<value name="DC measurement" value="6"></value>
-						<value name="Harmonics measurement" value="7"></value>
-						<value name="Power quality measurement" value="8"></value>
-				</attribute>
-			</attribute-set>
-			<attribute-set id="0x0300" description="AC (Non-phase Specific) Measurements">
-				<attribute id="0x0300" name="AC Frequency" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-				<attribute id="0x0304" name="Total Active Power" type="u32" access="r" required="o"></attribute>
-				<attribute id="0x0305" name="Total Reactive Power" type="u32" access="r" required="o"></attribute>
-				<attribute id="0x0306" name="Total Apparent Power" type="s32" access="r" required="o"></attribute>
-			</attribute-set>
-			<attribute-set id="0x0400" description="AC (Non-phase Specific) Formatting">
-				<attribute id="0x0402" name="Power Multiplier" type="u32" access="r" required="o" default="0x000001"></attribute>
-				<attribute id="0x0403" name="Power Divisor" type="u32" access="r" required="o" default="0x000001"></attribute>
-			</attribute-set>
-			<attribute-set id="0x0500" description="AC (Single Phase or Phase A) Measurements">
-				<attribute id="0x0505" name="RMS Voltage" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-				<attribute id="0x0508" name="RMS Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-				<attribute id="0x050a" name="Max Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-				<attribute id="0x050b" name="Active Power" type="s16" access="r" required="o" default="0x8000">
-					<description>Represents the single phase or Phase A, current demand of active power delivered or received at the premises, in Watts (W). Positive values indicate power delivered to the premises where negative values indicate power received from the premises.</description>
-				</attribute>
-				<attribute id="0x050e" name="Reactive Power" type="s16" access="r" required="o" default="0x8000"></attribute>
-				<attribute id="0x050f" name="Apparent Power" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-				<attribute id="0x0510" name="Power Factor" type="s8" access="r" required="o" default="0x00"></attribute>
-			</attribute-set>
-			<attribute-set id="0x0600" description="AC Formatting">
-				<attribute id="0x0600" name="AC Voltage Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
-				<attribute id="0x0601" name="AC Voltage Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
-				<attribute id="0x0602" name="AC Current Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
-				<attribute id="0x0603" name="AC Current Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
-				<attribute id="0x0604" name="AC Power Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
-				<attribute id="0x0605" name="AC Power Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
-			</attribute-set>
-			<attribute-set id="0x0900" description="AC (Phase B) Measurements">
-				<attribute id="0x0905" name="RMS Voltage" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-				<attribute id="0x0908" name="RMS Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-				<attribute id="0x090a" name="Max Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-				<attribute id="0x090f" name="RMS Power" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-			</attribute-set>
-			<attribute-set id="0x0a00" description="AC (Phase C) Measurements">
-				<attribute id="0x0a05" name="RMS Voltage" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-				<attribute id="0x0a08" name="RMS Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-				<attribute id="0x0a0a" name="Max Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-				<attribute id="0x0a0f" name="RMS Power" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-			</attribute-set>
-		</server>
-		<client>
-		</client>
-	</cluster>
-		<cluster id="0x0b05" name="Diagnostics">
-			<description>The diagnostics cluster provides access to information regarding the operation of the ZigBee stack over time.</description>
-				<server>
-					<attribute-set id="0x0000" description="Hardware Information">
-						<attribute id="0x0000" name="Number of Resets" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x0001" name="Persistens Memory Writes" type="u16" access="r" required="o" default="0x0000"></attribute>
-					</attribute-set>
-					<attribute-set id="0x0100" description="Stack/Network Information">
-						<attribute id="0x0100" name="Mac Rx Bcast" type="u32" access="r" required="o" default="0x00000000"></attribute>
-						<attribute id="0x0101" name="Mac Tx Bcast" type="u32" access="r" required="o" default="0x00000000"></attribute>
-						<attribute id="0x0102" name="Mac Rx Ucast" type="u32" access="r" required="o" default="0x00000000"></attribute>
-						<attribute id="0x0103" name="Mac Tx Ucast" type="u32" access="r" required="o" default="0x00000000"></attribute>
-						<attribute id="0x0104" name="Mac Tx Ucast Retry" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x0105" name="Mac Tx Ucast Fail" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x0106" name="APS Rx Bcast" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x0107" name="APS Tx Bcast" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x0108" name="APS Rx Ucast" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x0109" name="APS Tx Ucast Success" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x010a" name="APS Tx Ucast Retry" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x010b" name="APS Tx Ucast Fail" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x010c" name="Route Disc Initiated" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x010d" name="Neighbor Added" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x010e" name="Neighbor Removed" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x010f" name="Neighbor Stale" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x0110" name="Join Indication" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x0111" name="Child Moved" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x0112" name="NWK FC Failure" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x0113" name="APS FC Failure" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x0114" name="APS Unauthorized Key" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x0115" name="NWK Decrypt Failures" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x0116" name="APS Decrypt Failures" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x0117" name="Packet Buffer Alloc Failures" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x0118" name="Relayed Ucast" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x0119" name="Phy to MAC queue limit reached" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x011a" name="Packet Validate Dropcount" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x011b" name="Avg MAC Retry per APS Msg Sent" type="u16" access="r" required="o" default="0x0000"></attribute>
-						<attribute id="0x011c" name="Last Message LQI" type="u8" access="r" required="o" default="0x00"></attribute>
-						<attribute id="0x011d" name="Last Message RSSI" type="s8" access="r" required="o" default="0x00"></attribute>
-					</attribute-set>
-					<attribute-set id="0x4000" description="Vendor specific attributes">
-						<attribute id="0x4000" name="SW error code" type="bmp16" access="rw" default="0" required="o" mfcode="0x1246"></attribute>
-					</attribute-set>
-				</server>
-				<client>
-				</client>
-		</cluster>
-		<cluster id="0x0500" name="IAS Zone">
-			<description>The IAS Zone cluster defines an interface to the functionality of an IAS security zone device. IAS Zone supports up totwo alarm types per zone, low battery reports and supervision of the IAS network.</description>
-			<server>
-				<attribute-set id="0x0000" description="Zone information">
-					<attribute id="0x0000" name="Zone State" type="enum8" range="0x00,0x01" access="r" required="m">
-						<value name="Not enrolled" value="0x00"></value>
-						<value name="Enrolled" value="0x01"><description>The client will react to Zone
-						State Change Notification commands from the server.</description></value>
-					</attribute>
-					<attribute id="0x0001" name="Zone Type" type="enum16" range="0x0000,0xffff" access="r" required="m">
-						<value name="Standard CIE" value="0x0000"></value>
-						<value name="Motion sensor" value="0x000d"></value>
-						<value name="Contact switch" value="0x0015"></value>
-						<value name="Fire sensor" value="0x0028"></value>
-						<value name="Water sensor" value="0x002a"></value>
-						<value name="Carbon Monoxide (CO) sensor" value="0x002b"></value>
-						<value name="Personal emergency device" value="0x002c"></value>
-						<value name="Vibration / Movement sensor" value="0x002d"></value>
-						<value name="Remote Control" value="0x010f"></value>
-						<value name="Key fob" value="0x0115"></value>
-						<value name="Keypad" value="0x021d"></value>
-						<value name="Standard Warning Device" value="0x0225"></value>
-						<value name="Glass break sensor" value="0x0226"></value>
-						<value name="Security repeater" value="0x0229"></value>
-						<value name="Manufacturer specific" value="0x8000"></value>
-						<value name="Invalid Zone Type" value="0xffff"></value>
-					</attribute>
-					<attribute id="0x0002" type="bmp16" name="Zone Status" access="r" required="m">
-						<value name="Alarm 1" value="0"></value>
-						<value name="Alarm 2" value="1"></value>
-						<value name="Tamper" value="2"></value>
-						<value name="Battery" value="3"></value>
-						<value name="Supervision reports" value="4"></value>
-						<value name="Restore reports" value="5"></value>
-						<value name="Trouble" value="6"></value>
-						<value name="AC (mains)" value="7"></value>
-						<value name="Test" value="8"></value>
-						<value name="Battery defect" value="9"></value>
-					</attribute>
-				</attribute-set>
-				<attribute-set id="0x0010" description="Zone settings">
-					<attribute id="0x0010" name="IAS_CIE_Address" type="uid" access="rw" required="o" default="0"></attribute>
-					<attribute id="0x0011" name="Zone ID" type="u8" range="0x00,0xff" access="r" required="m"></attribute>
-				</attribute-set>
-				<attribute-set id="0x8000" description="Develco specific" mfcode="0x1015">
-					<attribute id="0x8000" name="Zone Status Interval" type="u16" access="rw" required="o" mfcode="0x1015"></attribute>
-					<attribute id="0x8001" name="Alarm Off Delay" type="u16" access="rw" required="o" mfcode="0x1015"></attribute>
-				</attribute-set>
-				<attribute-set id="0xf000" description="Xiaomi specific" mfcode="0x1037">
-					<attribute id="0xfff0" name="Device config" type="u64" access="r" required="o" mfcode="0x115f"></attribute>
-				</attribute-set>
-				<command id="0x00" dir="recv" name="Zone Enroll Response" required="m">
-					<payload>
-						<attribute id="0x00" type="enum8" name="Enroll response code" required="m">
-							<value name="Success" value="0x00"></value>
-							<value name="Not supported" value="0x01"></value>
-							<value name="No enroll permit" value="0x02"></value>
-							<value name="Too many zones" value="0x03"></value>
-						</attribute>
-						<attribute id="0x01" type="u8" name="Zone ID" required="m"></attribute>
-					</payload>
-				</command>
-				<command id="0x01" dir="recv" name="Initiate Normal Operation Mode" required="o">
-					<payload>
-					</payload>
-				</command>
-				<command id="0x00" dir="send" name="Zone Status Change Notification" required="m">
-					<payload>
-						<attribute id="0x00" type="bmp16" name="Zone Status" required="m">
-							<value name="Alarm 1" value="0"></value>
-							<value name="Alarm 2" value="1"></value>
-							<value name="Tamper" value="2"></value>
-							<value name="Battery" value="3"></value>
-							<value name="Supervision reports" value="4"></value>
-							<value name="Restore reports" value="5"></value>
-							<value name="Trouble" value="6"></value>
-							<value name="AC (mains)" value="7"></value>
-							<value name="Test" value="8"></value>
-							<value name="Battery defect" value="9"></value>
-						</attribute>
-						<attribute id="0x01" type="bmp8" name="Extended Status" default="0x00" required="m"></attribute>
-						<attribute id="0x02" type="u8" name="Zone ID" required="m"></attribute>
-						<attribute id="0x03" type="u16" name="Delay" required="m"></attribute>
-					</payload>
-				</command>
-				<command id="0x01" dir="send" name="Zone Enroll request" required="m">
-					<payload>
-						<attribute id="0x00" type="enum16" name="Zone Status" required="m">
-							<value name="Standard CIE" value="0x0000"></value>
-							<value name="Motion sensor" value="0x000d"></value>
-							<value name="Contact switch" value="0x0015"></value>
-							<value name="Fire sensor" value="0x0028"></value>
-							<value name="Water sensor" value="0x002a"></value>
-							<value name="Gas sensor" value="0x002b"></value>
-							<value name="Personal emergency device" value="0x002c"></value>
-							<value name="Vibration / Movement sensor" value="0x002d"></value>
-							<value name="Remote Control" value="0x010f"></value>
-							<value name="Key fob" value="0x0115"></value>
-							<value name="Keypad" value="0x021d"></value>
-							<value name="Standard Warning Device" value="0x0225"></value>
-							<value name="Invalid Zone Type" value="0xffff"></value>
-						</attribute>
-						<attribute id="0x01" type="u16" name="Manufacturer Code" required="m"></attribute>
-					</payload>
-				</command>
-			</server>
-			<client>
-			</client>
-		</cluster>
-
-		<cluster id="0x0501" name="IAS ACE">
-			<description>The IAS ACE cluster defines an interface to the functionality of any Ancillary Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE device can access a IAS CIE device and manipulate the IAS system, on behalf of a level-2 user.</description>
-			<server>
-				<attribute></attribute>
-				<command id="0x00" dir="recv" name="Arm" required="m">
-					<payload>
-						<attribute id="0x00" type="enum8" name="Arm Mode" required="m">
-							<value name="Disarm" value="0x00"></value>
-							<value name="Arm Day/Home Zones Only" value="0x01"></value>
-							<value name="Arm Night/Sleep Zones Only" value="0x02"></value>
-							<value name="Arm All Zones" value="0x03"></value>
-						</attribute>
-						<attribute id="0x01" type="cstring" name="Arm/Disarm Code" required="m"></attribute>
-						<attribute id="0x02" type="u8" name="Zone ID" required="m"></attribute>
-					</payload>
-				</command>
-				<command id="0x01" dir="recv" name="Bypass" required="m">
-					<payload>
-						<attribute id="0x00" type="u8" name="Number of Zones" required="m"></attribute>
-						<attribute id="0x01" type="u8" name="Zone ID" required="m"></attribute>
-						<attribute id="0x02" type="cstring" name="Arm/Disarm Code" required="m"></attribute>
-					</payload>
-				</command>
-				<command id="0x02" dir="recv" name="Emergency" required="m">
-				</command>
-				<command id="0x03" dir="recv" name="Fire" required="m">
-				</command>
-				<command id="0x04" dir="recv" name="Panic" required="m">
-				</command>
-				<command id="0x05" dir="recv" name="Get Zone ID Map" required="m">
-				</command>
-				<command id="0x06" dir="recv" name="Get Zone Information" required="m">
-					<payload>
-						<attribute id="0x00" type="u8" name="Zone ID" required="m"></attribute>
-					</payload>
-				</command>
-				<command id="0x07" dir="recv" name="Get Panel Status" required="m">
-				</command>
-				<command id="0x08" dir="recv" name="Get Bypassed Zone List" required="m">
-				</command>
-				<command id="0x09" dir="recv" name="Get Zone Status" required="m">
-					<payload>
-						<attribute id="0x00" type="u8" name="Starting Zone ID" required="m"></attribute>
-						<attribute id="0x01" type="u8" name="Max Number of Zone IDs" required="m"></attribute>
-						<attribute id="0x02" type="bool" name="Zone Status Mask Flag" required="m"></attribute>
-						<attribute id="0x03" type="bmp16" name="Zone Status Mask" required="m"></attribute>
-						<!--More to do here!!!-->
-					</payload>
-				</command>
-			</server>
-			<client>
-				<command id="0x00" dir="recv" name="Arm Response" required="m">
-					<payload>
-						<attribute id="0x00" type="enum8" name="Arm Notification" required="m">
-							<value name="All Zones Disarmed" value="0x00"></value>
-							<value name="Only Day/Home Zones Armed" value="0x01"></value>
-							<value name="Only Night/Sleep Zones Armed" value="0x02"></value>
-							<value name="All Zones Armed" value="0x03"></value>
-							<value name="Invalid Arm/Disarm Code" value="0x04"></value>
-							<value name="Not ready to arm" value="0x05"></value>
-							<value name="Already disarmed" value="0x06"></value>
-						</attribute>
-						<attribute id="0x01" type="cstring" name="Arm/Disarm Code" required="m"></attribute>
-						<attribute id="0x02" type="u8" name="Zone ID" required="m"></attribute>
-					</payload>
-				</command>
-				<command id="0x01" dir="recv" name="Get Zone ID Map Response" required="m">
-					<payload>
-						<attribute id="0x00" type="bmp16" name="Zone ID Map section 0" required="m"></attribute>
-						<!--More to do here!!!-->
-					</payload>
-				</command>
-				<command id="0x02" dir="recv" name="Get Zone Information Response" required="m">
-					<payload>
-						<attribute id="0x00" type="u8" name="Zone ID" required="m"></attribute>
-						<attribute id="0x01" type="enum16" name="Zone Type" required="m">
-							<value name="All Zones Disarmed" value="0x00"></value>
-							<value name="Only Day/Home Zones Armed" value="0x01"></value>
-							<value name="Only Night/Sleep Zones Armed" value="0x02"></value>
-							<value name="All Zones Armed" value="0x03"></value>
-							<value name="Invalid Arm/Disarm Code" value="0x04"></value>
-							<value name="Not ready to arm" value="0x05"></value>
-							<value name="Already disarmed" value="0x06"></value>
-						</attribute>
-						<attribute id="0x02" type="uid" name="IEEE address" required="m"></attribute>
-						<attribute id="0x03" type="cstring" name="Zone Label" required="m"></attribute>
-					</payload>
-				</command>
-				<command id="0x03" dir="recv" name="Zone Status Changed" required="m">
-					<payload>
-						<attribute id="0x00" type="u8" name="Zone ID" required="m"></attribute>
-						<attribute id="0x01" type="enum16" name="Zone Status" required="m">
-							<!--More to do here!!!-->
-							<value name="All Zones Disarmed" value="0x00"></value>
-							<value name="Only Day/Home Zones Armed" value="0x01"></value>
-							<value name="Only Night/Sleep Zones Armed" value="0x02"></value>
-							<value name="All Zones Armed" value="0x03"></value>
-							<value name="Invalid Arm/Disarm Code" value="0x04"></value>
-							<value name="Not ready to arm" value="0x05"></value>
-							<value name="Already disarmed" value="0x06"></value>
-						</attribute>
-						<attribute id="0x02" type="enum8" name="Audible Notification" default="0x01" required="m">
-							<value name="Mute" value="0x00"></value>
-							<value name="Default sound" value="0x01"></value>
-						</attribute>
-						<attribute id="0x03" type="cstring" name="Zone Label" required="m"></attribute>
-					</payload>
-				</command>
-				<command id="0x04" dir="recv" name="Panel Status Changed" required="m">
-					<payload>
-						<attribute id="0x00" type="enum8" name="Panel Status" required="m">
-							<value name="Panel disarmed (all zones disarmed) and ready to arm" value="0x00"></value>
-							<value name="Armed stay" value="0x01"></value>
-							<value name="Armed night" value="0x02"></value>
-							<value name="Armed away" value="0x03"></value>
-							<value name="Exit delay" value="0x04"></value>
-							<value name="Entry delay" value="0x05"></value>
-							<value name="Not ready to arm" value="0x06"></value>
-							<value name="In alarm" value="0x07"></value>
-							<value name="Arming stay" value="0x08"></value>
-							<value name="Arming night" value="0x09"></value>
-							<value name="Arming away" value="0x0a"></value>
-						</attribute>
-						<attribute id="0x01" type="u8" name="Seconds Remaining" default="0x00" required="m"></attribute>
-						<attribute id="0x02" type="enum8" name="Audible Notification" default="0x01" required="m">
-							<value name="Mute" value="0x00"></value>
-							<value name="Default sound" value="0x01"></value>
-						</attribute>
-						<attribute id="0x03" type="enum8" name="Alarm Status" default="0x00" required="m">
-							<value name="No alarm" value="0x00"></value>
-							<value name="Burglar" value="0x01"></value>
-							<value name="Fire" value="0x02"></value>
-							<value name="Emergency" value="0x03"></value>
-							<value name="Police Panic" value="0x04"></value>
-							<value name="Fire Panic" value="0x05"></value>
-							<value name="Emergency Panic (i.e., medical issue)" value="0x06"></value>
-						</attribute>
-						<attribute id="0x04" type="cstring" name="Zone Label" required="m"></attribute>
-					</payload>
-				</command>
-				<command id="0x05" dir="recv" name="Get Panel Status Response" required="m">
-					<payload>
-						<attribute id="0x00" type="enum8" name="Panel Status" required="m">
-							<value name="Panel disarmed (all zones disarmed) and ready to arm" value="0x00"></value>
-							<value name="Armed stay" value="0x01"></value>
-							<value name="Armed night" value="0x02"></value>
-							<value name="Armed away" value="0x03"></value>
-							<value name="Exit delay" value="0x04"></value>
-							<value name="Entry delay" value="0x05"></value>
-							<value name="Not ready to arm" value="0x06"></value>
-							<value name="In alarm" value="0x07"></value>
-							<value name="Arming stay" value="0x08"></value>
-							<value name="Arming night" value="0x09"></value>
-							<value name="Arming away" value="0x0a"></value>
-						</attribute>
-						<attribute id="0x01" type="u8" name="Seconds Remaining" default="0x00" required="m"></attribute>
-						<attribute id="0x02" type="enum8" name="Audible Notification" default="0x01" required="m">
-							<value name="Mute" value="0x00"></value>
-							<value name="Default sound" value="0x01"></value>
-						</attribute>
-						<attribute id="0x03" type="enum8" name="Alarm Status" default="0x00" required="m">
-							<value name="No alarm" value="0x00"></value>
-							<value name="Burglar" value="0x01"></value>
-							<value name="Fire" value="0x02"></value>
-							<value name="Emergency" value="0x03"></value>
-							<value name="Police Panic" value="0x04"></value>
-							<value name="Fire Panic" value="0x05"></value>
-							<value name="Emergency Panic (i.e., medical issue)" value="0x06"></value>
-						</attribute>
-						<attribute id="0x04" type="cstring" name="Zone Label" required="m"></attribute>
-					</payload>
-				</command>
-				<command id="0x06" dir="recv" name="Set Bypassed Zone List" required="m">
-					<payload>
-						<attribute id="0x00" type="u8" name="Number of Zones" required="m"></attribute>
-						<attribute id="0x01" type="u8" name="Zone ID 1" required="m"></attribute>
-						<attribute id="0x02" type="u8" name="Zone ID 2" required="m"></attribute>
-						<attribute id="0x03" type="u8" name="Zone ID 3" required="m"></attribute>
-						<attribute id="0x04" type="u8" name="Zone ID 4" required="m"></attribute>
-						<attribute id="0x05" type="u8" name="Zone ID 5" required="m"></attribute>
-						<attribute id="0x06" type="u8" name="Zone ID 6" required="m"></attribute>
-						<attribute id="0x07" type="u8" name="Zone ID 7" required="m"></attribute>
-						<attribute id="0x08" type="u8" name="Zone ID 8" required="m"></attribute>
-					</payload>
-				</command>
-				<command id="0x07" dir="recv" name="Bypass Response" required="m">
-					<payload>
-						<attribute id="0x00" type="u8" name="Number of Zones" required="m"></attribute>
-						<attribute id="0x01" type="u8" name="Bypass Result for Zone ID 1" required="m"></attribute>
-						<attribute id="0x02" type="u8" name="Bypass Result for Zone ID 2" required="m"></attribute>
-						<attribute id="0x03" type="u8" name="Bypass Result for Zone ID 3" required="m"></attribute>
-						<attribute id="0x04" type="u8" name="Bypass Result for Zone ID 4" required="m"></attribute>
-						<attribute id="0x05" type="u8" name="Bypass Result for Zone ID 5" required="m"></attribute>
-						<attribute id="0x06" type="u8" name="Bypass Result for Zone ID 6" required="m"></attribute>
-						<attribute id="0x07" type="u8" name="Bypass Result for Zone ID 7" required="m"></attribute>
-						<attribute id="0x08" type="u8" name="Bypass Result for Zone ID 8" required="m"></attribute>
-							<!--<value name="Zone bypassed" value="0x00"></value>
-							<value name="Zone not bypassed" value="0x01"></value>
-							<value name="Not allowed" value="0x02"></value>
-							<value name="Invalid Zone ID" value="0x03"></value>
-							<value name="Unknown Zone ID" value="0x04"></value>
-							<value name="Invalid Arm/Disarm Code" value="0x05"></value>-->
-					</payload>
-				</command>
-				<command id="0x08" dir="recv" name="Get Zone Status Response" required="m">
-					<payload>
-						<attribute id="0x00" type="bool" name="Zone Status Complete" required="m"></attribute>
-						<attribute id="0x01" type="u8" name="Number of Zones" required="m"></attribute>
-						<attribute id="0x02" type="u8" name="Zone ID 1" required="m"></attribute>
-						<attribute id="0x03" type="bmp16" name="Zone ID 1 Zone Status" required="m"></attribute>
-						<attribute id="0x04" type="u8" name="Zone ID 2" required="m"></attribute>
-						<attribute id="0x05" type="bmp16" name="Zone ID 2 Zone Status" required="m"></attribute>
-						<attribute id="0x06" type="u8" name="Zone ID 3" required="m"></attribute>
-						<attribute id="0x07" type="bmp16" name="Zone ID 3 Zone Status" required="m"></attribute>
-						<attribute id="0x08" type="u8" name="Zone ID 4" required="m"></attribute>
-						<attribute id="0x09" type="bmp16" name="Zone ID 4 Zone Status" required="m"></attribute>
-					</payload>
-				</command>
-			</client>
-		</cluster>
-
-		<cluster id="0x0502" name="IAS WD">
-			<description>The IAS WD cluster provides an interface to the functionality of any Warning Device equipment of the IAS system. Using this cluster, a ZigBee enabled CIE device can access a ZigBee enabled IAS WD device and issue alarm warning indications (siren, strobe lighting, etc.) when a system alarm condition is detected.</description>
-			<server>
-				<attribute id="0x0000" name="Max Duration" type="u16" range="0x0000,0xfffe" access="rw" required="m" default="240"></attribute>
-				<command id="0x00" dir="recv" name="Start warning" required="m">
-					<payload>
-						<attribute id="0x00" type="bmp8" name="Options" required="m">
-							<value name="Siren level 0" value="0"></value>
-							<value name="Siren level 1" value="1"></value>
-							<value name="Strobe" value="2"></value>
-							<value name="Warning mode 0" value="4"></value>
-							<value name="Warning mode 1" value="5"></value>
-							<value name="Warning mode 2" value="6"></value>
-							<value name="Warning mode 3" value="7"></value>
-						</attribute>
-						<attribute id="0x01" type="u16" name="Warning duration" required="m"></attribute>
-						<attribute id="0x02" type="u8" name="Strobe duty cycle" required="m" default="0x00"></attribute>
-						<attribute id="0x00" type="enum8" name="Strobe level" required="m">
-							<value name="Low" value="0x00"></value>
-							<value name="Medium" value="0x01"></value>
-							<value name="High" value="0x02"></value>
-							<value name="Very high" value="0x03"></value>
-						</attribute>
-					</payload>
-				</command>
-				<command id="0x01" dir="recv" name="Squawk" required="m">
-					<payload>
-						<attribute id="0x00" type="bmp8" name="Options" required="m">
-							<value name="Sqawk level 0" value="0"></value>
-							<value name="Sqawk level 1" value="1"></value>
-							<value name="Strobe" value="3"></value>
-							<value name="Sound for disarmed" value="4"></value>
-						</attribute>
-					</payload>
-				</command>
-			</server>
-			<client>
-			</client>
-		</cluster>
-	</domain>
-	<domain name="Security and safety" low_bound="0500" high_bound="05ff" description="The security and safety functional domain contains clusters and information to build devices in the security and safety domain, e.g. alarm units.">
-	</domain>
-	<domain name="Protocol interfaces" low_bound="0600" high_bound="06ff" description="The protocol interfaces functional domain contains clusters and information to build devices to interface to other protocols, e.g. BACnet.">
-	</domain>
-	<domain name="Smart energy" low_bound="0700" high_bound="07ff" description="TODO Smart Energy Description">
-		<cluster id="0x0700" name="Price">
-			<description>The Price Cluster provides the mechanism for communicating Gas, Energy, or Water pricing information within the premise. This pricing information is distributed to the ESP from either the utilities or from regional energy providers.</description>
-			<server>
-				<attribute id="0000" name="Tier1 Price Label" type="ostring" access="rw" required="o" range="0,12" default="Tier1"></attribute>
-				<attribute id="0001" name="Tier2 Price Label" type="ostring" access="rw" required="o" range="0,12" default="Tier2"></attribute>
-				<attribute id="0002" name="Tier3 Price Label" type="ostring" access="rw" required="o" range="0,12" default="Tier3"></attribute>
-				<attribute id="0003" name="Tier4 Price Label" type="ostring" access="rw" required="o" range="0,12" default="Tier4"></attribute>
-				<attribute id="0004" name="Tier5 Price Label" type="ostring" access="rw" required="o" range="0,12" default="Tier5"></attribute>
-				<attribute id="0005" name="Tier6 Price Label" type="ostring" access="rw" required="o" range="0,12" default="Tier6"></attribute>
-				<command id="00" dir="recv" name="Get Current Price" required="m">
-					<payload>
-						<attribute id="0x0000" type="bmp8" name="Command Options" required="m">
-							<value name="Requestor Rx On When Idle" value="0x00"/>
-						</attribute>
-					</payload>
-				</command>
-				<command id="01" dir="recv" name="Get Scheduled Prices" required="o">
-					<payload>
-						<attribute id="0x0000" type="utc" name="Start Time" required="m"></attribute>
-						<attribute id="0x0001" type="u8" name="Number of Events" required="m"></attribute>
-					</payload>
-				</command>
-			</server>
-			<client>
-			<!-- TODO -->
-			</client>
-		</cluster>
-		<cluster id="0x0701" name="Demand Response and Load Control">
-			<description>This cluster provides an interface to the functionality of Smart Energy Demand Response and Load Control. Devices targeted by this cluster include thermostats and devices that support load control.</description>
-		<client>
-		<attribute id="0000" name="Utility Enrolment Group" type="u8" access="rw" default="0" range="0x00,0xff" required="m"></attribute>
-		<attribute id="0001" name="Start Randomize Minutes" type="u8" access="rw" default="0x1e" range="0x00,0x3c" required="m"></attribute>
-		<attribute id="0002" name="Stop Randomize Minutes" type="u8" access="rw" default="0x1e" range="0x00,0x3c" required="m"></attribute>
-		<attribute id="0003" name="Device Class Value" type="u16" access="r" default="0x1e" range="0x00,0xff" required="m"></attribute>
-		</client>
-		<server>
-		<!-- TODO -->
-		</server>
-		</cluster>
-		<cluster id="0x0702" name="Simple Metering">
-			<description>The Simple Metering Cluster provides a mechanism to retrieve usage information from Electric, Gas, Water, and potentially Thermal metering devices. These
-devices can operate on either battery or mains power, and can have a wide variety of sophistication.</description>
-			<server>
-			<attribute-set id="0x0000" description="Reading Information Set">
-				<attribute id="0x0000" name="Current Summation Delivered" type="u48" access="r" required="m"></attribute>
-				<attribute id="0x0001" name="Current Summation Received" type="u48" access="r" required="o"></attribute>
-				<attribute id="0x041b" name="Unknown" type="u64" access="rw" required="o" mfcode="0x1037"></attribute>
-				<!-- TODO -->
-			</attribute-set>
-			<attribute-set id="0x0100" description="TOU Information Set">
-                <attribute id="0x0100" name="Index HCHC/EJPHN/BBRHCJB, Current Summation Delivered (1)" type="u48" access="r" required="m"></attribute>
-                <attribute id="0x0102" name="Index HCHP/EJPHPM/BBRHPJB, Current Summation Delivered(2)" type="u48" access="r" required="m"></attribute>
-			<!-- TODO -->
-			</attribute-set>
-			<attribute-set id="0x0200" description="Meter Status">
-				<attribute id="0x0200" name="Status" type="bmp8" default="00000000" access="r" required="m">
-					<value name="Check Meter" value="0"></value>
-					<value name="Low Battery" value="1"></value>
-					<value name="Tamper Detect" value="2"></value>
-					<value name="Power Failure" value="3"></value>
-					<value name="Power Quality" value="4"></value>
-					<value name="Leak Detect" value="5"></value>
-					<value name="Service Disconnect Open" value="6"></value>
-				</attribute>
-			</attribute-set>
-			<attribute-set id="0x0300" description="Formatting">
-				<attribute id="0x0300" name="Unit of Measure" type="enum8" default="0" access="r" required="m">
-					<value name="kW &amp; kWh binary" value="0"></value>
-					<value name="m³ &amp; m³/h binary" value="1"></value>
-					<value name="ft³ &amp; ft³/h binary" value="2"></value>
-					<value name="ccf &amp; ccf/h binary" value="3"></value>
-					<value name="US gl &amp; Us gl/h binary" value="4"></value>
-					<value name="IMP gl &amp; IMP gl/h binary" value="5"></value>
-					<value name="BTUs &amp; BTU/h binary" value="6"></value>
-					<value name="Liters &amp; l/h binary" value="7"></value>
-					<value name="kPA(gauge) binary" value="8"></value>
-					<value name="kPA(absolute) binary" value="9"></value>
-
-					<value name="kW &amp; kWh BCD" value="80"></value>
-					<value name="m³ &amp; m³/h BCD" value="81"></value>
-					<value name="ft³ &amp; ft³/h BCD" value="82"></value>
-					<value name="ccf &amp; ccf/h BCD" value="83"></value>
-					<value name="US gl &amp; Us gl/h BCD" value="84"></value>
-					<value name="IMP gl &amp; IMP gl/h BCD" value="85"></value>
-					<value name="BTUs &amp; BTU/h BCD" value="86"></value>
-					<value name="Liters &amp; l/h BCD" value="87"></value>
-					<value name="kPA(gauge) BCD" value="88"></value>
-					<value name="kPA(absolute) BCD" value="89"></value>
-				</attribute>
-				<attribute id="0x0301" name="Multiplier" type="u24" access="r" required="o"></attribute>
-				<attribute id="0x0302" name="Divisor" type="u24" access="r" required="o"></attribute>
-				<attribute id="0x0303" name="Summation Formatting" type="bmp8" access="r" required="m">
-					<value name="Number Digits Right" description="Number of Digets to the right of the Decimal Point" value="0,2"></value>
-					<value name="Number Digits Left" description="Number of Digets to the left of the Decimal Point" value="3,6"></value>
-					<value name="Suppress Leading Zeros" value="7"></value>
-				</attribute>
-				<attribute id="0x0304" name="Demand Formatting" type="bmp8" access="r" required="o">
-					<value name="Number Digits Right" description="Number of Digets to the right of the Decimal Point" value="0,2"></value>
-					<value name="Number Digits Left" description="Number of Digets to the left of the Decimal Point" value="3,6"></value>
-					<value name="Suppress Leading Zeros" value="7"></value>
-				</attribute>
-				<!-- TODO -->
-				<attribute id="0x0306" name="Metering Device Type" type="enum8" access="r" required="m">
-					<value name="Electric Metering" value="0"></value>
-					<value name="Gas Metering" value="1"></value>
-					<value name="Water Metering" value="2"></value>
-					<value name="Thermal Metering" value="3"></value>
-					<value name="Pressure Metering" value="4"></value>
-					<value name="Heat Metering" value="5"></value>
-					<value name="Cooling Metering" value="6"></value>
-
-					<value name="Mirrored Gas Metering" value="128"></value>
-					<value name="Mirrored Water Metering" value="129"></value>
-					<value name="Mirrored Thermal Metering" value="130"></value>
-					<value name="Mirrored Pressure Metering" value="131"></value>
-					<value name="Mirrored Heat Metering" value="132"></value>
-					<value name="Mirrored Cooling Metering" value="133"></value>
-				</attribute>
-				<attribute id="0x0308" name="Meter Serial Number" type="ostring" range="0,24" access="r" required="o"></attribute>
-				<!-- TODO -->
-			</attribute-set>
-			<attribute-set id="0x0300" description="Develco specific" mfcode="0x1015">
-				<attribute id="0x0300" name="Pulse Configuration" type="u16" access="rw" required="o" mfcode="0x1015"></attribute>
-				<attribute id="0x0301" name="Current Summation" type="u48" access="w" required="o" mfcode="0x1015"></attribute>
-				<attribute id="0x0302" name="Interface Mode" type="enum16" access="rw" required="o" mfcode="0x1015">
-					<value name="Pulse Counting on an Electricity Meter – Unit KWh" value="0x0000"></value>
-					<value name="Pulse Counting on a Gas Meter – Unit m3" value="0x0001"></value>
-					<value name="Pulse Counting on a Water Meter – Unit m3" value="0x0002"></value>
-					<value name="Kamstrup KMP Protocol" value="0x0100"></value>
-					<value name="Not Supported - Linky Protocol" value="0x0101"></value>
-					<value name="DLMS-COSEM - IEC62056-21 mod A" value="0x0102"></value>
-					<value name="P1 Dutch Standard – DSMR 2.3 Version" value="0x0103"></value>
-					<value name="P1 Dutch Standard – DSMR 4.0 Version" value="0x0104"></value>
-				</attribute>
-			</attribute-set>
-			<attribute-set id="0x0400" description="ESP Historical Consumption">
-				<attribute id="0x0400" name="Instantaneous Demand" type="s24" access="r" required="o"></attribute>
-			</attribute-set>
-			<attribute-set id="0x0500" description="Load Profile Configuration">
-			</attribute-set>
-			<attribute-set id="0x0600" description="Supply Limit">
-			</attribute-set>
-			<!-- TODO -->
-			<!-- dont support generated commands yet
-			<command id="01" dir="send" name="Get Profile Response" required="o">
-				<payload>
-					<field type="utc" name="End Time">
-					</field>
-					<field type="enum8" name="Status">
-						<value name="Success" value="0x00"/>
-						<value name="Undefined Interval Channel requested" value="0x01"/>
-						<value name="Interval Channel not supported" value="0x02"/>
-						<value name="Invalid End Time" value="0x03"/>
-						<value name="More periods requested then can be returned" value="0x04"/>
-						<value name="No intervals available for the requested time" value="0x05"/>
-					</field>
-					<field type="enum8" name="Profile Interval Period">
-						<value name="Daily" value="0"/>
-						<value name="60 minutes" value="1"/>
-						<value name="30 minutes" value="2"/>
-						<value name="15 minutes" value="3"/>
-						<value name="10 minutes" value="4"/>
-						<value name="7.5 minutes" value="5"/>
-						<value name="5 minutes" value="6"/>
-						<value name="2.5 minutes" value="7"/>
-					</field>
-					<field type="u8" name="Number Of Periods Delivered">
-					</field>
-					<field type="u24" name="Intervals" list="true">
-					</field>
-				</payload>
-			</command>
-			 -->
-			<command id="00" dir="recv" name="Get Profile" required="o">
-				<payload>
-					<attribute id="0x0000" type="u8" name="Interval Channel" required="m">
-						<value name="Consumption Delivered" value="0x00"/>
-						<value name="Consumption Received" value="0x01"/>
-					</attribute>
-					<attribute id="0x0001" type="utc" name="End Time" required="m"></attribute>
-					<attribute id="0x0002" type="u8" name="Number Of Periods" required="m"></attribute>
-				</payload>
-			</command>
-			<command id="01" dir="recv" name="Request Mirror Response" required="o">
-				<payload>
-					<attribute id="0x0000" type="u16" name="EndPoint ID" range="0x0001,0x00f0" required="m"></attribute>
-				</payload>
-			</command>
-			<command id="02" dir="recv" name="Mirror Removed" required="o">
-				<payload>
-					<attribute id="0x0000" type="u16" name="Removed EndPoint ID" range="0x0001,0x00f0" required="m"></attribute>
-				</payload>
-			</command>
-			</server>
-			<client>
-			<!-- TODO -->
-			</client>
-		</cluster>
-		<cluster id="0x0703" name="Message">
-			<description>This cluster provides an interface for passing text messages between ZigBee devices.</description>
-			<server>
-			</server>
-			<client>
-			</client>
-			<!-- TODO -->
-		</cluster>
-		<cluster id="0x0704" name="Smart Energy Tunneling (Complex Metering)">
-			<description>The tunneling cluster provides an interface for tunneling protocols.</description>
-			<server>
-				<attribute id="0000" name="Close Tunnel Timeout" type="u16" range="0x0001,0xFFFF" default="0xFFFF" access="r" required="m"></attribute>
-			</server>
-			<client>
-			</client>
-			<!-- TODO -->
-		</cluster>
-		<cluster id="0x0705" name="Prepayment">
-			<description></description>
-			<!-- TODO -->
-		</cluster>
-	</domain>
-
+          </command>
+          -->
+          <command id="00" dir="recv" name="Get Profile" required="o">
+            <payload>
+              <attribute id="0x0000" type="u8" name="Interval Channel" required="m">
+                <value name="Consumption Delivered" value="0x00"/>
+                <value name="Consumption Received" value="0x01"/>
+              </attribute>
+              <attribute id="0x0001" type="utc" name="End Time" required="m"></attribute>
+              <attribute id="0x0002" type="u8" name="Number Of Periods" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="01" dir="recv" name="Request Mirror Response" required="o">
+            <payload>
+              <attribute id="0x0000" type="u16" name="EndPoint ID" range="0x0001,0x00f0" required="m"></attribute>
+            </payload>
+          </command>
+          <command id="02" dir="recv" name="Mirror Removed" required="o">
+            <payload>
+              <attribute id="0x0000" type="u16" name="Removed EndPoint ID" range="0x0001,0x00f0" required="m"></attribute>
+            </payload>
+          </command>
+        </server>
+        <client>
+          <!-- TODO -->
+        </client>
+      </cluster>
+      
+      <cluster id="0x0703" name="Message">
+        <description>This cluster provides an interface for passing text messages between ZigBee devices.</description>
+        <server>
+        </server>
+        <client>
+        </client>
+        <!-- TODO -->
+      </cluster>
+      
+      <cluster id="0x0704" name="Smart Energy Tunneling (Complex Metering)">
+        <description>The tunneling cluster provides an interface for tunneling protocols.</description>
+        <server>
+          <attribute id="0000" name="Close Tunnel Timeout" type="u16" range="0x0001,0xFFFF" default="0xFFFF" access="r" required="m"></attribute>
+        </server>
+        <client>
+        </client>
+        <!-- TODO -->
+      </cluster>
+      
+      <cluster id="0x0705" name="Prepayment">
+        <description></description>
+        <!-- TODO -->
+      </cluster>
+    </domain>
+    
     <domain name="Appliances" low_bound="0b00" high_bound="0b03" description="The Appliance clusters are typically used in ZigBee appliance management.">
-		<cluster id="0x001b" name="Appliance Control">
-			<description>The Appliance Control cluster provides an interface to remotely control and to program household appliances. Example of control is Start, Stop and Pause commands.</description>
-			<server>
-			<!-- TODO -->
-			</server>
-			<client>
-			<!-- TODO -->
-			</client>
-		</cluster>
-        <cluster id="0x0b00" name="Appliance Identification">
-			<description>Attributes and commands for determining basic information about a device and setting user device information. The Appliance Identification Cluster is a transposition of EN50523 "Identify Product" functional block.</description>
-			<server>
-			<!-- TODO -->
-			</server>
-			<client>
-			<!-- TODO -->
-			</client>
-		</cluster>
-        <cluster id="0x0b01" name="Meter Identification">
-			<description>Attributes and commands that provide an interface to meter identification.</description>
-			<server>
-                <attribute id="0x0000" type="cstring" name="CompanyName" access="r" required="m"/>
-                <attribute id="0x0001" type="u16" name="MeterTypeID" access="r" required="m"/>
-                <attribute id="0x0004" type="u16" name="DataQualityID" access="r" required="m"/>
-                <attribute id="0x0005" type="cstring" name="CustomerName" access="r" required="m"/>
-                <attribute id="0x0006" type="ostring" name="Model" access="r" required="m"/>
-                <attribute id="0x0007" type="ostring" name="PartNumber" access="r" required="m"/>
-                <attribute id="0x0008" type="ostring" name="ProductRevision" access="r" required="m"/>
-                <attribute id="0x000a" type="ostring" name="SoftwareRevision" access="r" required="m"/>
-                <attribute id="0x000b" type="cstring" name="UtilityName" access="r" required="m"/>
-                <attribute id="0x000c" type="u16" name="POD" access="r" required="m"/>
-			    <attribute id="0x000d" type="s24" name="AvailablePower" access="r" required="m"/>
-                <attribute id="0x000e" type="s24" name="PowerThreshold" access="r" required="m"/>
-			</server>
-			<client>
-			<!-- TODO -->
-			</client>
-		</cluster>
-        <cluster id="0x0b02" name="Appliance Events and Alerts">
-			<description>Attributes and commands for transmitting or notifying the occurrence of an event, such as "temperature reached" and of an alert such as alarm, fault or warning. It is based on the "Signal event" syntax of EN50523 and completed where necessary.</description>
-			<server>
-                <command id="0x00" dir="recv" name="Get Alerts" required="m">
-					<description>The get group identifiers request command is used to retrieve the actual group identifiers that the endpoint is using in its multicast communication in controlling different (remote) devices.</description>
-				</command>
-			</server>
-			<client>
-			<!-- TODO -->
-			</client>
-		</cluster>
-        <cluster id="0x0b03" name="Appliance Statistics">
-			<description>The Appliance Statistics provides a mechanism for transmitting appliance statistics to a collection unit (gateway). The statistics can be in format of data logs.</description>
-			<server>
-			<!-- TODO -->
-			</server>
-			<client>
-			<!-- TODO -->
-			</client>
-		</cluster>
-	</domain>
-
-	<domain name="Light Link" useZcl="true"
-		description="The light link domain contains clusters and information that provides ZLL specific functions and attributes.">
-		<cluster id="0x1000" name="ZLL commissioning">
-		<description>Attributes and commands for ZLL commissioning.</description>
-			<server>
-				<command id="0x41" dir="recv" name="Get group identifiers" required="m" response="0x41">
-					<description>The get group identifiers request command is used to retrieve the actual group identifiers that the endpoint is using in its multicast communication in controlling different (remote) devices.</description>
-					<payload>
-						<attribute id="0x0000" type="u8" name="Start index" showas="dec" required="m" default="0"></attribute>
-					</payload>
-				</command>
-				<command id="0x42" dir="recv" name="Get endpoint list" required="m" response="0x42">
-					<description>The get endpoint list request command is used to retrieve addressing information for each endpoint the device is using in its unicast communication in controlling different (remote) devices.</description>
-					<payload>
-						<attribute id="0x0000" type="u8" name="Start index" showas="dec" required="m" default="0"></attribute>
-					</payload>
-				</command>
-				<command id="0xd0" dir="recv" name="Write MAC address" required="m" vendor="0x1135">
-					<description>Non standard write MAC address (DDEL).</description>
-					<payload>
-						<attribute id="0x0000" type="u64" name="MAC address" showas="hex" required="m" default="0"></attribute>
-					</payload>
-				</command>
-			</server>
-			<client>
-				<command id="0x41" dir="recv" name="Get group identifiers response" required="m">
-					<description>The get group identifiers response command allows a remote device to respond to the get group identifiers request command.</description>
-					<payload>
-						<attribute id="0x0000" type="u8" name="Total" required="m" default="0"></attribute>
-						<attribute id="0x0001" type="u8" name="Start index" required="m" default="0"></attribute>
-						<attribute id="0x0002" type="u8" name="Count" required="m" default="0"></attribute>
-
-						<!-- TODO this will display only first item of the list -->
-						<attribute id="0x0003" type="u16" name="First group ID" showas="hex" required="m" default="0x0000"></attribute>
-						<attribute id="0x0004" type="u8" name="First group type" showas="hex" required="m" default="0x00"></attribute>
-					</payload>
-				</command>
-				<command id="0x42" dir="recv" name="Get endpoint list response" required="m">
-					<description>The get group identifiers response command allows a remote device to respond to the get group identifiers request command.</description>
-					<payload>
-						<attribute id="0x0000" type="u8" name="Total" required="m" default="0"></attribute>
-						<attribute id="0x0001" type="u8" name="Start index" required="m" default="0"></attribute>
-						<attribute id="0x0002" type="u8" name="Count" required="m" default="0"></attribute>
-
-						<!-- TODO this will display only first item of the list -->
-						<attribute id="0x0003" type="u16" name="NWK address" showas="hex" required="m" default="0x0000"></attribute>
-						<attribute id="0x0004" type="u8" name="Endpoint" showas="hex" required="m" default="0x00"></attribute>
-						<attribute id="0x0005" type="u16" name="Profile ID" showas="hex" required="m" default="0x0000"></attribute>
-						<attribute id="0x0006" type="u16" name="Device ID" showas="hex" required="m" default="0x0000"></attribute>
-						<attribute id="0x0007" type="u8" name="Version" showas="hex" required="m" default="0x00"></attribute>
-					</payload>
-				</command>
-			</client>
-		</cluster>
-
-	</domain>
-
-	<domain name="Green Power" useZcl="true"
-		description="The green power domain contains clusters and information that provides ZGP specific functions and attributes.">
-		<cluster id="0x0021" name="Green Power">
-		<description>Attributes and commands.</description>
-			<server>
-				<attribute id="0x0000" name="Max Sink Table Entries" type="u8" default="0x00" access="r" required="m" showas="hex">
-					<description>Maximum number of Sink Table entries supported by this device.</description>
-				</attribute>
-				<attribute id="0x0001" name="Sink Table" type="lostring" default="0x0000" access="r" required="m" showas="hex">
-					<description>Sink Table, holding information about local bindings between a particular GPD and target‘s local endpoints.</description>
-				</attribute>
-				<attribute id="0x0002" name="Communication Mode" type="bmp8" default="0x01" access="rw" required="m" showas="hex">
-					<description>Default communication mode requested by this sink.</description>
-				</attribute>
-				<attribute id="0x0003" name="Commissioning Exit Mode" type="bmp8" default="0x02" access="rw" required="m" showas="hex">
-					<description>Conditions for the sink to exit the commissioning mode.</description>
-				</attribute>
-				<attribute id="0x0004" name="Commissioning Window" type="u16" default="0x00B4" access="rw" required="o" showas="hex">
-					<description>Default duration of the Commissioning window duration, in seconds, as requested by this sink.</description>
-				</attribute>
-				<attribute id="0x0005" name="Security Level" type="bmp8" default="0x06" access="rw" required="m" showas="hex">
-					<description>The minimum required security level to be supported by the paired GPDs.</description>
-				</attribute>
-				<attribute id="0x0006" name="Functionality" type="bmp24" default="0x0" access="r" required="m" showas="hex">
-					<description>The optional GP functionality supported by this sink.</description>
-				</attribute>
-				<attribute id="0x0007" name="Active Functionality" type="bmp24" default="0xffffff" access="r" required="m" showas="hex">
-					<description>The optional GP functionality supported by this sink that is active.</description>
-				</attribute>
-				<attribute id="0x0020" name="Shared Security Key Type" type="bmp8" default="0x00" access="r" required="m" showas="hex">
-				</attribute>
-				<attribute id="0x0021" name="Shared Security Key" type="seckey" access="r" required="m" showas="hex">
-				</attribute>
-				<attribute id="0x0022" name="GP Link Key" type="seckey" access="r" required="m" showas="hex">
-				</attribute>
-			</server>
-			<client>
-			</client>
-		</cluster>
-		<device id="0x0060" name="GP Proxy" description=""></device>
-		<device id="0x0061" name="GP Proxy Basic" description=""></device>
-		<device id="0x0062" name="GP Target Plus" description=""></device>
-		<device id="0x0063" name="GP Target" description=""></device>
-		<device id="0x0064" name="GP Commissioning Tool" description=""></device>
-		<device id="0x0065" name="GP Combo" description=""></device>
-		<device id="0x0066" name="GP Combo Basic" description=""></device>
-	</domain>
-
-	<domain name="Manufacturer Specific" useZcl="true"
-		description="Manufacturer specific clusters.">
-
-		<!-- Dresden Elektronik -->
-		<cluster id="0xfc00" name="Spectral Measurement" mfcode="0x1135">
-			<description>Dresden Elektronik Specific clusters.</description>
-			<server>
-				<attribute id="0x0000" type="u8" name="On" required="m" access="rw" default="0">
-					<description>Enable Sensor </description>
-				</attribute>
-
-				<attribute id="0x0001" name="X-Value" type="u16" default="0x0000" access="r" required="m" showas="dec">
-					<description>X-Value</description>
-				</attribute>
-
-				<attribute id="0x0002" name="Y-Value" type="u16" default="0x0000" access="r" required="m" showas="dec">
-					<description>Y-Value</description>
-				</attribute>
-
-				<attribute id="0x0003" name="Z-Value" type="u16" default="0x0000" access="r" required="m" showas="dec">
-					<description>Z-Value</description>
-				</attribute>
-
-			</server>
-			<client>
-			</client>
-		</cluster>
-
-    <!-- Hue -->
-    <cluster id="0xfc00" name="Hue" mfcode="0x100b">
-      <description>Hue-specific cluster.</description>
-      <server>
-        <command id="0x00" dir="send" name="Button Action Notification" required="m">
-          <payload>
-            <attribute id="0x0000" type="u16" name="Button" required="m"/>
-            <attribute id="0x0001" type="enum8" name="Type" required="m">
-              <value name="Push" value="0x00"/>
-              <value name="Rotary" value="0x01"/>
+      <cluster id="0x001b" name="Appliance Control">
+        <description>The Appliance Control cluster provides an interface to remotely control and to program household appliances. Example of control is Start, Stop and Pause commands.</description>
+        <server>
+          <!-- TODO -->
+        </server>
+        <client>
+          <!-- TODO -->
+        </client>
+      </cluster>
+      
+      <cluster id="0x0b00" name="Appliance Identification">
+        <description>Attributes and commands for determining basic information about a device and setting user device information. The Appliance Identification Cluster is a transposition of EN50523 "Identify Product" functional block.</description>
+        <server>
+          <!-- TODO -->
+        </server>
+        <client>
+          <!-- TODO -->
+        </client>
+      </cluster>
+      <cluster id="0x0b01" name="Meter Identification">
+        <description>Attributes and commands that provide an interface to meter identification.</description>
+        <server>
+          <attribute id="0x0000" type="cstring" name="CompanyName" access="r" required="m"/>
+          <attribute id="0x0001" type="u16" name="MeterTypeID" access="r" required="m"/>
+          <attribute id="0x0004" type="u16" name="DataQualityID" access="r" required="m"/>
+          <attribute id="0x0005" type="cstring" name="CustomerName" access="r" required="m"/>
+          <attribute id="0x0006" type="ostring" name="Model" access="r" required="m"/>
+          <attribute id="0x0007" type="ostring" name="PartNumber" access="r" required="m"/>
+          <attribute id="0x0008" type="ostring" name="ProductRevision" access="r" required="m"/>
+          <attribute id="0x000a" type="ostring" name="SoftwareRevision" access="r" required="m"/>
+          <attribute id="0x000b" type="cstring" name="UtilityName" access="r" required="m"/>
+          <attribute id="0x000c" type="u16" name="POD" access="r" required="m"/>
+          <attribute id="0x000d" type="s24" name="AvailablePower" access="r" required="m"/>
+          <attribute id="0x000e" type="s24" name="PowerThreshold" access="r" required="m"/>
+        </server>
+        <client>
+          <!-- TODO -->
+        </client>
+      </cluster>
+      
+      <cluster id="0x0b02" name="Appliance Events and Alerts">
+        <description>Attributes and commands for transmitting or notifying the occurrence of an event, such as "temperature reached" and of an alert such as alarm, fault or warning. It is based on the "Signal event" syntax of EN50523 and completed where necessary.</description>
+        <server>
+          <command id="0x00" dir="recv" name="Get Alerts" required="m">
+            <description>The get group identifiers request command is used to retrieve the actual group identifiers that the endpoint is using in its multicast communication in controlling different (remote) devices.</description>
+          </command>
+        </server>
+        <client>
+          <!-- TODO -->
+        </client>
+      </cluster>
+      
+      <cluster id="0x0b03" name="Appliance Statistics">
+        <description>The Appliance Statistics provides a mechanism for transmitting appliance statistics to a collection unit (gateway). The statistics can be in format of data logs.</description>
+        <server>
+          <!-- TODO -->
+        </server>
+        <client>
+          <!-- TODO -->
+        </client>
+      </cluster>
+    </domain>
+    
+    <domain name="Light Link" useZcl="true" description="The light link domain contains clusters and information that provides ZLL specific functions and attributes.">
+      <cluster id="0x1000" name="ZLL commissioning">
+        <description>Attributes and commands for ZLL commissioning.</description>
+        <server>
+          <command id="0x41" dir="recv" name="Get group identifiers" required="m" response="0x41">
+            <description>The get group identifiers request command is used to retrieve the actual group identifiers that the endpoint is using in its multicast communication in controlling different (remote) devices.</description>
+            <payload>
+              <attribute id="0x0000" type="u8" name="Start index" showas="dec" required="m" default="0"></attribute>
+            </payload>
+          </command>
+          <command id="0x42" dir="recv" name="Get endpoint list" required="m" response="0x42">
+            <description>The get endpoint list request command is used to retrieve addressing information for each endpoint the device is using in its unicast communication in controlling different (remote) devices.</description>
+            <payload>
+              <attribute id="0x0000" type="u8" name="Start index" showas="dec" required="m" default="0"></attribute>
+            </payload>
+          </command>
+          <command id="0xd0" dir="recv" name="Write MAC address" required="m" vendor="0x1135">
+            <description>Non standard write MAC address (DDEL).</description>
+            <payload>
+              <attribute id="0x0000" type="u64" name="MAC address" showas="hex" required="m" default="0"></attribute>
+            </payload>
+          </command>
+        </server>
+        <client>
+          <command id="0x41" dir="recv" name="Get group identifiers response" required="m">
+            <description>The get group identifiers response command allows a remote device to respond to the get group identifiers request command.</description>
+            <payload>
+              <attribute id="0x0000" type="u8" name="Total" required="m" default="0"></attribute>
+              <attribute id="0x0001" type="u8" name="Start index" required="m" default="0"></attribute>
+              <attribute id="0x0002" type="u8" name="Count" required="m" default="0"></attribute>
+              
+              <!-- TODO this will display only first item of the list -->
+              <attribute id="0x0003" type="u16" name="First group ID" showas="hex" required="m" default="0x0000"></attribute>
+              <attribute id="0x0004" type="u8" name="First group type" showas="hex" required="m" default="0x00"></attribute>
+            </payload>
+          </command>
+          <command id="0x42" dir="recv" name="Get endpoint list response" required="m">
+            <description>The get group identifiers response command allows a remote device to respond to the get group identifiers request command.</description>
+            <payload>
+              <attribute id="0x0000" type="u8" name="Total" required="m" default="0"></attribute>
+              <attribute id="0x0001" type="u8" name="Start index" required="m" default="0"></attribute>
+              <attribute id="0x0002" type="u8" name="Count" required="m" default="0"></attribute>
+              
+              <!-- TODO this will display only first item of the list -->
+              <attribute id="0x0003" type="u16" name="NWK address" showas="hex" required="m" default="0x0000"></attribute>
+              <attribute id="0x0004" type="u8" name="Endpoint" showas="hex" required="m" default="0x00"></attribute>
+              <attribute id="0x0005" type="u16" name="Profile ID" showas="hex" required="m" default="0x0000"></attribute>
+              <attribute id="0x0006" type="u16" name="Device ID" showas="hex" required="m" default="0x0000"></attribute>
+              <attribute id="0x0007" type="u8" name="Version" showas="hex" required="m" default="0x00"></attribute>
+            </payload>
+          </command>
+        </client>
+      </cluster>
+    </domain>
+    
+    <domain name="Green Power" useZcl="true"
+      description="The green power domain contains clusters and information that provides ZGP specific functions and attributes.">
+      <cluster id="0x0021" name="Green Power">
+        <description>Attributes and commands.</description>
+        <server>
+          <attribute id="0x0000" name="Max Sink Table Entries" type="u8" default="0x00" access="r" required="m" showas="hex">
+            <description>Maximum number of Sink Table entries supported by this device.</description>
+          </attribute>
+          <attribute id="0x0001" name="Sink Table" type="lostring" default="0x0000" access="r" required="m" showas="hex">
+            <description>Sink Table, holding information about local bindings between a particular GPD and target‘s local endpoints.</description>
+          </attribute>
+          <attribute id="0x0002" name="Communication Mode" type="bmp8" default="0x01" access="rw" required="m" showas="hex">
+            <description>Default communication mode requested by this sink.</description>
+          </attribute>
+          <attribute id="0x0003" name="Commissioning Exit Mode" type="bmp8" default="0x02" access="rw" required="m" showas="hex">
+            <description>Conditions for the sink to exit the commissioning mode.</description>
+          </attribute>
+          <attribute id="0x0004" name="Commissioning Window" type="u16" default="0x00B4" access="rw" required="o" showas="hex">
+            <description>Default duration of the Commissioning window duration, in seconds, as requested by this sink.</description>
+          </attribute>
+          <attribute id="0x0005" name="Security Level" type="bmp8" default="0x06" access="rw" required="m" showas="hex">
+            <description>The minimum required security level to be supported by the paired GPDs.</description>
+          </attribute>
+          <attribute id="0x0006" name="Functionality" type="bmp24" default="0x0" access="r" required="m" showas="hex">
+            <description>The optional GP functionality supported by this sink.</description>
+          </attribute>
+          <attribute id="0x0007" name="Active Functionality" type="bmp24" default="0xffffff" access="r" required="m" showas="hex">
+            <description>The optional GP functionality supported by this sink that is active.</description>
+          </attribute>
+          <attribute id="0x0020" name="Shared Security Key Type" type="bmp8" default="0x00" access="r" required="m" showas="hex">
+          </attribute>
+          <attribute id="0x0021" name="Shared Security Key" type="seckey" access="r" required="m" showas="hex">
+          </attribute>
+          <attribute id="0x0022" name="GP Link Key" type="seckey" access="r" required="m" showas="hex">
+          </attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      <device id="0x0060" name="GP Proxy" description=""></device>
+      <device id="0x0061" name="GP Proxy Basic" description=""></device>
+      <device id="0x0062" name="GP Target Plus" description=""></device>
+      <device id="0x0063" name="GP Target" description=""></device>
+      <device id="0x0064" name="GP Commissioning Tool" description=""></device>
+      <device id="0x0065" name="GP Combo" description=""></device>
+      <device id="0x0066" name="GP Combo Basic" description=""></device>
+    </domain>
+    
+    <domain name="Manufacturer Specific" useZcl="true" description="Manufacturer specific clusters.">
+      <!-- Dresden Elektronik -->
+      <cluster id="0xfc00" name="Spectral Measurement" mfcode="0x1135">
+        <description>Dresden Elektronik Specific clusters.</description>
+        <server>
+          <attribute id="0x0000" type="u8" name="On" required="m" access="rw" default="0">
+            <description>Enable Sensor </description>
+          </attribute>
+          
+          <attribute id="0x0001" name="X-Value" type="u16" default="0x0000" access="r" required="m" showas="dec">
+            <description>X-Value</description>
+          </attribute>
+          
+          <attribute id="0x0002" name="Y-Value" type="u16" default="0x0000" access="r" required="m" showas="dec">
+            <description>Y-Value</description>
+          </attribute>
+          
+          <attribute id="0x0003" name="Z-Value" type="u16" default="0x0000" access="r" required="m" showas="dec">
+            <description>Z-Value</description>
+          </attribute>
+          
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <!-- Hue -->
+      <cluster id="0xfc00" name="Hue" mfcode="0x100b">
+        <description>Hue-specific cluster.</description>
+        <server>
+          <command id="0x00" dir="send" name="Button Action Notification" required="m">
+            <payload>
+              <attribute id="0x0000" type="u16" name="Button" required="m"/>
+              <attribute id="0x0001" type="enum8" name="Type" required="m">
+                <value name="Push" value="0x00"/>
+                <value name="Rotary" value="0x01"/>
+              </attribute>
+              <attribute id="0x0002" type="u8" name="" showas="hex" required="m"/>
+              <attribute id="0x0003" type="enum8" name="Action" required="m">
+                <value name="Press" value="0x00"/>
+                <value name="Hold" value="0x01"/>
+                <value name="Release" value="0x02"/>
+                <value name="Long Release" value="0x03"/>
+              </attribute>
+              <attribute id="0x0004" type="u8" name="" showas="hex" required="m"/>
+              <attribute id="0x0000" type="u16" name="Duration" required="m"/>
+            </payload>
+          </command>
+        </server>
+      </cluster>
+      
+      <!-- Hue for Lutron Aurora -->
+      <cluster id="0xfc00" name="Hue" mfcode="0x1144">
+        <description>Hue-specific cluster.</description>
+        <server>
+          <command id="0x00" dir="send" name="Button Action Notification" required="m">
+            <payload>
+              <attribute id="0x0000" type="u16" name="Button" required="m"/>
+              <attribute id="0x0001" type="enum8" name="Type" required="m">
+                <value name="Push" value="0x00"/>
+                <value name="Rotary" value="0x01"/>
+              </attribute>
+              <attribute id="0x0002" type="u8" name="" showas="hex" required="m"/>
+              <attribute id="0x0003" type="enum8" name="Action" required="m">
+                <value name="Press" value="0x00"/>
+                <value name="Hold" value="0x01"/>
+                <value name="Release" value="0x02"/>
+                <value name="Long Release" value="0x03"/>
+              </attribute>
+              <attribute id="0x0004" type="u8" name="" showas="hex" required="m"/>
+              <attribute id="0x0000" type="u16" name="Duration" required="m"/>
+            </payload>
+          </command>
+        </server>
+      </cluster>
+      
+      
+      <!-- Sunricher C4 -->
+      <cluster id="0xfc00" name="Device Setup" mfcode="0x1224">
+        <description>Sunricher-specific cluster.</description>
+        <server>
+          <attribute id="0x0000" type="array" name="Input Configurations" access="rw" required="m" mfcode="0x1224"/>
+          <attribute id="0x0001" type="array" name="Input Actions" access="rw" required="m" mfcode="0x1224"/>
+        </server>
+      </cluster>
+      
+      <!-- LiXee -->
+      <cluster id="0xff66" name="LiXee specific cluster" mfcode="0x1037">
+        <description>LiXee specific cluster.</description>
+        <server>
+          <attribute id="0x0000" type="cstring" name="Option tarifaire" access="r" required="m"/>
+          <attribute id="0x0002" type="u8" name="Horaire HP-HC" access="r" required="m" default="0x00"/>
+          <attribute id="0x0003" type="u8" name="Présence des potentiels" access="r" required="m" default="0x00"/>
+          <attribute id="0x0004" type="u8" name="Préavis début EJP" access="r" required="m" default="0x00"/>
+          <attribute id="0x0005" type="u16" name="Avertissement de Dépassement De Puissance Souscrite" access="r" required="m" default="0x00"/>
+          <attribute id="0x0006" type="u16" name="Avertissement de Dépassement D'intensité P1" access="r" required="m" default="0x00"/>
+          <attribute id="0x0007" type="u16" name="Avertissement de Dépassement D'intensité P2" access="r" required="m" default="0x00"/>
+          <attribute id="0x0008" type="u16" name="Avertissement de Dépassement D'intensité P3" access="r" required="m" default="0x00"/>
+          <attribute id="0x0200" type="cstring" name="Libellé tarif fournisseur en cours" access="r" required="m"/>
+          <attribute id="0x0203" type="u32" name="Energie active soutirée Distributeur, index 01" access="r" required="m" default="0x00"/>
+          <attribute id="0x0203" type="u32" name="Energie active soutirée Distributeur, index 01" access="r" required="m" default="0x00"/>
+          <attribute id="0x0207" type="u16" name="Puissance app. Instantanée injectée" access="r" required="m" default="0x00"/>
+          <attribute id="0x0217" type="cstring" name="Registre de Statuts" access="r" required="m"/>
+          <attribute id="0x0300" type="u8" name="Protocole Linky" access="r" required="m" default="0x00"/>
+        </server>
+      </cluster>
+      
+      <!-- Tuya -->
+      <cluster id="0xef00" name="Tuya specific" mfcode="0x1002">
+        <description>Tuya Specific clusters.</description>
+        <server>
+          <command id="00" dir="recv" name="Data Request" required="m">
+            <description>Request datapoint (fields are big-endian!)</description>
+            <payload>
+              <attribute id="0x0000" type="u16" name="Sequence number" required="m" showas="hex" default="0"></attribute>
+              <attribute id="0x0001" type="u8" name="DPID" required="m" showas="hex" default="0x00"></attribute>
+              <attribute id="0x0002" type="enum8" name="Type" required="m" showas="hex" default="0x00">
+                <value name="Raw" value="0x00"/>
+                <value name="Bool" value="0x01"/>
+                <value name="Value" value="0x02"/>
+                <value name="String" value="0x03"/>
+                <value name="Enum" value="0x04"/>
+                <value name="Bitmap" value="0x05"/>
+              </attribute>
+              <attribute id="0x0003" type="u16" name="Length" required="m" showas="hex" default="0x00"></attribute>
+              <attribute id="0x0004" type="u32" name="Value" required="m" showas="hex" default="0"></attribute>
+            </payload>
+          </command>
+          <command id="0x03" dir="recv" name="Data Query" required="m">
+            <description>Trigger report all datapoints.</description>
+          </command>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <!-- Legrand -->
+      <cluster id="0xfc01" name="Legrand - Specific clusters" mfcode="1021">
+        <description>Legrand Classic Specific clusters, used by all devices. But take care they are device specific.
+          
+          > Dimmer switch without neutral : Option 1 = Dimmer on/off.
+          > Cable outlet : Option 1 = Fil pilote on/off.
+          > Contactor : On/off=0003 - HP/HC=0004.
+        </description>
+        <server>
+          <attribute id="0x0000" type="dat16" name="Option 1" default="0x0101" access="rw" required="m" showas="hex">
+            <description>Choose correctly according to your device Dimmer OR fil pilote.
+              Dimmer > Off=0100 - On=0101
+              Fil pilote > Off=0001 - On=0002
+              Contactor > On/off=0003 - HP/HC=0004</description>
+          </attribute>
+          <attribute id="0x0001" type="bool" name="Option 2" required="m" access="rw" default="0">
+            <description>Option 1</description>
+          </attribute>
+          <attribute id="0x0002" type="bool" name="Option 3" required="m" access="rw" default="0">
+            <description>Option 2</description>
+          </attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0xfc40" name="Legrand - Specific clusters 2" mfcode="1021">
+        <description>Legrand Specific clusters, Used by cable outlet.</description>
+        <server>
+          
+          <command id="00" dir="recv" name="Unknow" required="m">
+            <description>Set fil pilote mode</description>
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Mode" required="m" default="0x00">
+                <value name="Comfort" value="0x00"></value>
+                <value name="Comfort -1" value="0x01"></value>
+                <value name="Comfort -2" value="0x02"></value>
+                <value name="Eco" value="0x03"></value>
+                <value name="Hors-Gel" value="0x04"></value>
+                <value name="Off" value="0x05"></value>
+              </attribute>
+            </payload>
+          </command>
+          
+          <attribute id="0x0000" type="enum8" name="Mode" default="0x00" access="r" required="m">
+            <description>Heating mode</description>
+            <value name="Comfort" value="0x00"></value>
+            <value name="Comfort -1" value="0x01"></value>
+            <value name="Comfort -2" value="0x02"></value>
+            <value name="Eco" value="0x03"></value>
+            <value name="Hors-Gel" value="0x04"></value>
+            <value name="Off" value="0x05"></value>
+          </attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <!-- ubisys -->
+      <cluster id="0xfc00" name="Device Setup" mfcode="0x10f2">
+        <description>Attributes and commands.</description>
+        <server>
+          <attribute id="0x0000" name="Input Configurations" type="array" default="0" access="r" required="m">
+          </attribute>
+          <attribute id="0x0001" name="Input Actions" type="array" default="0" access="r" required="m">
+          </attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0xfc01" name="Dimmer Setup" mfcode="0x10f2">
+        <description>Attributes and commands.</description>
+        <server>
+          <attribute id="0x0000" name="Capabilities" type="bmp8" default="00000000" access="r" required="m">
+            <value name="Forward Phase Control" value="0"></value>
+            <value name="Reverse Phase Control" value="1"></value>
+            <value name="Reactance Discriminator" value="5"></value>
+            <value name="Configurable Curve" value="6"></value>
+            <value name="Overload detection" value="7"></value>
+          </attribute>
+          
+          <attribute id="0x0001" name="Status" type="bmp8" default="00000000" access="r" required="m">
+            <value name="Forward Phase Control" value="0"></value>
+            <value name="Reverse Phase Control" value="1"></value>
+            <value name="Operational" value="2"></value>
+            <value name="Overload" value="3"></value>
+            <value name="Capacitive Load" value="6"></value>
+            <value name="Inductive Load" value="7"></value>
+          </attribute>
+          
+          <attribute id="0x0002" name="Mode" type="bmp8" default="00000000" access="r" required="m">
+            <value name="Automatic Phase Control" value="0"></value>
+            <value name="Forward Phase Control" value="1"></value>
+            <value name="Reverse Phase Control" value="2"></value>
+          </attribute>
+          
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <!-- Samjin -->
+      <cluster id="0xfc02" name="Samjin specific" mfcode="0x104e">
+        <description>Samjin manufacturer-specifc cluster for SmartThings multi sensor.</description>
+        <server>
+          <attribute id="0x0000" name="Motion Threshold Multiplier" type="u8" mfcode="0x104e" default="0" access="rw" required="m"> </attribute>
+          <attribute id="0x0002" name="Motion Threshold" type="u16" mfcode="0x104e" default="0" access="rw" required="m"> </attribute>
+          <attribute id="0x0010" name="Active" type="bmp8" mfcode="0x104e" default="0" access="r" required="m">
+            <value name="Active" value="0"></value>
+          </attribute>
+          <attribute id="0x0012" name="Acceleration X" type="s16" mfcode="0x104e" default="0" access="r" required="m"> </attribute>
+          <attribute id="0x0013" name="Acceleration Y" type="s16" mfcode="0x104e" default="0" access="r" required="m"> </attribute>
+          <attribute id="0x0014" name="Acceleration Z" type="s16" mfcode="0x104e" default="0" access="r" required="m"> </attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0xfc02" name="Samjin" mfcode="0x110a">
+        <description>Samjin manufacturer-specifc cluster for SmartThings multi sensor.</description>
+        <server>
+          <attribute id="0x0000" name="Motion Threshold Multiplier" type="u8" mfcode="0x110a" default="0" access="rw" required="m"> </attribute>
+          <attribute id="0x0002" name="Motion Threshold" type="u16" mfcode="0x110a" default="0" access="rw" required="m"> </attribute>
+          <attribute id="0x0010" name="Active" type="bmp8" mfcode="0x110a" default="0" access="r" required="m">
+            <value name="Active" value="0"></value>
+          </attribute>
+          <attribute id="0x0012" name="Acceleration X" type="s16" mfcode="0x110a" default="0" access="r" required="m"> </attribute>
+          <attribute id="0x0013" name="Acceleration Y" type="s16" mfcode="0x110a" default="0" access="r" required="m"> </attribute>
+          <attribute id="0x0014" name="Acceleration Z" type="s16" mfcode="0x110a" default="0" access="r" required="m"> </attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0xfc02" name="Samjin" mfcode="0x1241">
+        <description>Samjin manufacturer-specifc cluster for SmartThings multi sensor.</description>
+        <server>
+          <attribute id="0x0000" name="Motion Threshold Multiplier" type="u8" mfcode="0x1241" default="0" access="rw" required="m"> </attribute>
+          <attribute id="0x0010" name="Active" type="bmp8" mfcode="0x1241" default="0" access="r" required="m">
+            <value name="Active" value="0"></value>
+          </attribute>
+          <attribute id="0x0012" name="Acceleration X" type="s16" mfcode="0x1241" default="0" access="r" required="m"> </attribute>
+          <attribute id="0x0013" name="Acceleration Y" type="s16" mfcode="0x1241" default="0" access="r" required="m"> </attribute>
+          <attribute id="0x0014" name="Acceleration Z" type="s16" mfcode="0x1241" default="0" access="r" required="m"> </attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <!-- OSRAM -->
+      <cluster id="0xfc0f" name="OSRAM specific" mfcode="0xbbaa">
+        <description>OSRAM manufacturer-specific cluster to set power-on defaults.</description>
+        <server>
+          <command id="0x01" dir="recv" name="Store Power-On Defaults" required="o">
+          </command>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <!-- LEDVANCE -->
+      <cluster id="0xfc01" name="LEDVANCE specific" mfcode="0x1189">
+        <description>LEDVANCE manufacturer-specific cluster to set power-on defaults.</description>
+        <server>
+          <command id="0x01" dir="recv" name="Store Power-On Defaults" required="o">
+          </command>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <!-- E-Wand -->
+      <cluster id="0xfc10" name="E-Wand specific" mfcode="0x1263">
+        <description>E-Wand manufacturer specific window covering configuration.</description>
+        <server>
+          <command id="0x23" dir="recv" name="Set Direction" required="o">
+            <description></description>
+            <payload>
+              <attribute id="0x0000" type="enum8" name="Mode" required="m" default="0x00">
+                <value name="Standard" value="0x00"></value>
+                <value name="Reversed" value="0x01"></value>
+                <value name="Toggle" value="0x02"></value>
+              </attribute>
+            </payload>
+          </command>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <!-- IKEA -->
+      <cluster id="0xfc7c" name="IKEA specific" mfcode="0x117c">
+        <description>IKEA control outlet cluster.</description>
+        <server>
+          <attribute id="0x0010" name="Unknown 1" type="u8" access="rw" required="m" showas="hex" mfcode="0x117c">
+            <description></description>
+          </attribute>
+          <attribute id="0xfffd" name="Cluster Revision" type="u16" required="m" access="rw" showas="hex" mfcode="0x117c">
+            <description></description>
+          </attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0xfc7d" name="Air Purifier Control" mfcode="0x117c">
+        <description>Cluster to control the IKEA Starkvind Air Purifier.</description>
+        <server>
+          <attribute id="0x0000" name="Filter Run Time" type="u32" access="r" required="m" mfcode="0x117c"></attribute>
+          <attribute id="0x0001" name="Replace Filter" type="u8" access="r" required="m" mfcode="0x117c"></attribute>
+          <attribute id="0x0002" name="Filter Life Time" type="u32" access="rw" required="m" mfcode="0x117c"></attribute>
+          <attribute id="0x0003" name="Disable LEDs" type="bool" access="rw" required="m" mfcode="0x117c"></attribute>
+          <attribute id="0x0004" name="Air Quality" type="u16" access="r" required="m" mfcode="0x117c"></attribute>
+          <attribute id="0x0005" name="Lock Controls" type="bool" access="rw" required="m" mfcode="0x117c"></attribute>
+          <attribute id="0x0006" name="Target Mode" type="u8" access="rw" required="m" mfcode="0x117c"></attribute>
+          <attribute id="0x0007" name="Current Mode" type="u8" access="r" required="m" mfcode="0x117c"></attribute>
+          <attribute id="0x0008" name="Device Run Time" type="u32" access="r" required="m" mfcode="0x117c"></attribute>
+        </server>
+      </cluster>
+      
+      <!-- LUMI -->
+      <cluster id="0xfcc0" name="Lumi specific" mfcode="0x115f">
+        <description>Lumi specific attributes.</description>
+        <server>
+          <attribute-set id="0x0000" description="Unknown">
+            <attribute id="0x0001" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0002" name="Power Outages" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0003" name="Unknown" type="enum8" mfcode="0x115f" access="r" required="m"> </attribute>
+            <value name="0" value="0x00"></value>
+            <value name="1" value="0x01"></value>
+            <value name="2" value="0x02"></value>
+            <value name="3" value="0x03"></value>
+            <value name="4" value="0x04"></value>
+            <attribute id="0x0006" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0007" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0008" name="Unknown (write only)" type="ostring" mfcode="0x115f" access="w" required="m"> </attribute>
+            <attribute id="0x0009" name="Device operation mode" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x000A" name="Switch mode" type="u8" mfcode="0x115f" access="rw" required="m">
+              <description>Switch mode: 1 - event based switching, 2 - zigbee group switching, 3 - Xiaomi specific switching</description>
             </attribute>
-            <attribute id="0x0002" type="u8" name="" showas="hex" required="m"/>
-            <attribute id="0x0003" type="enum8" name="Action" required="m">
-              <value name="Press" value="0x00"/>
-              <value name="Hold" value="0x01"/>
-              <value name="Release" value="0x02"/>
-              <value name="Long Release" value="0x03"/>
+            <attribute id="0x000C" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x000D" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x00E8" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x00E9" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x00EA" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x00EB" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x00ED" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x00EE" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x00F0" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x00F1" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x00F3" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x00F4" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x00F5" name="Unknown" type="u32" mfcode="0x115f" access="r" required="m"> </attribute>
+            <attribute id="0x00F6" name="Reporting Interval" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x00F7" name="Unknown" type="ostring" mfcode="0x115f" access="r" required="m"> </attribute>
+            <attribute id="0x00F8" name="Unknown" type="u64" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x00F9" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x00FA" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x00FB" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x00FC" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x00FE" name="Serial Number" type="cstring" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x00FF" name="Unknown (write only)" type="ostring" mfcode="0x115f" access="w" required="m"> </attribute>
+            <attribute id="0x0100" name="Unknown" type="u8" mfcode="0x115f" access="r" required="m"> </attribute>
+            <attribute id="0x0102" name="Motion cool off time" type="u8" mfcode="0x115f" access="rw" required="m">
+              <description>Time in seconds when RTCGQ13LM sets motion to false if no further motion has been detected</description>
             </attribute>
-            <attribute id="0x0004" type="u8" name="" showas="hex" required="m"/>
-            <attribute id="0x0000" type="u16" name="Duration" required="m"/>
-          </payload>
-        </command>
-      </server>
-    </cluster>
-
-    <!-- Hue for Lutron Aurora -->
-    <cluster id="0xfc00" name="Hue" mfcode="0x1144">
-      <description>Hue-specific cluster.</description>
-      <server>
-        <command id="0x00" dir="send" name="Button Action Notification" required="m">
-          <payload>
-            <attribute id="0x0000" type="u16" name="Button" required="m"/>
-            <attribute id="0x0001" type="enum8" name="Type" required="m">
-              <value name="Push" value="0x00"/>
-              <value name="Rotary" value="0x01"/>
+            <attribute id="0x010C" name="Motion sensitivity" type="u8" mfcode="0x115f" access="rw" required="m">
+              <description>Motion sensitivity: 1 - low, 2 - medium, 3 - high</description>
             </attribute>
-            <attribute id="0x0002" type="u8" name="" showas="hex" required="m"/>
-            <attribute id="0x0003" type="enum8" name="Action" required="m">
-              <value name="Press" value="0x00"/>
-              <value name="Hold" value="0x01"/>
-              <value name="Release" value="0x02"/>
-              <value name="Long Release" value="0x03"/>
+            <attribute id="0x0112" name="Unknown" type="u32" mfcode="0x115f" access="r" required="m"> </attribute>
+            <attribute id="0x0114" name="TVOC unit config" type="u8" mfcode="0x115f" access="rw" required="m">
+              <description>0 - µg/m³ + °C, 1 - ppb + °C, 16 - µg/m³ + °F, 17 - ppb + °F</description>
             </attribute>
-            <attribute id="0x0004" type="u8" name="" showas="hex" required="m"/>
-            <attribute id="0x0000" type="u16" name="Duration" required="m"/>
-          </payload>
-        </command>
-      </server>
-    </cluster>
-
-
-    <!-- Sunricher C4 -->
-    <cluster id="0xfc00" name="Device Setup" mfcode="0x1224">
-      <description>Sunricher-specific cluster.</description>
-      <server>
-        <attribute id="0x0000" type="array" name="Input Configurations" access="rw" required="m" mfcode="0x1224"/>
-        <attribute id="0x0001" type="array" name="Input Actions" access="rw" required="m" mfcode="0x1224"/>
-      </server>
-    </cluster>
-
-    <!-- LiXee -->
-    <cluster id="0xff66" name="LiXee specific cluster" mfcode="0x1037">
-      <description>LiXee specific cluster.</description>
-      <server>
-        <attribute id="0x0000" type="cstring" name="Option tarifaire" access="r" required="m"/>
-        <attribute id="0x0002" type="u8" name="Horaire HP-HC" access="r" required="m" default="0x00"/>
-        <attribute id="0x0003" type="u8" name="Présence des potentiels" access="r" required="m" default="0x00"/>
-        <attribute id="0x0004" type="u8" name="Préavis début EJP" access="r" required="m" default="0x00"/>
-        <attribute id="0x0005" type="u16" name="Avertissement de Dépassement De Puissance Souscrite" access="r" required="m" default="0x00"/>
-        <attribute id="0x0006" type="u16" name="Avertissement de Dépassement D'intensité P1" access="r" required="m" default="0x00"/>
-        <attribute id="0x0007" type="u16" name="Avertissement de Dépassement D'intensité P2" access="r" required="m" default="0x00"/>
-        <attribute id="0x0008" type="u16" name="Avertissement de Dépassement D'intensité P3" access="r" required="m" default="0x00"/>
-        <attribute id="0x0200" type="cstring" name="Libellé tarif fournisseur en cours" access="r" required="m"/>
-        <attribute id="0x0203" type="u32" name="Energie active soutirée Distributeur, index 01" access="r" required="m" default="0x00"/>
-        <attribute id="0x0203" type="u32" name="Energie active soutirée Distributeur, index 01" access="r" required="m" default="0x00"/>
-        <attribute id="0x0207" type="u16" name="Puissance app. Instantanée injectée" access="r" required="m" default="0x00"/>
-        <attribute id="0x0217" type="cstring" name="Registre de Statuts" access="r" required="m"/>
-        <attribute id="0x0300" type="u8" name="Protocole Linky" access="r" required="m" default="0x00"/>
-      </server>
-    </cluster>
-
-		<!-- Tuya -->
-		<cluster id="0xef00" name="Tuya specific" mfcode="0x1002">
-			<description>Tuya Specific clusters.</description>
-			<server>
-				<command id="00" dir="recv" name="Data Request" required="m">
-					<description>Request datapoint (fields are big-endian!)</description>
-					<payload>
-						<attribute id="0x0000" type="u16" name="Sequence number" required="m" showas="hex" default="0"></attribute>
-						<attribute id="0x0001" type="u8" name="DPID" required="m" showas="hex" default="0x00"></attribute>
-						<attribute id="0x0002" type="enum8" name="Type" required="m" showas="hex" default="0x00">
-							<value name="Raw" value="0x00"/>
-							<value name="Bool" value="0x01"/>
-							<value name="Value" value="0x02"/>
-							<value name="String" value="0x03"/>
-							<value name="Enum" value="0x04"/>
-							<value name="Bitmap" value="0x05"/>
-						</attribute>
-						<attribute id="0x0003" type="u16" name="Length" required="m" showas="hex" default="0x00"></attribute>
-						<attribute id="0x0004" type="u32" name="Value" required="m" showas="hex" default="0"></attribute>
-					</payload>
-				</command>
-
-				<command id="0x03" dir="recv" name="Data Query" required="m">
-					<description>Trigger report all datapoints.</description>
-				</command>
-			</server>
-			<client>
-			</client>
-		</cluster>
-
-		<!-- Legrand -->
-		<cluster id="0xfc01" name="Legrand - Specific clusters" mfcode="1021">
-			<description>Legrand Classic Specific clusters, used by all devices. But take care they are device specific.
-
-> Dimmer switch without neutral : Option 1 = Dimmer on/off.
-> Cable outlet : Option 1 = Fil pilote on/off.
-> Contactor : On/off=0003 - HP/HC=0004.
-			</description>
-			<server>
-				<attribute id="0x0000" type="dat16" name="Option 1" default="0x0101" access="rw" required="m" showas="hex">
-					<description>Choose correctly according to your device Dimmer OR fil pilote.
-Dimmer > Off=0100 - On=0101
-Fil pilote > Off=0001 - On=0002
-Contactor > On/off=0003 - HP/HC=0004</description>
-				</attribute>
-				<attribute id="0x0001" type="bool" name="Option 2" required="m" access="rw" default="0">
-					<description>Option 1</description>
-				</attribute>
-				<attribute id="0x0002" type="bool" name="Option 3" required="m" access="rw" default="0">
-					<description>Option 2</description>
-				</attribute>
-			</server>
-			<client>
-			</client>
-		</cluster>
-		<cluster id="0xfc40" name="Legrand - Specific clusters 2" mfcode="1021">
-			<description>Legrand Specific clusters, Used by cable outlet.</description>
-			<server>
-
-			<command id="00" dir="recv" name="Unknow" required="m">
-				<description>Set fil pilote mode</description>
-				<payload>
-					<attribute id="0x0000" type="enum8" name="Mode" required="m" default="0x00">
-						<value name="Comfort" value="0x00"></value>
-						<value name="Comfort -1" value="0x01"></value>
-						<value name="Comfort -2" value="0x02"></value>
-						<value name="Eco" value="0x03"></value>
-						<value name="Hors-Gel" value="0x04"></value>
-						<value name="Off" value="0x05"></value>
-					</attribute>
-				</payload>
-			</command>
-
-			<attribute id="0x0000" type="enum8" name="Mode" default="0x00" access="r" required="m">
-				<description>Heating mode</description>
-					<value name="Comfort" value="0x00"></value>
-					<value name="Comfort -1" value="0x01"></value>
-					<value name="Comfort -2" value="0x02"></value>
-					<value name="Eco" value="0x03"></value>
-					<value name="Hors-Gel" value="0x04"></value>
-					<value name="Off" value="0x05"></value>
-			</attribute>
-			</server>
-			<client>
-			</client>
-                </cluster>
-
-		<!-- ubisys -->
-		<cluster id="0xfc00" name="Device Setup" mfcode="0x10f2">
-			<description>Attributes and commands.</description>
-			<server>
-				<attribute id="0x0000" name="Input Configurations" type="array" default="0" access="r" required="m">
-				</attribute>
-				<attribute id="0x0001" name="Input Actions" type="array" default="0" access="r" required="m">
-				</attribute>
-			</server>
-			<client>
-			</client>
-		</cluster>
-
-		<cluster id="0xfc01" name="Dimmer Setup" mfcode="0x10f2">
-			<description>Attributes and commands.</description>
-			<server>
-				<attribute id="0x0000" name="Capabilities" type="bmp8" default="00000000" access="r" required="m">
-					<value name="Forward Phase Control" value="0"></value>
-					<value name="Reverse Phase Control" value="1"></value>
-					<value name="Reactance Discriminator" value="5"></value>
-					<value name="Configurable Curve" value="6"></value>
-					<value name="Overload detection" value="7"></value>
-				</attribute>
-
-				<attribute id="0x0001" name="Status" type="bmp8" default="00000000" access="r" required="m">
-					<value name="Forward Phase Control" value="0"></value>
-					<value name="Reverse Phase Control" value="1"></value>
-					<value name="Operational" value="2"></value>
-					<value name="Overload" value="3"></value>
-					<value name="Capacitive Load" value="6"></value>
-					<value name="Inductive Load" value="7"></value>
-				</attribute>
-
-				<attribute id="0x0002" name="Mode" type="bmp8" default="00000000" access="r" required="m">
-					<value name="Automatic Phase Control" value="0"></value>
-					<value name="Forward Phase Control" value="1"></value>
-					<value name="Reverse Phase Control" value="2"></value>
-				</attribute>
-
-			</server>
-			<client>
-			</client>
-		</cluster>
-
-		<!-- Samjin -->
-    <cluster id="0xfc02" name="Samjin specific" mfcode="0x104e">
-			<description>Samjin manufacturer-specifc cluster for SmartThings multi sensor.</description>
-			<server>
-        <attribute id="0x0000" name="Motion Threshold Multiplier" type="u8" mfcode="0x104e" default="0" access="rw" required="m"> </attribute>
-        <attribute id="0x0002" name="Motion Threshold" type="u16" mfcode="0x104e" default="0" access="rw" required="m"> </attribute>
-        <attribute id="0x0010" name="Active" type="bmp8" mfcode="0x104e" default="0" access="r" required="m">
-          <value name="Active" value="0"></value>
-        </attribute>
-				<attribute id="0x0012" name="Acceleration X" type="s16" mfcode="0x104e" default="0" access="r" required="m"> </attribute>
-				<attribute id="0x0013" name="Acceleration Y" type="s16" mfcode="0x104e" default="0" access="r" required="m"> </attribute>
-				<attribute id="0x0014" name="Acceleration Z" type="s16" mfcode="0x104e" default="0" access="r" required="m"> </attribute>
-			</server>
-			<client>
-			</client>
-		</cluster>
-    <cluster id="0xfc02" name="Samjin" mfcode="0x110a">
-			<description>Samjin manufacturer-specifc cluster for SmartThings multi sensor.</description>
-			<server>
-        <attribute id="0x0000" name="Motion Threshold Multiplier" type="u8" mfcode="0x110a" default="0" access="rw" required="m"> </attribute>
-        <attribute id="0x0002" name="Motion Threshold" type="u16" mfcode="0x110a" default="0" access="rw" required="m"> </attribute>
-        <attribute id="0x0010" name="Active" type="bmp8" mfcode="0x110a" default="0" access="r" required="m">
-          <value name="Active" value="0"></value>
-        </attribute>
-				<attribute id="0x0012" name="Acceleration X" type="s16" mfcode="0x110a" default="0" access="r" required="m"> </attribute>
-				<attribute id="0x0013" name="Acceleration Y" type="s16" mfcode="0x110a" default="0" access="r" required="m"> </attribute>
-				<attribute id="0x0014" name="Acceleration Z" type="s16" mfcode="0x110a" default="0" access="r" required="m"> </attribute>
-			</server>
-			<client>
-			</client>
-		</cluster>
-		<cluster id="0xfc02" name="Samjin" mfcode="0x1241">
-			<description>Samjin manufacturer-specifc cluster for SmartThings multi sensor.</description>
-			<server>
-				<attribute id="0x0000" name="Motion Threshold Multiplier" type="u8" mfcode="0x1241" default="0" access="rw" required="m"> </attribute>
-        <attribute id="0x0010" name="Active" type="bmp8" mfcode="0x1241" default="0" access="r" required="m">
-          <value name="Active" value="0"></value>
-        </attribute>
-				<attribute id="0x0012" name="Acceleration X" type="s16" mfcode="0x1241" default="0" access="r" required="m"> </attribute>
-				<attribute id="0x0013" name="Acceleration Y" type="s16" mfcode="0x1241" default="0" access="r" required="m"> </attribute>
-				<attribute id="0x0014" name="Acceleration Z" type="s16" mfcode="0x1241" default="0" access="r" required="m"> </attribute>
-			</server>
-			<client>
-			</client>
-		</cluster>
-
-		<!-- OSRAM -->
-		<cluster id="0xfc0f" name="OSRAM specific" mfcode="0xbbaa">
-			<description>OSRAM manufacturer-specific cluster to set power-on defaults.</description>
-			<server>
-				<command id="0x01" dir="recv" name="Store Power-On Defaults" required="o">
-				</command>
-			</server>
-			<client>
-			</client>
-		</cluster>
-
-		<!-- LEDVANCE -->
-		<cluster id="0xfc01" name="LEDVANCE specific" mfcode="0x1189">
-			<description>LEDVANCE manufacturer-specific cluster to set power-on defaults.</description>
-			<server>
-				<command id="0x01" dir="recv" name="Store Power-On Defaults" required="o">
-				</command>
-			</server>
-			<client>
-			</client>
-		</cluster>
-
-		<!-- E-Wand -->
-		<cluster id="0xfc10" name="E-Wand specific" mfcode="0x1263">
-			<description>E-Wand manufacturer specific window covering configuration.</description>
-			<server>
-				<command id="0x23" dir="recv" name="Set Direction" required="o">
-					<description></description>
-					<payload>
-						<attribute id="0x0000" type="enum8" name="Mode" required="m" default="0x00">
-							<value name="Standard" value="0x00"></value>
-							<value name="Reversed" value="0x01"></value>
-							<value name="Toggle" value="0x02"></value>
-						</attribute>
-					</payload>
-				</command>
-			</server>
-			<client>
-			</client>
-		</cluster>
-
-		<!-- IKEA -->
-		<cluster id="0xfc7c" name="IKEA specific" mfcode="0x117c">
-			<description>IKEA control outlet cluster.</description>
-			<server>
-				<attribute id="0x0010" name="Unknown 1" type="u8" access="rw" required="m" showas="hex" mfcode="0x117c">
-					<description></description>
-				</attribute>
-				<attribute id="0xfffd" name="Cluster Revision" type="u16" required="m" access="rw" showas="hex" mfcode="0x117c">
-					<description></description>
-				</attribute>
-			</server>
-			<client>
-			</client>
-		</cluster>
-
-    <cluster id="0xfc7d" name="Air Purifier Control" mfcode="0x117c">
-      <description>Cluster to control the IKEA Starkvind Air Purifier.</description>
-      <server>
-        <attribute id="0x0000" name="Filter Run Time" type="u32" access="r" required="m" mfcode="0x117c"></attribute>
-        <attribute id="0x0001" name="Replace Filter" type="u8" access="r" required="m" mfcode="0x117c"></attribute>
-        <attribute id="0x0002" name="Filter Life Time" type="u32" access="rw" required="m" mfcode="0x117c"></attribute>
-        <attribute id="0x0003" name="Disable LEDs" type="bool" access="rw" required="m" mfcode="0x117c"></attribute>
-        <attribute id="0x0004" name="Air Quality" type="u16" access="r" required="m" mfcode="0x117c"></attribute>
-        <attribute id="0x0005" name="Lock Controls" type="bool" access="rw" required="m" mfcode="0x117c"></attribute>
-        <attribute id="0x0006" name="Target Mode" type="u8" access="rw" required="m" mfcode="0x117c"></attribute>
-        <attribute id="0x0007" name="Current Mode" type="u8" access="r" required="m" mfcode="0x117c"></attribute>
-        <attribute id="0x0008" name="Device Run Time" type="u32" access="r" required="m" mfcode="0x117c"></attribute>
-      </server>
-    </cluster>
-
-		<!-- LUMI -->
-		<cluster id="0xfcc0" name="Lumi specific" mfcode="0x115f">
-			<description>Lumi specific attributes.</description>
-			<server>
-				<attribute-set id="0x0000" description="Unknown">
-					<attribute id="0x0001" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0002" name="Power Outages" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0003" name="Unknown" type="enum8" mfcode="0x115f" access="r" required="m"> </attribute>
-						<value name="0" value="0x00"></value>
-						<value name="1" value="0x01"></value>
-						<value name="2" value="0x02"></value>
-						<value name="3" value="0x03"></value>
-						<value name="4" value="0x04"></value>
-					<attribute id="0x0006" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0007" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0008" name="Unknown (write only)" type="ostring" mfcode="0x115f" access="w" required="m"> </attribute>
-					<attribute id="0x0009" name="Device operation mode" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x000A" name="Switch mode" type="u8" mfcode="0x115f" access="rw" required="m">
-						<description>Switch mode: 1 - event based switching, 2 - zigbee group switching, 3 - Xiaomi specific switching</description>
-					</attribute>
-					<attribute id="0x000C" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x000D" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x00E8" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x00E9" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x00EA" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x00EB" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x00ED" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x00EE" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x00F0" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x00F1" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x00F3" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x00F4" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x00F5" name="Unknown" type="u32" mfcode="0x115f" access="r" required="m"> </attribute>
-					<attribute id="0x00F6" name="Reporting Interval" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x00F7" name="Unknown" type="ostring" mfcode="0x115f" access="r" required="m"> </attribute>
-					<attribute id="0x00F8" name="Unknown" type="u64" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x00F9" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x00FA" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x00FB" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x00FC" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x00FE" name="Serial Number" type="cstring" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x00FF" name="Unknown (write only)" type="ostring" mfcode="0x115f" access="w" required="m"> </attribute>
-					<attribute id="0x0100" name="Unknown" type="u8" mfcode="0x115f" access="r" required="m"> </attribute>
-					<attribute id="0x0102" name="Motion cool off time" type="u8" mfcode="0x115f" access="rw" required="m">
-						<description>Time in seconds when RTCGQ13LM sets motion to false if no further motion has been detected</description>
-					</attribute>
-					<attribute id="0x010C" name="Motion sensitivity" type="u8" mfcode="0x115f" access="rw" required="m">
-						<description>Motion sensitivity: 1 - low, 2 - medium, 3 - high</description>
-					</attribute>
-					<attribute id="0x0112" name="Unknown" type="u32" mfcode="0x115f" access="r" required="m"> </attribute>
-					<attribute id="0x0114" name="TVOC unit config" type="u8" mfcode="0x115f" access="rw" required="m">
-						<description>0 - µg/m³ + °C, 1 - ppb + °C, 16 - µg/m³ + °F, 17 - ppb + °F</description>
-					</attribute>
-					<attribute id="0x0125" name="Multiclick mode" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0135" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0136" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0137" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0138" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0152" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0200" name="Child lock off" type="u8" mfcode="0x115f" access="rw" required="m">
-						<description>Child lock off: 0 - false, 1 - true</description>
-					</attribute>
-					<attribute id="0x0201" name="Restore Power on Outage" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0202" name="Auto-off after 20m below Threshold" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0203" name="Device LED off (9pm-9am)" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0204" name="Min. Power Change for Report (W)" type="float" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0205" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m">
-						<description>Attribute 0x0205 has range between 1 and 50 only</description>
-					</attribute>
-					<attribute id="0x0206" name="Power Threshold for Auto-off" type="float" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0207" name="Consumer Connected" type="bool" mfcode="0x115f" access="r" required="m"> </attribute>
-					<attribute id="0x020B" name="Max. Load Exceeded at (W)" type="float" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x020C" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x020D" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x020E" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x023B" name="Unknown" type="float" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x023E" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"> </attribute>
-				</attribute-set>
-				<attribute-set id="0x0400" description="Aqara Roller Shade Driver E1">
-					<attribute id="0x0400" name="Reverse Direction" type="bool" mfcode="0x115f" access="rw" required="o">
-						<description>Reverse the direction of up/open and down/close.</description>
-					</attribute>
-					<attribute id="0x0402" name="Positions Stored" type="bool" mfcode="0x115f" access="rw" required="o">
-						<description>Position clearing: write false to clear the stored up/open and down/close positions.</description>
-					</attribute>
-					<attribute id="0x0407" name="Store Position" type="u8" mfcode="0x115f" access="rw" required="o">
-						<description>Position setting: write 1 to store the up/open position, 2 to store the down/close position.</description>
-					</attribute>
-					<attribute id="0x0408" name="Speed" type="u8" mfcode="0x115f" access="rw" required="o">
-						<description>Motor speed: 2: high, 1: medium, 0: low.</description>
-					</attribute>
-					<attribute id="0x0409" name="Charging" type="u8" mfcode="0x115f" access="r" required="o">
-						<description>Battery charging state: 1: charging, 2: not charging.</description>
-					</attribute>
-				</attribute-set>
-				<attribute-set id="0x0500" description="Unknown">
-					<attribute id="0x0700" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0701" name="Unknown" type="s8" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0702" name="Unknown" type="s8" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0703" name="Unknown" type="s8" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0704" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0705" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0740" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0780" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0781" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0782" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x0783" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0x07C0" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0xF000" name="Report Consumer Connected" type="u8" mfcode="0x115f" access="rw" required="m">
-						<description>Report Consumer Connected: 1 - false, 0 - true</description>
-					</attribute>
-					<attribute id="0xF001" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0xF002" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0xFFF2" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"> </attribute>
-					<attribute id="0xFFFD" name="Cluster Revision" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
-				</attribute-set>
-			</server>
-			<client>
-			</client>
-		</cluster>
-
-		<!-- AQARA -->
-		<cluster id="0xfcc0" name="Aqara specific" mfcode="0x1234">
-			<description>Aqara specific attributes.</description>
-			<server>
-				<attribute-set id="0x0000" description="Unknown">
-					<attribute id="0x0006" name="Unknown" type="ostring" access="rw" required="m"> </attribute>
-					<attribute id="0x0007" name="Unknown" type="ostring" access="rw" required="m"> </attribute>
-					<attribute id="0x00E4" name="Unknown" type="u32" access="rw" required="m"> </attribute>
-					<attribute id="0x00F7" name="Unknown" type="ostring" access="r" required="m"> </attribute>
-					<attribute id="0x00FA" name="Unknown" type="bool" access="rw" required="m"> </attribute>
-					<attribute id="0x00FC" name="Unknown" type="bool" access="rw" required="m"> </attribute>
-					<attribute id="0x00FE" name="Serial Number" type="cstring" access="rw" required="m"> </attribute>
-					<attribute id="0x00FF" name="Unknown" type="ostring" access="rw" required="m"> </attribute>
-					<attribute id="0x010C" name="Unknown" type="u8" access="rw" required="m"> </attribute>
-					<attribute id="0x0133" name="Unknown" type="u8" access="rw" required="m"> </attribute>
-					<attribute id="0x0134" name="Unknown" type="ostring" access="rw" required="m"> </attribute>
-					<attribute id="0x0142" name="Unknown" type="u8" access="rw" required="m"> </attribute>
-					<attribute id="0x0143" name="Unknown" type="u8" access="rw" required="m"> </attribute>
-					<attribute id="0x0144" name="Unknown" type="u8" access="rw" required="m"> </attribute>
-					<attribute id="0x0145" name="Unknown" type="bool" access="rw" required="m"> </attribute>
-					<attribute id="0x0146" name="Unknown" type="u8" access="rw" required="m"> </attribute>
-					<attribute id="0x0147" name="Unknown" type="u8" access="rw" required="m"> </attribute>
-					<attribute id="0x0148" name="Unknown" type="u8" access="rw" required="m"> </attribute>
-					<attribute id="0x0149" name="Unknown" type="u8" access="rw" required="m"> </attribute>
-					<attribute id="0x0150" name="Unknown" type="ostring" access="rw" required="m"> </attribute>
-					<attribute id="0x0151" name="Unknown" type="ostring" access="rw" required="m"> </attribute>
-					<attribute id="0x0153" name="Unknown" type="u32" access="rw" required="m"> </attribute>
-					<attribute id="0x0154" name="Unknown" type="u32" access="rw" required="m"> </attribute>
-					<attribute id="0x0155" name="Unknown" type="u8" access="rw" required="m"> </attribute>
-					<attribute id="0x0156" name="Unknown" type="u32" access="rw" required="m"> </attribute>
-					<attribute id="0x0157" name="Unknown" type="u8" access="w" required="m"> </attribute>
-				</attribute-set>
-			</server>
-			<client>
-			</client>
-		</cluster>
-
-		<!-- SINOPE -->
-		<cluster id="0xff01" name="Sinope specific" mfcode="0x119c">
-			<description>Sinope specific attributes.
-
-Outdoor Temp to Display Timeout: set 30 for 'off' and 10800 for 'on'</description>
-			<server>
-				<attribute id="0x0010" name="Outdoor Temp on Display" type="s16" mfcode="0x119c" access="rw" required="m"> </attribute>
-				<attribute id="0x0011" name="Outdoor Temp on Display Timeout" type="u16" mfcode="0x119c" access="rw" required="m"> </attribute>
-				<attribute id="0x0020" name="Current Time on Display" type="u32" mfcode="0x119c" access="rw" required="m"> </attribute>
-				<attribute id="0x0105" name="Floor Control Mode" type="enum8" mfcode="0x119c" access="rw" required="m">
-					<value name="Ambient" value="0x01"></value>
-					<value name="Floor" value="0x02"></value>
-				</attribute>
-				<attribute id="0x0108" name="Ambient Max Heat Setpoint Limit" type="s16" mfcode="0x119c" access="rw" required="m"> </attribute>
-				<attribute id="0x0109" name="Floor Min Heat Setpoint Limit" type="s16" mfcode="0x119c" access="rw" required="m"> </attribute>
-				<attribute id="0x0110" name="Floor Max Heat Setpoint Limit" type="s16" mfcode="0x119c" access="rw" required="m"> </attribute>
-				<attribute id="0x0111" name="Temperature Sensor" type="enum8" mfcode="0x119c" access="rw" required="m">
-					<value name="10k" value="0x00"></value>
-					<value name="12k" value="0x01"></value>
-				</attribute>
-				<attribute id="0x0112" name="Floor Limit Status" type="enum8" mfcode="0x119c" access="r" required="m">
-					<value name="Off" value="0x00"></value>
-					<value name="On" value="0x01"></value>
-				</attribute>
-				<attribute id="0x0114" name="Time Format on Display" type="enum8" mfcode="0x119c" access="rw" required="m">
-					<value name="24h" value="0x00"></value>
-					<value name="12h" value="0x01"></value>
-				</attribute>
-				<attribute id="0x0115" name="GFCi Status" type="enum8" mfcode="0x119c" access="r" required="m">
-					<value name="Off" value="0x00"></value>
-					<value name="On" value="0x01"></value>
-				</attribute>
-			</server>
-			<client>
-			</client>
-		</cluster>
-
-		<!-- INNR -->
-		<cluster id="0xfc82" name="innr specific" mfcode="0x1166">
-			<description>innr specific attributes.</description>
-			<server>
-				<attribute id="0x0006" name="Unknown" type="cstring" mfcode="0x1166" access="rw" required="m"> </attribute>
-				<attribute id="0x0010" name="Unknown" type="u32" mfcode="0x1166" access="r" required="m"> </attribute>
-				<attribute id="0x0011" name="Unknown" type="u32" mfcode="0x1166" access="r" required="m"> </attribute>
-				<attribute id="0x0012" name="Unknown" type="u32" mfcode="0x1166" access="r" required="m"> </attribute>
-				<attribute id="0x0013" name="Unknown" type="u32" mfcode="0x1166" access="rw" required="m"> </attribute>
-				<attribute id="0x0014" name="Unknown" type="u32" mfcode="0x1166" access="rw" required="m"> </attribute>
-				<attribute id="0x0015" name="Unknown" type="u32" mfcode="0x1166" access="rw" required="m"> </attribute>
-				<attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x1166" access="r" required="m"> </attribute>
-			</server>
-			<client>
-			</client>
-		</cluster>
-
-		<!-- IMMAX -->
-		<cluster id="0xfc82" name="Immax specific" mfcode="0x1037">
-			<description>Immax specific attributes.</description>
-			<server>
-				<attribute id="0x0010" name="Turned on since" type="u32" mfcode="0x1037" access="r" required="m"> </attribute>
-				<attribute id="0x0011" name="Turned on (total)" type="u32" mfcode="0x1037" access="r" required="m"> </attribute>
-				<attribute id="0x0012" name="Consumption since turned on" type="u32" mfcode="0x1037" access="r" required="m"> </attribute>
-				<attribute id="0x0013" name="Unknown" type="u32" mfcode="0x1037" access="rw" required="m"> </attribute>
-				<attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x1037" access="r" required="m"> </attribute>
-			</server>
-			<client>
-			</client>
-		</cluster>
-
-		<!-- BOSCH -->
-		<cluster id="0xfcac" name="Bosch specific" mfcode="0x1209">
-			<description>Bosch specific attributes.</description>
-			<server>
-				<attribute id="0x0000" name="Device setup time remaining" type="u16" mfcode="0x1209" access="rw" required="m"> </attribute>
-				<attribute id="0x0001" name="Motion alert reset" type="u16" mfcode="0x1209" access="rw" required="m"> </attribute>
-				<attribute id="0x0002" name="Device setup time" type="u16" mfcode="0x1209" access="rw" required="m"> </attribute>
-				<attribute id="0x0003" name="Audio alert on motion" type="bool" mfcode="0x1209" access="rw" required="m"> </attribute>
-				<attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x1209" access="r" required="m"> </attribute>
-			</server>
-			<client>
-			</client>
-		</cluster>
-
-		<cluster id="0xfdee" name="AIR Measurement Config" mfcode="0x1155">
-			<description>BOSCH Thermotechnik indoor air quality configuration</description>
-			<server>
-			<attribute id="0x4001" name="Unknown" type="enum8" required="m" access="r" default="0">
-				<description></description>
-			</attribute>
-			<attribute id="0x4002" name="Unknown" type="lcstring" access="r" required="m">
-				<description></description>
-			</attribute>
-			<attribute id="0x4003" name="Unknown" type="ostring" required="m" access="r">
-				<description></description>
-			</attribute>
-			<attribute id="0x4004" name="Unknown" type="u8" required="m" access="r" default="0">
-				<description></description>
-			</attribute>
-			<attribute id="0x4005" name="Unknown" type="u8" required="m" access="r" default="0">
-				<description></description>
-			</attribute>
-			<attribute id="0x4006" name="Unknown" type="u32" required="m" access="r" default="0">
-				<description></description>
-			</attribute>
-		  </server>
-		  <client>
-		  </client>
-		</cluster>
-
-		<cluster id="0xfdef" name="AIR Measurement" mfcode="0x1155">
-			<description>BOSCH Thermotechnik indoor air quality</description>
-			<server>
-			<attribute id="0x4001" name="Air pressure" type="u16" required="m" access="r" default="0">
-				<description>Air pressure (mBar)</description>
-			</attribute>
-			<attribute id="0x4002" name="Temperature" type="s16" access="r" required="m">
-				<description>Temperature (°C)</description>
-			</attribute>
-			<attribute id="0x4003" name="Humidity" type="u8" required="m" access="r" default="0">
-				<description>Relative humidity (%)</description>
-			</attribute>
-			<attribute id="0x4004" name="Air quality" type="u16" required="m" access="r" default="0">
-				<description>Air quality VOC (ppm) </description>
-			</attribute>
-			<attribute id="0x4005" name="Brightness" type="u16" required="m" access="r" default="0">
-				<description>Ambient light brightness (lux)</description>
-			</attribute>
-			<attribute id="0x4006" name="Loudness" type="u8" required="m" access="r" default="0">
-				<description>Noise level (dB)</description>
-			</attribute>
-			<attribute id="0x4008" name="timestamp" type="u32" required="m" access="r" default="0">
-				<description>Relative timestamp since start(seconds)</description>
-			</attribute>
-			<attribute id="0x4009" name="Trigger" type="enum8" required="m" access="r" default="0">
-				<value name="by timer" value="0x00"></value>
-				<value name="by double tap" value="0x01"></value>
-				<description>Trigger of this measurement</description>
-			</attribute>
-			<attribute id="0x400B" name="ModeOfOperation" type="enum8" required="m" access="r" default="0">
-				<value name="normal, day mode" value="0x00"></value>
-				<value name="night, up side down" value="0x01"></value>
-				<description>Device orientation</description>
-			</attribute>
-		  </server>
-		  <client>
-		  </client>
-		</cluster>
-
-		<!-- DEVELCO -->
-		<cluster id="0xfc03" name="VOC Measurement" mfcode="0x1015">
-			<description>Develco specific attributes.</description>
-			<server>
-				<attribute id="0x0000" name="Measured value" type="u16" mfcode="0x1015" access="r" required="m"> </attribute>
-				<attribute id="0x0001" name="Min. measured value" type="u16" mfcode="0x1015" access="r" required="m"> </attribute>
-				<attribute id="0x0002" name="Max. measured value" type="u16" mfcode="0x1015" access="r" required="m"> </attribute>
-				<attribute id="0x0003" name="Resolution" type="u16" mfcode="0x1015" access="r" required="m"> </attribute>
-			</server>
-			<client>
-			</client>
-		</cluster>
-
-		<!-- NIKO -->
-		<cluster id="0xfc00" name="Niko specific" mfcode="0x125f">
-			<description>Niko specific attributes.
-
-LED color: 0 - off, 255 - white, 65280 - blue, 16711680 - red
-Child lock on: 0, Child lock off: 1
-LED on: 1, LED off: 0
-0x0300: Switches permission to write either to 0x0202 (1) or to 0x0302 (0)
-Writing 1 to 0x0202 and 0x0302 makes 0x0300 writable. Then writing 1 to 0x0300 sets 0x0300 bitmap from 0x11 to 0x12, but block all other writes to 0x03XX attributes.</description>
-			<server>
-				<attribute id="0x0000" name="Unknown" type="bmp8" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0100" name="LED color" type="u24" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0101" name="Child lock" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0102" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0103" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0104" name="LED on/off" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0200" name="Connected to power since" type="u32" mfcode="0x125f" access="r" required="m"> </attribute>
-				<attribute id="0x0201" name="Unknown" type="u48" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0202" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0300" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0301" name="Unknown" type="bmp8" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0302" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0303" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0304" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0305" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0306" name="Unknown" type="u32" mfcode="0x125f" access="r" required="m"> </attribute>
-				<attribute id="0x0307" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0308" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0309" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x030A" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0400" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0401" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0500" name="Unknown" type="u16" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0501" name="Unknown" type="u16" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0502" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0503" name="Unknown" type="u16" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0504" name="Unknown" type="u16" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0505" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0506" name="Unknown" type="u8" mfcode="0x125f" access="r" required="m"> </attribute>
-				<attribute id="0x0507" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0508" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0600" name="Unknown" type="seckey" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0x0601" name="Unknown" type="seckey" mfcode="0x125f" access="rw" required="m"> </attribute>
-				<attribute id="0xFFFD" name="Cluster Revision" type="u16" mfcode="0x125f" access="rw" required="m"> </attribute>
-			</server>
-			<client>
-			</client>
-		</cluster>
-
-		<!-- DATEK -->
-		<cluster id="0xfee1" name="Datek on/off configuration" mfcode="0x1337">
-			<description>Datek on/off configuration attributes.</description>
-			<server>
-				<attribute id="0x0000" name="Off if offline" type="u8" mfcode="0x1337" access="rw" required="m"> </attribute>
-				<attribute id="0x0001" name="Frost guard temperature" type="u8" mfcode="0x1337" access="rw" required="m"> </attribute>
-				<attribute id="0x0002" name="Frost guard temperature hysteresis" type="u8" mfcode="0x1337" access="rw" required="m"> </attribute>
-				<attribute id="0x0003" name="Frost guard mins between change" type="u8" mfcode="0x1337" access="rw" required="m"> </attribute>
-				<attribute id="0x0004" name="On time" type="u16" mfcode="0x1337" access="rw" required="m"> </attribute>
-				<attribute id="0x0010" name="On/off configuration mode" type="enum8" mfcode="0x1337" access="rw" required="m">
-					<value name="Off" value="0x00"></value>
-					<value name="On" value="0x01"></value>
-				</attribute>
-				<attribute id="0xFFFD" name="Cluster revision" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
-			</server>
-			<client>
-			</client>
-		</cluster>
-		<cluster id="0xfeed" name="Datek diagnostics" mfcode="0x1337">
-			<description>Datek diagnostics cluster attributes.</description>
-			<server>
-				<attribute id="0x0000" name="Last reset info" type="u8" mfcode="0x1337" access="r" required="m"> </attribute>
-				<attribute id="0x0001" name="Last extended reset info" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
-				<attribute id="0x0002" name="Reboot counter" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
-				<attribute id="0x0003" name="Last hop LQI" type="u8" mfcode="0x1337" access="r" required="m"> </attribute>
-				<attribute id="0x0004" name="Last hop RSSI" type="s8" mfcode="0x1337" access="r" required="m"> </attribute>
-				<attribute id="0x0005" name="Tx power" type="s8" mfcode="0x1337" access="r" required="m"> </attribute>
-				<attribute id="0x0010" name="Button 0 click counter" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
-				<attribute id="0x0020" name="Button 0 ms click counter" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
-				<attribute id="0x0100" name="Electrical measurement avg" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
-				<attribute id="0x0101" name="Electrical measurement raw" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
-				<attribute id="0x0102" name="Electrical measurement noise w load" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
-				<attribute id="0x0103" name="Electrical measurement noise w/o load" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
-				<attribute id="0xFFFD" name="Cluster revision" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
-			</server>
-			<client>
-			</client>
-		</cluster>
-
-		<!-- MERTEN WISER -->
-		<cluster id="0xff17" name="Merten specific" mfcode="0x105e">
-			<description>Merten specific attributes.</description>
-			<server>
-				<attribute id="0x0000" name="Unknown" type="enum8" mfcode="0x105e" access="rw" required="m">
-					<value name="Unknown" value="0"></value>
-					<value name="Unknown" value="1"></value>
-					<value name="Unknown" value="2"></value>
-					<value name="Unknown" value="3"></value>
-					<value name="Unknown" value="4"></value>
-					<value name="Unknown" value="5"></value>
-					<value name="Unknown" value="6"></value>
-					<value name="Unknown" value="7"></value>
-				</attribute>
-				<attribute id="0x0001" name="Unknown" type="enum8" mfcode="0x105e" access="rw" required="m">
-					<value name="Unknown" value="0"></value>
-					<value name="Unknown" value="1"></value>
-					<value name="Unknown" value="2"></value>
-					<value name="Unknown" value="3"></value>
-					<value name="Unknown" value="4"></value>
-					<value name="Unknown" value="5"></value>
-					<value name="Unknown" value="6"></value>
-					<value name="Unknown" value="7"></value>
-				</attribute>
-				<attribute id="0x0010" name="Unknown" type="u8" mfcode="0x105e" access="rw" required="m"> </attribute>
-				<attribute id="0x0011" name="Unknown" type="u16" mfcode="0x105e" access="rw" required="m"> </attribute>
-				<attribute id="0x0020" name="Unknown" type="u8" mfcode="0x105e" access="rw" required="m"> </attribute>
-				<attribute id="0x0021" name="Unknown" type="u16" mfcode="0x105e" access="rw" required="m"> </attribute>
-				<attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x105e" access="r" required="m"> </attribute>
-			</server>
-			<client>
-			</client>
-		</cluster>
-
-	</domain>
-
-	<profile id="0104" name="Home Automation" description="This profile defines device descriptions and standard practices for applications needed in a residential or light commercial environment. Installation scenarios range from a single room to an entire home up to 20,000 square feet (approximately 1850m2)." version="1.0" rev="25" icon="ha.png">
-		<domain-ref name="General" low_bound="0000" />
-		<domain-ref name="Measurement and Sensing" low_bound="0400" />
-		<domain-ref name="Lighting" low_bound="0300" />
-		<domain-ref name="HVAC" low_bound="0200" />
-		<domain-ref name="Closures" low_bound="0100" />
-		<domain-ref name="Security and Safety" low_bound="0500" />
-		<domain-ref name="Smart Energy" low_bound="0x0700" />
-        <domain-ref name="Appliances" low_bound="0x0b00" />
-		<domain-ref name="Light Link" low_bound="1000" />
-		<domain-ref name="Manufacturer Specific" low_bound="0xfc00" />
-		<device id="0x000c" name="Simple sensor" icon="dev-light-sensor.png">
-			<description></description>
-		</device>
-		<device id="0x0010" name="On/off plug-in unit" description=""></device>
-		<device id="0x0051" name="Smart plug" description=""></device>
-		<device id="0x0100" name="On/off light" description="" icon="dev-on-off-light.png"></device>
-		<device id="0x0110" name="Dimmable plug-in unit" description="" icon="dev-on-off-light.png"></device>
-		<device id="0x0200" name="Color light" description="" icon="dev-on-off-light.png"></device>
-		<device id="0x0210" name="Extended color light" description="" icon="dev-on-off-light.png"></device>
-		<device id="0x0220" name="Color temperature light" description="" icon="dev-on-off-light.png"></device>
-		<device id="0x0800" name="Color controller" description=""></device>
-		<device id="0x0810" name="Color scene controller" description=""></device>
-		<device id="0x0820" name="Non color controller" description=""></device>
-		<device id="0x0830" name="Non color scene controller" description=""></device>
-		<device id="0x0840" name="Control bridge" description=""></device>
-		<device id="0x0850" name="On/off sensor" description=""></device>
-	</profile>
-
-	<profile id="0109" name="Smart Energy" description="This profile defines device descriptions and standard practices for Demand Response and Load Management 'Smart Energy' applications needed in a Smart Energy based residential or light commercial environment." version="1.0" rev="15" icon="se.png">
-		<domain-ref name="General" low_bound="0000" />
-		<domain-ref name="Smart Energy" low_bound="0700" />
-	</profile>
-
-	<profile id="0xc05e" name="Light Link" description="This profile defines device descriptions and standard practices for ZigBee Light Link." version="1.0" rev="15" icon="zll.png">
-		<domain-ref name="General" low_bound="0000" />
-		<domain-ref name="Light Link" low_bound="1000" />
-		<domain-ref name="Lighting" low_bound="0300" />
-		<domain-ref name="Measurement and Sensing" low_bound="0400" />
-		<domain-ref name="Smart Energy" low_bound="0x0700" />
-		<domain-ref name="Manufacturer Specific" low_bound="0xfc00" />
-		<device id="0x0000" name="On/off light" description="" icon="dev-on-off-light.png"></device>
-		<device id="0x0010" name="On/off plug-in unit" description=""></device>
-		<device id="0x0100" name="Dimmable light" description="" icon="dev-on-off-light.png"></device>
-		<device id="0x0110" name="Dimmable plug-in unit" description="" icon="dev-on-off-light.png"></device> -->
-		<device id="0x0200" name="Color light" description="" icon="dev-on-off-light.png"></device>
-		<device id="0x0210" name="Extended color light" description="" icon="dev-on-off-light.png"></device>
-		<device id="0x0220" name="Color temperature light" description="" icon="dev-on-off-light.png"></device>
-		<device id="0x0800" name="Color controller" description=""></device>
-		<device id="0x0810" name="Color scene controller" description=""></device>
-		<device id="0x0820" name="Non color controller" description=""></device>
-		<device id="0x0830" name="Non color scene controller" description=""></device>
-		<device id="0x0840" name="Control bridge" description=""></device>
-		<device id="0x0850" name="On/off sensor" description=""></device>
-	</profile>
-
-	<profile id="0xa1e0" name="Green Power" description="This profile defines device descriptions and standard practices for ZigBee Green Power." version="1.1" rev="15" icon="zll.png">
-		<domain-ref name="Green Power" low_bound="0x0021" />
-	</profile>
-
-	<profile id="0xc105" name="Drop-In Networking" description="This profile defines the Digi Drop-In Networking used by the XBee." version="1.0" rev="15" icon="dev-unknown.svg">
-		<device id="0x0001" name="XBee" description="" icon="dev-range-extender.png"></device>
-	</profile>
-
-	<profile id="0xde00" name="dresden elektronik" description="Profile used by dresden elektronik." version="1.0" rev="15" icon="de.png">
-		<device id="0x0001" name="Configuration Tool" description="" icon="dev-configuration-tool.png"></device>
-	</profile>
-
-	<profile id="0xc0c9" name="Develco Private Profile" description="Profile used by dresden elektronik." version="1.0" rev="15" icon="dev-unknown.svg">
-		<device id="0x0001" name="Develco Utility" description="Private profile for internal Develco Products use only."></device>
-	</profile>
-
-	<devices>
-		<!-- Generic -->
-		<device id="0x0000" name="On/Off Switch" description="" icon="dev-on-off-switch.png">
-		</device>
-		<device id="0x0001" name="Level Control Switch">
-			<description></description>
-		</device>
-		<device id="0x0002" name="On/Off Output">
-			<description></description>
-		</device>
-		<device id="0x0003" name="Level Controllable Output">
-			<description></description>
-		</device>
-		<device id="0x0004" name="Scene Selector">
-			<description></description>
-		</device>
-		<device id="0x0005" name="Configuration Tool" description="" icon="dev-configuration-tool.png">
-			<description></description>
-		</device>
-		<device id="0x0006" name="Remote Control">
-			<description></description>
-		</device>
-		<device id="0x0007" name="Combined Interface" description="" icon="dev-combined-interface.svg">
-			<description></description>
-		</device>
-		<device id="0x0008" name="Range Extender" icon="dev-range-extender.png">
-			<description></description>
-		</device>
-		<device id="0x0009" name="Mains Power Outlet">
-			<description></description>
-		</device>
-		<device id="0x000a" name="Door Lock">
-			<description></description>
-		</device>
-		<device id="0x000b" name="Door Lock Controller">
-			<description></description>
-		</device>
-		<device id="0x000c" name="Simple Sensor">
-			<description></description>
-		</device>
-		<device id="0x000d" name="Consumption Awareness Device">
-			<description></description>
-		</device>
-		<device id="0x0050" name="Home Gateway">
-			<description></description>
-		</device>
-		<device id="0x0051" name="Smart Plug">
-			<description></description>
-		</device>
-		<device id="0x0052" name="White Goods">
-			<description></description>
-		</device>
-		<device id="0x0053" name="Meter Interface">
-			<description></description>
-		</device>
-		<!-- Lighting -->
-		<device id="0x0100" name="On/Off Light" icon="dev-on-off-light.png">
-			<description></description>
-		</device>
-		<device id="0x0101" name="Dimmable Light" icon="dev-on-off-light.png">
-			<description></description>
-		</device>
-		<device id="0x0102" name="Color Dimmable Light" icon="dev-on-off-light.png">
-			<description></description>
-		</device>
-		<device id="0x0103" name="On/Off Light Switch" icon="dev-on-off-switch.png">
-			<description></description>
-		</device>
-		<device id="0x0104" name="Dimmer Switch">
-			<description></description>
-		</device>
-		<device id="0x0105" name="Color Dimmer Switch">
-			<description></description>
-		</device>
-		<device id="0x0106" name="Light Sensor" icon="dev-light-sensor.png">
-			<description></description>
-		</device>
-		<device id="0x0107" name="Occupancy Sensor" icon="dev-occupancy-sensor.png">
-			<description></description>
-		</device>
-		<device id="0x0108" name="On/off ballast" icon="dev-on-off-light.png">
-			<description></description>
-		</device>
-		<device id="0x0109" name="Dimmable ballast" icon="dev-on-off-light.png">
-			<description></description>
-		</device>
-		<device id="0x010a" name="On/off plugin unit" icon="dev-on-off-light.png">
-			<description></description>
-		</device>
-		<device id="0x010b" name="Dimmable plugin unit" icon="dev-on-off-light.png">
-			<description></description>
-		</device>
-		<device id="0x010c" name="Color temperature light" icon="dev-on-off-light.png">
-			<description></description>
-		</device>
-		<device id="0x010d" name="Extended color light" icon="dev-on-off-light.png">
-			<description></description>
-		</device>
-		<device id="0x010e" name="Light level sensor" icon="dev-light-sensor.png">
-			<description></description>
-		</device>
-
-		<!-- Closures -->
-		<device id="0x0200" name="Shade">
-			<description></description>
-		</device>
-		<device id="0x0201" name="Shade Controller">
-			<description></description>
-		</device>
-		<device id="0x0202" name="Window Covering Device">
-			<description></description>
-		</device>
-		<device id="0x0203" name="Window Covering Controller">
-			<description></description>
-		</device>
-		<!-- HVAC -->
-		<device id="0x0300" name="Heating/Cooling Unit">
-			<description></description>
-		</device>
-		<device id="0x0301" name="Thermostat" description="" icon="dev-thermostat.png">
-			<description></description>
-		</device>
-		<device id="0x0302" name="Temperature Sensor" icon="dev-temperature-sensor.png">
-			<description></description>
-		</device>
-		<device id="0x0303" name="Pump">
-			<description></description>
-		</device>
-		<device id="0x0304" name="Pump Controller">
-			<description></description>
-		</device>
-		<device id="0x0305" name="Pressure Sensor">
-			<description></description>
-		</device>
-		<device id="0x0306" name="Flow Sensor">
-			<description></description>
-		</device>
-		<device id="0x0307" name="Mini Split AC">
-			<description></description>
-		</device>
-		<!-- Intruder Alarm Systems -->
-		<device id="0x0400" name="IAS Control and Indicating Equipment">
-			<description></description>
-		</device>
-		<device id="0x0401" name="IAS Ancillary Control Equipment">
-			<description></description>
-		</device>
-		<device id="0x0402" name="IAS Zone">
-			<description></description>
-		</device>
-		<device id="0x0403" name="IAS Warning Device">
-			<description></description>
-		</device>
-		<!-- Smart Energy -->
-		<device id="0x0500" name="Energy Service Portal">
-			<description></description>
-		</device>
-		<device id="0x0501" name="Metering Device">
-			<description></description>
-		</device>
-		<device id="0x0502" name="In-Premise Display">
-			<description></description>
-		</device>
-		<device id="0x0503" name="Programmable Communicating Thermostat (PCT)" description="" icon="dev-prog-thermostat.png">
-			<description></description>
-		</device>
-		<device id="0x0504" name="Load Control Device">
-			<description></description>
-		</device>
-		<device id="0x0505" name="Smart Appliance">
-			<description></description>
-		</device>
-		<device id="0x0506" name="Prepayment Terminal">
-			<description></description>
-		</device>
-		<device id="0x0507" name="Device Management">
-			<description></description>
-		</device>
-	</devices>
-</zcl>
+            <attribute id="0x0125" name="Multiclick mode" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0135" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0136" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0137" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0138" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0152" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0200" name="Child lock off" type="u8" mfcode="0x115f" access="rw" required="m">
+              <description>Child lock off: 0 - false, 1 - true</description>
+            </attribute>
+            <attribute id="0x0201" name="Restore Power on Outage" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0202" name="Auto-off after 20m below Threshold" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0203" name="Device LED off (9pm-9am)" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0204" name="Min. Power Change for Report (W)" type="float" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0205" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m">
+              <description>Attribute 0x0205 has range between 1 and 50 only</description>
+            </attribute>
+            <attribute id="0x0206" name="Power Threshold for Auto-off" type="float" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0207" name="Consumer Connected" type="bool" mfcode="0x115f" access="r" required="m"> </attribute>
+            <attribute id="0x020B" name="Max. Load Exceeded at (W)" type="float" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x020C" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x020D" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x020E" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x023B" name="Unknown" type="float" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x023E" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"> </attribute>
+          </attribute-set>
+          <attribute-set id="0x0400" description="Aqara Roller Shade Driver E1">
+            <attribute id="0x0400" name="Reverse Direction" type="bool" mfcode="0x115f" access="rw" required="o">
+              <description>Reverse the direction of up/open and down/close.</description>
+            </attribute>
+            <attribute id="0x0402" name="Positions Stored" type="bool" mfcode="0x115f" access="rw" required="o">
+              <description>Position clearing: write false to clear the stored up/open and down/close positions.</description>
+            </attribute>
+            <attribute id="0x0407" name="Store Position" type="u8" mfcode="0x115f" access="rw" required="o">
+              <description>Position setting: write 1 to store the up/open position, 2 to store the down/close position.</description>
+            </attribute>
+            <attribute id="0x0408" name="Speed" type="u8" mfcode="0x115f" access="rw" required="o">
+              <description>Motor speed: 2: high, 1: medium, 0: low.</description>
+            </attribute>
+            <attribute id="0x0409" name="Charging" type="u8" mfcode="0x115f" access="r" required="o">
+              <description>Battery charging state: 1: charging, 2: not charging.</description>
+            </attribute>
+          </attribute-set>
+          <attribute-set id="0x0500" description="Unknown">
+            <attribute id="0x0700" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0701" name="Unknown" type="s8" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0702" name="Unknown" type="s8" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0703" name="Unknown" type="s8" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0704" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0705" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0740" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0780" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0781" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0782" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x0783" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0x07C0" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0xF000" name="Report Consumer Connected" type="u8" mfcode="0x115f" access="rw" required="m">
+              <description>Report Consumer Connected: 1 - false, 0 - true</description>
+            </attribute>
+            <attribute id="0xF001" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0xF002" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0xFFF2" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"> </attribute>
+            <attribute id="0xFFFD" name="Cluster Revision" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
+          </attribute-set>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <!-- AQARA -->
+      <cluster id="0xfcc0" name="Aqara specific" mfcode="0x1234">
+        <description>Aqara specific attributes.</description>
+        <server>
+          <attribute-set id="0x0000" description="Unknown">
+            <attribute id="0x0006" name="Unknown" type="ostring" access="rw" required="m"> </attribute>
+            <attribute id="0x0007" name="Unknown" type="ostring" access="rw" required="m"> </attribute>
+            <attribute id="0x00E4" name="Unknown" type="u32" access="rw" required="m"> </attribute>
+            <attribute id="0x00F7" name="Unknown" type="ostring" access="r" required="m"> </attribute>
+            <attribute id="0x00FA" name="Unknown" type="bool" access="rw" required="m"> </attribute>
+            <attribute id="0x00FC" name="Unknown" type="bool" access="rw" required="m"> </attribute>
+            <attribute id="0x00FE" name="Serial Number" type="cstring" access="rw" required="m"> </attribute>
+            <attribute id="0x00FF" name="Unknown" type="ostring" access="rw" required="m"> </attribute>
+            <attribute id="0x010C" name="Unknown" type="u8" access="rw" required="m"> </attribute>
+            <attribute id="0x0133" name="Unknown" type="u8" access="rw" required="m"> </attribute>
+            <attribute id="0x0134" name="Unknown" type="ostring" access="rw" required="m"> </attribute>
+            <attribute id="0x0142" name="Unknown" type="u8" access="rw" required="m"> </attribute>
+            <attribute id="0x0143" name="Unknown" type="u8" access="rw" required="m"> </attribute>
+            <attribute id="0x0144" name="Unknown" type="u8" access="rw" required="m"> </attribute>
+            <attribute id="0x0145" name="Unknown" type="bool" access="rw" required="m"> </attribute>
+            <attribute id="0x0146" name="Unknown" type="u8" access="rw" required="m"> </attribute>
+            <attribute id="0x0147" name="Unknown" type="u8" access="rw" required="m"> </attribute>
+            <attribute id="0x0148" name="Unknown" type="u8" access="rw" required="m"> </attribute>
+            <attribute id="0x0149" name="Unknown" type="u8" access="rw" required="m"> </attribute>
+            <attribute id="0x0150" name="Unknown" type="ostring" access="rw" required="m"> </attribute>
+            <attribute id="0x0151" name="Unknown" type="ostring" access="rw" required="m"> </attribute>
+            <attribute id="0x0153" name="Unknown" type="u32" access="rw" required="m"> </attribute>
+            <attribute id="0x0154" name="Unknown" type="u32" access="rw" required="m"> </attribute>
+            <attribute id="0x0155" name="Unknown" type="u8" access="rw" required="m"> </attribute>
+            <attribute id="0x0156" name="Unknown" type="u32" access="rw" required="m"> </attribute>
+            <attribute id="0x0157" name="Unknown" type="u8" access="w" required="m"> </attribute>
+          </attribute-set>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <!-- SINOPE -->
+      <cluster id="0xff01" name="Sinope specific" mfcode="0x119c">
+        <description>Sinope specific attributes.
+          
+          Outdoor Temp to Display Timeout: set 30 for 'off' and 10800 for 'on'</description>
+        <server>
+          <attribute id="0x0010" name="Outdoor Temp on Display" type="s16" mfcode="0x119c" access="rw" required="m"> </attribute>
+          <attribute id="0x0011" name="Outdoor Temp on Display Timeout" type="u16" mfcode="0x119c" access="rw" required="m"> </attribute>
+          <attribute id="0x0020" name="Current Time on Display" type="u32" mfcode="0x119c" access="rw" required="m"> </attribute>
+          <attribute id="0x0105" name="Floor Control Mode" type="enum8" mfcode="0x119c" access="rw" required="m">
+            <value name="Ambient" value="0x01"></value>
+            <value name="Floor" value="0x02"></value>
+          </attribute>
+          <attribute id="0x0108" name="Ambient Max Heat Setpoint Limit" type="s16" mfcode="0x119c" access="rw" required="m"> </attribute>
+          <attribute id="0x0109" name="Floor Min Heat Setpoint Limit" type="s16" mfcode="0x119c" access="rw" required="m"> </attribute>
+          <attribute id="0x0110" name="Floor Max Heat Setpoint Limit" type="s16" mfcode="0x119c" access="rw" required="m"> </attribute>
+          <attribute id="0x0111" name="Temperature Sensor" type="enum8" mfcode="0x119c" access="rw" required="m">
+            <value name="10k" value="0x00"></value>
+            <value name="12k" value="0x01"></value>
+          </attribute>
+          <attribute id="0x0112" name="Floor Limit Status" type="enum8" mfcode="0x119c" access="r" required="m">
+            <value name="Off" value="0x00"></value>
+            <value name="On" value="0x01"></value>
+          </attribute>
+          <attribute id="0x0114" name="Time Format on Display" type="enum8" mfcode="0x119c" access="rw" required="m">
+            <value name="24h" value="0x00"></value>
+            <value name="12h" value="0x01"></value>
+          </attribute>
+          <attribute id="0x0115" name="GFCi Status" type="enum8" mfcode="0x119c" access="r" required="m">
+            <value name="Off" value="0x00"></value>
+            <value name="On" value="0x01"></value>
+          </attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <!-- INNR -->
+      <cluster id="0xfc82" name="innr specific" mfcode="0x1166">
+        <description>innr specific attributes.</description>
+        <server>
+          <attribute id="0x0006" name="Unknown" type="cstring" mfcode="0x1166" access="rw" required="m"> </attribute>
+          <attribute id="0x0010" name="Unknown" type="u32" mfcode="0x1166" access="r" required="m"> </attribute>
+          <attribute id="0x0011" name="Unknown" type="u32" mfcode="0x1166" access="r" required="m"> </attribute>
+          <attribute id="0x0012" name="Unknown" type="u32" mfcode="0x1166" access="r" required="m"> </attribute>
+          <attribute id="0x0013" name="Unknown" type="u32" mfcode="0x1166" access="rw" required="m"> </attribute>
+          <attribute id="0x0014" name="Unknown" type="u32" mfcode="0x1166" access="rw" required="m"> </attribute>
+          <attribute id="0x0015" name="Unknown" type="u32" mfcode="0x1166" access="rw" required="m"> </attribute>
+          <attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x1166" access="r" required="m"> </attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <!-- IMMAX -->
+      <cluster id="0xfc82" name="Immax specific" mfcode="0x1037">
+        <description>Immax specific attributes.</description>
+        <server>
+          <attribute id="0x0010" name="Turned on since" type="u32" mfcode="0x1037" access="r" required="m"> </attribute>
+          <attribute id="0x0011" name="Turned on (total)" type="u32" mfcode="0x1037" access="r" required="m"> </attribute>
+          <attribute id="0x0012" name="Consumption since turned on" type="u32" mfcode="0x1037" access="r" required="m"> </attribute>
+          <attribute id="0x0013" name="Unknown" type="u32" mfcode="0x1037" access="rw" required="m"> </attribute>
+          <attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x1037" access="r" required="m"> </attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <!-- BOSCH -->
+      <cluster id="0xfcac" name="Bosch specific" mfcode="0x1209">
+        <description>Bosch specific attributes.</description>
+        <server>
+          <attribute id="0x0000" name="Device setup time remaining" type="u16" mfcode="0x1209" access="rw" required="m"> </attribute>
+          <attribute id="0x0001" name="Motion alert reset" type="u16" mfcode="0x1209" access="rw" required="m"> </attribute>
+          <attribute id="0x0002" name="Device setup time" type="u16" mfcode="0x1209" access="rw" required="m"> </attribute>
+          <attribute id="0x0003" name="Audio alert on motion" type="bool" mfcode="0x1209" access="rw" required="m"> </attribute>
+          <attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x1209" access="r" required="m"> </attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0xfdee" name="AIR Measurement Config" mfcode="0x1155">
+        <description>BOSCH Thermotechnik indoor air quality configuration</description>
+        <server>
+          <attribute id="0x4001" name="Unknown" type="enum8" required="m" access="r" default="0">
+            <description></description>
+          </attribute>
+          <attribute id="0x4002" name="Unknown" type="lcstring" access="r" required="m">
+            <description></description>
+          </attribute>
+          <attribute id="0x4003" name="Unknown" type="ostring" required="m" access="r">
+            <description></description>
+          </attribute>
+          <attribute id="0x4004" name="Unknown" type="u8" required="m" access="r" default="0">
+            <description></description>
+          </attribute>
+          <attribute id="0x4005" name="Unknown" type="u8" required="m" access="r" default="0">
+            <description></description>
+          </attribute>
+          <attribute id="0x4006" name="Unknown" type="u32" required="m" access="r" default="0">
+            <description></description>
+          </attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <cluster id="0xfdef" name="AIR Measurement" mfcode="0x1155">
+        <description>BOSCH Thermotechnik indoor air quality</description>
+        <server>
+          <attribute id="0x4001" name="Air pressure" type="u16" required="m" access="r" default="0">
+            <description>Air pressure (mBar)</description>
+          </attribute>
+          <attribute id="0x4002" name="Temperature" type="s16" access="r" required="m">
+            <description>Temperature (°C)</description>
+          </attribute>
+          <attribute id="0x4003" name="Humidity" type="u8" required="m" access="r" default="0">
+            <description>Relative humidity (%)</description>
+          </attribute>
+          <attribute id="0x4004" name="Air quality" type="u16" required="m" access="r" default="0">
+            <description>Air quality VOC (ppm) </description>
+          </attribute>
+          <attribute id="0x4005" name="Brightness" type="u16" required="m" access="r" default="0">
+            <description>Ambient light brightness (lux)</description>
+          </attribute>
+          <attribute id="0x4006" name="Loudness" type="u8" required="m" access="r" default="0">
+            <description>Noise level (dB)</description>
+          </attribute>
+          <attribute id="0x4008" name="timestamp" type="u32" required="m" access="r" default="0">
+            <description>Relative timestamp since start(seconds)</description>
+          </attribute>
+          <attribute id="0x4009" name="Trigger" type="enum8" required="m" access="r" default="0">
+            <value name="by timer" value="0x00"></value>
+            <value name="by double tap" value="0x01"></value>
+            <description>Trigger of this measurement</description>
+          </attribute>
+          <attribute id="0x400B" name="ModeOfOperation" type="enum8" required="m" access="r" default="0">
+            <value name="normal, day mode" value="0x00"></value>
+            <value name="night, up side down" value="0x01"></value>
+            <description>Device orientation</description>
+          </attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <!-- DEVELCO -->
+      <cluster id="0xfc03" name="VOC Measurement" mfcode="0x1015">
+        <description>Develco specific attributes.</description>
+        <server>
+          <attribute id="0x0000" name="Measured value" type="u16" mfcode="0x1015" access="r" required="m"> </attribute>
+          <attribute id="0x0001" name="Min. measured value" type="u16" mfcode="0x1015" access="r" required="m"> </attribute>
+          <attribute id="0x0002" name="Max. measured value" type="u16" mfcode="0x1015" access="r" required="m"> </attribute>
+          <attribute id="0x0003" name="Resolution" type="u16" mfcode="0x1015" access="r" required="m"> </attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <!-- NIKO -->
+      <cluster id="0xfc00" name="Niko specific" mfcode="0x125f">
+        <description>Niko specific attributes.
+          
+          LED color: 0 - off, 255 - white, 65280 - blue, 16711680 - red
+          Child lock on: 0, Child lock off: 1
+          LED on: 1, LED off: 0
+          0x0300: Switches permission to write either to 0x0202 (1) or to 0x0302 (0)
+          Writing 1 to 0x0202 and 0x0302 makes 0x0300 writable. Then writing 1 to 0x0300 sets 0x0300 bitmap from 0x11 to 0x12, but block all other writes to 0x03XX attributes.</description>
+        <server>
+          <attribute id="0x0000" name="Unknown" type="bmp8" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0100" name="LED color" type="u24" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0101" name="Child lock" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0102" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0103" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0104" name="LED on/off" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0200" name="Connected to power since" type="u32" mfcode="0x125f" access="r" required="m"> </attribute>
+          <attribute id="0x0201" name="Unknown" type="u48" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0202" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0300" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0301" name="Unknown" type="bmp8" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0302" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0303" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0304" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0305" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0306" name="Unknown" type="u32" mfcode="0x125f" access="r" required="m"> </attribute>
+          <attribute id="0x0307" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0308" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0309" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x030A" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0400" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0401" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0500" name="Unknown" type="u16" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0501" name="Unknown" type="u16" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0502" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0503" name="Unknown" type="u16" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0504" name="Unknown" type="u16" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0505" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0506" name="Unknown" type="u8" mfcode="0x125f" access="r" required="m"> </attribute>
+          <attribute id="0x0507" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0508" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0600" name="Unknown" type="seckey" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0x0601" name="Unknown" type="seckey" mfcode="0x125f" access="rw" required="m"> </attribute>
+          <attribute id="0xFFFD" name="Cluster Revision" type="u16" mfcode="0x125f" access="rw" required="m"> </attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <!-- DATEK -->
+      <cluster id="0xfee1" name="Datek on/off configuration" mfcode="0x1337">
+        <description>Datek on/off configuration attributes.</description>
+        <server>
+          <attribute id="0x0000" name="Off if offline" type="u8" mfcode="0x1337" access="rw" required="m"> </attribute>
+          <attribute id="0x0001" name="Frost guard temperature" type="u8" mfcode="0x1337" access="rw" required="m"> </attribute>
+          <attribute id="0x0002" name="Frost guard temperature hysteresis" type="u8" mfcode="0x1337" access="rw" required="m"> </attribute>
+          <attribute id="0x0003" name="Frost guard mins between change" type="u8" mfcode="0x1337" access="rw" required="m"> </attribute>
+          <attribute id="0x0004" name="On time" type="u16" mfcode="0x1337" access="rw" required="m"> </attribute>
+          <attribute id="0x0010" name="On/off configuration mode" type="enum8" mfcode="0x1337" access="rw" required="m">
+            <value name="Off" value="0x00"></value>
+            <value name="On" value="0x01"></value>
+          </attribute>
+          <attribute id="0xFFFD" name="Cluster revision" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      <cluster id="0xfeed" name="Datek diagnostics" mfcode="0x1337">
+        <description>Datek diagnostics cluster attributes.</description>
+        <server>
+          <attribute id="0x0000" name="Last reset info" type="u8" mfcode="0x1337" access="r" required="m"> </attribute>
+          <attribute id="0x0001" name="Last extended reset info" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
+          <attribute id="0x0002" name="Reboot counter" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
+          <attribute id="0x0003" name="Last hop LQI" type="u8" mfcode="0x1337" access="r" required="m"> </attribute>
+          <attribute id="0x0004" name="Last hop RSSI" type="s8" mfcode="0x1337" access="r" required="m"> </attribute>
+          <attribute id="0x0005" name="Tx power" type="s8" mfcode="0x1337" access="r" required="m"> </attribute>
+          <attribute id="0x0010" name="Button 0 click counter" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
+          <attribute id="0x0020" name="Button 0 ms click counter" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
+          <attribute id="0x0100" name="Electrical measurement avg" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
+          <attribute id="0x0101" name="Electrical measurement raw" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
+          <attribute id="0x0102" name="Electrical measurement noise w load" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
+          <attribute id="0x0103" name="Electrical measurement noise w/o load" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
+          <attribute id="0xFFFD" name="Cluster revision" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+      
+      <!-- MERTEN WISER -->
+      <cluster id="0xff17" name="Merten specific" mfcode="0x105e">
+        <description>Merten specific attributes.</description>
+        <server>
+          <attribute id="0x0000" name="Unknown" type="enum8" mfcode="0x105e" access="rw" required="m">
+            <value name="Unknown" value="0"></value>
+            <value name="Unknown" value="1"></value>
+            <value name="Unknown" value="2"></value>
+            <value name="Unknown" value="3"></value>
+            <value name="Unknown" value="4"></value>
+            <value name="Unknown" value="5"></value>
+            <value name="Unknown" value="6"></value>
+            <value name="Unknown" value="7"></value>
+          </attribute>
+          <attribute id="0x0001" name="Unknown" type="enum8" mfcode="0x105e" access="rw" required="m">
+            <value name="Unknown" value="0"></value>
+            <value name="Unknown" value="1"></value>
+            <value name="Unknown" value="2"></value>
+            <value name="Unknown" value="3"></value>
+            <value name="Unknown" value="4"></value>
+            <value name="Unknown" value="5"></value>
+            <value name="Unknown" value="6"></value>
+            <value name="Unknown" value="7"></value>
+          </attribute>
+          <attribute id="0x0010" name="Unknown" type="u8" mfcode="0x105e" access="rw" required="m"> </attribute>
+          <attribute id="0x0011" name="Unknown" type="u16" mfcode="0x105e" access="rw" required="m"> </attribute>
+          <attribute id="0x0020" name="Unknown" type="u8" mfcode="0x105e" access="rw" required="m"> </attribute>
+          <attribute id="0x0021" name="Unknown" type="u16" mfcode="0x105e" access="rw" required="m"> </attribute>
+          <attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x105e" access="r" required="m"> </attribute>
+        </server>
+        <client>
+        </client>
+      </cluster>
+    </domain>
+    
+    <profile id="0104" name="Home Automation" description="This profile defines device descriptions and standard practices for applications needed in a residential or light commercial environment. Installation scenarios range from a single room to an entire home up to 20,000 square feet (approximately 1850m2)." version="1.0" rev="25" icon="ha.png">
+      <domain-ref name="General" low_bound="0000" />
+      <domain-ref name="Measurement and Sensing" low_bound="0400" />
+      <domain-ref name="Lighting" low_bound="0300" />
+      <domain-ref name="HVAC" low_bound="0200" />
+      <domain-ref name="Closures" low_bound="0100" />
+      <domain-ref name="Security and Safety" low_bound="0500" />
+      <domain-ref name="Smart Energy" low_bound="0x0700" />
+      <domain-ref name="Appliances" low_bound="0x0b00" />
+      <domain-ref name="Light Link" low_bound="1000" />
+      <domain-ref name="Manufacturer Specific" low_bound="0xfc00" />
+      <device id="0x000c" name="Simple sensor" icon="dev-light-sensor.png">
+        <description></description>
+      </device>
+      <device id="0x0010" name="On/off plug-in unit" description=""></device>
+      <device id="0x0051" name="Smart plug" description=""></device>
+      <device id="0x0100" name="On/off light" description="" icon="dev-on-off-light.png"></device>
+      <device id="0x0110" name="Dimmable plug-in unit" description="" icon="dev-on-off-light.png"></device>
+      <device id="0x0200" name="Color light" description="" icon="dev-on-off-light.png"></device>
+      <device id="0x0210" name="Extended color light" description="" icon="dev-on-off-light.png"></device>
+      <device id="0x0220" name="Color temperature light" description="" icon="dev-on-off-light.png"></device>
+      <device id="0x0800" name="Color controller" description=""></device>
+      <device id="0x0810" name="Color scene controller" description=""></device>
+      <device id="0x0820" name="Non color controller" description=""></device>
+      <device id="0x0830" name="Non color scene controller" description=""></device>
+      <device id="0x0840" name="Control bridge" description=""></device>
+      <device id="0x0850" name="On/off sensor" description=""></device>
+    </profile>
+    
+    <profile id="0109" name="Smart Energy" description="This profile defines device descriptions and standard practices for Demand Response and Load Management 'Smart Energy' applications needed in a Smart Energy based residential or light commercial environment." version="1.0" rev="15" icon="se.png">
+      <domain-ref name="General" low_bound="0000" />
+      <domain-ref name="Smart Energy" low_bound="0700" />
+    </profile>
+    
+    <profile id="0xc05e" name="Light Link" description="This profile defines device descriptions and standard practices for ZigBee Light Link." version="1.0" rev="15" icon="zll.png">
+      <domain-ref name="General" low_bound="0000" />
+      <domain-ref name="Light Link" low_bound="1000" />
+      <domain-ref name="Lighting" low_bound="0300" />
+      <domain-ref name="Measurement and Sensing" low_bound="0400" />
+      <domain-ref name="Smart Energy" low_bound="0x0700" />
+      <domain-ref name="Manufacturer Specific" low_bound="0xfc00" />
+      <device id="0x0000" name="On/off light" description="" icon="dev-on-off-light.png"></device>
+      <device id="0x0010" name="On/off plug-in unit" description=""></device>
+      <device id="0x0100" name="Dimmable light" description="" icon="dev-on-off-light.png"></device>
+      <device id="0x0110" name="Dimmable plug-in unit" description="" icon="dev-on-off-light.png"></device>
+      <device id="0x0200" name="Color light" description="" icon="dev-on-off-light.png"></device>
+      <device id="0x0210" name="Extended color light" description="" icon="dev-on-off-light.png"></device>
+      <device id="0x0220" name="Color temperature light" description="" icon="dev-on-off-light.png"></device>
+      <device id="0x0800" name="Color controller" description=""></device>
+      <device id="0x0810" name="Color scene controller" description=""></device>
+      <device id="0x0820" name="Non color controller" description=""></device>
+      <device id="0x0830" name="Non color scene controller" description=""></device>
+      <device id="0x0840" name="Control bridge" description=""></device>
+      <device id="0x0850" name="On/off sensor" description=""></device>
+    </profile>
+    
+    <profile id="0xa1e0" name="Green Power" description="This profile defines device descriptions and standard practices for ZigBee Green Power." version="1.1" rev="15" icon="zll.png">
+      <domain-ref name="Green Power" low_bound="0x0021" />
+    </profile>
+    
+    <profile id="0xc105" name="Drop-In Networking" description="This profile defines the Digi Drop-In Networking used by the XBee." version="1.0" rev="15" icon="dev-unknown.svg">
+      <device id="0x0001" name="XBee" description="" icon="dev-range-extender.png"></device>
+    </profile>
+    
+    <profile id="0xde00" name="dresden elektronik" description="Profile used by dresden elektronik." version="1.0" rev="15" icon="de.png">
+      <device id="0x0001" name="Configuration Tool" description="" icon="dev-configuration-tool.png"></device>
+    </profile>
+    
+    <profile id="0xc0c9" name="Develco Private Profile" description="Profile used by dresden elektronik." version="1.0" rev="15" icon="dev-unknown.svg">
+      <device id="0x0001" name="Develco Utility" description="Private profile for internal Develco Products use only."></device>
+    </profile>
+    
+    <devices>
+      <!-- Generic -->
+      <device id="0x0000" name="On/Off Switch" description="" icon="dev-on-off-switch.png">
+      </device>
+      <device id="0x0001" name="Level Control Switch">
+        <description></description>
+      </device>
+      <device id="0x0002" name="On/Off Output">
+        <description></description>
+      </device>
+      <device id="0x0003" name="Level Controllable Output">
+        <description></description>
+      </device>
+      <device id="0x0004" name="Scene Selector">
+        <description></description>
+      </device>
+      <device id="0x0005" name="Configuration Tool" description="" icon="dev-configuration-tool.png">
+        <description></description>
+      </device>
+      <device id="0x0006" name="Remote Control">
+        <description></description>
+      </device>
+      <device id="0x0007" name="Combined Interface" description="" icon="dev-combined-interface.svg">
+        <description></description>
+      </device>
+      <device id="0x0008" name="Range Extender" icon="dev-range-extender.png">
+        <description></description>
+      </device>
+      <device id="0x0009" name="Mains Power Outlet">
+        <description></description>
+      </device>
+      <device id="0x000a" name="Door Lock">
+        <description></description>
+      </device>
+      <device id="0x000b" name="Door Lock Controller">
+        <description></description>
+      </device>
+      <device id="0x000c" name="Simple Sensor">
+        <description></description>
+      </device>
+      <device id="0x000d" name="Consumption Awareness Device">
+        <description></description>
+      </device>
+      <device id="0x0050" name="Home Gateway">
+        <description></description>
+      </device>
+      <device id="0x0051" name="Smart Plug">
+        <description></description>
+      </device>
+      <device id="0x0052" name="White Goods">
+        <description></description>
+      </device>
+      <device id="0x0053" name="Meter Interface">
+        <description></description>
+      </device>
+      <!-- Lighting -->
+      <device id="0x0100" name="On/Off Light" icon="dev-on-off-light.png">
+        <description></description>
+      </device>
+      <device id="0x0101" name="Dimmable Light" icon="dev-on-off-light.png">
+        <description></description>
+      </device>
+      <device id="0x0102" name="Color Dimmable Light" icon="dev-on-off-light.png">
+        <description></description>
+      </device>
+      <device id="0x0103" name="On/Off Light Switch" icon="dev-on-off-switch.png">
+        <description></description>
+      </device>
+      <device id="0x0104" name="Dimmer Switch">
+        <description></description>
+      </device>
+      <device id="0x0105" name="Color Dimmer Switch">
+        <description></description>
+      </device>
+      <device id="0x0106" name="Light Sensor" icon="dev-light-sensor.png">
+        <description></description>
+      </device>
+      <device id="0x0107" name="Occupancy Sensor" icon="dev-occupancy-sensor.png">
+        <description></description>
+      </device>
+      <device id="0x0108" name="On/off ballast" icon="dev-on-off-light.png">
+        <description></description>
+      </device>
+      <device id="0x0109" name="Dimmable ballast" icon="dev-on-off-light.png">
+        <description></description>
+      </device>
+      <device id="0x010a" name="On/off plugin unit" icon="dev-on-off-light.png">
+        <description></description>
+      </device>
+      <device id="0x010b" name="Dimmable plugin unit" icon="dev-on-off-light.png">
+        <description></description>
+      </device>
+      <device id="0x010c" name="Color temperature light" icon="dev-on-off-light.png">
+        <description></description>
+      </device>
+      <device id="0x010d" name="Extended color light" icon="dev-on-off-light.png">
+        <description></description>
+      </device>
+      <device id="0x010e" name="Light level sensor" icon="dev-light-sensor.png">
+        <description></description>
+      </device>
+      <!-- Closures -->
+      <device id="0x0200" name="Shade">
+        <description></description>
+      </device>
+      <device id="0x0201" name="Shade Controller">
+        <description></description>
+      </device>
+      <device id="0x0202" name="Window Covering Device">
+        <description></description>
+      </device>
+      <device id="0x0203" name="Window Covering Controller">
+        <description></description>
+      </device>
+      <!-- HVAC -->
+      <device id="0x0300" name="Heating/Cooling Unit">
+        <description></description>
+      </device>
+      <device id="0x0301" name="Thermostat" description="" icon="dev-thermostat.png">
+        <description></description>
+      </device>
+      <device id="0x0302" name="Temperature Sensor" icon="dev-temperature-sensor.png">
+        <description></description>
+      </device>
+      <device id="0x0303" name="Pump">
+        <description></description>
+      </device>
+      <device id="0x0304" name="Pump Controller">
+        <description></description>
+      </device>
+      <device id="0x0305" name="Pressure Sensor">
+        <description></description>
+      </device>
+      <device id="0x0306" name="Flow Sensor">
+        <description></description>
+      </device>
+      <device id="0x0307" name="Mini Split AC">
+        <description></description>
+      </device>
+      <!-- Intruder Alarm Systems -->
+      <device id="0x0400" name="IAS Control and Indicating Equipment">
+        <description></description>
+      </device>
+      <device id="0x0401" name="IAS Ancillary Control Equipment">
+        <description></description>
+      </device>
+      <device id="0x0402" name="IAS Zone">
+        <description></description>
+      </device>
+      <device id="0x0403" name="IAS Warning Device">
+        <description></description>
+      </device>
+      <!-- Smart Energy -->
+      <device id="0x0500" name="Energy Service Portal">
+        <description></description>
+      </device>
+      <device id="0x0501" name="Metering Device">
+        <description></description>
+      </device>
+      <device id="0x0502" name="In-Premise Display">
+        <description></description>
+      </device>
+      <device id="0x0503" name="Programmable Communicating Thermostat (PCT)" description="" icon="dev-prog-thermostat.png">
+        <description></description>
+      </device>
+      <device id="0x0504" name="Load Control Device">
+        <description></description>
+      </device>
+      <device id="0x0505" name="Smart Appliance">
+        <description></description>
+      </device>
+      <device id="0x0506" name="Prepayment Terminal">
+        <description></description>
+      </device>
+      <device id="0x0507" name="Device Management">
+        <description></description>
+      </device>
+    </devices>
+  </zcl>


### PR DESCRIPTION
Re-indent `general.xml`, replacing TABs with SPACEs.
There was also an unmatched close comment (`-->`).

I'm doing this in a separate PR, as GitHub cannot show the changes in any useful way.
Double-checked with `diff -w` that this re-indent didn't break anything:
```
$ diff -w general.*
123,125c123,124
< 	<domain name="General" useZcl="true"
< 	description="The general functional domain contains clusters and information that provides generally applicable functions and attributes that are not specific to other functional domains.">
< 
---
>   <domain name="General" useZcl="true" description="The general functional domain contains clusters and information that provides generally applicable functions and attributes that are not specific to other functional domains.">
>     <domain name="General" useZcl="true" description="The general functional domain contains clusters and information that provides generally applicable functions and attributes that are not specific to other functional domains.">
280a280
>       
322,324c322
< 			<attribute id="0x003e" name="Battery Alarm State" type="bmp32" access="rw" default="0" required="o">
< 
< 			</attribute>
---
>             <attribute id="0x003e" name="Battery Alarm State" type="bmp32" access="rw" default="0" required="o"></attribute>
329a328
>       
349a349
>       
398a399
>       
477a479
>       
628a631
>       
666d668
< 
739d740
< 
768a770
>       
865a868
>       
883a887
>       
906a911
>       
933a939
>       
968a975
>       
1004a1012
>       
1036a1045
>       
1079a1089
>       
1121a1132
>       
1156a1168
>       
1187a1200
>       
1220a1234
>       
1252a1267
>       
1388a1404
>       
1430d1445
< 
1444a1460
>       
1458d1473
< 
1491a1507
>     
1496a1513
>       
1521a1539
>       
1821a1840
>       
1937a1957
>     
1942a1963
>       
2452a2474
>       
2475a2498
>       
2479a2503
>       
2507a2532
>       
2518a2544
>     
2836a2863
>       
2876a2904
>     
2907a2936
>       
2911a2941
>       
2925a2956
>       
2937a2969
>       
2945a2978
>       
2958a2992
>       
3001a3036
>       
3014a3050
>       
3075a3112
>       
3121a3159
>       
3492a3531
>     
3494a3534
>     
3496a3537
>     
3524a3566
>       
3536a3579
>       
3695a3739
>       
3703a3748
>       
3712a3758
>       
3728a3775
>       
3757a3805
>       
3768a3817
>       
3780,3781c3829
< 	<domain name="Light Link" useZcl="true"
< 		description="The light link domain contains clusters and information that provides ZLL specific functions and attributes.">
---
>     <domain name="Light Link" useZcl="true" description="The light link domain contains clusters and information that provides ZLL specific functions and attributes.">
3834d3881
< 
3885,3887c3932
< 	<domain name="Manufacturer Specific" useZcl="true"
< 		description="Manufacturer specific clusters.">
< 
---
>     <domain name="Manufacturer Specific" useZcl="true" description="Manufacturer specific clusters.">
4015d4059
< 
4048a4093
>       
4140a4186
>       
4155a4202
>       
4681d4727
< 
4728c4774
< 		<device id="0x0110" name="Dimmable plug-in unit" description="" icon="dev-on-off-light.png"></device> -->
---
>       <device id="0x0110" name="Dimmable plug-in unit" description="" icon="dev-on-off-light.png"></device>
4857d4902
< 
```
