### PR TITLE
Fix light type for LEDVANCE A19 RGBW

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -3269,7 +3269,6 @@ void DeRestPluginPrivate::setLightNodeStaticCapabilities(LightNode *lightNode)
         lightNode->addItem(DataTypeUInt16, RConfigCtMin)->setValue(142);
         lightNode->addItem(DataTypeUInt16, RConfigCtMax)->setValue(666);
         lightNode->addItem(DataTypeUInt16, RConfigColorCapabilities)->setValue(0x0001 | 0x0008 | 0x0010);
-        lightNode->addItem(DataTypeString, RStateColorMode)->setValue(QVariant("ct"));
     }
     else if (lightNode->modelId() == QLatin1String("LIGHTIFY A19 RGBW"))
     {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -3257,7 +3257,9 @@ void DeRestPluginPrivate::setLightNodeStaticCapabilities(LightNode *lightNode)
         item = lightNode->item(RAttrType);
         if (item)
         {
-            item->setValue(QVariant("Color temperature light"));
+            // The LEDVANCE A19 RGBW is reported as a color dimmable light. However, it supports both
+            // color and color temperature, so override the type to extended color light here.
+            item->setValue(QVariant("Extended color light"));
         }
         if (lightNode->item(RConfigColorCapabilities) != nullptr)
         {


### PR DESCRIPTION
Light type should be `Extended color light` because color is also supported. This was previously incorrectly set to `Color temperature light`. The light seems to originally report `Color dimmable light`.

Fix https://github.com/dresden-elektronik/deconz-rest-plugin/issues/6591
Fix https://github.com/dresden-elektronik/deconz-rest-plugin/pull/3721
Fix https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3365