### PR TITLE
Fix state/colormode default DDF item

### DIFF
--- a/devices/generic/items/state_colormode_item.json
+++ b/devices/generic/items/state_colormode_item.json
@@ -5,7 +5,7 @@
 	"access": "R",
 	"public": true,
 	"description": "The currently active color mode.",
-	"parse": {"fn": "zcl", "ep": 0, "cl": "0x0300", "at": "0x0008", "eval": "Item.val = Attr.val"},
+	"parse": {"fn": "zcl", "ep": 0, "cl": "0x0300", "at": "0x0008", "script": "../generic/color_control_cluster/parse_color_mode.js"},
 	"read": {"fn": "zcl", "ep": 0, "cl": "0x0300", "at": "0x0008"},
 	"values": [
 		["\"hs\"", "hue and saturation"],


### PR DESCRIPTION
`Item.val = Attr.val` produces "2" from the enum8 value, use the generic script to get proper "hs", "ct", etc. strings.