### PR TITLE
Ignore invalid Aqara -100 temperature

### DIFF
--- a/devices/xiaomi/xiaomi_wsdcgq11lm_temp_hum_press_sensor.json
+++ b/devices/xiaomi/xiaomi_wsdcgq11lm_temp_hum_press_sensor.json
@@ -168,7 +168,14 @@
           "name": "state/lastupdated"
         },
         {
-          "name": "state/temperature"
+          "name": "state/temperature",
+          "parse": {
+            "at": "0x0000",
+            "cl": "0x0402",
+            "ep": 0,
+            "eval": "if (Attr.val + R.item('config/offset').val != -10000) {Item.val = Attr.val + R.item('config/offset').val}",
+            "fn": "zcl"
+          }
         }
       ]
     },


### PR DESCRIPTION
When `xiaomi/xiaomi_wsdcgq11lm_temp_hum_press_sensor.json` was introduced, a workaround for #1748 was [removed](https://github.com/dresden-elektronik/deconz-rest-plugin/pull/5812/files#diff-d0aaee66bc2f60fdd243c0e5b86aebca01fa3eb36c7ec39578d5beeca47078abL8859-L8862).

This PR brings the workaround to the DDF. I have simply added the `parse` section from `generic/items/state_temperature_item.json` and modified it with an `if`.

I did test that this works but I have no experience with DDF so I am quite sure that there is an improved way to do it.