### PR TITLE
Update various definitions

### DIFF
--- a/devices/generic/items/config_colorcapabilities_item.json
+++ b/devices/generic/items/config_colorcapabilities_item.json
@@ -1,11 +1,16 @@
 {
-	"schema": "resourceitem1.schema.json",
-	"id": "config/colorcapabilities",
-	"datatype": "UInt16",
-	"access": "R",
-	"public": true,
-	"description": "The supported color modes as bitmap.",
-	"parse": {"fn": "zcl", "ep": 0, "cl": "0x0300", "at": "0x400a", "eval": "Item.val = Attr.val"},
-	"read": {"fn": "zcl", "ep": 0, "cl": "0x0300", "at": "0x400a"},
-	"refresh.interval": 84000
+  "schema": "resourceitem1.schema.json",
+  "id": "config/colorcapabilities",
+  "datatype": "UInt16",
+  "access": "R",
+  "public": true,
+  "description": "The supported color modes as bitmap.",
+  "parse": {
+    "fn": "zcl", "ep": 0, "cl": "0x0300", "at": "0x400a",
+    "eval": "Item.val = Attr.val"
+  },
+  "read": {
+    "fn": "zcl", "ep": 0, "cl": "0x0300", "at": ["0x400a", "0x400b", "0x400c"]
+  },
+  "refresh.interval": 86400
 }

--- a/devices/generic/items/config_ctmax_item.json
+++ b/devices/generic/items/config_ctmax_item.json
@@ -1,11 +1,13 @@
 {
-	"schema": "resourceitem1.schema.json",
-	"id": "config/ctmax",
-	"datatype": "UInt16",
-	"access": "R",
-	"public": true,
-	"description": "Maximum supported color temperature.",
-	"parse": {"fn": "zcl", "ep": 0, "cl": "0x0300", "at": "0x400c", "eval": "Item.val = Attr.val"},
-	"read": {"fn": "zcl", "ep": 0, "cl": "0x0300", "at": "0x400c"},
-	"refresh.interval": 84000
+  "schema": "resourceitem1.schema.json",
+  "id": "config/ctmax",
+  "datatype": "UInt16",
+  "access": "R",
+  "public": true,
+  "description": "Maximum supported color temperature.",
+  "default": "0xfeff",
+  "parse": {
+    "fn": "zcl", "ep": 0, "cl": "0x0300", "at": "0x400c",
+    "eval": "Item.val = Attr.val"
+  }
 }

--- a/devices/generic/items/config_ctmin_item.json
+++ b/devices/generic/items/config_ctmin_item.json
@@ -1,11 +1,13 @@
 {
-	"schema": "resourceitem1.schema.json",
-	"id": "config/ctmin",
-	"datatype": "UInt16",
-	"access": "R",
-	"public": true,
-	"description": "Minimum supported color temperature.",
-	"parse": {"fn": "zcl", "ep": 0, "cl": "0x0300", "at": "0x400b", "eval": "Item.val = Attr.val"},
-	"read": {"fn": "zcl", "ep": 0, "cl": "0x0300", "at": "0x400b"},
-	"refresh.interval": 84000
+  "schema": "resourceitem1.schema.json",
+  "id": "config/ctmin",
+  "datatype": "UInt16",
+  "access": "R",
+  "public": true,
+  "description": "Minimum supported color temperature.",
+  "default": 0,
+  "parse": {
+    "fn": "zcl", "ep": 0, "cl": "0x0300", "at": "0x400b",
+    "eval": "Item.val = Attr.val"
+  }
 }

--- a/devices/generic/items/state_colormode_item.json
+++ b/devices/generic/items/state_colormode_item.json
@@ -1,16 +1,20 @@
 {
-	"schema": "resourceitem1.schema.json",
-	"id": "state/colormode",
-	"datatype": "String",
-	"access": "R",
-	"public": true,
-	"description": "The currently active color mode.",
-	"parse": {"fn": "zcl", "ep": 0, "cl": "0x0300", "at": "0x0008", "eval": "Item.val = Attr.val"},
-	"read": {"fn": "zcl", "ep": 0, "cl": "0x0300", "at": "0x0008"},
-	"values": [
-		["\"hs\"", "hue and saturation"],
-		["\"xy\"", "CIE xy color space coordinates"],
-		["\"ct\"", "color temperature"]
-	],
-	"refresh.interval": 300
+  "schema": "resourceitem1.schema.json",
+  "id": "state/colormode",
+  "datatype": "String",
+  "access": "R",
+  "public": true,
+  "description": "The currently active color mode.",
+  "values": [
+    ["\"hs\"", "hue and saturation"],
+    ["\"xy\"", "CIE xy color space coordinates"],
+    ["\"ct\"", "color temperature"]
+  ],
+  "parse": {
+    "fn": "zcl", "ep": 0, "cl": "0x0300", "at": "0x0008",
+    "eval": "Item.val = ['hs', 'xy', 'ct'][Attr.val]"},
+  "read": {
+    "fn": "zcl", "ep": 0, "cl": "0x0300", "at": "0x0008"
+  },
+  "refresh.interval": 300
 }

--- a/devices/generic/items/state_effect_item.json
+++ b/devices/generic/items/state_effect_item.json
@@ -1,14 +1,22 @@
 {
-	"schema": "resourceitem1.schema.json",
-	"id": "state/effect",
-	"datatype": "String",
-	"access": "RW",
-	"public": true,
-	"managed": true,
-	"description": "The currently active effect.",
-	"default": "none",
-	"values": [
-		["\"none\"", "no effect is active"],
-		["\"colorloop\"", "colorloop through hue values"]
-	]
+  "schema": "resourceitem1.schema.json",
+  "id": "state/effect",
+  "datatype": "String",
+  "access": "RW",
+  "public": true,
+  "managed": true,
+  "description": "The currently active effect.",
+  "default": "none",
+  "values": [
+    ["\"none\"", "no effect is active"],
+    ["\"colorloop\"", "colorloop through hue values"]
+  ],
+  "parse": {
+    "fn": "zcl", "ep": 0, "cl": "0x0300", "at": "0x4002",
+    "eval": "Item.val = Attr.val ? 'colorloop' : 'none'"
+  },
+  "read": {
+    "fn": "zcl", "ep": 0, "cl": "0x0300", "at": "0x4002"
+  },
+  "refresh.interval": 300
 }

--- a/devices/generic/subdevices/Window_covering_device.json
+++ b/devices/generic/subdevices/Window_covering_device.json
@@ -7,7 +7,7 @@
     "uuid": ["$address.ext", "0x01"],
     "items": [
         "state/lift",
-        "state/reachable",
-        "state/open"
+        "state/open",
+        "state/reachable"
     ]
 }

--- a/devices/generic/subdevices/alarm_sensor.json
+++ b/devices/generic/subdevices/alarm_sensor.json
@@ -6,13 +6,13 @@
     "order": 30,
     "uuid": ["$address.ext", "0x01", "0x0500"],
     "items": [
+        "config/battery",
         "config/on",
         "config/enrolled",
         "config/pending",
         "config/reachable",
-        "config/battery",
         "state/alarm",
-        "state/lowbattery",
-        "state/lastupdated"
+        "state/lastupdated",
+        "state/lowbattery"
     ]
 }

--- a/devices/generic/subdevices/color_light.json
+++ b/devices/generic/subdevices/color_light.json
@@ -1,0 +1,21 @@
+{
+    "schema": "subdevice1.schema.json",
+    "type": "$TYPE_COLOR_LIGHT",
+    "name": "Color light",
+    "restapi": "/lights",
+    "order": 10,
+    "uuid": ["$address.ext", "0x01"],
+    "items": [
+        "config/colorcapabilities",
+        "state/alert",
+        "state/bri",
+        "state/colormode",
+        "state/effect",
+        "state/hue",
+        "state/on",
+        "state/reachable",
+        "state/sat",
+        "state/x",
+        "state/y"
+    ]
+}

--- a/devices/generic/subdevices/color_temperature_light.json
+++ b/devices/generic/subdevices/color_temperature_light.json
@@ -9,7 +9,6 @@
         "config/ctmax",
         "config/ctmin",
         "state/alert",
-        "state/reachable",
         "state/bri",
         "state/colormode",
         "state/ct",

--- a/devices/generic/subdevices/color_temperature_light.json
+++ b/devices/generic/subdevices/color_temperature_light.json
@@ -13,6 +13,7 @@
         "state/bri",
         "state/colormode",
         "state/ct",
-        "state/on"
+        "state/on",
+        "state/reachable"
     ]
 }

--- a/devices/generic/subdevices/dimmable_light.json
+++ b/devices/generic/subdevices/dimmable_light.json
@@ -8,6 +8,7 @@
     "items": [
         "state/alert",
         "state/bri",
-        "state/on"
+        "state/on",
+        "state/reachable"
     ]
 }

--- a/devices/generic/subdevices/dimmable_plugin_unit.json
+++ b/devices/generic/subdevices/dimmable_plugin_unit.json
@@ -7,7 +7,7 @@
     "uuid": ["$address.ext", "0x01"],
     "items": [
         "state/bri",
-        "state/reachable",
-        "state/on"
+        "state/on",
+        "state/reachable"
     ]
 }

--- a/devices/generic/subdevices/door_lock.json
+++ b/devices/generic/subdevices/door_lock.json
@@ -7,8 +7,8 @@
     "uuid": ["$address.ext", "0x01", "0x0101"],
     "items": [
         "config/lock",
-        "state/reachable",
-        "state/open",
-        "state/lockstate"
+        "config/reachable",
+        "state/lockstate",
+        "state/open"
     ]
 }

--- a/devices/generic/subdevices/door_lock_controller.json
+++ b/devices/generic/subdevices/door_lock_controller.json
@@ -6,7 +6,7 @@
     "order": 11,
     "uuid": ["$address.ext", "0x01"],
     "items": [
-        "state/reachable",
-        "state/on"
+        "state/on",
+        "state/reachable"
     ]
 }

--- a/devices/generic/subdevices/humidity_sensor.json
+++ b/devices/generic/subdevices/humidity_sensor.json
@@ -6,8 +6,8 @@
     "order": 23,
     "uuid": ["$address.ext", "0x01", "0x0405"],
     "items": [
-        "config/on",
         "config/offset",
+        "config/on",
         "config/reachable",
         "state/humidity",
         "state/lastupdated"

--- a/devices/generic/subdevices/lightlevel_sensor.json
+++ b/devices/generic/subdevices/lightlevel_sensor.json
@@ -12,8 +12,8 @@
         "config/tholdoffset",
         "state/dark",
         "state/daylight",
+        "state/lastupdated",
         "state/lightlevel",
-        "state/lux",
-        "state/lastupdated"
+        "state/lux"
     ]
 }

--- a/devices/generic/subdevices/onoff_light.json
+++ b/devices/generic/subdevices/onoff_light.json
@@ -6,7 +6,7 @@
     "order": 11,
     "uuid": ["$address.ext", "0x01"],
     "items": [
-        "state/reachable",
-        "state/on"
+        "state/on",
+        "state/reachable"
     ]
 }

--- a/devices/generic/subdevices/onoff_output.json
+++ b/devices/generic/subdevices/onoff_output.json
@@ -6,7 +6,7 @@
     "order": 11,
     "uuid": ["$address.ext", "0x01"],
     "items": [
-        "state/reachable",
-        "state/on"
+        "state/on",
+        "state/reachable"
     ]
 }

--- a/devices/generic/subdevices/onoff_plugin_unit.json
+++ b/devices/generic/subdevices/onoff_plugin_unit.json
@@ -6,7 +6,7 @@
     "order": 11,
     "uuid": ["$address.ext", "0x01"],
     "items": [
-        "state/reachable",
-        "state/on"
+        "state/on",
+        "state/reachable"
     ]
 }

--- a/devices/generic/subdevices/openclose_sensor.json
+++ b/devices/generic/subdevices/openclose_sensor.json
@@ -8,7 +8,7 @@
     "items": [
         "config/on",
         "config/reachable",
-        "state/open",
-        "state/lastupdated"
+        "state/lastupdated",
+        "state/open"
     ]
 }

--- a/devices/generic/subdevices/presence_sensor.json
+++ b/devices/generic/subdevices/presence_sensor.json
@@ -6,10 +6,10 @@
     "order": 20,
     "uuid": ["$address.ext", "0x01", "0x0406"],
     "items": [
-        "config/on",
         "config/duration",
+        "config/on",
         "config/reachable",
-        "state/presence",
-        "state/lastupdated"
+        "state/lastupdated",
+        "state/presence"
     ]
 }

--- a/devices/generic/subdevices/pressure_sensor.json
+++ b/devices/generic/subdevices/pressure_sensor.json
@@ -6,10 +6,10 @@
     "order": 24,
     "uuid": ["$address.ext", "0x01", "0x0403"],
     "items": [
-        "config/on",
         "config/offset",
+        "config/on",
         "config/reachable",
-        "state/pressure",
-        "state/lastupdated"
+        "state/lastupdated",
+        "state/pressure"
     ]
 }

--- a/devices/generic/subdevices/smart_plug.json
+++ b/devices/generic/subdevices/smart_plug.json
@@ -6,7 +6,7 @@
     "order": 11,
     "uuid": ["$address.ext", "0x01"],
     "items": [
-        "state/reachable",
-        "state/on"
+        "state/on",
+        "state/reachable"
     ]
 }

--- a/devices/generic/subdevices/switch.json
+++ b/devices/generic/subdevices/switch.json
@@ -8,7 +8,7 @@
     "items": [
         "config/on",
         "config/reachable",
-        "state/lastupdated",
-        "state/buttonevent"
+        "state/buttonevent",
+        "state/lastupdated"
     ]
 }

--- a/devices/generic/subdevices/temperature_sensor.json
+++ b/devices/generic/subdevices/temperature_sensor.json
@@ -6,10 +6,10 @@
     "order": 23,
     "uuid": ["$address.ext", "0x01", "0x0402"],
     "items": [
-        "config/on",
         "config/offset",
+        "config/on",
         "config/reachable",
-        "state/temperature",
-        "state/lastupdated"
+        "state/lastupdated",
+        "state/temperature"
     ]
 }

--- a/devices/generic/subdevices/thermostat.json
+++ b/devices/generic/subdevices/thermostat.json
@@ -11,9 +11,9 @@
         "config/offset",
         "config/on",
         "config/reachable",
+        "state/lastupdated",
         "state/on",
         "state/temperature",
-        "state/valve",
-        "state/lastupdated"
+        "state/valve"
     ]
 }

--- a/devices/generic/subdevices/vibration_sensor.json
+++ b/devices/generic/subdevices/vibration_sensor.json
@@ -8,7 +8,7 @@
     "items": [
         "config/on",
         "config/reachable",
-        "state/vibration",
-        "state/lastupdated"
+        "state/lastupdated",
+        "state/vibration"
     ]
 }

--- a/devices/generic/subdevices/warning_device.json
+++ b/devices/generic/subdevices/warning_device.json
@@ -6,7 +6,7 @@
     "order": 11,
     "uuid": ["$address.ext", "0x01"],
     "items": [
-        "state/reachable",
-        "state/alert"
+        "state/alert",
+        "state/reachable"
     ]
 }

--- a/devices/generic/subdevices/waterleak_sensor.json
+++ b/devices/generic/subdevices/waterleak_sensor.json
@@ -8,7 +8,7 @@
     "items": [
         "config/on",
         "config/reachable",
-        "state/water",
-        "state/lastupdated"
+        "state/lastupdated",
+        "state/water"
     ]
 }

