### PR TITLE
DDF for Tuya Single Phase 65A Din Rail Smart Energy Meter

### DIFF
--- a/devices/tuya/_TZE200_byzdayie_din_enrgy_meter.json
+++ b/devices/tuya/_TZE200_byzdayie_din_enrgy_meter.json
@@ -1,0 +1,188 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": ["_TZE200_byzdayie", "_TZE200_fsb6zw01", "_TZE200_ewxhg6o9"],
+  "modelid": ["TS0601", "TS0601", "TS0601"],
+  "product": "Single Phase 65A Din Rail Smart Energy Meter",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+      {
+      "type": "$TYPE_ON_OFF_OUTPUT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001", "script": "tuya_swversion.js"},
+          "read": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001"}
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/on",
+          "parse": {"fn": "tuya", "dpid": 1, "eval": "Item.val = Attr.val;" },
+          "write": {"fn": "tuya", "dpid": 1, "dt": "0x10", "eval": "Item.val == 1 ? 1 : 0;"},
+          "read": {"fn": "tuya"}
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_CONSUMPTION_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0702"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001", "script": "tuya_swversion.js"},
+          "read": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001"}
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/offset",
+          "default": 0
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/consumption",
+          "parse": {"fn": "tuya", "dpid": 17, "eval": "Item.val = Attr.val * 10;" },
+          "read": {"fn": "none"},
+          "default": 0
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_POWER_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0b04"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001", "script": "tuya_swversion.js"},
+          "read": {"fn": "none"}
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/offset",
+          "default": 0
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/current",
+          "parse": {"fn": "tuya", "dpid": 18, "eval": "Item.val = Attr.val / 1000;" },
+          "read": {"fn": "none"},
+          "default": 0
+        },
+        {
+          "name": "state/voltage",
+          "parse": {"fn": "tuya", "dpid": 20, "eval": "Item.val = Attr.val / 10;" },
+          "read": {"fn": "none"},
+          "default": 0
+        },
+        {
+          "name": "state/power",
+          "parse": {"fn": "tuya", "dpid": 19, "eval": "Item.val = Attr.val / 10;" },
+          "read": {"fn": "none"},
+          "default": 0
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Replace the PR https://github.com/dresden-elektronik/deconz-rest-plugin/pull/5287
With 2 clones

-    Manufacturer: _TZE200_byzdayie , _TZE200_fsb6zw01 ,  _TZE200_ewxhg6o9
-    Model identifier: TS0601

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/4957
