### PR TITLE
Fix regression for `config/devicemode` usage

### DIFF
--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -821,7 +821,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                     }
                 }
 
-                if (rid.suffix == RConfigDeviceMode && !data.string.isEmpty() && RConfigDeviceModeValues.indexOf(data.string) >= 0)
+                if (rid.suffix == RConfigDeviceMode) // String
                 {
                     if (devManaged && rsub)
                     {
@@ -830,7 +830,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                         updated = true;
                     }
                 }
-                else if (rid.suffix == RConfigClickMode && !data.string.isEmpty()) // String
+                else if (rid.suffix == RConfigClickMode) // String
                 {
                     if (devManaged && rsub)
                     {
@@ -900,7 +900,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                         updated = true;
                     }
                 }
-                else if (rid.suffix == RConfigTriggerDistance && !data.string.isEmpty()) // String
+                else if (rid.suffix == RConfigTriggerDistance) // String
                 {
                     if (devManaged && rsub)
                     {


### PR DESCRIPTION
This should allow other devices to make use of `config/devicemode` again (other than Hue wall switch module). A few duplicate string checks have been removed as well, which are already part for the preceding data type check.