--- a/general.xml
+++ b/general.xml
@@ -402,9 +402,7 @@
         <attribute id="0000" name="Name Support" type="bmp8" range="x0000000" access="r" required="m">
           <value name="Name Support" value="7"></value>
         </attribute>
-        <attribute id="0x0001" name="IKEA Scene" type="u32" access="rw" required="m" showas="hex" mfcode="0x117c">
-
-        </attribute>
+        <attribute id="0x0001" name="IKEA Scene" type="u32" access="rw" required="m" showas="hex" mfcode="0x117c"></attribute>
         <command id="00" dir="recv" name="Add group" required="m" response="0x00">
           <description>Add a group to the device.</description>
           <payload>
@@ -439,16 +437,14 @@
         <command id="00" dir="recv" name="Add group response" required="m">
           <description>The Response to the add group request.</description>
           <payload>
-            <attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status">
-            </attribute>
+            <attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status"></attribute>
             <attribute id="0x0001" type="u16" name="Group ID" showas="hex" required="m" default="0x0000"></attribute>
           </payload>
         </command>
         <command id="01" dir="recv" name="View group response" required="m">
           <description>The Response to the view group request.</description>
           <payload>
-            <attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status">
-            </attribute>
+            <attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status"></attribute>
             <attribute id="0x0001" type="u16" name="Group ID" showas="hex" required="m" default="0x0000"></attribute>
             <attribute id="0x0002" type="cstring" name="Group Name" required="m"></attribute>
             <condition id="0x0000" op="!=" value="0x00">
@@ -468,8 +464,7 @@
         <command id="03" dir="recv" name="Remove group response" required="m">
           <description>The Response to the remove group request.</description>
           <payload>
-            <attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status">
-            </attribute>
+            <attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status"></attribute>
             <attribute id="0x0001" type="u16" name="Group ID" showas="hex" required="m" default="0x0000"></attribute>
           </payload>
         </command>
@@ -490,7 +485,7 @@
           <payload>
             <attribute id="0x0000" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
             <attribute id="0x0001" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
-            <attribute id="0x0002" type="u16" name="Transition time" required="m" showas="hex" default="0x0000"></attribute>
+            <attribute id="0x0002" type="u16" name="Transition Time" required="m" showas="hex" default="0x0000"></attribute>
             <attribute id="0x0003" type="u8" name="Name Length" required="m" showas="hex" default="0x00"></attribute>
           </payload>
         </command>
@@ -579,7 +574,7 @@
             <attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status"></attribute>
             <attribute id="0x0001" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
             <attribute id="0x0002" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
-            <attribute id="0x0003" type="u16" name="Transition time" required="m" showas="hex" default="0x0000"></attribute>
+            <attribute id="0x0003" type="u16" name="Transition Time" required="m" showas="hex" default="0x0000"></attribute>
           </payload>
         </command>
         <command id="0x02" dir="recv" name="Remove scene response" required="m">
@@ -620,7 +615,7 @@
             <attribute id="0x0000" type="enum8" name="Status" required="m" default="0x00" enumeration="ZCL_Status"></attribute>
             <attribute id="0x0001" type="u16" name="Group ID" required="m" showas="hex" default="0x0000"></attribute>
             <attribute id="0x0002" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
-            <attribute id="0x0003" type="u16" name="Transition time" required="m" showas="dec" default="0x00"></attribute>
+            <attribute id="0x0003" type="u16" name="Transition Time" required="m" showas="dec" default="0x00"></attribute>
             <attribute id="0x0004" type="cstring" name="Name" required="m"></attribute>
           </payload>
         </command>
@@ -636,15 +631,10 @@
             <value name="On" value="1"></value>
             <value name="Off" value="0"></value>
           </attribute>
-        </attribute-set>
-        <attribute-set id="0x4000" description="ZLL extensions">
-          <attribute id="0x4000" name="GlobalSceneControl" type="bool" access="r" default="0" required="o">
-          </attribute>
-          <attribute id="0x4001" name="OnTime" type="u16" access="r" default="0" required="o">
-          </attribute>
-          <attribute id="0x4002" name="OffWaitTime" type="u16" access="r" default="0" required="o">
-          </attribute>
-          <attribute id="0x4003" name="PowerOn OnOff" type="enum8" access="rw" default="0x01" required="o">
+          <attribute id="0x4000" name="GlobalSceneControl" type="bool" access="r" default="0" required="o"></attribute>
+          <attribute id="0x4001" name="OnTime" type="u16" access="r" default="0" required="o"></attribute>
+          <attribute id="0x4002" name="OffWaitTime" type="u16" access="r" default="0" required="o"></attribute>
+          <attribute id="0x4003" name="StartUp OnOff" type="enum8" access="rw" default="0x01" required="o">
             <value name="Off" value="0x00"></value>
             <value name="On" value="0x01"></value>
             <value name="Previous" value="0xff"></value>
@@ -714,18 +704,16 @@
       <client>
       </client>
     </cluster>
+
     <cluster id="0xde06" name="RGB Color">
       <description>Attributes and commands for setting devices light color. The color is specified in the RGB range from 0 - 255.</description>
       <server>
-        <attribute id="0000" name="CurrentColorSet" type="u32" access="r" default="0" required="m" showas="hex">
-        </attribute>
-        <attribute id="0001" name="ColorSetCount" type="u8" access="r" default="0" required="m">
-        </attribute>
+        <attribute id="0000" name="CurrentColorSet" type="u32" access="r" default="0" required="m" showas="hex"></attribute>
+        <attribute id="0001" name="ColorSetCount" type="u8" access="r" default="0" required="m"></attribute>
         <command id="00" dir="recv" name="Set Color" required="m">
           <description>On receipt of this command, the color of the light shall be changed and the current index updatet.</description>
           <payload>
-            <attribute id="0x0000" type="u8" name="Red" required="m" default="0x00" range="0x00,0xFF" showas="slider">
-            </attribute>
+            <attribute id="0x0000" type="u8" name="Red" required="m" default="0x00" range="0x00,0xFF" showas="slider"></attribute>
             <attribute id="0x0001" type="u8" name="Green" required="m" default="0x00" range="0x00,0xFF" showas="slider"></attribute>
             <attribute id="0x0002" type="u8" name="Blue" required="m" default="0x00" range="0x00,0xFF" showas="slider"></attribute>
             <attribute id="0x0003" type="u8" name="Set Index" required="m" default="0x00"></attribute>
@@ -739,6 +727,7 @@
       <client>
       </client>
     </cluster>
+
     <cluster id="0x0007" name="On/Off Switch Configuration">
       <description>Attributes and commands for configuring On/Off switching devices</description>
       <server>
@@ -776,6 +765,9 @@
         <attribute id = "0x0001" name="Remaining Time" type="u16" range="0x0000,0xffff" access="r" required="o" default="0x0000">
           <description>The RemainingTime attribute represents the time remaining until the current command is complete - it is specified in 1/10ths of a second.</description>
         </attribute>
+        <attribute id = "0x000f" name="Options" type="bmp8" access="rw" required="o">
+          <value name="Execute If Off" value="0"></value>
+        </attribute>
         <attribute id = "0x0010" name="OnOff Transistion Time" type="u16" range="0x0000,0xffff" access="rw" required="o" default="0x0000">
           <description>The OnOffTransitionTime attribute represents the time taken to move to or from the target level when On of Off commands are received by an On/Off cluster on the same endpoint. It is specified in 1/10ths of a second. The actual time taken should be as close to OnOffTransitionTime as the device is able.</description>
         </attribute>
@@ -791,11 +783,7 @@
         <attribute id = "0x0014" name="Default Move Rate" type="u8" range="0x00,0xfe" access="rw" required="o">
           <description>The DefaultMoveRate attribute determines the movement rate, in units per second, when a Move command is received with a Rate parameter of 0xFF.</description>
         </attribute>
-        <attribute id = "0x000f" name="Unknown" type="bmp8" access="rw" required="o">
-          <description>IKEA specific.</description>
-        </attribute>
-        <attribute id="0x4000" name="PowerOn Level" type="u8" access="rw" required="o">
-        </attribute>
+        <attribute id="0x4000" name="StartUp Current Level" type="u8" access="rw" required="o"></attribute>
         <command id="0x00" dir="recv" name="Move to Level" required="m">
           <description></description>
           <payload>
@@ -821,7 +809,7 @@
               <value name="Down" value="0x01"></value>
             </attribute>
             <attribute id="0x0001" type="u8" name="Step size" required="m" default="0x00"></attribute>
-            <attribute id="0x0002" type="u16" name="Transition time" required="m" default="0x0000"></attribute>
+            <attribute id="0x0002" type="u16" name="Transition Time" required="m" default="0x0000"></attribute>
           </payload>
         </command>
         <command id="0x03" dir="recv" name="Stop" required="m">
@@ -852,7 +840,7 @@
               <value name="Down" value="0x01"></value>
             </attribute>
             <attribute id="0x0001" type="u8" name="Step size" required="m" default="0x00"></attribute>
-            <attribute id="0x0002" type="u16" name="Transition time" required="m" default="0x0000"></attribute>
+            <attribute id="0x0002" type="u16" name="Transition Time" required="m" default="0x0000"></attribute>
           </payload>
         </command>
         <command id="0x07" dir="recv" name="Stop (with On/Off)" required="m">
@@ -874,8 +862,7 @@
         </attribute-set>
         <command id="0x00" dir="send" name="Alarm" required="m">
           <payload>
-            <attribute id="0x0000" type="u8" name="Alarm code" default="0x00" required="m" showas="hex">
-            </attribute>
+            <attribute id="0x0000" type="u8" name="Alarm code" default="0x00" required="m" showas="hex"></attribute>
             <attribute id="0x0001" type="u16" name="Cluster Id" default="0x0000" required="m" showas="hex"></attribute>
           </payload>
         </command>
@@ -1344,16 +1331,14 @@
         <command id="01" dir="recv" name="Save Startup Parameters" required="o" response="0x01">
           <description>The Save Startup Parameters Request command allows for the current attribute set to be stored under a given index.</description>
           <payload>
-            <attribute id="0x0000" name="Options" type="bmp8" default="00000000" access="rw" required="m">
-            </attribute>
+            <attribute id="0x0000" name="Options" type="bmp8" default="00000000" access="rw" required="m"></attribute>
             <attribute id="0x0001" type="u8" name="Index" required="m"></attribute>
           </payload>
         </command>
         <command id="02" dir="recv" name="Restore Startup Parameters" required="o" response="0x02">
           <description>This command allows a saved startup parameters attribute set to be restored to current status overwriting whatever was there previously.</description>
           <payload>
-            <attribute id="0x0000" name="Options" type="bmp8" default="00000000" access="rw" required="m">
-            </attribute>
+            <attribute id="0x0000" name="Options" type="bmp8" default="00000000" access="rw" required="m"></attribute>
             <attribute id="0x0001" type="u8" name="Index" required="m"></attribute>
           </payload>
         </command>
@@ -1373,29 +1358,25 @@
         <command id="00" dir="recv" name="Restart Device Response" required="m">
           <description>On receipt of this command the client is made aware that the server has received the corresponding request and is informed of the status of the request.</description>
           <payload>
-            <attribute id="0x0000" name="Status" type="enum8" access="rw" required="m" enumeration="ZCL_Status">
-            </attribute>
+            <attribute id="0x0000" name="Status" type="enum8" access="rw" required="m" enumeration="ZCL_Status"></attribute>
           </payload>
         </command>
         <command id="01" dir="recv" name="Save Startup Parameters Response" required="m">
           <description>On receipt of this command the client is made aware that the server has received the corresponding request and is informed of the status of the request.</description>
           <payload>
-            <attribute id="0x0000" name="Status" type="enum8" access="rw" required="m" enumeration="ZCL_Status">
-            </attribute>
+            <attribute id="0x0000" name="Status" type="enum8" access="rw" required="m" enumeration="ZCL_Status"></attribute>
           </payload>
         </command>
         <command id="02" dir="recv" name="Restore Startup Parameters Response" required="m">
           <description>On receipt of this command the client is made aware that the server has received the corresponding request and is informed of the status of the request.</description>
           <payload>
-            <attribute id="0x0000" name="Status" type="enum8" access="rw" required="m" enumeration="ZCL_Status">
-            </attribute>
+            <attribute id="0x0000" name="Status" type="enum8" access="rw" required="m" enumeration="ZCL_Status"></attribute>
           </payload>
         </command>
         <command id="03" dir="recv" name="Reset Startup Parameters Response" required="m">
           <description>On receipt of this command the client is made aware that the server has received the corresponding request and is informed of the status of the request.</description>
           <payload>
-            <attribute id="0x0000" name="Status" type="enum8" access="rw" required="m" enumeration="ZCL_Status">
-            </attribute>
+            <attribute id="0x0000" name="Status" type="enum8" access="rw" required="m" enumeration="ZCL_Status"></attribute>
           </payload>
         </command>
       </client>
@@ -1458,8 +1439,7 @@
     </cluster>
 
     <cluster id="0x0020" name="Poll Control">
-      <description>Provides a mechanism for the management of an end device’s MAC
-        Data Request rate.</description>
+      <description>Provides a mechanism for the management of an end device’s MAC Data Request rate.</description>
       <client>
       </client>
       <server>
@@ -1471,11 +1451,7 @@
         <attribute id="0x0005" name="Long Poll Interval Min" type="u32" default="0" access="r" required="o"></attribute>
         <attribute id="0x0006" name="Fast Poll Timeout Max" type="u16" default="0" access="r" required="o"></attribute>
         <command id="0x00" dir="send" name="Check-in" required="m">
-          <description>The Poll Control Cluster server sends out a Check-in command to the devices to which it is paired based on
-            the server‘s Check-inInterval attribute. It does this to find out if any of the Poll Control Cluster Clients with
-            which it is paired are interested in having it enter fast poll mode so that it can be managed. This request is sent
-            out based on either the Check-inInterval, or the next Check-in value in the Fast Poll Stop Request generated
-            by the Poll Control Cluster Client.</description>
+          <description>The Poll Control Cluster server sends out a Check-in command to the devices to which it is paired based on the server‘s Check-inInterval attribute. It does this to find out if any of the Poll Control Cluster Clients with which it is paired are interested in having it enter fast poll mode so that it can be managed. This request is sent out based on either the Check-inInterval, or the next Check-in value in the Fast Poll Stop Request generated by the Poll Control Cluster Client.</description>
           <payload></payload>
         </command>
         <command id="0x01" dir="send" name="Stop" required="m">
@@ -1496,6 +1472,7 @@
         </command>
       </server>
     </cluster>
+
     <cluster id="0x0800" name="Key Establishment">
       <description></description>
       <client></client>
@@ -1899,9 +1876,8 @@
           </attribute>
           <attribute id="0xf003" name="Calibration time (tenth of a second)" type="u16" default="0x0000" required="m" access="rw"></attribute>
         </attribute-set>
-
         <attribute-set id="0xe000" description="Merten specific" mfcode="0x105e">
-          <attribute id="0xe000" name="Cover run time" type="u16" default="0" required="m" access="rw" mfcode="0x105e"> </attribute>
+          <attribute id="0xe000" name="Cover run time" type="u16" default="0" required="m" access="rw" mfcode="0x105e"></attribute>
           <attribute id="0xe010" name="Unknown" type="bmp8" required="m" access="r" mfcode="0x105e">
             <value name="Unknown" value="0"></value>
             <value name="Unknown" value="1"></value>
@@ -1912,7 +1888,7 @@
             <value name="Unknown" value="6"></value>
             <value name="Unknown" value="7"></value>
           </attribute>
