### PR TITLE
Use simpler and more robust endpoint match expression for Xiaomi smart plugs

### DIFF
--- a/devices/xiaomi/xiaomi_sp-euc01_smart_plug.json
+++ b/devices/xiaomi/xiaomi_sp-euc01_smart_plug.json
@@ -7,7 +7,7 @@
   "sleeper": false,
   "status": "Gold",
   "comment": "DDF for device firmwares at least above 0.0.0_0022, paired with xBee I fw 0x26400500 / xBee II fw 0x266f0700 and above",
-  "matchexpr": "R.endpoints.includes(0x15) && R.endpoints.includes(0x1F)",
+  "matchexpr": "(R.endpoints.indexOf(0x15) !== -1) && (R.endpoints.indexOf(0x1F) !== -1);",
   "md:known_issues": [ "xiaomi_known_issues_plugfw.md" ],
   "subdevices": [
     {

--- a/devices/xiaomi/xiaomi_zncz04lm_smart_plug.json
+++ b/devices/xiaomi/xiaomi_zncz04lm_smart_plug.json
@@ -7,7 +7,7 @@
   "sleeper": false,
   "status": "Gold",
   "comment": "DDF for device firmwares equal or below 0.0.0_0022",
-  "matchexpr": "R.endpoints.includes(0x15) && R.endpoints.includes(0x16)",
+  "matchexpr": "(R.endpoints.indexOf(0x15) !== -1) && (R.endpoints.indexOf(0x16) !== -1);",
   "md:known_issues": [ "xiaomi_known_issues_plugfw.md" ],
   "subdevices": [
     {

--- a/devices/xiaomi/xiaomi_zncz04lm_smart_plug_v24.json
+++ b/devices/xiaomi/xiaomi_zncz04lm_smart_plug_v24.json
@@ -7,7 +7,7 @@
   "sleeper": false,
   "status": "Gold",
   "comment": "DDF for device firmwares equal or above 0.0.0_0024",
-  "matchexpr": "R.endpoints.includes(0x15) && R.endpoints.includes(0x1F)",
+  "matchexpr": "(R.endpoints.indexOf(0x15) !== -1) && (R.endpoints.indexOf(0x1F) !== -1);",
   "md:known_issues": [ "xiaomi_known_issues_plugfw.md" ],
   "subdevices": [
     {


### PR DESCRIPTION
Apparently, another rare combination fo system characteristics making this hard to catch.

The previous `matchexpr` seemingly failed on "older" qt JSEngine versions leading to the DDF not being picked up at all and causing various issues. Oddly, this primarily occurred on HA installations/setups.

The amended expression is simpler, more robust and has also been tested with the next JS engine.