### PR TITLE
Fix missing whitespace trimming on strings

### DIFF
--- a/resource.cpp
+++ b/resource.cpp
@@ -911,33 +911,7 @@ bool ResourceItem::toBool() const
 
 bool ResourceItem::setValue(const QString &val, ValueSource source)
 {
-    if (m_rid->type == DataTypeString)
-    {
-        setItemString(val);
-    }
-
-    if (m_str)
-    {
-        if (m_rid->type == DataTypeTime)
-        {
-            return setValue(QVariant(val), source);
-        }
-
-        m_valueSource = source;
-        m_lastSet = QDateTime::currentDateTime();
-        m_flags |= FlagNeedPushSet;
-        const auto str = val.trimmed();
-        setItemString(str);
-        if (*m_str != str)
-        {
-            *m_str = str;
-            m_lastChanged = m_lastSet;
-            m_flags |= FlagNeedPushChange;
-        }
-        return true;
-    }
-
-    return false;
+    return setValue(QVariant(val), source);
 }
 
 bool ResourceItem::setValue(qint64 val, ValueSource source)

--- a/resource.cpp
+++ b/resource.cpp
@@ -926,9 +926,11 @@ bool ResourceItem::setValue(const QString &val, ValueSource source)
         m_valueSource = source;
         m_lastSet = QDateTime::currentDateTime();
         m_flags |= FlagNeedPushSet;
-        if (*m_str != val)
+        const auto str = val.trimmed();
+        setItemString(str);
+        if (*m_str != str)
         {
-            *m_str = val;
+            *m_str = str;
             m_lastChanged = m_lastSet;
             m_flags |= FlagNeedPushChange;
         }


### PR DESCRIPTION
If you read a string on an attribute using the GUI, this one can be updated in the API with added space.
Like for Legrand for exemple

```
    "manufacturername": " Legrand",
    "modelid": " Cable outlet",
```

Can cause all check based on string will fail.