### PR TITLE
Improve scheduling of APS requests

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -832,6 +832,9 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
     connect(apsCtrl, SIGNAL(apsdeDataIndication(deCONZ::ApsDataIndication)),
             this, SLOT(apsdeDataIndication(deCONZ::ApsDataIndication)));
 
+    connect(apsCtrl, SIGNAL(apsdeDataRequestEnqueued(deCONZ::ApsDataRequest)),
+            this, SLOT(apsdeDataRequestEnqueued(deCONZ::ApsDataRequest)));
+
     connect(apsCtrl, SIGNAL(nodeEvent(deCONZ::NodeEvent)),
             this, SLOT(nodeEvent(deCONZ::NodeEvent)));
 
@@ -1610,6 +1613,7 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
 void DeRestPluginPrivate::apsdeDataConfirm(const deCONZ::ApsDataConfirm &conf)
 {
     pollManager->apsdeDataConfirm(conf);
+    DA_ApsRequestConfirmed(conf);
 
     if (conf.dstAddress().hasExt())
     {
@@ -1730,6 +1734,11 @@ void DeRestPluginPrivate::apsdeDataConfirm(const deCONZ::ApsDataConfirm &conf)
     {
         return;
     }
+}
+
+void DeRestPluginPrivate::apsdeDataRequestEnqueued(const deCONZ::ApsDataRequest &req)
+{
+    DA_ApsRequestEnqueued(req);
 }
 
 /*! Process incoming green power button event.

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1284,6 +1284,7 @@ public Q_SLOTS:
     void apsdeDataIndicationDevice(const deCONZ::ApsDataIndication &ind, Device *device);
     void apsdeDataIndication(const deCONZ::ApsDataIndication &ind);
     void apsdeDataConfirm(const deCONZ::ApsDataConfirm &conf);
+    void apsdeDataRequestEnqueued(const deCONZ::ApsDataRequest &req);
     void gpDataIndication(const deCONZ::GpDataIndication &ind);
     void gpProcessButtonEvent(const deCONZ::GpDataIndication &ind);
     void configurationChanged();

--- a/device_access_fn.h
+++ b/device_access_fn.h
@@ -20,6 +20,8 @@ class ResourceItem;
 
 namespace deCONZ {
     class ApsController;
+    class ApsDataConfirm;
+    class ApsDataRequest;
     class ApsDataIndication;
     class ZclFrame;
 }
@@ -42,5 +44,10 @@ bool parseTuyaData(Resource *r, ResourceItem *item, const deCONZ::ApsDataIndicat
 ParseFunction_t DA_GetParseFunction(const QVariant &params);
 ReadFunction_t DA_GetReadFunction(const QVariant &params);
 WriteFunction_t DA_GetWriteFunction(const QVariant &params);
+
+unsigned DA_ApsUnconfirmedRequests();
+unsigned DA_ApsUnconfirmedRequestsForExtAddress(uint64_t extAddr);
+void DA_ApsRequestEnqueued(const deCONZ::ApsDataRequest &req);
+void DA_ApsRequestConfirmed(const deCONZ::ApsDataConfirm &conf);
 
 #endif // DEVICE_ACCESS_FN_H

--- a/device_tick.cpp
+++ b/device_tick.cpp
@@ -163,7 +163,7 @@ static void DT_StateIdle(DeviceTickPrivate *d, const Event &event)
         if (event.what() == REventStateTimeout)
         {
             int timeout = DEV_OtauBusy() ? TICK_INTERVAL_IDLE_OTAU : TICK_INTERVAL_IDLE;
-            if (DEV_ApsQueueSize() < 4)
+            if (DA_ApsUnconfirmedRequests() < 4)
             {
                 DT_PollNextIdleDevice(d);
             }

--- a/state_change.cpp
+++ b/state_change.cpp
@@ -34,16 +34,29 @@ StateChange::StateChange(StateChange::State initialState, StateChangeFunction_t 
 /*! Tick function for the inner state machine.
 
     Is called from the Device state machine on certain events.
+    \returns 0 when nothing was sent, 1 if an APS request was enqueued
 */
-StateChange::State StateChange::tick(Resource *r, deCONZ::ApsController *apsCtrl)
+int StateChange::tick(uint64_t extAddr, Resource *r, deCONZ::ApsController *apsCtrl)
 {
+    int result = 0;
+
     if (m_state == StateFinished || m_state == StateFailed)
     {
-        return m_state;
+        return result;
     }
 
     Q_ASSERT(m_stateTimer.isValid());
     Q_ASSERT(m_changeTimer.isValid());
+
+    const char *uniqueId = "";
+
+    {
+        const ResourceItem *item = r->item(RAttrUniqueId);
+        if (item)
+        {
+            uniqueId = item->toCString();
+        }
+    }
 
     if (m_state == StateWaitSync)
     {
@@ -55,7 +68,6 @@ StateChange::State StateChange::tick(Resource *r, deCONZ::ApsController *apsCtrl
             {
                 if (i.verified == VerifyUnknown) // didn't receive a ZCL attribute read or report command
                 {
-                    DBG_Printf(DBG_INFO, "SC tick --> StateRead\n");
                     m_state = StateRead;
                     break;
                 }
@@ -71,13 +83,15 @@ StateChange::State StateChange::tick(Resource *r, deCONZ::ApsController *apsCtrl
     {
         m_state = StateFailed;
     }
+    else if (DA_ApsUnconfirmedRequests() > 5)
+    {
+        // wait
+    }
     else if (m_state == StateCallFunction && m_changeFunction)
     {
         DBG_Printf(DBG_INFO, "SC tick --> StateCallFunction\n");
         if (m_changeFunction(r, this, apsCtrl) == 0)
         {
-            m_stateTimer.start();
-
             for (auto &i : m_items)
             {
                 if (i.verified == VerifyNotSynced)
@@ -85,10 +99,12 @@ StateChange::State StateChange::tick(Resource *r, deCONZ::ApsController *apsCtrl
                     i.verified = VerifyUnknown; // read again
                 }
             }
+            m_stateTimer.start();
             m_state = StateWaitSync;
+            result = 1;
         }
     }
-    else if (m_state == StateRead)
+    else if (m_state == StateRead && DA_ApsUnconfirmedRequestsForExtAddress(extAddr) == 0)
     {
         ResourceItem *item = nullptr;
         for (auto &i : m_items)
@@ -101,6 +117,7 @@ StateChange::State StateChange::tick(Resource *r, deCONZ::ApsController *apsCtrl
         }
 
         m_state = StateFailed;
+        m_readResult = {};
         if (item)
         {
             const auto &ddfItem = DDF_GetItem(item);
@@ -111,14 +128,17 @@ StateChange::State StateChange::tick(Resource *r, deCONZ::ApsController *apsCtrl
 
                 if (m_readResult.isEnqueued)
                 {
-                    m_stateTimer.start();
-                    m_state = StateWaitSync;
+                    DBG_Printf(DBG_INFO, "SC tick --> StateRead %s, %s\n", item->descriptor().suffix, uniqueId);
+                    result = 1;
                 }
+
+                m_stateTimer.start();
+                m_state = StateWaitSync;
             }
         }
     }
 
-    return m_state;
+    return result;
 }
 
 /*! Should be called when the item was set by a ZCL read or report attribute command.

--- a/state_change.h
+++ b/state_change.h
@@ -105,7 +105,7 @@ public:
      */
     explicit StateChange(State initialState, StateChangeFunction_t fn, quint8 dstEndpoint);
     State state() const { return m_state; }
-    State tick(Resource *r, deCONZ::ApsController *apsCtrl);
+    int tick(uint64_t extAddr, Resource *r, deCONZ::ApsController *apsCtrl);
     void verifyItemChange(const ResourceItem *item);
     void addTargetValue(const char *suffix, const QVariant &value);
     void addParameter(const QString &name, const QVariant &value);


### PR DESCRIPTION
Track running unicast APS requests of the plugin and core. In Device poll handling and `StateChange` processing check that the queue isn't too busy before adding new APS requests.

This fixes too many `StateChanges` to be fired in parallel as seen for Philips Hue sensors and switches (and likely others).

Related issues: https://github.com/dresden-elektronik/deconz-rest-plugin/issues/6461 https://github.com/dresden-elektronik/deconz-rest-plugin/issues/6445