### PR TITLE
Negative value for zclFrame.payload().at() on x86

### DIFF
--- a/device_js/device_js_duktape.cpp
+++ b/device_js/device_js_duktape.cpp
@@ -602,8 +602,7 @@ static duk_ret_t DJS_GetZclFramePayloadAt(duk_context *ctx)
     {
         if (i >= 0 && i < zf->payload().size())
         {
-            quint8 value = zf->payload().at(i);
-            duk_push_int(ctx, value);
+            duk_push_int(ctx, (uint8_t) zf->payload().at(i));
             return 1;  /* one return value */
 
         }

--- a/device_js/device_js_duktape.cpp
+++ b/device_js/device_js_duktape.cpp
@@ -602,7 +602,8 @@ static duk_ret_t DJS_GetZclFramePayloadAt(duk_context *ctx)
     {
         if (i >= 0 && i < zf->payload().size())
         {
-            duk_push_int(ctx, zf->payload().at(i));
+            quint8 value = zf->payload().at(i);
+            duk_push_int(ctx, value);
             return 1;  /* one return value */
 
         }

--- a/device_js/device_js_wrappers.cpp
+++ b/device_js/device_js_wrappers.cpp
@@ -263,8 +263,7 @@ int JsZclFrame::at(int i) const
 {
     if (zclFrame && i >= 0 && i < zclFrame->payload().size())
     {
-        quint8 value = zclFrame->payload().at(i);
-        return value;
+        return (uint8_t) zclFrame->payload().at(i);
     }
 
     return 0;

--- a/device_js/device_js_wrappers.cpp
+++ b/device_js/device_js_wrappers.cpp
@@ -263,7 +263,8 @@ int JsZclFrame::at(int i) const
 {
     if (zclFrame && i >= 0 && i < zclFrame->payload().size())
     {
-        return zclFrame->payload().at(i);
+        quint8 value = zclFrame->payload().at(i);
+        return value;
     }
 
     return 0;


### PR DESCRIPTION
Use intermediate `quint8` variable for value for `zclFrame.payload().at()` to force an unsigned value, see #6670.

Found and fixed same issue for Qt Javascript engine as well.

Unfortunately, I cannot test as I don't have an x64 system running deCONZ.
