### PR TITLE
Fix group membership tasks not executing

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -12768,6 +12768,7 @@ void DeRestPluginPrivate::processGroupTasks()
 
     if (!nodes[groupTaskNodeIter].isAvailable())
     {
+        groupTaskNodeIter++;
         return;
     }
 


### PR DESCRIPTION
A non available device could block the processing.
This could lead to lights not being added or removed to a group when requested via REST-API.