-          <attribute id="0xe012" name="Unknown" type="u16" default="0" required="m" access="rw" mfcode="0x105e"> </attribute>
+          <attribute id="0xe012" name="Unknown" type="u16" default="0" required="m" access="rw" mfcode="0x105e"></attribute>
           <attribute id="0xe013" name="Unknown" type="bmp8" required="m" access="r" mfcode="0x105e">
             <value name="Unknown" value="0"></value>
             <value name="Unknown" value="1"></value>
@@ -1924,7 +1900,6 @@
             <value name="Unknown" value="7"></value>
           </attribute>
         </attribute-set>
-
         <command id="0x00" dir="recv" name="Up / Open" required="m"></command>
         <command id="0x01" dir="recv" name="Down / Close" required="m"></command>
         <command id="0x02" dir="recv" name="Stop" required="m"></command>
@@ -2040,11 +2015,10 @@
           <attribute id="0x0024" name="Temperature Setpoint Hold Duration" type="u16" range="0x05a0,0xffff" default="0xffff" access="rw" required="o"></attribute>
           <attribute id="0x0025" name="Thermostat Programming Operation Mode" type="bmp8" default="0" access="rw" required="o">
             <value name="Simple/setpoint mode" value="0">
-              <description>0 – This mode means the thermostat setpoint is altered only by manual
-                up/down changes at the thermostat or remotely, not by internal schedule programming.
-                1 – Schedule programming mode. This enables or disables any programmed weekly schedule con-
-                figurations.
-                Note: It does not clear or delete previous weekly schedule programming configurations.</description></value>
+              <description>0 – This mode means the thermostat setpoint is altered only by manual up/down changes at the thermostat or remotely, not by internal schedule programming.
+1 – Schedule programming mode. This enables or disables any programmed weekly schedule con-figurations.
+Note: It does not clear or delete previous weekly schedule programming configurations.</description>
+            </value>
             <value name="Auto/recovery mode" value="1"></value>
             <value name="Economy/EnergyStar mode" value="2"></value>
           </attribute>
@@ -2069,7 +2043,6 @@
           <attribute id="0x0031" name="Setpoint Change Amount" type="s16" access="r" required="o" default="0x8000"/>
           <attribute id="0x0032" name="Setpoint Change Timestamp" type="utc" access="r" required="o" default="0"/>
         </attribute-set>
-
         <attribute-set id="0x0040" description="AC Information">
           <attribute id="0x0040" name="AC Type" type="enum8" access="rw" required="o">
             <value name="Cooling and Fixed Speed" value="1"></value>
@@ -2107,13 +2080,11 @@
             <value name="BTUh" value="0"></value>
           </attribute>
         </attribute-set>
-
         <attribute-set id="0x0080" description="eCozy" mfcode="0x1014">
           <attribute id="0x0080" name="Unknown" type="s16" access="r" required="o"/>
           <attribute id="0x0081" name="Unknown" type="s16" access="r" required="o"/>
           <attribute id="0x0082" name="Unknown (Heat Setpoint?)" type="s16" access="r" required="o"/>
         </attribute-set>
-
         <!-- ELKO specific -->
         <attribute-set id="0x0400" description="ELKO specific" mfcode="0x1002">
           <attribute id="0x0401" name="Unknown" type="u16" access="rw" required="m"></attribute>
@@ -2139,7 +2110,6 @@
           <attribute id="0x0418" name="Unknown" type="u8" access="rw" required="m"></attribute>
           <attribute id="0x0419" name="Unknown" type="u8" access="rw" required="m"></attribute>
         </attribute-set>
-
         <!-- Eurotronic manufacturer specific -->
         <attribute-set id="0x4000" description="Eurotronic" mfcode="0x1037">
           <attribute id="0x4000" name="TRV Mode" type="enum8" default="0x02" access="rw" required="m" mfcode="0x1037">
@@ -2161,7 +2131,6 @@
           <attribute id="0x4003" name="Current Temperature Setpoint" type="s16" default="0x07d0" access="rw" required="m" mfcode="0x1037"></attribute>
           <attribute id="0x4008" name="Host Flags" type="u24" default="0x000000" showas="hex" access="rw" required="m" mfcode="0x1037"></attribute>
         </attribute-set>
-
         <!-- Danfoss manufacturer specific -->
         <attribute-set id="0x4000" description="Danfoss specific" mfcode="0x1246">
           <attribute id="0x4000" name="eTRV Open Window Detection" type="enum8" default="0x00" access="r" required="o" mfcode="0x1246">
@@ -2213,7 +2182,6 @@
           <attribute id="0x4050" name="Preheat Time" type="u32" access="r" required="o" mfcode="0x1246"></attribute>
           <attribute id="0x4051" name="Window Open Feature On" type="bool" default="0x01" access="rw" required="o" mfcode="0x1246"></attribute>
         </attribute-set>
-
         <!-- Sinope manufacturer specific -->
         <attribute-set id="0x0400" description="Sinope specific" mfcode="0x119c">
           <attribute id="0x0400" name="Occupancy" type="enum8" access="rw" required="m" mfcode="0x119c">
@@ -2225,7 +2193,6 @@
             <value name="Sensing" value="0x01"></value>
           </attribute>
         </attribute-set>
-
         <!-- Stelpro manufacturer specific -->
         <attribute-set id="0x4000" description="Stelpro specific" mfcode="0x1185">
           <attribute id="0x4001" name="Outdoor temp" type="s16" access="rw" required="m" mfcode="0x1185"></attribute>
@@ -2236,7 +2203,6 @@
             <description>States only supportedb by Stelpro thermostats (useless for Maestro).</description>
           </attribute>
         </attribute-set>
-
         <!-- Sunrichee manufacturer specific -->
         <attribute-set id="0x1000" description="Sunricher Specific Attributes" mfcode="0x1224">
           <attribute id="0x1000" name="Display LED Brightness" type="enum8" access="rw" default="0x01" required="m" mfcode="0x1224">
@@ -2328,7 +2294,6 @@
             <value name="Vacation Schedule" value="0x01"></value>
           </attribute>
         </attribute-set>
-
         <command id="0x00" dir="recv" name="Setpoint Raise/Lower" required="m">
           <description>This command increases (or decreases) the setpoint(s) by amount, in steps of 0.1°C.</description>
           <payload>
@@ -2411,10 +2376,8 @@
             </attribute>
           </payload>
         </command>
-        <command id="0x03" dir="recv" name="Clear Weekly Schedule" required="o">
-        </command>
-        <command id="0x04" dir="recv" name="Get Relay Status Log" required="o">
-        </command>
+        <command id="0x03" dir="recv" name="Clear Weekly Schedule" required="o"></command>
+        <command id="0x04" dir="recv" name="Get Relay Status Log" required="o"></command>
       </server>
       <client>
         <command id="0x00" dir="recv" name="Get Weekly Schedule Response" required="o">
@@ -2501,8 +2464,7 @@
     </cluster>
 
     <cluster id="0x0204" name="Thermostat User Interface Configuration">
-      <description>This cluster provides an interface to allow configuration of the user interface for a thermostat, or a thermostat
-        controller device, that supports a keypad and LCD screen.</description>
+      <description>This cluster provides an interface to allow configuration of the user interface for a thermostat, or a thermostat controller device, that supports a keypad and LCD screen.</description>
       <server>
         <attribute id="0x0000" name="Temperature Display Mode" type="enum8" access="rw" range="0x00,0x01" default="0x00" required="m">
           <value name="Temperature in °C" value="0x00"></value>
@@ -2542,137 +2504,138 @@
   </domain>
 
   <domain name="Lighting" low_bound="0300" high_bound="03ff" description="The lighting functional domain contains clusters and information to build devices in the lighting domain, e.g. ballast units.">
-    <cluster id="0x0300" name="Color control">
+    <cluster id="0x0300" name="Color Control">
       <description>Attributes and commands for controlling the color properties of a color-capable light.</description>
       <server>
         <attribute-set id="0x0000" description="Color Information">
-          <attribute id="0x0000" name="Current hue" type="u8" access="r" range="0x00,0xfe" default="0x00" required="o"></attribute>
-          <attribute id="0x0001" name="Current saturation" type="u8" access="r" range="0x00,0xfe" default="0x00" required="o"></attribute>
-          <attribute id="0x0002" name="Remaining time" type="u16" access="r" range="0x0000,0xfffe" default="0x0000" required="o"></attribute>
-          <attribute id="0x0003" name="Current x" type="u16" access="r" range="0x0000,0xfeff" default="0x61eb" required="m"></attribute>
-          <attribute id="0x0004" name="Current y" type="u16" access="r" range="0x0000,0xfeff" default="0x607b" required="m"></attribute>
-          <attribute id="0x0007" name="Color temperature" type="u16" access="r" range="0x0000,0xfeff" default="0" required="m"></attribute>
-          <!-- TODO -->
+          <attribute id="0x0000" name="Current Hue" type="u8" access="r" range="0x00,0xfe" default="0x00" required="o"></attribute>
+          <attribute id="0x0001" name="Current Saturation" type="u8" access="r" range="0x00,0xfe" default="0x00" required="o"></attribute>
+          <attribute id="0x0002" name="Remaining Time" type="u16" access="r" range="0x0000,0xfffe" default="0x0000" required="o"></attribute>
+          <attribute id="0x0003" name="Current X" type="u16" access="r" range="0x0000,0xfeff" default="0x61eb" required="m"></attribute>
+          <attribute id="0x0004" name="Current Y" type="u16" access="r" range="0x0000,0xfeff" default="0x607b" required="m"></attribute>
+          <!--
+          <attribute id="0x0003" mfcode="0x100b" name="StartUp Current X" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
+          <attribute id="0x0004" mfcode="0x100b" name="StartUp Current Y" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
+          -->
+          <attribute id="0x0007" name="Color Temperature Mireds" type="u16" access="r" range="0x0000,0xfeff" default="0" required="m"></attribute>
           <attribute id="0x0008" name="Color Mode" type="enum8" access="r" range="0x00,0x02" default="0x01" required="o">
             <value name="Current hue and current saturation" value="0x00"></value>
             <value name="Current x and current y" value="0x01"></value>
             <value name="Color temperature" value="0x02"></value>
           </attribute>
-        </attribute-set>
-        <attribute-set id="0x0010" description="Defined Primaries Information">
-          <attribute id="0x0010" name="Number of primaries" type="u8" access="r" range="0x00,0x06" required="o"></attribute>
-          <attribute id="0x0011" name="Primary1 x" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0012" name="Primary1 y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0013" name="Primary1 intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
-          <attribute id="0x0015" name="Primary2 x" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0016" name="Primary2 y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0017" name="Primary2 intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
-          <attribute id="0x0019" name="Primary3 x" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x001a" name="Primary3 y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x001b" name="Primary3 intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
-        </attribute-set>
-        <attribute-set id="0x0020" description="Additional Defined Primaries Information">
-          <attribute id="0x0020" name="Primary4 x" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0021" name="Primary4 y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0022" name="Primary4 intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
-          <attribute id="0x0024" name="Primary5 x" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0025" name="Primary5 y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0026" name="Primary5 intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
-          <attribute id="0x0028" name="Primary6 x" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0029" name="Primary6 y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x002a" name="Primary6 intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
-        </attribute-set>
-        <attribute-set id="0x0030" description="Defined Color Points Settings">
-          <attribute id="0x0030" name="WhitePoint x" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0031" name="WhitePoint y" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0032" name="ColorPoint r x" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0033" name="ColorPoint r y" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0034" name="ColorPoint r intensity" type="u8" access="rw" range="0x00,0xff" required="o"></attribute>
-          <attribute id="0x0036" name="ColorPoint g x" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0037" name="ColorPoint g y" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0038" name="ColorPoint g intensity" type="u8" access="rw" range="0x00,0xff" required="o"></attribute>
-          <attribute id="0x003a" name="ColorPoint b x" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x003b" name="ColorPoint b y" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x003c" name="ColorPoint b intensity" type="u8" access="rw" range="0x00,0xff" required="o"></attribute>
-        </attribute-set>
-        <attribute-set id="0x4000" description="ZLL extensions">
-          <attribute id="0x4000" name="Enhanced current hue" type="u16" access="r" range="0x0000,0xffff" default="0x0000" required="m"></attribute>
-          <attribute id="0x4001" name="Enhanced color mode" type="enum8" access="r" range="0x00,0xff" default="0x00" required="m">
+          <attribute id = "0x000f" name="Options" type="bmp8" access="rw" required="o">
+            <value name="Execute If Off" value="0"></value>
+          </attribute>
+          <!-- TODO -->
+          <attribute id="0x4000" name="Enhanced Current Hue" type="u16" access="r" range="0x0000,0xffff" default="0x0000" required="m"></attribute>
+          <attribute id="0x4001" name="Enhanced Color Mode" type="enum8" access="r" range="0x00,0xff" default="0x00" required="m">
             <value name="Current hue and current saturation" value="0x00"></value>
             <value name="Current x and current y" value="0x01"></value>
             <value name="Color temperature" value="0x02"></value>
             <value name="Enhanced current hue and current saturation" value="0x03"></value>
           </attribute>
-          <attribute id="0x4002" name="Color loop active" type="u8" access="r" range="0x00,0xff" default="0x00" required="m"></attribute>
-          <attribute id="0x4003" name="Color loop direction" type="u8" access="r" range="0x00,0xff" default="0x00" required="m"></attribute>
-          <attribute id="0x4004" name="Color loop time" type="u16" access="r" range="0x00,0xff" default="0x0019" required="m"></attribute>
-          <attribute id="0x4005" name="Color loop start - enhanced hue" type="u16" access="r" range="0x00,0xff" default="0x2300" required="m"></attribute>
-          <attribute id="0x4006" name="Color loop stored - enhanced hue" type="u16" access="r" range="0x00,0xff" default="0x0000" required="m"></attribute>
-          <attribute id="0x400a" type="bmp16" name="Color capabilities" access="r" required="m" default="0x0000">
+          <attribute id="0x4002" name="Color Loop Active" type="u8" access="r" range="0x00,0xff" default="0x00" required="m"></attribute>
+          <attribute id="0x4003" name="Color Loop Direction" type="u8" access="r" range="0x00,0xff" default="0x00" required="m"></attribute>
+          <attribute id="0x4004" name="Color Loop Time" type="u16" access="r" range="0x00,0xff" default="0x0019" required="m"></attribute>
+          <attribute id="0x4005" name="Color Loop Start Enhanced Hue" type="u16" access="r" range="0x00,0xff" default="0x2300" required="m"></attribute>
+          <attribute id="0x4006" name="Color Loop Stored Enhanced Hue" type="u16" access="r" range="0x00,0xff" default="0x0000" required="m"></attribute>
+          <attribute id="0x400a" type="bmp16" name="Color Capabilities" access="r" required="m" default="0x0000">
             <value name="Hue saturation" value="0"></value>
             <value name="Enhanced Hue saturation" value="1"></value>
             <value name="Color loop" value="2"></value>
             <value name="CIE 1931 XY" value="3"></value>
             <value name="Color temperature" value="4"></value>
           </attribute>
