### PR TITLE
Fix DDF remove unused battery field for IOMZB-110

### DIFF
--- a/devices/develco/iomzb-110_switch_module.json
+++ b/devices/develco/iomzb-110_switch_module.json
@@ -125,10 +125,6 @@
           "name": "attr/uniqueid"
         },
         {
-          "name": "config/battery",
-          "awake": true
-        },
-        {
           "name": "config/on"
         },
         {
@@ -179,10 +175,6 @@
         },
         {
           "name": "attr/uniqueid"
-        },
-        {
-          "name": "config/battery",
-          "awake": true
         },
         {
           "name": "config/on"
@@ -237,10 +229,6 @@
           "name": "attr/uniqueid"
         },
         {
-          "name": "config/battery",
-          "awake": true
-        },
-        {
           "name": "config/on"
         },
         {
@@ -291,10 +279,6 @@
         },
         {
           "name": "attr/uniqueid"
-        },
-        {
-          "name": "config/battery",
-          "awake": true
         },
         {
           "name": "config/on"


### PR DESCRIPTION
This device is a wired one, so no need battery field.