### PR TITLE
DDF, add support for Woox R7052 Smart SOS Button

### DIFF
--- a/devices/woox/woox_r7052_ts0215a.json
+++ b/devices/woox/woox_r7052_ts0215a.json
@@ -1,7 +1,7 @@
 {
 	"schema": "devcap1.schema.json",
-	"manufacturername": "_TZ3000_ssp0maqm",
-	"modelid": "TS0215A",
+	"manufacturername": ["_TZ3000_ssp0maqm", "_TZ3000_zsh6uat3"],
+	"modelid": ["TS0215A", "TS0215A"],
 	"vendor": "Woox",
 	"product": "R7052 Smart SOS Button",
 	"sleeper": true,

--- a/devices/woox/woox_r7052_ts0215a.json
+++ b/devices/woox/woox_r7052_ts0215a.json
@@ -1,0 +1,88 @@
+{
+	"schema": "devcap1.schema.json",
+	"manufacturername": "_TZ3000_ssp0maqm",
+	"modelid": "TS0215A",
+	"vendor": "Woox",
+	"product": "R7052 Smart SOS Button",
+	"sleeper": true,
+	"status": "Gold",
+	"subdevices": [
+	{
+		"type": "$TYPE_SWITCH",
+		"restapi": "/sensors",
+		"uuid": [
+			"$address.ext",
+			"0x01",
+			"0x0500"
+		],
+		"fingerprint": {
+			"profile": "0x0104",
+			"device": "0x0401",
+			"endpoint": "0x01",
+				"in": [
+					"0x0000",
+					"0x0500",
+					"0x0501"
+				]
+		},
+		"items": [
+			{ "name": "attr/id" },
+			{ "name": "attr/lastannounced" },
+			{ "name": "attr/lastseen" },
+			{ "name": "attr/manufacturername" },
+			{ "name": "attr/modelid" },
+			{ "name": "attr/name" },
+			{ "name": "attr/swversion" },
+			{ "name": "attr/type" },
+			{ "name": "attr/uniqueid" },
+			{
+				"name": "config/enrolled",
+				"public": false
+			},
+			{ "name": "config/on" },
+			{ "name": "config/pending" },
+			{ "name": "config/battery" },
+			{ "name": "config/reachable" },
+			{
+				"name": "state/buttonevent",
+				"awake": true,
+					"parse": {
+					"cl": "0x0501",
+					"cmd": "0x02",
+					"ep": 1,
+					"eval": "Item.val = 1002",
+					"fn": "zcl"
+					}
+			},
+			{ "name": "state/lastupdated" },
+			{ "name": "state/lowbattery" }
+		]
+	}
+	],
+	"bindings": [
+		{
+			"bind": "unicast",
+			"src.ep": 1,
+			"cl": "0x0500"
+		},
+		{
+			"bind": "unicast",
+			"src.ep": 1,
+			"cl": "0x0501"
+		},
+		{
+			"bind":"unicast",
+			"src.ep":1,
+			"cl":"0x0001",
+			"report":[
+				{
+					"at":"0x0021",
+					"dt":"0x20",
+					"min":600,
+					"max":6000,
+					"change":"0x00000001"
+		   		}
+			]
+		}
+	]
+}

--- a/devices/woox/woox_r7052_ts0215a.json
+++ b/devices/woox/woox_r7052_ts0215a.json
@@ -1,88 +1,118 @@
 {
-	"schema": "devcap1.schema.json",
-	"manufacturername": ["_TZ3000_ssp0maqm", "_TZ3000_zsh6uat3"],
-	"modelid": ["TS0215A", "TS0215A"],
-	"vendor": "Woox",
-	"product": "R7052 Smart SOS Button",
-	"sleeper": true,
-	"status": "Gold",
-	"subdevices": [
-	{
-		"type": "$TYPE_SWITCH",
-		"restapi": "/sensors",
-		"uuid": [
-			"$address.ext",
-			"0x01",
-			"0x0500"
-		],
-		"fingerprint": {
-			"profile": "0x0104",
-			"device": "0x0401",
-			"endpoint": "0x01",
-				"in": [
-					"0x0000",
-					"0x0500",
-					"0x0501"
-				]
-		},
-		"items": [
-			{ "name": "attr/id" },
-			{ "name": "attr/lastannounced" },
-			{ "name": "attr/lastseen" },
-			{ "name": "attr/manufacturername" },
-			{ "name": "attr/modelid" },
-			{ "name": "attr/name" },
-			{ "name": "attr/swversion" },
-			{ "name": "attr/type" },
-			{ "name": "attr/uniqueid" },
-			{
-				"name": "config/enrolled",
-				"public": false
-			},
-			{ "name": "config/on" },
-			{ "name": "config/pending" },
-			{ "name": "config/battery" },
-			{ "name": "config/reachable" },
-			{
-				"name": "state/buttonevent",
-				"awake": true,
-					"parse": {
-					"cl": "0x0501",
-					"cmd": "0x02",
-					"ep": 1,
-					"eval": "Item.val = 1002",
-					"fn": "zcl"
-					}
-			},
-			{ "name": "state/lastupdated" },
-			{ "name": "state/lowbattery" }
-		]
-	}
-	],
-	"bindings": [
-		{
-			"bind": "unicast",
-			"src.ep": 1,
-			"cl": "0x0500"
-		},
-		{
-			"bind": "unicast",
-			"src.ep": 1,
-			"cl": "0x0501"
-		},
-		{
-			"bind":"unicast",
-			"src.ep":1,
-			"cl":"0x0001",
-			"report":[
-				{
-					"at":"0x0021",
-					"dt":"0x20",
-					"min":600,
-					"max":6000,
-					"change":"0x00000001"
-		   		}
-			]
-		}
-	]
+   "schema":"devcap1.schema.json",
+   "manufacturername":["_TZ3000_ssp0maqm", "_TZ3000_zsh6uat3"],
+   "modelid":["TS0215A", "TS0215A"],
+   "vendor":"Woox",
+   "product":"R7052 Smart SOS Button",
+   "sleeper":true,
+   "status":"Gold",
+   "subdevices":[
+      {
+         "type":"$TYPE_SWITCH",
+         "restapi":"/sensors",
+         "uuid":[
+            "$address.ext",
+            "0x01",
+            "0x0500"
+         ],
+         "fingerprint":{
+            "profile":"0x0104",
+            "device":"0x0401",
+            "endpoint":"0x01",
+            "in":[
+               "0x0000",
+               "0x0500",
+               "0x0501"
+            ]
+         },
+         "items":[
+            {
+               "name":"attr/id"
+            },
+            {
+               "name":"attr/lastannounced"
+            },
+            {
+               "name":"attr/lastseen"
+            },
+            {
+               "name":"attr/manufacturername"
+            },
+            {
+               "name":"attr/modelid"
+            },
+            {
+               "name":"attr/name"
+            },
+            {
+               "name":"attr/swversion"
+            },
+            {
+               "name":"attr/type"
+            },
+            {
+               "name":"attr/uniqueid"
+            },
+            {
+               "name":"config/enrolled",
+               "public":false
+            },
+            {
+               "name":"config/on"
+            },
+            {
+               "name":"config/pending"
+            },
+            {
+               "name":"config/battery"
+            },
+            {
+               "name":"config/reachable"
+            },
+            {
+               "name":"state/buttonevent",
+               "awake":true,
+               "parse":{
+                  "cl":"0x0501",
+                  "cmd":"0x02",
+                  "ep":1,
+                  "eval":"Item.val = 1002",
+                  "fn":"zcl"
+               }
+            },
+            {
+               "name":"state/lastupdated"
+            },
+            {
+               "name":"state/lowbattery"
+            }
+         ]
+      }
+   ],
+   "bindings":[
+      {
+         "bind":"unicast",
+         "src.ep":1,
+         "cl":"0x0500"
+      },
+      {
+         "bind":"unicast",
+         "src.ep":1,
+         "cl":"0x0501"
+      },
+      {
+         "bind":"unicast",
+         "src.ep":1,
+         "cl":"0x0001",
+         "report":[
+            {
+               "at":"0x0021",
+               "dt":"0x20",
+               "min":600,
+               "max":6000,
+               "change":"0x00000001"
+            }
+         ]
+      }
+   ]
 }


### PR DESCRIPTION
- Product name: Woox R7052 Smart SOS Button
- Manufacturer: _TZ_3000_ssp0maqm and _TZ3000_zsh6uat3
- Model identifier: TS0215

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/4323