-          <attribute id="0x400b" name="Color temperature min" type="u16" access="r" range="0x0000,0xfeff" default="0" required="m"></attribute>
-          <attribute id="0x400c" name="Color temperature max" type="u16" access="r" range="0x0000,0xfeff" default="0xfeff" required="m"></attribute>
-          <attribute id="0x4010" name="PowerOn Color Temperature" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
-          <!--
-          <attribute id="0x0003" mfcode="0x100b" name="PowerOn X" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
-          <attribute id="0x0004" mfcode="0x100b" name="PowerOn Y" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
-          -->
+          <attribute id="0x400b" name="Color Temperature Min Mireds" type="u16" access="r" range="0x0000,0xfeff" default="0" required="m"></attribute>
+          <attribute id="0x400c" name="Color Temperature Max Mireds" type="u16" access="r" range="0x0000,0xfeff" default="0xfeff" required="m"></attribute>
+          <attribute id="0x4010" name="StartUp Color Temperature Mireds" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
+        </attribute-set>
+        <attribute-set id="0x0010" description="Defined Primaries Information">
+          <attribute id="0x0010" name="Number of Primaries" type="u8" access="r" range="0x00,0x06" required="o"></attribute>
+          <attribute id="0x0011" name="Primary1 X" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+          <attribute id="0x0012" name="Primary1 Y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+          <attribute id="0x0013" name="Primary1 Intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
+          <attribute id="0x0015" name="Primary2 X" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+          <attribute id="0x0016" name="Primary2 Y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+          <attribute id="0x0017" name="Primary2 Intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
+          <attribute id="0x0019" name="Primary3 X" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+          <attribute id="0x001a" name="Primary3 Y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+          <attribute id="0x001b" name="Primary3 Intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
+        </attribute-set>
+        <attribute-set id="0x0020" description="Additional Defined Primaries Information">
+          <attribute id="0x0020" name="Primary4 X" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+          <attribute id="0x0021" name="Primary4 Y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+          <attribute id="0x0022" name="Primary4 Intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
+          <attribute id="0x0024" name="Primary5 X" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+          <attribute id="0x0025" name="Primary5 Y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+          <attribute id="0x0026" name="Primary5 Intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
+          <attribute id="0x0028" name="Primary6 X" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+          <attribute id="0x0029" name="Primary6 Y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+          <attribute id="0x002a" name="Primary6 Intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
+        </attribute-set>
+        <attribute-set id="0x0030" description="Defined Color Points Settings">
+          <attribute id="0x0030" name="WhitePoint X" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
+          <attribute id="0x0031" name="WhitePoint Y" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
+          <attribute id="0x0032" name="ColorPoint R X" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
+          <attribute id="0x0033" name="ColorPoint R Y" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
+          <attribute id="0x0034" name="ColorPoint R Intensity" type="u8" access="rw" range="0x00,0xff" required="o"></attribute>
+          <attribute id="0x0036" name="ColorPoint G X" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
+          <attribute id="0x0037" name="ColorPoint G Y" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
+          <attribute id="0x0038" name="ColorPoint G Intensity" type="u8" access="rw" range="0x00,0xff" required="o"></attribute>
+          <attribute id="0x003a" name="ColorPoint B X" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
+          <attribute id="0x003b" name="ColorPoint B Y" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
+          <attribute id="0x003c" name="ColorPoint B Intensity" type="u8" access="rw" range="0x00,0xff" required="o"></attribute>
         </attribute-set>
         <attribute-set id="0xde00" description="FLS extensions" mfcode="0x1135">
           <attribute id="0xde01" name="Active channels" type="u8" access="r" range="0x00,0xff" default="0x00" required="m"></attribute>
         </attribute-set>
-        <command id="0x00" dir="recv" name="Move to hue" required="o">
+        <command id="0x00" dir="recv" name="Move to Hue" required="o">
           <payload>
             <attribute id="0x0000" type="u8" name="Hue" required="m"></attribute>
             <attribute id="0x0001" type="enum8" name="Direction" required="m">
-              <value name="Shortest distance" value="0x00"></value>
+              <value name="Shortest Distance" value="0x00"></value>
               <value name="Longest Distance" value="0x01"></value>
               <value name="Up" value="0x02"></value>
               <value name="Down" value="0x03"></value>
             </attribute>
-            <attribute id="0x0002" type="u16" name="Transition time" required="m">
+            <attribute id="0x0002" type="u16" name="Transition Time" required="m">
               <description>The transition time in 1/10ths of a second.</description>
             </attribute>
           </payload>
         </command>
-        <command id="0x01" dir="recv" name="Move hue" required="o">
+        <command id="0x01" dir="recv" name="Move Hue" required="o">
           <payload>
-            <attribute id="0x0001" type="enum8" name="Move mode" required="m">
+            <attribute id="0x0001" type="enum8" name="Move Mode" required="m">
               <value name="Stop" value="0x00"></value>
               <value name="Up" value="0x01"></value>
               <value name="Down" value="0x03"></value>
             </attribute>
-            <attribute id="0x0002" type="u8" name="Steps/second" required="m"></attribute>
+            <attribute id="0x0002" type="u8" name="Rate" required="m"></attribute>
           </payload>
         </command>
-        <command id="0x02" dir="recv" name="Step hue" required="o">
+        <command id="0x02" dir="recv" name="Step Hue" required="o">
           <payload>
-            <attribute id="0x0000" type="enum8" name="Step mode" required="m">
+            <attribute id="0x0000" type="enum8" name="Step Mode" required="m">
               <value name="Up" value="0x01"></value>
               <value name="Down" value="0x03"></value>
             </attribute>
-            <attribute id="0x0001" type="u8" name="Step size" required="m"></attribute>
-            <attribute id="0x0002" type="u8" name="Transition time" required="m">
-              <description>The transitiontime in 1/10 seconds.</description>
+            <attribute id="0x0001" type="u8" name="Step Size" required="m"></attribute>
+            <attribute id="0x0002" type="u8" name="Transition Time" required="m">
+              <description>The transition time in 1/10 seconds.</description>
             </attribute>
           </payload>
         </command>
-        <command id="0x03" dir="recv" name="Move to saturation" required="o">
+        <command id="0x03" dir="recv" name="Move to Saturation" required="o">
           <payload>
             <attribute id="0x0000" type="u8" name="Saturation" required="m"></attribute>
-            <attribute id="0x0001" type="u16" name="Transition time" required="m">
-              <description>The transitiontime in 1/10 seconds.</description>
+            <attribute id="0x0001" type="u16" name="Transition Time" required="m">
+              <description>The transition time in 1/10 seconds.</description>
             </attribute>
           </payload>
         </command>
-        <command id="0x04" dir="recv" name="Move saturation" required="o">
+        <command id="0x04" dir="recv" name="Move Saturation" required="o">
           <payload>
-            <attribute id="0x0000" type="enum8" name="Move mode" required="m">
+            <attribute id="0x0000" type="enum8" name="Move Mode" required="m">
               <value name="Stop" value="0x00"></value>
               <value name="Up" value="0x01"></value>
               <value name="Down" value="0x03"></value>
@@ -2682,37 +2645,37 @@
             </attribute>
           </payload>
         </command>
-        <command id="0x05" dir="recv" name="Step saturation" required="o">
+        <command id="0x05" dir="recv" name="Step Saturation" required="o">
           <payload>
-            <attribute id="0x0000" type="enum8" name="Step mode" required="m">
+            <attribute id="0x0000" type="enum8" name="Step Mode" required="m">
               <value name="Up" value="0x01"></value>
               <value name="Down" value="0x03"></value>
             </attribute>
-            <attribute id="0x0001" type="u8" name="Step size" required="m"></attribute>
-            <attribute id="0x0002" type="u8" name="Transition time" required="m">
-              <description>The transitiontime in 1/10 seconds.</description>
+            <attribute id="0x0001" type="u8" name="Step Size" required="m"></attribute>
+            <attribute id="0x0002" type="u8" name="Transition Time" required="m">
+              <description>The transition time in 1/10 seconds.</description>
             </attribute>
           </payload>
         </command>
-        <command id="0x06" dir="recv" name="Move to hue and saturation" required="o">
+        <command id="0x06" dir="recv" name="Move to Hue and Saturation" required="o">
           <payload>
             <attribute id="0x0000" type="u8" name="Hue" required="m"></attribute>
             <attribute id="0x0001" type="u8" name="Saturation" required="m"></attribute>
-            <attribute id="0x0002" type="u16" name="Transition time" required="m">
-              <description>The transitiontime in 1/10 seconds.</description>
+            <attribute id="0x0002" type="u16" name="Transition Time" required="m">
+              <description>The transition time in 1/10 seconds.</description>
             </attribute>
           </payload>
         </command>
-        <command id="0x07" dir="recv" name="Move to color" required="m">
+        <command id="0x07" dir="recv" name="Move to Color" required="m">
           <payload>
-            <attribute id="0x0000" type="u16" name="ColorX" required="m"></attribute>
-            <attribute id="0x0001" type="u16" name="ColorY" required="m"></attribute>
-            <attribute id="0x0002" type="u16" name="Transition time" required="m">
-              <description>The transitiontime in 1/10 seconds.</description>
+            <attribute id="0x0000" type="u16" name="Color X" required="m"></attribute>
+            <attribute id="0x0001" type="u16" name="Color Y" required="m"></attribute>
+            <attribute id="0x0002" type="u16" name="Transition Time" required="m">
+              <description>The transition time in 1/10 seconds.</description>
             </attribute>
           </payload>
         </command>
-        <command id="0x08" dir="recv" name="Move color" required="o">
+        <command id="0x08" dir="recv" name="Move Color" required="o">
           <payload>
             <attribute id="0x0000" type="s16" name="Rate X" required="m">
               <description>The steps per second.</description>
@@ -2722,40 +2685,40 @@
             </attribute>
           </payload>
         </command>
-        <command id="0x09" dir="recv" name="Step color" required="o">
+        <command id="0x09" dir="recv" name="Step Color" required="o">
           <payload>
             <attribute id="0x0000" type="s16" name="Step X" required="m"></attribute>
             <attribute id="0x0001" type="s16" name="Step Y" required="m"></attribute>
-            <attribute id="0x0002" type="u16" name="Transition time" required="m">
-              <description>The transitiontime in 1/10 seconds.</description>
+            <attribute id="0x0002" type="u16" name="Transition Time" required="m">
+              <description>The transition time in 1/10 seconds.</description>
             </attribute>
           </payload>
         </command>
-        <command id="0x0a" dir="recv" name="Move to color temperature" required="o">
+        <command id="0x0a" dir="recv" name="Move to Color Temperature" required="o">
           <payload>
-            <attribute id="0x0000" type="u16" name="Color temperature" required="m"></attribute>
-            <attribute id="0x0001" type="u16" name="Transition time" required="m">
-              <description>The transitiontime in 1/10 seconds.</description>
+            <attribute id="0x0000" type="u16" name="Color temperature Mireds" required="m"></attribute>
+            <attribute id="0x0001" type="u16" name="Transition Time" required="m">
+              <description>The transition time in 1/10 seconds.</description>
             </attribute>
           </payload>
         </command>
-        <command id="0x40" dir="recv" name="Enhanced move to hue" required="m">
+        <command id="0x40" dir="recv" name="Enhanced Move to Hue" required="m">
           <payload>
-            <attribute id="0x0000" type="u16" name="Enhanced hue" required="m"></attribute>
+            <attribute id="0x0000" type="u16" name="Enhanced Hue" required="m"></attribute>
             <attribute id="0x0001" type="enum8" name="Direction" required="m">
-              <value name="Shortest distance" value="0x00"></value>
+              <value name="Shortest Distance" value="0x00"></value>
               <value name="Longest Distance" value="0x01"></value>
               <value name="Up" value="0x02"></value>
               <value name="Down" value="0x03"></value>
             </attribute>
-            <attribute id="0x0002" type="u16" name="Transition time" required="m">
-              <description>The transitiontime in 1/10 seconds.</description>
+            <attribute id="0x0002" type="u16" name="Transition Time" required="m">
+              <description>The transition time in 1/10 seconds.</description>
             </attribute>
           </payload>
         </command>
-        <command id="0x41" dir="recv" name="Enhanced move hue" required="m">
+        <command id="0x41" dir="recv" name="Enhanced Move Hue" required="m">
           <payload>
-            <attribute id="0x0000" type="enum8" name="Move mode" required="m">
+            <attribute id="0x0000" type="enum8" name="Move Mode" required="m">
               <value name="Stop" value="0x00"></value>
               <value name="Up" value="0x01"></value>
               <value name="Down" value="0x03"></value>
@@ -2765,58 +2728,57 @@
             </attribute>
           </payload>
         </command>
-        <command id="0x42" dir="recv" name="Enhanced step hue" required="m">
+        <command id="0x42" dir="recv" name="Enhanced Step Hue" required="m">
           <payload>
-            <attribute id="0x0000" type="enum8" name="Step mode" required="m">
+            <attribute id="0x0000" type="enum8" name="Step Mode" required="m">
               <value name="Up" value="0x01"></value>
               <value name="Down" value="0x03"></value>
             </attribute>
-            <attribute id="0x0001" type="u16" name="Step size" required="m"></attribute>
-            <attribute id="0x0002" type="u16" name="Transition time" required="m">
-              <description>The transitiontime in 1/10 seconds.</description>
+            <attribute id="0x0001" type="u16" name="Step Size" required="m"></attribute>
+            <attribute id="0x0002" type="u16" name="Transition Time" required="m">
+              <description>The transition time in 1/10 seconds.</description>
             </attribute>
           </payload>
         </command>
-        <command id="0x43" dir="recv" name="Enhanced move to hue and saturation" required="m">
+        <command id="0x43" dir="recv" name="Enhanced Move to Hue and Saturation" required="m">
           <payload>
-            <attribute id="0x0000" type="u16" name="Enhanced hue" required="m"></attribute>
+            <attribute id="0x0000" type="u16" name="Enhanced Hue" required="m"></attribute>
             <attribute id="0x0001" type="u8" name="Saturation" required="m"></attribute>
-            <attribute id="0x0002" type="u16" name="Transition time" required="m">
-              <description>The transitiontime in 1/10 seconds.</description>
+            <attribute id="0x0002" type="u16" name="Transition Time" required="m">
+              <description>The transition time in 1/10 seconds.</description>
             </attribute>
           </payload>
         </command>
-        <command id="0x44" dir="recv" name="Color loop set" required="m">
+        <command id="0x44" dir="recv" name="Color Loop Set" required="m">
           <payload>
-            <attribute id="0x0000" type="bmp8" name="Update flags" required="m">
-              <value name="Update action" value="0"></value>
-              <value name="Update direction" value="1"></value>
-              <value name="Update time" value="2"></value>
-              <value name="Update start hue" value="3"></value>
+            <attribute id="0x0000" type="bmp8" name="Update Flags" required="m">
+              <value name="Update Action" value="0"></value>
+              <value name="Update Direction" value="1"></value>
+              <value name="Update Time" value="2"></value>
+              <value name="Update Start Hue" value="3"></value>
             </attribute>
             <attribute id="0x0001" type="enum8" name="Action" required="m">
               <value name="De-activate color loop" value="0x00"></value>
-              <value name="Activate from ColorLoopStartEnhancedHue" value="0x01"></value>
-              <value name="Activate from EnhancedCurrentHue" value="0x02"></value>
+              <value name="Activate from Color Loop Start Enhanced Hue" value="0x01"></value>
+              <value name="Activate from Enhanced Current Hue" value="0x02"></value>
             </attribute>
             <attribute id="0x0002" type="enum8" name="Direction" required="m">
-              <value name="Decrement hue" value="0x00"></value>
-              <value name="Increment hue" value="0x01"></value>
+              <value name="Decrement Hue" value="0x00"></value>
+              <value name="Increment Hue" value="0x01"></value>
             </attribute>
             <attribute id="0x0003" type="u16" name="Time" required="m">
               <description>Time in seconds used for a whole color loop.</description>
             </attribute>
-            <attribute id="0x0004" type="u16" name="Start enhanced hue" required="m"></attribute>
+            <attribute id="0x0004" type="u16" name="Start Enhanced Hue" required="m"></attribute>
           </payload>
         </command>
         <command id="0x47" dir="recv" name="Stop move step" required="m">
           <description>Stops move to and step commands. It has no effect on a active color loop.</description>
