### PR TITLE
DDF : add support for Innr 250

### DIFF
--- a/devices/innr/rc_250.json
+++ b/devices/innr/rc_250.json
@@ -12,7 +12,7 @@
       "uuid": [
         "$address.ext",
         "0x01",
-        "0x0006"
+        "0xfd01"
       ],
       "items": [
         {
@@ -73,7 +73,7 @@
             "cl": "0xfd01",
             "cmd": "0x12",
             "mf": "0x1168",
-            "eval": "if (ZclFrame.at(2)<6){const e = [0x00, 0x01, 0x02, 0x04, 0x02, 0x03, 0x03]; Item.val = ZclFrame.at(1) * 1000 + e[ZclFrame.at(2)]}"
+            "eval": "const t={'1':0,'8':2,'2':3,'10':9};if(ZclFrame.at(2) in t){Item.val=ZclFrame.at(1)*1000+t[ZclFrame.at(2)]}"
           }
         },
         {
@@ -96,18 +96,6 @@
           "change": "0x00000001"
         }
       ]
-    },
-    {
-      "bind": "unicast",
-      "src.ep": 1,
-      "dst.ep": 1,
-      "cl": "0x0006"
-    },
-    {
-      "bind": "unicast",
-      "src.ep": 1,
-      "dst.ep": 1,
-      "cl": "0x0008"
     },
     {
       "bind": "unicast",

--- a/devices/innr/rc_250.json
+++ b/devices/innr/rc_250.json
@@ -1,0 +1,119 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "innr",
+  "modelid": "RC 250",
+  "product": "Battery switch",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_SWITCH",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0006"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "awake": true,
+          "refresh.interval": 84000,
+          "read": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "eval": "Item.val = Attr.val / 2"
+          },
+          "default": 0
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/buttonevent",
+          "awake": true,
+          "parse": {
+            "cl": "0xfd01",
+            "cmd": "0x12",
+            "mf": "0x1168",
+            "eval": "if (ZclFrame.at(2)<6){const e = [0x00, 0x01, 0x02, 0x04, 0x02, 0x03, 0x03]; Item.val = ZclFrame.at(1) * 1000 + e[ZclFrame.at(2)]}"
+          }
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 60,
+          "max": 3600,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0006"
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0008"
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0xfd01"
+    }
+  ]
+}

--- a/general.xml
+++ b/general.xml
@@ -4652,6 +4652,15 @@ Outdoor Temp to Display Timeout: set 30 for 'off' and 10800 for 'on'</descriptio
       <client>
       </client>
     </cluster>
+    <cluster id="0xfd01" name="innr specific 2" mfcode="0x1166">
+      <description>innr specific attributes 2.</description>
+      <server>
+        <attribute id="0x0004" name="Key Report Mask Read/Write" mfcode="0x1166" type="u8" default="0" access="rw" required="m">
+        </attribute>
+      </server>
+      <client>
+      </client>
+    </cluster>
 
     <!-- IMMAX -->
     <cluster id="0xfc82" name="Immax specific" mfcode="0x1037">


### PR DESCRIPTION
Ok so long story, with the @Idaho947 help, see https://github.com/dresden-elektronik/deconz-rest-plugin/issues/6618

This device can work with button map, but not possible for all buttons, thoses one just cycle some vlaues.
@kasteleman that know a lot this device have found a solution.

Need to use the GUI, to update the attribute 0x0004 in the cluster 0xfd01 with the value 63

> Attribute is uint8 you should set the first 6 so that would be 00111111
> 00111111 is 63 in dec and 0x3F in hex

After that the device use the special cluster to send special command. So the DDF can work without the buttonmap file.

The manufacture number of the device is 0x1166 but need to use 0x1169 in the request .....