### PR TITLE
Zusatzgerät für Lidl Silvercrest Gartenspieß mit 2 Steckdosen HG06620 

### DIFF
--- a/product_match.cpp
+++ b/product_match.cpp
@@ -220,6 +220,7 @@ static const lidlDevice lidlDevices[] = { // Sorted by zigbeeManufacturerName
     { "_TZ3000_el5kt5im", "TS0502A", "LIDL Livarno Lux", "HG06492A" }, // CT Light (GU10)
     { "_TZ3000_gek6snaj", "TS0505A", "LIDL Livarno Lux", "14149506L" }, // Lichtleiste
     { "_TZ3000_kdi2o9m6", "TS011F",  "LIDL Silvercrest", "HG06337" }, // Smart plug (EU)
+    { "_TZ3000_br3laukf", "TS0101",  "LIDL Silvercrest", "HG06620"}, // Garden Spike with 2 Sockets
     { "_TZ3000_kdpxju99", "TS0505A", "LIDL Livarno Lux", "HG06106A" }, // RGB Light (GU10)
     { "_TZ3000_oborybow", "TS0502A", "LIDL Livarno Lux", "HG06492B" }, // CT Light (E14)
     { "_TZ3000_odygigth", "TS0505A", "LIDL Livarno Lux", "HG06106B" }, // RGB Light (E14)


### PR DESCRIPTION
Added device for Lidl Silvercrest Garden Spike with 2 Sockets HG06620