-          <payload>
-          </payload>
+          <payload></payload>
         </command>
-        <command id="0x4b" dir="recv" name="Move color temperature" required="m">
+        <command id="0x4b" dir="recv" name="Move Color Temperature" required="m">
           <payload>
-            <attribute id="0x0000" type="enum8" name="Move mode" required="m">
+            <attribute id="0x0000" type="enum8" name="Move Mode" required="m">
               <value name="Stop" value="0x00"></value>
               <value name="Up" value="0x01"></value>
               <value name="Down" value="0x03"></value>
@@ -2824,40 +2786,39 @@
             <attribute id="0x0001" type="u16" name="Rate" required="m">
               <description>Steps per second.</description>
             </attribute>
-            <attribute id="0x0002" type="u16" name="Color temperature min" required="m">
+            <attribute id="0x0002" type="u16" name="Color Temperature Min Mireds" required="m">
               <description>Specifies a lower bound on the color temperature for the current move operation.</description>
             </attribute>
-            <attribute id="0x0003" type="u16" name="Color temperature max" required="m">
+            <attribute id="0x0003" type="u16" name="Color Temperature Max Mireds" required="m">
               <description>Specifies a upper bound on the color temperature for the current move operation.</description>
             </attribute>
           </payload>
         </command>
-        <command id="0x4c" dir="recv" name="Step color temperature" required="m">
+        <command id="0x4c" dir="recv" name="Step Color Temperature" required="m">
           <payload>
-            <attribute id="0x0000" type="enum8" name="Step mode" required="m">
+            <attribute id="0x0000" type="enum8" name="Step Mode" required="m">
               <value name="Up" value="0x01"></value>
               <value name="Down" value="0x03"></value>
             </attribute>
-            <attribute id="0x0001" type="u16" name="Step size" required="m"></attribute>
-            <attribute id="0x0002" type="u16" name="Transition time" required="m">
-              <description>The transitiontime in 1/10 seconds.</description>
+            <attribute id="0x0001" type="u16" name="Step Size" required="m"></attribute>
+            <attribute id="0x0002" type="u16" name="Transition Time" required="m">
+              <description>The transition time in 1/10 seconds.</description>
             </attribute>
-            <attribute id="0x0003" type="u16" name="Color temperature min" required="m">
+            <attribute id="0x0003" type="u16" name="Color Temperature Min Mireds" required="m">
               <description>Specifies a lower bound on the color temperature for the current step operation.</description>
             </attribute>
-            <attribute id="0x0004" type="u16" name="Color temperature max" required="m">
+            <attribute id="0x0004" type="u16" name="Color Temperature Max Mireds" required="m">
               <description>Specifies a upper bound on the color temperature for the current step operation.</description>
             </attribute>
           </payload>
         </command>
-        <command id="0xd0" dir="recv" name="Set active channels" required="m">
+        <command id="0xd0" dir="recv" name="Set Active Channels" required="m">
           <payload>
             <attribute id="0x00" type="u8" name="Channels" required="m"></attribute>
           </payload>
         </command>
       </server>
-      <client>
-      </client>
+      <client></client>
     </cluster>
 
     <cluster id="0x0301" name="Ballast Configuration">
@@ -2871,7 +2832,6 @@
             <value name="Lamp not in socket" value="1"></value>
           </attribute>
         </attribute-set>
-
         <attribute-set id="0x0010" description="Ballast Settings">
           <attribute id="0x0010" name="Min Level" type="u8" access="rw" range="0x01,0xfe" default="0x01" required="o"></attribute>
           <attribute id="0x0011" name="Max Level" type="u8" access="rw" range="0x01,0xfe" default="0xfe" required="o"></attribute>
@@ -2880,11 +2840,9 @@
           <attribute id="0x0014" name="Intrinsic Ballast Factor" type="u8" access="rw" range="0x00,0xfe" default="0x00" required="o"></attribute>
           <attribute id="0x0015" name="Ballast Factor Adjustment" type="u8" access="rw" range="0x64,0xff" default="0xff" required="o"></attribute>
         </attribute-set>
-
         <attribute-set id="0x0020" description="Lamp Information">
           <attribute id="0x0020" name="Lamp Quantity" type="u8" access="r" range="0x00,0xfe" default="0x00" required="o"></attribute>
         </attribute-set>
-
         <attribute-set id="0x0030" description="Lamp Settings">
           <attribute id="0x0030" name="Lamp Type" type="cstring" access="rw" required="o"></attribute>
           <attribute id="0x0031" name="Lamp Manufacturer" type="cstring" access="rw" required="o"></attribute>
@@ -2921,9 +2879,15 @@
       <client>
         <attribute-set id="0xf000" description="Illuminance Adjustement Configuration">
           <attribute id="0xf000" name="Hysteresis" type="u16" access="rw" required="o"></attribute>
-          <attribute id="0xf001" name="Max Up Speed" type="u16" access="rw" required="o"><description>Maximum up adjustment speed in 1/10 seconds.</description></attribute>
-          <attribute id="0xf002" name="Max Down Speed" type="u16" access="rw" required="o"><description>Maximum down adjustment speed in 1/10 seconds.</description></attribute>
-          <attribute id="0xf003" name="Target Value" type="u16" access="rw" required="o"><description>Target value in Lux which should be kept.</description></attribute>
+          <attribute id="0xf001" name="Max Up Speed" type="u16" access="rw" required="o">
+            <description>Maximum up adjustment speed in 1/10 seconds.</description>
+          </attribute>
+          <attribute id="0xf002" name="Max Down Speed" type="u16" access="rw" required="o">
+            <description>Maximum down adjustment speed in 1/10 seconds.</description>
+          </attribute>
+          <attribute id="0xf003" name="Target Value" type="u16" access="rw" required="o">
+            <description>Target value in Lux which should be kept.</description>
+          </attribute>
           <attribute id="0xf004" name="Startup Type" type="enum8" access="rw" required="o">
             <description>Brightness control startup type.</description>
             <value name="Default Level" value="0x00"></value>
@@ -2990,7 +2954,9 @@
     </cluster>
 
     <cluster id="0x0406" name="Occupancy sensing">
-      <description><!-- TODO --></description>
+      <description>
+        <!-- TODO -->
+      </description>
       <server>
         <attribute-set id="0x0000" description="Occupancy sensor information">
           <attribute id="0x0000" name="Occupancy" type="bmp8" range="0000000x" access="r" required="m"></attribute>
@@ -3162,8 +3128,9 @@
         <attribute-set id="0x0000" description="Zone information">
           <attribute id="0x0000" name="Zone State" type="enum8" range="0x00,0x01" access="r" required="m">
             <value name="Not enrolled" value="0x00"></value>
-            <value name="Enrolled" value="0x01"><description>The client will react to Zone
-              State Change Notification commands from the server.</description></value>
+            <value name="Enrolled" value="0x01">
+              <description>The client will react to Zone State Change Notification commands from the server.</description>
+            </value>
           </attribute>
           <attribute id="0x0001" name="Zone Type" type="enum16" range="0x0000,0xffff" access="r" required="m">
             <value name="Standard CIE" value="0x0000"></value>
@@ -3289,23 +3256,17 @@
             <attribute id="0x02" type="cstring" name="Arm/Disarm Code" required="m"></attribute>
           </payload>
         </command>
-        <command id="0x02" dir="recv" name="Emergency" required="m">
-        </command>
-        <command id="0x03" dir="recv" name="Fire" required="m">
-        </command>
-        <command id="0x04" dir="recv" name="Panic" required="m">
-        </command>
-        <command id="0x05" dir="recv" name="Get Zone ID Map" required="m">
-        </command>
+        <command id="0x02" dir="recv" name="Emergency" required="m"></command>
+        <command id="0x03" dir="recv" name="Fire" required="m"></command>
+        <command id="0x04" dir="recv" name="Panic" required="m"></command>
+        <command id="0x05" dir="recv" name="Get Zone ID Map" required="m"></command>
         <command id="0x06" dir="recv" name="Get Zone Information" required="m">
           <payload>
             <attribute id="0x00" type="u8" name="Zone ID" required="m"></attribute>
           </payload>
         </command>
-        <command id="0x07" dir="recv" name="Get Panel Status" required="m">
-        </command>
-        <command id="0x08" dir="recv" name="Get Bypassed Zone List" required="m">
-        </command>
+        <command id="0x07" dir="recv" name="Get Panel Status" required="m"></command>
+        <command id="0x08" dir="recv" name="Get Bypassed Zone List" required="m"></command>
         <command id="0x09" dir="recv" name="Get Zone Status" required="m">
           <payload>
             <attribute id="0x00" type="u8" name="Starting Zone ID" required="m"></attribute>
@@ -3462,12 +3423,14 @@
             <attribute id="0x06" type="u8" name="Bypass Result for Zone ID 6" required="m"></attribute>
             <attribute id="0x07" type="u8" name="Bypass Result for Zone ID 7" required="m"></attribute>
             <attribute id="0x08" type="u8" name="Bypass Result for Zone ID 8" required="m"></attribute>
-            <!--<value name="Zone bypassed" value="0x00"></value>
-            <value name="Zone not bypassed" value="0x01"></value>
-            <value name="Not allowed" value="0x02"></value>
-            <value name="Invalid Zone ID" value="0x03"></value>
-            <value name="Unknown Zone ID" value="0x04"></value>
-            <value name="Invalid Arm/Disarm Code" value="0x05"></value>-->
+            <!--
+              <value name="Zone bypassed" value="0x00"></value>
+              <value name="Zone not bypassed" value="0x01"></value>
+              <value name="Not allowed" value="0x02"></value>
+              <value name="Invalid Zone ID" value="0x03"></value>
+              <value name="Unknown Zone ID" value="0x04"></value>
+              <value name="Invalid Arm/Disarm Code" value="0x05"></value>
+            -->
           </payload>
         </command>
         <command id="0x08" dir="recv" name="Get Zone Status Response" required="m">
@@ -3577,8 +3540,8 @@
     </cluster>
 
     <cluster id="0x0702" name="Simple Metering">
-      <description>The Simple Metering Cluster provides a mechanism to retrieve usage information from Electric, Gas, Water, and potentially Thermal metering devices. These
-        devices can operate on either battery or mains power, and can have a wide variety of sophistication.</description>
+      <description>The Simple Metering Cluster provides a mechanism to retrieve usage information from Electric, Gas, Water, and potentially Thermal metering devices.
+These devices can operate on either battery or mains power, and can have a wide variety of sophistication.</description>
       <server>
         <attribute-set id="0x0000" description="Reading Information Set">
           <attribute id="0x0000" name="Current Summation Delivered" type="u48" access="r" required="m"></attribute>
@@ -3614,7 +3577,6 @@
             <value name="Liters &amp; l/h binary" value="7"></value>
             <value name="kPA(gauge) binary" value="8"></value>
             <value name="kPA(absolute) binary" value="9"></value>
-
             <value name="kW &amp; kWh BCD" value="80"></value>
             <value name="m³ &amp; m³/h BCD" value="81"></value>
             <value name="ft³ &amp; ft³/h BCD" value="82"></value>
@@ -3647,7 +3609,6 @@
             <value name="Pressure Metering" value="4"></value>
             <value name="Heat Metering" value="5"></value>
             <value name="Cooling Metering" value="6"></value>
-
             <value name="Mirrored Gas Metering" value="128"></value>
             <value name="Mirrored Water Metering" value="129"></value>
             <value name="Mirrored Thermal Metering" value="130"></value>
@@ -3682,32 +3643,29 @@
         <!-- TODO -->
         <!-- dont support generated commands yet
         <command id="01" dir="send" name="Get Profile Response" required="o">
-        <payload>
-        <field type="utc" name="End Time">
-        </field>
-        <field type="enum8" name="Status">
-        <value name="Success" value="0x00"/>
-        <value name="Undefined Interval Channel requested" value="0x01"/>
-        <value name="Interval Channel not supported" value="0x02"/>
-        <value name="Invalid End Time" value="0x03"/>
-        <value name="More periods requested then can be returned" value="0x04"/>
-        <value name="No intervals available for the requested time" value="0x05"/>
-        </field>
-        <field type="enum8" name="Profile Interval Period">
-        <value name="Daily" value="0"/>
-        <value name="60 minutes" value="1"/>
-        <value name="30 minutes" value="2"/>
-        <value name="15 minutes" value="3"/>
-        <value name="10 minutes" value="4"/>
-        <value name="7.5 minutes" value="5"/>
-        <value name="5 minutes" value="6"/>
-        <value name="2.5 minutes" value="7"/>
-        </field>
-        <field type="u8" name="Number Of Periods Delivered">
-        </field>
-        <field type="u24" name="Intervals" list="true">
-        </field>
-        </payload>
+          <payload>
+            <field type="utc" name="End Time"></field>
+            <field type="enum8" name="Status">
+              <value name="Success" value="0x00"/>
+              <value name="Undefined Interval Channel requested" value="0x01"/>
+              <value name="Interval Channel not supported" value="0x02"/>
+              <value name="Invalid End Time" value="0x03"/>
+              <value name="More periods requested then can be returned" value="0x04"/>
+              <value name="No intervals available for the requested time" value="0x05"/>
+            </field>
+            <field type="enum8" name="Profile Interval Period">
+              <value name="Daily" value="0"/>
+              <value name="60 minutes" value="1"/>
+              <value name="30 minutes" value="2"/>
+              <value name="15 minutes" value="3"/>
+              <value name="10 minutes" value="4"/>
+              <value name="7.5 minutes" value="5"/>
+              <value name="5 minutes" value="6"/>
+              <value name="2.5 minutes" value="7"/>
+            </field>
+            <field type="u8" name="Number Of Periods Delivered"></field>
+            <field type="u24" name="Intervals" list="true"></field>
+          </payload>
         </command>
         -->
         <command id="00" dir="recv" name="Get Profile" required="o">
@@ -3781,6 +3739,7 @@
         <!-- TODO -->
       </client>
     </cluster>
+
     <cluster id="0x0b01" name="Meter Identification">
       <description>Attributes and commands that provide an interface to meter identification.</description>
       <server>
@@ -3855,7 +3814,6 @@
             <attribute id="0x0000" type="u8" name="Total" required="m" default="0"></attribute>
             <attribute id="0x0001" type="u8" name="Start index" required="m" default="0"></attribute>
             <attribute id="0x0002" type="u8" name="Count" required="m" default="0"></attribute>
-
             <!-- TODO this will display only first item of the list -->
             <attribute id="0x0003" type="u16" name="First group ID" showas="hex" required="m" default="0x0000"></attribute>
             <attribute id="0x0004" type="u8" name="First group type" showas="hex" required="m" default="0x00"></attribute>
@@ -3867,7 +3825,6 @@
             <attribute id="0x0000" type="u8" name="Total" required="m" default="0"></attribute>
             <attribute id="0x0001" type="u8" name="Start index" required="m" default="0"></attribute>
             <attribute id="0x0002" type="u8" name="Count" required="m" default="0"></attribute>
-
             <!-- TODO this will display only first item of the list -->
             <attribute id="0x0003" type="u16" name="NWK address" showas="hex" required="m" default="0x0000"></attribute>
             <attribute id="0x0004" type="u8" name="Endpoint" showas="hex" required="m" default="0x00"></attribute>
@@ -3909,12 +3866,9 @@
         <attribute id="0x0007" name="Active Functionality" type="bmp24" default="0xffffff" access="r" required="m" showas="hex">
           <description>The optional GP functionality supported by this sink that is active.</description>
         </attribute>
