### PR TITLE
Adds new manufacturerName for HAMA TRV

### DIFF
--- a/product_match.cpp
+++ b/product_match.cpp
@@ -65,6 +65,7 @@ static const ProductMap products[] =
     {"_TZE200_zivfvd7h", "TS0601", "Siterwell", "Tuya_THD GS361A-H04 TRV"},
     {"_TYST11_yw7cahqs", "w7cahqs", "Hama", "Tuya_THD Smart radiator TRV"},
     {"_TZE200_yw7cahqs", "TS0601", "Hama", "Tuya_THD Smart radiator TRV"},
+    {"_TZE200_h4cgnbzg", "TS0601", "Hama", "Tuya_THD Smart radiator TRV"},
     {"_TZE200_cwnjrr72", "TS0601", "MOES", "Tuya_THD HY368 TRV"},
     {"_TZE200_cpmgn2cf", "TS0601", "MOES", "Tuya_THD HY368 TRV"},
     {"_TZE200_b6wax7g0", "TS0601", "MOES", "Tuya_THD BRT-100"},


### PR DESCRIPTION
Added new manufacturerName "_TZE200_h4cgnbzg" of my brand new Hama Thermostats to the product match list.

Signed-off-by: Johannes Ott <mail@johannes-ott.net>