### PR TITLE
Update SMT402AD swversion attr to be fullfilled from Application version

### DIFF
--- a/devices/stelpro/smt402ad.json
+++ b/devices/stelpro/smt402ad.json
@@ -34,7 +34,21 @@
           "name": "attr/name"
         },
         {
-          "name": "attr/swversion"
+          "name": "attr/swversion",
+          "refresh.interval": 86400,
+          "read": {
+            "at": "0x0001",
+            "cl": "0x0000",
+            "ep": 0,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0001",
+            "cl": "0x0000",
+            "ep": 255,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl"
+          }
         },
         {
           "name": "attr/type"
@@ -183,7 +197,21 @@
           "name": "attr/name"
         },
         {
-          "name": "attr/swversion"
+          "name": "attr/swversion",
+          "refresh.interval": 86400,
+          "read": {
+            "at": "0x0001",
+            "cl": "0x0000",
+            "ep": 0,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0001",
+            "cl": "0x0000",
+            "ep": 255,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl"
+          }
         },
         {
           "name": "attr/type"


### PR DESCRIPTION
swversion is not proposed by device, filled from App version attribute to don't have it empty. More cosmetic than other concern.