### PR TITLE
Fix too frequent database writes

### DIFF
--- a/device_compat.cpp
+++ b/device_compat.cpp
@@ -137,10 +137,41 @@ static Resource *DEV_InitLightNodeFromDescription(Device *device, const DeviceDe
         }
     }
 
+    // check if a sub-resource explicitly has static modelid / manufacturername (example.: FLS-PP3)
+    int thingsDone = 0;
+    for (const DeviceDescription::Item &ddfItem : sub.items)
+    {
+        if (ddfItem.descriptor.suffix == RAttrManufacturerName && ddfItem.isStatic)
+        {
+            lightNode.setManufacturerName(ddfItem.defaultValue.toString());
+            thingsDone++;
+        }
+        else if (ddfItem.descriptor.suffix == RAttrModelId && ddfItem.isStatic)
+        {
+            lightNode.setModelId(ddfItem.defaultValue.toString());
+            thingsDone++;
+        }
+
+        if (thingsDone == 2) // break out early if everything was done what could be done
+        {
+            break;
+        }
+    }
+
+    if (lightNode.modelId().isEmpty())
+    {
+        lightNode.setModelId(device->item(RAttrModelId)->toCString());
+    }
+
+    if (lightNode.manufacturer().isEmpty())
+    {
+        lightNode.setManufacturerName(device->item(RAttrManufacturerName)->toCString());
+    }
+
     lightNode.address().setExt(device->item(RAttrExtAddress)->toNumber());
     lightNode.address().setNwk(device->item(RAttrNwkAddress)->toNumber());
-    lightNode.setModelId(device->item(RAttrModelId)->toCString());
-    lightNode.setManufacturerName(device->item(RAttrManufacturerName)->toCString());
+
+
     lightNode.setManufacturerCode(device->node()->nodeDescriptor().manufacturerCode());
     lightNode.setNode(const_cast<deCONZ::Node*>(device->node())); // TODO this is evil
 

--- a/utils/utils.cpp
+++ b/utils/utils.cpp
@@ -15,6 +15,54 @@
 #include "utils.h"
 #include "resource.h"
 
+unsigned U_StringLength(const char *str)
+{
+    unsigned result = 0;
+
+    if (str && str[0])
+    {
+        result = (unsigned)strlen(str);
+    }
+
+    return result;
+}
+
+uint64_t U_ParseUint64(const char *str, int len, int base)
+{
+    uint64_t result = 0;
+
+    DBG_Assert(str != nullptr);
+    DBG_Assert(len == -1 || len > 0);
+
+    if (!str || !(len == -1 || len > 0))
+    {
+        return result;
+    }
+
+    if (!(base == 2 || base == 10 || base == 16))
+    {
+        return result;
+    }
+
+    if (len == -1)
+    {
+        len = (int)U_StringLength(str);
+    }
+
+    if (len > 0)
+    {
+        char *endp;
+        errno = 0;
+        result = (uint64_t)strtoull(str, &endp, base);
+        if (errno != 0)
+        {
+            result = 0;
+        }
+    }
+
+    return result;
+}
+
 /*! Generates a new uniqueid in various formats based on the input parameters.
 
     extAddress           endpoint  cluster    result

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -61,6 +61,10 @@ struct RestData
     bool valid = false;
 };
 
+unsigned U_StringLength(const char *str);
+uint64_t U_ParseUint64(const char *str, int len, int base);
+
+
 QString generateUniqueId(quint64 extAddress, quint8 endpoint, quint16 clusterId);
 bool startsWith(QLatin1String str, QLatin1String needle);
 int indexOf(QLatin1String haystack, QLatin1String needle);


### PR DESCRIPTION
When a resource item is changed by DDF code is written to the database quickly. The PR throttles this so that `state/*` items are only written if they don't exist or the version in the database is older than 10 minutes.

In future we need to denote items via JSON to have a storage interval. There are many items which aren't that important and are ok to be stored in larger intervals or only when deCONZ is closed.

The PR also fixes that static modelid and manufacturername items are respected in the DDF init code.