### PR TITLE
DDF for Tuya door sensor ZG-102Z (_TZE200_pay2byax)

### DIFF
--- a/devices/tuya/_TZE200_pay2byax_door_sensor.json
+++ b/devices/tuya/_TZE200_pay2byax_door_sensor.json
@@ -1,0 +1,69 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": ["_TZE200_pay2byax", "_TZE200_kltffuzl", "_TZE200_fwoorn8y"],
+  "modelid": ["TS0601", "TS0601", "TS0601"],
+  "product": "ZG-102Z",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_OPEN_CLOSE_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0xef00"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "parse": {"fn": "tuya", "dpid": 2, "eval" : "Item.val = Attr.val;" },
+          "read": {"fn": "none"},
+          "default": 0
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/open",
+          "parse": {"fn": "tuya", "dpid": 1, "eval": "Item.val = Attr.val;" },
+          "read": {"fn": "tuya"},
+          "default": false
+        }
+      ]
+    }
+  ]
+}

--- a/devices/tuya/_TZE200_pay2byax_openclose_sensor.json
+++ b/devices/tuya/_TZE200_pay2byax_openclose_sensor.json
@@ -2,7 +2,7 @@
   "schema": "devcap1.schema.json",
   "manufacturername": ["_TZE200_pay2byax", "_TZE200_kltffuzl", "_TZE200_fwoorn8y"],
   "modelid": ["TS0601", "TS0601", "TS0601"],
-  "product": "ZG-102Z or TM001-ZA or TM081",
+  "product": "ZG-102Z or TM001-ZA or TM081 open/close sensor",
   "sleeper": true,
   "status": "Gold",
   "subdevices": [

--- a/devices/tuya/_TZE200_pay2byax_openclose_sensor.json
+++ b/devices/tuya/_TZE200_pay2byax_openclose_sensor.json
@@ -2,7 +2,7 @@
   "schema": "devcap1.schema.json",
   "manufacturername": ["_TZE200_pay2byax", "_TZE200_kltffuzl", "_TZE200_fwoorn8y"],
   "modelid": ["TS0601", "TS0601", "TS0601"],
-  "product": "ZG-102Z",
+  "product": "ZG-102Z or TM001-ZA or TM081",
   "sleeper": true,
   "status": "Gold",
   "subdevices": [
@@ -34,7 +34,9 @@
           "name": "attr/name"
         },
         {
-          "name": "attr/swversion"
+          "name": "attr/swversion",
+          "parse": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001", "script": "tuya_swversion.js"},
+          "read": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001"}
         },
         {
           "name": "attr/type"


### PR DESCRIPTION
See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/6597

- Product name: Zigbee Door Sensor ZG-102Z
- Manufacturer: _TZE200_pay2byax
- Model identifier: TS0601

Clone
- _TZE200_kltffuzl
- _TZE200_fwoorn8y