### PR TITLE
Add additional model identifier for Danfoss Ally to DDF

### DIFF
--- a/devices/danfoss/etrv0100_thermostat.json
+++ b/devices/danfoss/etrv0100_thermostat.json
@@ -1,7 +1,7 @@
 {
   "schema": "devcap1.schema.json",
-  "manufacturername": "Danfoss",
-  "modelid": "eTRV0100",
+  "manufacturername": ["Danfoss", "Danfoss"],
+  "modelid": ["eTRV0100", "eTRV0103"],
   "vendor": "Danfoss",
   "product": "Ally thermostat",
   "sleeper": false,


### PR DESCRIPTION
Danfoss has released a thermostat with a new microcontroller. From a functionality perspective, it is identical to the previous hardware, except for the model identifier.