### PR TITLE
Add DDF for Nedis ZBRC10WT 4 button remote

### DIFF
--- a/button_maps.json
+++ b/button_maps.json
@@ -1117,7 +1117,8 @@
         },
         "TuyaKeyfobMap": {
             "vendor": "Woox",
-            "modelids": ["_TZ3000_0zrccfgx"],
+            "doc": "4 button remotes from Woox and Nedis",
+            "modelids": ["_TZ3000_0zrccfgx", "_TZ3000_fsiepnrh"],
             "map": [
                 [1, "0x01", "IAS_ACE", "ARM", "1", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "Arm day/home zones only"],
                 [1, "0x01", "IAS_ACE", "ARM", "0", "S_BUTTON_2", "S_BUTTON_ACTION_SHORT_RELEASED", "Disarm"],

--- a/devices/nedis/nedis_zbrc10wt.json
+++ b/devices/nedis/nedis_zbrc10wt.json
@@ -1,0 +1,112 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "_TZ3000_fsiepnrh",
+  "modelid": "TS0215A",
+  "vendor": "Nedis",
+  "product": "4 button remote",
+  "sleeper": true,
+  "status": "Gold",
+  "path": "/devices/nedis/nedis_zbrc10wt.json",
+  "subdevices": [
+    {
+      "type": "$TYPE_SWITCH",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0500"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0401",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0500",
+          "0x0501"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "awake": true,
+          "read": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "eval": "Item.val = Attr.val / 2",
+            "fn": "zcl"
+          },
+          "default": 0
+        },
+        {
+          "name": "config/enrolled",
+          "public": false
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/pending"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/buttonevent"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/lowbattery"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0500"
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0501"
+    }
+  ]
+}


### PR DESCRIPTION
Resolves https://github.com/dresden-elektronik/deconz-rest-plugin/issues/4524

The DDF is based on the DDF from https://github.com/dresden-elektronik/deconz-rest-plugin/pull/6506 as the devices seem to be very similar. 

```
Product name: Nedis ZBRC10WT
Manufacturer: TZ3000_fsiepnrh
Model identifier: TS0215A
Device type : Remote
```