### PR TITLE
Fix misleading debug message for resourcelinks

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -2159,7 +2159,7 @@ static int sqliteLoadAllResourcelinksCallback(void *user, int ncols, char **colv
         {
             QString val = QString::fromUtf8(colval[i]);
 
-            DBG_Printf(DBG_INFO_L2, "Sqlite schedule: %s = %s\n", colname[i], qPrintable(val));
+            DBG_Printf(DBG_INFO_L2, "Sqlite resourcelink: %s = %s\n", colname[i], qPrintable(val));
 
 
             if (strcmp(colname[i], "id") == 0)


### PR DESCRIPTION
I've noticed strange output in my debug log, resourcelinks are printed as schedules - fixing it.