### PR TITLE
Update ts0202_presence_sensor to support _TZ3000_6ygjfyll

### DIFF
--- a/devices/tuya/ts0202_presence_sensor.json
+++ b/devices/tuya/ts0202_presence_sensor.json
@@ -1,7 +1,7 @@
 {
    "schema":"devcap1.schema.json",
-   "manufacturername": ["_TZ3000_msl6wxk9", "_TZ3000_otvn3lne", "_TZ3040_6ygjfyll", "_TZ3000_mcxw5ehu"],
-   "modelid":["TS0202", "TS0202", "TS0202", "TS0202"],
+   "manufacturername": ["_TZ3000_msl6wxk9", "_TZ3000_otvn3lne", "_TZ3000_6ygjfyll", "_TZ3040_6ygjfyll", "_TZ3000_mcxw5ehu"],
+   "modelid":["TS0202", "TS0202", "TS0202", "TS0202", "TS0202"],
    "product":"TS0202 Presence sensor",
    "sleeper":true,
    "status":"Gold",


### PR DESCRIPTION
Received device off Aliexpress that is exposing `_TZ3000_6ygjfyll` instead of `_TZ3040_6ygjfyll`

Adding this extra entry fixes the issue.