-        <attribute id="0x0020" name="Shared Security Key Type" type="bmp8" default="0x00" access="r" required="m" showas="hex">
-        </attribute>
-        <attribute id="0x0021" name="Shared Security Key" type="seckey" access="r" required="m" showas="hex">
-        </attribute>
-        <attribute id="0x0022" name="GP Link Key" type="seckey" access="r" required="m" showas="hex">
-        </attribute>
+        <attribute id="0x0020" name="Shared Security Key Type" type="bmp8" default="0x00" access="r" required="m" showas="hex"></attribute>
+        <attribute id="0x0021" name="Shared Security Key" type="seckey" access="r" required="m" showas="hex"></attribute>
+        <attribute id="0x0022" name="GP Link Key" type="seckey" access="r" required="m" showas="hex"></attribute>
       </server>
       <client>
       </client>
@@ -3936,27 +3890,23 @@
         <attribute id="0x0000" type="u8" name="On" required="m" access="rw" default="0">
           <description>Enable Sensor </description>
         </attribute>
-
         <attribute id="0x0001" name="X-Value" type="u16" default="0x0000" access="r" required="m" showas="dec">
           <description>X-Value</description>
         </attribute>
-
         <attribute id="0x0002" name="Y-Value" type="u16" default="0x0000" access="r" required="m" showas="dec">
           <description>Y-Value</description>
         </attribute>
-
         <attribute id="0x0003" name="Z-Value" type="u16" default="0x0000" access="r" required="m" showas="dec">
           <description>Z-Value</description>
         </attribute>
-
       </server>
       <client>
       </client>
     </cluster>
 
     <!-- Hue -->
-    <cluster id="0xfc00" name="Hue" mfcode="0x100b">
-      <description>Hue-specific cluster.</description>
+    <cluster id="0xfc00" name="Hue Button" mfcode="0x100b">
+      <description>Hue-specific cluster for Hue dimmer family.</description>
       <server>
         <command id="0x00" dir="send" name="Button Action Notification" required="m">
           <payload>
@@ -3976,12 +3926,46 @@
             <attribute id="0x0000" type="u16" name="Duration" required="m"/>
           </payload>
         </command>
+      </server>
+    </cluster>
+
+    <cluster id="0xfc01" name="Hue Entertainment" mfcode="0x100b">
+      <description>Hue-specific cluster for Hue (white and) color ambiance lights.  As yet unknown what this does.</description>
+      <server>
+      </server>
+      <client>
+      </client>
+    </cluster>
+
+    <cluster id="0xfc03" name="Hue Effects" mfcode="0x100b">
+      <description>Hue-specific cluster for Hue white and color ambiance lights.</description>
+      <server>
+        <command id="0x00" dir="recv" name="Set Dynamic Effect" vendor="0x100b" required="m">
+          <payload>
+            <attribute id="0x0000" type="u16" name="Command" showas="hex" default="0x0021" required="m"/>
+            <attribute id="0x0001" type="bool" name="Enable" required="m"/>
+            <attribute id="0x0002" type="enum8" name="Scene" required="m">
+              <value name="None" value="0x00"/>
+              <value name="Candle" value="0x01"/>
+              <value name="Fireplace" value="0x02"/>
+              <value name="Loop" value="0x03"/>
+            </attribute>
+          </payload>
+        </command>
+        <attribute id="0x0002" name="Light State" type="ostring" mfcode="0x100b" access="r" required="m"/>
+        <attribute id="0x0030" name="Gradient Pixel Count" type="u8" mfcode="0x100b" access="r" required="m"/>
+        <attribute id="0x0031" name="Gradient Pixel Length (in 0.1 mm)" type="u16" mfcode="0x100b" access="r" required="m"/>
+        <attribute id="0x0032" name="Gradient Unknown 32" type="u8" mfcode="0x100b" access="rw" required="m"/>
+        <attribute id="0x0033" name="Gradient Reverse Colors" type="u8" mfcode="0x100b" access="rw" required="m"/>
+        <attribute id="0x0034" name="Gradient Unknown 34" type="u8" mfcode="0x100b" access="rw" required="m"/>
+        <attribute id="0x0035" name="Gradient Unknown 35" type="u8" mfcode="0x100b" access="r" required="m"/>
+        <attribute id="0x0036" name="Gradient Max Segments" type="u8" mfcode="0x100b" access="r" required="m"/>
       </server>
     </cluster>
 
     <!-- Hue for Lutron Aurora -->
-    <cluster id="0xfc00" name="Hue" mfcode="0x1144">
-      <description>Hue-specific cluster.</description>
+    <cluster id="0xfc00" name="Hue Button" mfcode="0x1144">
+      <description>Hue-specific cluster for Hue dimmer family.</description>
       <server>
         <command id="0x00" dir="send" name="Button Action Notification" required="m">
           <payload>
@@ -4003,7 +3987,6 @@
         </command>
       </server>
     </cluster>
-
 
     <!-- Sunricher C4 -->
     <cluster id="0xfc00" name="Device Setup" mfcode="0x1224">
@@ -4067,17 +4050,15 @@
     <!-- Legrand -->
     <cluster id="0xfc01" name="Legrand - Specific clusters" mfcode="1021">
       <description>Legrand Classic Specific clusters, used by all devices. But take care they are device specific.
-
-        > Dimmer switch without neutral : Option 1 = Dimmer on/off.
-        > Cable outlet : Option 1 = Fil pilote on/off.
-        > Contactor : On/off=0003 - HP/HC=0004.
-      </description>
+> Dimmer switch without neutral : Option 1 = Dimmer on/off.
+> Cable outlet : Option 1 = Fil pilote on/off.
+> Contactor : On/off=0003 - HP/HC=0004.</description>
       <server>
         <attribute id="0x0000" type="dat16" name="Option 1" default="0x0101" access="rw" required="m" showas="hex">
           <description>Choose correctly according to your device Dimmer OR fil pilote.
-            Dimmer > Off=0100 - On=0101
-            Fil pilote > Off=0001 - On=0002
-            Contactor > On/off=0003 - HP/HC=0004</description>
+Dimmer > Off=0100 - On=0101
+Fil pilote > Off=0001 - On=0002
+Contactor > On/off=0003 - HP/HC=0004</description>
         </attribute>
         <attribute id="0x0001" type="bool" name="Option 2" required="m" access="rw" default="0">
           <description>Option 1</description>
@@ -4093,7 +4074,6 @@
     <cluster id="0xfc40" name="Legrand - Specific clusters 2" mfcode="1021">
       <description>Legrand Specific clusters, Used by cable outlet.</description>
       <server>
-
         <command id="00" dir="recv" name="Unknow" required="m">
           <description>Set fil pilote mode</description>
           <payload>
@@ -4107,7 +4087,6 @@
             </attribute>
           </payload>
         </command>
-
         <attribute id="0x0000" type="enum8" name="Mode" default="0x00" access="r" required="m">
           <description>Heating mode</description>
           <value name="Comfort" value="0x00"></value>
@@ -4126,10 +4105,8 @@
     <cluster id="0xfc00" name="Device Setup" mfcode="0x10f2">
       <description>Attributes and commands.</description>
       <server>
-        <attribute id="0x0000" name="Input Configurations" type="array" default="0" access="r" required="m">
-        </attribute>
-        <attribute id="0x0001" name="Input Actions" type="array" default="0" access="r" required="m">
-        </attribute>
+        <attribute id="0x0000" name="Input Configurations" type="array" default="0" access="r" required="m"></attribute>
+        <attribute id="0x0001" name="Input Actions" type="array" default="0" access="r" required="m"></attribute>
       </server>
       <client>
       </client>
@@ -4145,7 +4122,6 @@
           <value name="Configurable Curve" value="6"></value>
           <value name="Overload detection" value="7"></value>
         </attribute>
-
         <attribute id="0x0001" name="Status" type="bmp8" default="00000000" access="r" required="m">
           <value name="Forward Phase Control" value="0"></value>
           <value name="Reverse Phase Control" value="1"></value>
@@ -4154,13 +4130,11 @@
           <value name="Capacitive Load" value="6"></value>
           <value name="Inductive Load" value="7"></value>
         </attribute>
-
         <attribute id="0x0002" name="Mode" type="bmp8" default="00000000" access="r" required="m">
           <value name="Automatic Phase Control" value="0"></value>
           <value name="Forward Phase Control" value="1"></value>
           <value name="Reverse Phase Control" value="2"></value>
         </attribute>
-
       </server>
       <client>
       </client>
@@ -4170,14 +4144,14 @@
     <cluster id="0xfc02" name="Samjin specific" mfcode="0x104e">
       <description>Samjin manufacturer-specifc cluster for SmartThings multi sensor.</description>
       <server>
-        <attribute id="0x0000" name="Motion Threshold Multiplier" type="u8" mfcode="0x104e" default="0" access="rw" required="m"> </attribute>
-        <attribute id="0x0002" name="Motion Threshold" type="u16" mfcode="0x104e" default="0" access="rw" required="m"> </attribute>
+        <attribute id="0x0000" name="Motion Threshold Multiplier" type="u8" mfcode="0x104e" default="0" access="rw" required="m"></attribute>
+        <attribute id="0x0002" name="Motion Threshold" type="u16" mfcode="0x104e" default="0" access="rw" required="m"></attribute>
         <attribute id="0x0010" name="Active" type="bmp8" mfcode="0x104e" default="0" access="r" required="m">
           <value name="Active" value="0"></value>
         </attribute>
-        <attribute id="0x0012" name="Acceleration X" type="s16" mfcode="0x104e" default="0" access="r" required="m"> </attribute>
-        <attribute id="0x0013" name="Acceleration Y" type="s16" mfcode="0x104e" default="0" access="r" required="m"> </attribute>
-        <attribute id="0x0014" name="Acceleration Z" type="s16" mfcode="0x104e" default="0" access="r" required="m"> </attribute>
+        <attribute id="0x0012" name="Acceleration X" type="s16" mfcode="0x104e" default="0" access="r" required="m"></attribute>
+        <attribute id="0x0013" name="Acceleration Y" type="s16" mfcode="0x104e" default="0" access="r" required="m"></attribute>
+        <attribute id="0x0014" name="Acceleration Z" type="s16" mfcode="0x104e" default="0" access="r" required="m"></attribute>
       </server>
       <client>
       </client>
@@ -4186,14 +4160,14 @@
     <cluster id="0xfc02" name="Samjin" mfcode="0x110a">
       <description>Samjin manufacturer-specifc cluster for SmartThings multi sensor.</description>
       <server>
-        <attribute id="0x0000" name="Motion Threshold Multiplier" type="u8" mfcode="0x110a" default="0" access="rw" required="m"> </attribute>
-        <attribute id="0x0002" name="Motion Threshold" type="u16" mfcode="0x110a" default="0" access="rw" required="m"> </attribute>
+        <attribute id="0x0000" name="Motion Threshold Multiplier" type="u8" mfcode="0x110a" default="0" access="rw" required="m"></attribute>
+        <attribute id="0x0002" name="Motion Threshold" type="u16" mfcode="0x110a" default="0" access="rw" required="m"></attribute>
         <attribute id="0x0010" name="Active" type="bmp8" mfcode="0x110a" default="0" access="r" required="m">
           <value name="Active" value="0"></value>
         </attribute>
-        <attribute id="0x0012" name="Acceleration X" type="s16" mfcode="0x110a" default="0" access="r" required="m"> </attribute>
-        <attribute id="0x0013" name="Acceleration Y" type="s16" mfcode="0x110a" default="0" access="r" required="m"> </attribute>
-        <attribute id="0x0014" name="Acceleration Z" type="s16" mfcode="0x110a" default="0" access="r" required="m"> </attribute>
+        <attribute id="0x0012" name="Acceleration X" type="s16" mfcode="0x110a" default="0" access="r" required="m"></attribute>
+        <attribute id="0x0013" name="Acceleration Y" type="s16" mfcode="0x110a" default="0" access="r" required="m"></attribute>
+        <attribute id="0x0014" name="Acceleration Z" type="s16" mfcode="0x110a" default="0" access="r" required="m"></attribute>
       </server>
       <client>
       </client>
@@ -4202,13 +4176,13 @@
     <cluster id="0xfc02" name="Samjin" mfcode="0x1241">
       <description>Samjin manufacturer-specifc cluster for SmartThings multi sensor.</description>
       <server>
-        <attribute id="0x0000" name="Motion Threshold Multiplier" type="u8" mfcode="0x1241" default="0" access="rw" required="m"> </attribute>
+        <attribute id="0x0000" name="Motion Threshold Multiplier" type="u8" mfcode="0x1241" default="0" access="rw" required="m"></attribute>
         <attribute id="0x0010" name="Active" type="bmp8" mfcode="0x1241" default="0" access="r" required="m">
           <value name="Active" value="0"></value>
         </attribute>
-        <attribute id="0x0012" name="Acceleration X" type="s16" mfcode="0x1241" default="0" access="r" required="m"> </attribute>
-        <attribute id="0x0013" name="Acceleration Y" type="s16" mfcode="0x1241" default="0" access="r" required="m"> </attribute>
-        <attribute id="0x0014" name="Acceleration Z" type="s16" mfcode="0x1241" default="0" access="r" required="m"> </attribute>
+        <attribute id="0x0012" name="Acceleration X" type="s16" mfcode="0x1241" default="0" access="r" required="m"></attribute>
+        <attribute id="0x0013" name="Acceleration Y" type="s16" mfcode="0x1241" default="0" access="r" required="m"></attribute>
+        <attribute id="0x0014" name="Acceleration Z" type="s16" mfcode="0x1241" default="0" access="r" required="m"></attribute>
       </server>
       <client>
       </client>
@@ -4218,8 +4192,7 @@
     <cluster id="0xfc0f" name="OSRAM specific" mfcode="0xbbaa">
       <description>OSRAM manufacturer-specific cluster to set power-on defaults.</description>
       <server>
-        <command id="0x01" dir="recv" name="Store Power-On Defaults" required="o">
-        </command>
+        <command id="0x01" dir="recv" name="Store Power-On Defaults" required="o"></command>
       </server>
       <client>
       </client>
@@ -4229,8 +4202,7 @@
     <cluster id="0xfc01" name="LEDVANCE specific" mfcode="0x1189">
       <description>LEDVANCE manufacturer-specific cluster to set power-on defaults.</description>
       <server>
-        <command id="0x01" dir="recv" name="Store Power-On Defaults" required="o">
-        </command>
+        <command id="0x01" dir="recv" name="Store Power-On Defaults" required="o"></command>
       </server>
       <client>
       </client>
@@ -4290,78 +4262,78 @@
       <description>Lumi specific attributes.</description>
       <server>
         <attribute-set id="0x0000" description="Unknown">
-          <attribute id="0x0001" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x0002" name="Power Outages" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x0003" name="Unknown" type="enum8" mfcode="0x115f" access="r" required="m"> </attribute>
+          <attribute id="0x0001" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x0002" name="Power Outages" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x0003" name="Unknown" type="enum8" mfcode="0x115f" access="r" required="m"></attribute>
           <value name="0" value="0x00"></value>
           <value name="1" value="0x01"></value>
           <value name="2" value="0x02"></value>
           <value name="3" value="0x03"></value>
           <value name="4" value="0x04"></value>
-          <attribute id="0x0006" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x0007" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x0008" name="Unknown (write only)" type="ostring" mfcode="0x115f" access="w" required="m"> </attribute>
-          <attribute id="0x0009" name="Device operation mode" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
+          <attribute id="0x0006" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x0007" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x0008" name="Unknown (write only)" type="ostring" mfcode="0x115f" access="w" required="m"></attribute>
+          <attribute id="0x0009" name="Device operation mode" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
           <attribute id="0x000A" name="Switch mode" type="u8" mfcode="0x115f" access="rw" required="m">
             <description>Switch mode: 1 - event based switching, 2 - zigbee group switching, 3 - Xiaomi specific switching</description>
           </attribute>
