### PR TITLE
Fix DDF for Heiman Smart siren HS2WD-E, modifiying swversion attribute

### DIFF
--- a/devices/heiman/HS2WD-E.json
+++ b/devices/heiman/HS2WD-E.json
@@ -40,7 +40,21 @@
           "name": "attr/name"
         },
         {
-          "name": "attr/swversion"
+          "name": "attr/swversion",
+          "refresh.interval": 84000,
+          "read": {
+            "at": "0x0006",
+            "cl": "0x0000",
+            "ep": 0,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0006",
+            "cl": "0x0000",
+            "ep": 255,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl"
+          }
         },
         {
           "name": "attr/type"
@@ -95,7 +109,21 @@
           "name": "attr/name"
         },
         {
-          "name": "attr/swversion"
+          "name": "attr/swversion",
+          "refresh.interval": 84000,
+          "read": {
+            "at": "0x0006",
+            "cl": "0x0000",
+            "ep": 0,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0006",
+            "cl": "0x0000",
+            "ep": 255,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl"
+          }
         },
         {
           "name": "attr/type"


### PR DESCRIPTION
The original DDF refers to a non-existent attribute for this device. Changing it to "Date Code" attribute in cluster 0x0000