### PR TITLE
DDF support for the Nedis temperature/humidity sensor (_TZ3000_fie1dpkm)

### DIFF
--- a/devices/tuya/_TZ3000_yd2e749y_temp_hum_sensor.json
+++ b/devices/tuya/_TZ3000_yd2e749y_temp_hum_sensor.json
@@ -1,7 +1,7 @@
 {
   "schema": "devcap1.schema.json",
-  "manufacturername": ["_TZ3000_yd2e749y", "_TZ3000_fllyghyj"],
-  "modelid": ["TS0201", "TS0201"],
+  "manufacturername": ["_TZ3000_yd2e749y", "_TZ3000_fllyghyj", "_TZ3000_fie1dpkm"],
+  "modelid": ["TS0201", "TS0201", "TS0201"],
   "vendor": "Tuya",
   "product": "Temperature and humidity sensor",
   "sleeper": true,


### PR DESCRIPTION
This adds support for the Nedis ZBSC10WT temperature/humidity sensor. Which is nothing more than another TS0201 tuya device.

https://nedis.com/en-us/product/smart-home/climate/monitoring/550726063/smart-climate-sensor-zigbee-30-battery-powered-android-ios-white