-          <attribute id="0x000C" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x000D" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x00E8" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x00E9" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x00EA" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x00EB" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x00ED" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x00EE" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x00F0" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x00F1" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x00F3" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x00F4" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x00F5" name="Unknown" type="u32" mfcode="0x115f" access="r" required="m"> </attribute>
-          <attribute id="0x00F6" name="Reporting Interval" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x00F7" name="Unknown" type="ostring" mfcode="0x115f" access="r" required="m"> </attribute>
-          <attribute id="0x00F8" name="Unknown" type="u64" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x00F9" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x00FA" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x00FB" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x00FC" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x00FE" name="Serial Number" type="cstring" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x00FF" name="Unknown (write only)" type="ostring" mfcode="0x115f" access="w" required="m"> </attribute>
-          <attribute id="0x0100" name="Unknown" type="u8" mfcode="0x115f" access="r" required="m"> </attribute>
+          <attribute id="0x000C" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x000D" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x00E8" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x00E9" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x00EA" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x00EB" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x00ED" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x00EE" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x00F0" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x00F1" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x00F3" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x00F4" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x00F5" name="Unknown" type="u32" mfcode="0x115f" access="r" required="m"></attribute>
+          <attribute id="0x00F6" name="Reporting Interval" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x00F7" name="Unknown" type="ostring" mfcode="0x115f" access="r" required="m"></attribute>
+          <attribute id="0x00F8" name="Unknown" type="u64" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x00F9" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x00FA" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x00FB" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x00FC" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x00FE" name="Serial Number" type="cstring" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x00FF" name="Unknown (write only)" type="ostring" mfcode="0x115f" access="w" required="m"></attribute>
+          <attribute id="0x0100" name="Unknown" type="u8" mfcode="0x115f" access="r" required="m"></attribute>
           <attribute id="0x0102" name="Motion cool off time" type="u8" mfcode="0x115f" access="rw" required="m">
             <description>Time in seconds when RTCGQ13LM sets motion to false if no further motion has been detected</description>
           </attribute>
           <attribute id="0x010C" name="Motion sensitivity" type="u8" mfcode="0x115f" access="rw" required="m">
             <description>Motion sensitivity: 1 - low, 2 - medium, 3 - high</description>
           </attribute>
-          <attribute id="0x0112" name="Unknown" type="u32" mfcode="0x115f" access="r" required="m"> </attribute>
+          <attribute id="0x0112" name="Unknown" type="u32" mfcode="0x115f" access="r" required="m"></attribute>
           <attribute id="0x0114" name="TVOC unit config" type="u8" mfcode="0x115f" access="rw" required="m">
             <description>0 - µg/m³ + °C, 1 - ppb + °C, 16 - µg/m³ + °F, 17 - ppb + °F</description>
           </attribute>
-          <attribute id="0x0125" name="Multiclick mode" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x0135" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x0136" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x0137" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x0138" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x0152" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
+          <attribute id="0x0125" name="Multiclick mode" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x0135" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x0136" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x0137" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x0138" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x0152" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
           <attribute id="0x0200" name="Child lock off" type="u8" mfcode="0x115f" access="rw" required="m">
             <description>Child lock off: 0 - false, 1 - true</description>
           </attribute>
-          <attribute id="0x0201" name="Restore Power on Outage" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x0202" name="Auto-off after 20m below Threshold" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x0203" name="Device LED off (9pm-9am)" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x0204" name="Min. Power Change for Report (W)" type="float" mfcode="0x115f" access="rw" required="m"> </attribute>
+          <attribute id="0x0201" name="Restore Power on Outage" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x0202" name="Auto-off after 20m below Threshold" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x0203" name="Device LED off (9pm-9am)" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x0204" name="Min. Power Change for Report (W)" type="float" mfcode="0x115f" access="rw" required="m"></attribute>
           <attribute id="0x0205" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m">
             <description>Attribute 0x0205 has range between 1 and 50 only</description>
           </attribute>
-          <attribute id="0x0206" name="Power Threshold for Auto-off" type="float" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x0207" name="Consumer Connected" type="bool" mfcode="0x115f" access="r" required="m"> </attribute>
-          <attribute id="0x020B" name="Max. Load Exceeded at (W)" type="float" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x020C" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x020D" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x020E" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x023B" name="Unknown" type="float" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x023E" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"> </attribute>
+          <attribute id="0x0206" name="Power Threshold for Auto-off" type="float" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x0207" name="Consumer Connected" type="bool" mfcode="0x115f" access="r" required="m"></attribute>
+          <attribute id="0x020B" name="Max. Load Exceeded at (W)" type="float" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x020C" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x020D" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x020E" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x023B" name="Unknown" type="float" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x023E" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
         </attribute-set>
         <attribute-set id="0x0400" description="Aqara Roller Shade Driver E1">
           <attribute id="0x0400" name="Reverse Direction" type="bool" mfcode="0x115f" access="rw" required="o">
@@ -4381,25 +4353,25 @@
           </attribute>
         </attribute-set>
         <attribute-set id="0x0500" description="Unknown">
-          <attribute id="0x0700" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x0701" name="Unknown" type="s8" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x0702" name="Unknown" type="s8" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x0703" name="Unknown" type="s8" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x0704" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x0705" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x0740" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x0780" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x0781" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x0782" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x0783" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0x07C0" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"> </attribute>
+          <attribute id="0x0700" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x0701" name="Unknown" type="s8" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x0702" name="Unknown" type="s8" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x0703" name="Unknown" type="s8" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x0704" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x0705" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x0740" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x0780" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x0781" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x0782" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x0783" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x07C0" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
           <attribute id="0xF000" name="Report Consumer Connected" type="u8" mfcode="0x115f" access="rw" required="m">
             <description>Report Consumer Connected: 1 - false, 0 - true</description>
           </attribute>
-          <attribute id="0xF001" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0xF002" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0xFFF2" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0xFFFD" name="Cluster Revision" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
+          <attribute id="0xF001" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0xF002" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0xFFF2" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0xFFFD" name="Cluster Revision" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
         </attribute-set>
       </server>
       <client>
@@ -4411,32 +4383,32 @@
       <description>Aqara specific attributes.</description>
       <server>
         <attribute-set id="0x0000" description="Unknown">
-          <attribute id="0x0006" name="Unknown" type="ostring" access="rw" required="m"> </attribute>
-          <attribute id="0x0007" name="Unknown" type="ostring" access="rw" required="m"> </attribute>
-          <attribute id="0x00E4" name="Unknown" type="u32" access="rw" required="m"> </attribute>
-          <attribute id="0x00F7" name="Unknown" type="ostring" access="r" required="m"> </attribute>
-          <attribute id="0x00FA" name="Unknown" type="bool" access="rw" required="m"> </attribute>
-          <attribute id="0x00FC" name="Unknown" type="bool" access="rw" required="m"> </attribute>
-          <attribute id="0x00FE" name="Serial Number" type="cstring" access="rw" required="m"> </attribute>
-          <attribute id="0x00FF" name="Unknown" type="ostring" access="rw" required="m"> </attribute>
-          <attribute id="0x010C" name="Unknown" type="u8" access="rw" required="m"> </attribute>
-          <attribute id="0x0133" name="Unknown" type="u8" access="rw" required="m"> </attribute>
-          <attribute id="0x0134" name="Unknown" type="ostring" access="rw" required="m"> </attribute>
-          <attribute id="0x0142" name="Unknown" type="u8" access="rw" required="m"> </attribute>
-          <attribute id="0x0143" name="Unknown" type="u8" access="rw" required="m"> </attribute>
-          <attribute id="0x0144" name="Unknown" type="u8" access="rw" required="m"> </attribute>
-          <attribute id="0x0145" name="Unknown" type="bool" access="rw" required="m"> </attribute>
-          <attribute id="0x0146" name="Unknown" type="u8" access="rw" required="m"> </attribute>
-          <attribute id="0x0147" name="Unknown" type="u8" access="rw" required="m"> </attribute>
-          <attribute id="0x0148" name="Unknown" type="u8" access="rw" required="m"> </attribute>
-          <attribute id="0x0149" name="Unknown" type="u8" access="rw" required="m"> </attribute>
-          <attribute id="0x0150" name="Unknown" type="ostring" access="rw" required="m"> </attribute>
-          <attribute id="0x0151" name="Unknown" type="ostring" access="rw" required="m"> </attribute>
-          <attribute id="0x0153" name="Unknown" type="u32" access="rw" required="m"> </attribute>
-          <attribute id="0x0154" name="Unknown" type="u32" access="rw" required="m"> </attribute>
-          <attribute id="0x0155" name="Unknown" type="u8" access="rw" required="m"> </attribute>
-          <attribute id="0x0156" name="Unknown" type="u32" access="rw" required="m"> </attribute>
-          <attribute id="0x0157" name="Unknown" type="u8" access="w" required="m"> </attribute>
+          <attribute id="0x0006" name="Unknown" type="ostring" access="rw" required="m"></attribute>
+          <attribute id="0x0007" name="Unknown" type="ostring" access="rw" required="m"></attribute>
+          <attribute id="0x00E4" name="Unknown" type="u32" access="rw" required="m"></attribute>
+          <attribute id="0x00F7" name="Unknown" type="ostring" access="r" required="m"></attribute>
+          <attribute id="0x00FA" name="Unknown" type="bool" access="rw" required="m"></attribute>
+          <attribute id="0x00FC" name="Unknown" type="bool" access="rw" required="m"></attribute>
+          <attribute id="0x00FE" name="Serial Number" type="cstring" access="rw" required="m"></attribute>
+          <attribute id="0x00FF" name="Unknown" type="ostring" access="rw" required="m"></attribute>
+          <attribute id="0x010C" name="Unknown" type="u8" access="rw" required="m"></attribute>
+          <attribute id="0x0133" name="Unknown" type="u8" access="rw" required="m"></attribute>
+          <attribute id="0x0134" name="Unknown" type="ostring" access="rw" required="m"></attribute>
+          <attribute id="0x0142" name="Unknown" type="u8" access="rw" required="m"></attribute>
+          <attribute id="0x0143" name="Unknown" type="u8" access="rw" required="m"></attribute>
+          <attribute id="0x0144" name="Unknown" type="u8" access="rw" required="m"></attribute>
+          <attribute id="0x0145" name="Unknown" type="bool" access="rw" required="m"></attribute>
+          <attribute id="0x0146" name="Unknown" type="u8" access="rw" required="m"></attribute>
+          <attribute id="0x0147" name="Unknown" type="u8" access="rw" required="m"></attribute>
+          <attribute id="0x0148" name="Unknown" type="u8" access="rw" required="m"></attribute>
+          <attribute id="0x0149" name="Unknown" type="u8" access="rw" required="m"></attribute>
+          <attribute id="0x0150" name="Unknown" type="ostring" access="rw" required="m"></attribute>
+          <attribute id="0x0151" name="Unknown" type="ostring" access="rw" required="m"></attribute>
+          <attribute id="0x0153" name="Unknown" type="u32" access="rw" required="m"></attribute>
+          <attribute id="0x0154" name="Unknown" type="u32" access="rw" required="m"></attribute>
+          <attribute id="0x0155" name="Unknown" type="u8" access="rw" required="m"></attribute>
+          <attribute id="0x0156" name="Unknown" type="u32" access="rw" required="m"></attribute>
+          <attribute id="0x0157" name="Unknown" type="u8" access="w" required="m"></attribute>
         </attribute-set>
       </server>
       <client>
@@ -4447,18 +4419,18 @@
     <cluster id="0xff01" name="Sinope specific" mfcode="0x119c">
       <description>Sinope specific attributes.
 
-        Outdoor Temp to Display Timeout: set 30 for 'off' and 10800 for 'on'</description>
+Outdoor Temp to Display Timeout: set 30 for 'off' and 10800 for 'on'</description>
       <server>
-        <attribute id="0x0010" name="Outdoor Temp on Display" type="s16" mfcode="0x119c" access="rw" required="m"> </attribute>
-        <attribute id="0x0011" name="Outdoor Temp on Display Timeout" type="u16" mfcode="0x119c" access="rw" required="m"> </attribute>
-        <attribute id="0x0020" name="Current Time on Display" type="u32" mfcode="0x119c" access="rw" required="m"> </attribute>
+        <attribute id="0x0010" name="Outdoor Temp on Display" type="s16" mfcode="0x119c" access="rw" required="m"></attribute>
+        <attribute id="0x0011" name="Outdoor Temp on Display Timeout" type="u16" mfcode="0x119c" access="rw" required="m"></attribute>
+        <attribute id="0x0020" name="Current Time on Display" type="u32" mfcode="0x119c" access="rw" required="m"></attribute>
         <attribute id="0x0105" name="Floor Control Mode" type="enum8" mfcode="0x119c" access="rw" required="m">
           <value name="Ambient" value="0x01"></value>
           <value name="Floor" value="0x02"></value>
         </attribute>
-        <attribute id="0x0108" name="Ambient Max Heat Setpoint Limit" type="s16" mfcode="0x119c" access="rw" required="m"> </attribute>
-        <attribute id="0x0109" name="Floor Min Heat Setpoint Limit" type="s16" mfcode="0x119c" access="rw" required="m"> </attribute>
-        <attribute id="0x0110" name="Floor Max Heat Setpoint Limit" type="s16" mfcode="0x119c" access="rw" required="m"> </attribute>
+        <attribute id="0x0108" name="Ambient Max Heat Setpoint Limit" type="s16" mfcode="0x119c" access="rw" required="m"></attribute>
+        <attribute id="0x0109" name="Floor Min Heat Setpoint Limit" type="s16" mfcode="0x119c" access="rw" required="m"></attribute>
+        <attribute id="0x0110" name="Floor Max Heat Setpoint Limit" type="s16" mfcode="0x119c" access="rw" required="m"></attribute>
         <attribute id="0x0111" name="Temperature Sensor" type="enum8" mfcode="0x119c" access="rw" required="m">
           <value name="10k" value="0x00"></value>
           <value name="12k" value="0x01"></value>
@@ -4484,14 +4456,14 @@
     <cluster id="0xfc82" name="innr specific" mfcode="0x1166">
       <description>innr specific attributes.</description>
       <server>
-        <attribute id="0x0006" name="Unknown" type="cstring" mfcode="0x1166" access="rw" required="m"> </attribute>
-        <attribute id="0x0010" name="Unknown" type="u32" mfcode="0x1166" access="r" required="m"> </attribute>
-        <attribute id="0x0011" name="Unknown" type="u32" mfcode="0x1166" access="r" required="m"> </attribute>
-        <attribute id="0x0012" name="Unknown" type="u32" mfcode="0x1166" access="r" required="m"> </attribute>
-        <attribute id="0x0013" name="Unknown" type="u32" mfcode="0x1166" access="rw" required="m"> </attribute>
-        <attribute id="0x0014" name="Unknown" type="u32" mfcode="0x1166" access="rw" required="m"> </attribute>
-        <attribute id="0x0015" name="Unknown" type="u32" mfcode="0x1166" access="rw" required="m"> </attribute>
-        <attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x1166" access="r" required="m"> </attribute>
+        <attribute id="0x0006" name="Unknown" type="cstring" mfcode="0x1166" access="rw" required="m"></attribute>
+        <attribute id="0x0010" name="Unknown" type="u32" mfcode="0x1166" access="r" required="m"></attribute>
+        <attribute id="0x0011" name="Unknown" type="u32" mfcode="0x1166" access="r" required="m"></attribute>
+        <attribute id="0x0012" name="Unknown" type="u32" mfcode="0x1166" access="r" required="m"></attribute>
+        <attribute id="0x0013" name="Unknown" type="u32" mfcode="0x1166" access="rw" required="m"></attribute>
+        <attribute id="0x0014" name="Unknown" type="u32" mfcode="0x1166" access="rw" required="m"></attribute>
+        <attribute id="0x0015" name="Unknown" type="u32" mfcode="0x1166" access="rw" required="m"></attribute>
+        <attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x1166" access="r" required="m"></attribute>
       </server>
       <client>
       </client>
@@ -4501,11 +4473,11 @@
     <cluster id="0xfc82" name="Immax specific" mfcode="0x1037">
       <description>Immax specific attributes.</description>
       <server>
-        <attribute id="0x0010" name="Turned on since" type="u32" mfcode="0x1037" access="r" required="m"> </attribute>
-        <attribute id="0x0011" name="Turned on (total)" type="u32" mfcode="0x1037" access="r" required="m"> </attribute>
-        <attribute id="0x0012" name="Consumption since turned on" type="u32" mfcode="0x1037" access="r" required="m"> </attribute>
-        <attribute id="0x0013" name="Unknown" type="u32" mfcode="0x1037" access="rw" required="m"> </attribute>
-        <attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x1037" access="r" required="m"> </attribute>
+        <attribute id="0x0010" name="Turned on since" type="u32" mfcode="0x1037" access="r" required="m"></attribute>
+        <attribute id="0x0011" name="Turned on (total)" type="u32" mfcode="0x1037" access="r" required="m"></attribute>
+        <attribute id="0x0012" name="Consumption since turned on" type="u32" mfcode="0x1037" access="r" required="m"></attribute>
+        <attribute id="0x0013" name="Unknown" type="u32" mfcode="0x1037" access="rw" required="m"></attribute>
+        <attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x1037" access="r" required="m"></attribute>
       </server>
       <client>
       </client>
@@ -4515,11 +4487,11 @@
     <cluster id="0xfcac" name="Bosch specific" mfcode="0x1209">
       <description>Bosch specific attributes.</description>
       <server>
-        <attribute id="0x0000" name="Device setup time remaining" type="u16" mfcode="0x1209" access="rw" required="m"> </attribute>
-        <attribute id="0x0001" name="Motion alert reset" type="u16" mfcode="0x1209" access="rw" required="m"> </attribute>
-        <attribute id="0x0002" name="Device setup time" type="u16" mfcode="0x1209" access="rw" required="m"> </attribute>
-        <attribute id="0x0003" name="Audio alert on motion" type="bool" mfcode="0x1209" access="rw" required="m"> </attribute>
-        <attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x1209" access="r" required="m"> </attribute>
+        <attribute id="0x0000" name="Device setup time remaining" type="u16" mfcode="0x1209" access="rw" required="m"></attribute>
+        <attribute id="0x0001" name="Motion alert reset" type="u16" mfcode="0x1209" access="rw" required="m"></attribute>
+        <attribute id="0x0002" name="Device setup time" type="u16" mfcode="0x1209" access="rw" required="m"></attribute>
+        <attribute id="0x0003" name="Audio alert on motion" type="bool" mfcode="0x1209" access="rw" required="m"></attribute>
+        <attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x1209" access="r" required="m"></attribute>
       </server>
       <client>
       </client>
@@ -4594,10 +4566,10 @@
     <cluster id="0xfc03" name="VOC Measurement" mfcode="0x1015">
       <description>Develco specific attributes.</description>
       <server>
-        <attribute id="0x0000" name="Measured value" type="u16" mfcode="0x1015" access="r" required="m"> </attribute>
-        <attribute id="0x0001" name="Min. measured value" type="u16" mfcode="0x1015" access="r" required="m"> </attribute>
-        <attribute id="0x0002" name="Max. measured value" type="u16" mfcode="0x1015" access="r" required="m"> </attribute>
-        <attribute id="0x0003" name="Resolution" type="u16" mfcode="0x1015" access="r" required="m"> </attribute>
+        <attribute id="0x0000" name="Measured value" type="u16" mfcode="0x1015" access="r" required="m"></attribute>
+        <attribute id="0x0001" name="Min. measured value" type="u16" mfcode="0x1015" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max. measured value" type="u16" mfcode="0x1015" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Resolution" type="u16" mfcode="0x1015" access="r" required="m"></attribute>
       </server>
       <client>
       </client>
@@ -4607,46 +4579,46 @@
     <cluster id="0xfc00" name="Niko specific" mfcode="0x125f">
       <description>Niko specific attributes.
 
-        LED color: 0 - off, 255 - white, 65280 - blue, 16711680 - red
-        Child lock on: 0, Child lock off: 1
-        LED on: 1, LED off: 0
-        0x0300: Switches permission to write either to 0x0202 (1) or to 0x0302 (0)
-        Writing 1 to 0x0202 and 0x0302 makes 0x0300 writable. Then writing 1 to 0x0300 sets 0x0300 bitmap from 0x11 to 0x12, but block all other writes to 0x03XX attributes.</description>
+LED color: 0 - off, 255 - white, 65280 - blue, 16711680 - red
+Child lock on: 0, Child lock off: 1
+LED on: 1, LED off: 0
+0x0300: Switches permission to write either to 0x0202 (1) or to 0x0302 (0)
+Writing 1 to 0x0202 and 0x0302 makes 0x0300 writable. Then writing 1 to 0x0300 sets 0x0300 bitmap from 0x11 to 0x12, but block all other writes to 0x03XX attributes.</description>
       <server>
-        <attribute id="0x0000" name="Unknown" type="bmp8" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0100" name="LED color" type="u24" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0101" name="Child lock" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0102" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0103" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0104" name="LED on/off" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0200" name="Connected to power since" type="u32" mfcode="0x125f" access="r" required="m"> </attribute>
-        <attribute id="0x0201" name="Unknown" type="u48" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0202" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0300" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0301" name="Unknown" type="bmp8" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0302" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0303" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0304" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0305" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0306" name="Unknown" type="u32" mfcode="0x125f" access="r" required="m"> </attribute>
-        <attribute id="0x0307" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0308" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0309" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x030A" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0400" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0401" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0500" name="Unknown" type="u16" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0501" name="Unknown" type="u16" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0502" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0503" name="Unknown" type="u16" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0504" name="Unknown" type="u16" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0505" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0506" name="Unknown" type="u8" mfcode="0x125f" access="r" required="m"> </attribute>
-        <attribute id="0x0507" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0508" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0600" name="Unknown" type="seckey" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0x0601" name="Unknown" type="seckey" mfcode="0x125f" access="rw" required="m"> </attribute>
-        <attribute id="0xFFFD" name="Cluster Revision" type="u16" mfcode="0x125f" access="rw" required="m"> </attribute>
+        <attribute id="0x0000" name="Unknown" type="bmp8" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0100" name="LED color" type="u24" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0101" name="Child lock" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0102" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0103" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0104" name="LED on/off" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0200" name="Connected to power since" type="u32" mfcode="0x125f" access="r" required="m"></attribute>
+        <attribute id="0x0201" name="Unknown" type="u48" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0202" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0300" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0301" name="Unknown" type="bmp8" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0302" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0303" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0304" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0305" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0306" name="Unknown" type="u32" mfcode="0x125f" access="r" required="m"></attribute>
+        <attribute id="0x0307" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0308" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0309" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x030A" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0400" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0401" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0500" name="Unknown" type="u16" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0501" name="Unknown" type="u16" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0502" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0503" name="Unknown" type="u16" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0504" name="Unknown" type="u16" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0505" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0506" name="Unknown" type="u8" mfcode="0x125f" access="r" required="m"></attribute>
+        <attribute id="0x0507" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0508" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0600" name="Unknown" type="seckey" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0x0601" name="Unknown" type="seckey" mfcode="0x125f" access="rw" required="m"></attribute>
+        <attribute id="0xFFFD" name="Cluster Revision" type="u16" mfcode="0x125f" access="rw" required="m"></attribute>
       </server>
       <client>
       </client>
@@ -4656,36 +4628,37 @@
     <cluster id="0xfee1" name="Datek on/off configuration" mfcode="0x1337">
       <description>Datek on/off configuration attributes.</description>
       <server>
-        <attribute id="0x0000" name="Off if offline" type="u8" mfcode="0x1337" access="rw" required="m"> </attribute>
-        <attribute id="0x0001" name="Frost guard temperature" type="u8" mfcode="0x1337" access="rw" required="m"> </attribute>
-        <attribute id="0x0002" name="Frost guard temperature hysteresis" type="u8" mfcode="0x1337" access="rw" required="m"> </attribute>
-        <attribute id="0x0003" name="Frost guard mins between change" type="u8" mfcode="0x1337" access="rw" required="m"> </attribute>
-        <attribute id="0x0004" name="On time" type="u16" mfcode="0x1337" access="rw" required="m"> </attribute>
+        <attribute id="0x0000" name="Off if offline" type="u8" mfcode="0x1337" access="rw" required="m"></attribute>
+        <attribute id="0x0001" name="Frost guard temperature" type="u8" mfcode="0x1337" access="rw" required="m"></attribute>
+        <attribute id="0x0002" name="Frost guard temperature hysteresis" type="u8" mfcode="0x1337" access="rw" required="m"></attribute>
+        <attribute id="0x0003" name="Frost guard mins between change" type="u8" mfcode="0x1337" access="rw" required="m"></attribute>
+        <attribute id="0x0004" name="On time" type="u16" mfcode="0x1337" access="rw" required="m"></attribute>
         <attribute id="0x0010" name="On/off configuration mode" type="enum8" mfcode="0x1337" access="rw" required="m">
           <value name="Off" value="0x00"></value>
           <value name="On" value="0x01"></value>
         </attribute>
-        <attribute id="0xFFFD" name="Cluster revision" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
+        <attribute id="0xFFFD" name="Cluster revision" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
       </server>
       <client>
       </client>
     </cluster>
+
     <cluster id="0xfeed" name="Datek diagnostics" mfcode="0x1337">
       <description>Datek diagnostics cluster attributes.</description>
       <server>
-        <attribute id="0x0000" name="Last reset info" type="u8" mfcode="0x1337" access="r" required="m"> </attribute>
-        <attribute id="0x0001" name="Last extended reset info" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
-        <attribute id="0x0002" name="Reboot counter" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
-        <attribute id="0x0003" name="Last hop LQI" type="u8" mfcode="0x1337" access="r" required="m"> </attribute>
-        <attribute id="0x0004" name="Last hop RSSI" type="s8" mfcode="0x1337" access="r" required="m"> </attribute>
-        <attribute id="0x0005" name="Tx power" type="s8" mfcode="0x1337" access="r" required="m"> </attribute>
-        <attribute id="0x0010" name="Button 0 click counter" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
-        <attribute id="0x0020" name="Button 0 ms click counter" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
-        <attribute id="0x0100" name="Electrical measurement avg" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
-        <attribute id="0x0101" name="Electrical measurement raw" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
-        <attribute id="0x0102" name="Electrical measurement noise w load" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
-        <attribute id="0x0103" name="Electrical measurement noise w/o load" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
-        <attribute id="0xFFFD" name="Cluster revision" type="u16" mfcode="0x1337" access="r" required="m"> </attribute>
+        <attribute id="0x0000" name="Last reset info" type="u8" mfcode="0x1337" access="r" required="m"></attribute>
+        <attribute id="0x0001" name="Last extended reset info" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Reboot counter" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Last hop LQI" type="u8" mfcode="0x1337" access="r" required="m"></attribute>
+        <attribute id="0x0004" name="Last hop RSSI" type="s8" mfcode="0x1337" access="r" required="m"></attribute>
+        <attribute id="0x0005" name="Tx power" type="s8" mfcode="0x1337" access="r" required="m"></attribute>
+        <attribute id="0x0010" name="Button 0 click counter" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
+        <attribute id="0x0020" name="Button 0 ms click counter" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
+        <attribute id="0x0100" name="Electrical measurement avg" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
+        <attribute id="0x0101" name="Electrical measurement raw" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
+        <attribute id="0x0102" name="Electrical measurement noise w load" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
+        <attribute id="0x0103" name="Electrical measurement noise w/o load" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
+        <attribute id="0xFFFD" name="Cluster revision" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
       </server>
       <client>
       </client>
@@ -4715,11 +4688,11 @@
           <value name="Unknown" value="6"></value>
           <value name="Unknown" value="7"></value>
         </attribute>
-        <attribute id="0x0010" name="Unknown" type="u8" mfcode="0x105e" access="rw" required="m"> </attribute>
-        <attribute id="0x0011" name="Unknown" type="u16" mfcode="0x105e" access="rw" required="m"> </attribute>
-        <attribute id="0x0020" name="Unknown" type="u8" mfcode="0x105e" access="rw" required="m"> </attribute>
-        <attribute id="0x0021" name="Unknown" type="u16" mfcode="0x105e" access="rw" required="m"> </attribute>
-        <attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x105e" access="r" required="m"> </attribute>
+        <attribute id="0x0010" name="Unknown" type="u8" mfcode="0x105e" access="rw" required="m"></attribute>
+        <attribute id="0x0011" name="Unknown" type="u16" mfcode="0x105e" access="rw" required="m"></attribute>
+        <attribute id="0x0020" name="Unknown" type="u8" mfcode="0x105e" access="rw" required="m"></attribute>
+        <attribute id="0x0021" name="Unknown" type="u16" mfcode="0x105e" access="rw" required="m"></attribute>
+        <attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x105e" access="r" required="m"></attribute>
       </server>
       <client>
       </client>


### PR DESCRIPTION
Update of several definition, not impacting any C++ code:

Update `general.xml`:
- XML layout beautification;
- Update _On/Off_, _Level Control_, and _Color Control_ with latest ZCL spec (rev 8 from Dec 2019), see #6454;
- Add/update Hue-specific clusters, see #5891, #6192.

Update DDF subdevices:
- Sort attributes alphabetically;
- Add color light;
- Fix `ZHADoorLock`: `state/reachable` -> `config/reachable`.

Update DDF items:
- Read _Color Capabilities_, _Color Temperature Max Mireds_, and _Color Temeprature Min Mireds_ in one command, once a day;
- _Color Mode_ as string, fixes #6415;
- _Effect_: add `parse` and `read` functions.

I don't particularly like the following, but not sure how best to handle that.  @manup, @SwoopX, please chime in.
- Using the default item definitions, _Color Control_ cluster is now polled every 5 seconds, using 4 different commands: `xy`, `ct` `hue`, `sat`.  Furthermore, `effect`, and `colormode` are read every 5 minutes, with two more commands.
For the Hue lights, I will read these 7 attributes in one `read` (from `colormode`).  I would like to do the same just using the default definitions, but we probably need to define this in the subdevice, where we know what attributes are supported.
- The default items use _Enhanced Current Hue_ for `hue`, but _Color Mode_ for `colormode`.  That doesn't make sense, since most lights (with the exception of Mueller) will either support both _Enhanced Current Hue_ and _Enhanced Color Mode_ or neither.  Now I need always to override the item default definitions.
- I would like multiple items for the same API attributes (like _Enhanced_ vs normal versions of the above, but also for polling vs reporting), but the items are identified by API attribute.
- I would like to limit polling when the light is off (although you might not want this with _Execute If Off_).
- I would like to force-read "static" attributes (like _Color Capabilities_) when the light reboots, to handle changes in hardware or firmware (see my remark on Discord).