### PR TITLE
DDF, add support for Adeo\Lexman door+vibration sensor

### DIFF
--- a/devices/adeo/ledsenk08_door_vibration_sensor.json
+++ b/devices/adeo/ledsenk08_door_vibration_sensor.json
@@ -74,6 +74,7 @@
         },
         {
           "name": "config/battery",
+          "refresh.interval": 84000,
           "awake": true,
           "parse": {
             "at": "0x0021",
@@ -164,6 +165,7 @@
         },
         {
           "name": "config/battery",
+          "refresh.interval": 84000,
           "awake": true,
           "parse": {
             "at": "0x0021",

--- a/devices/adeo/ledsenk08_door_vibration_sensor.json
+++ b/devices/adeo/ledsenk08_door_vibration_sensor.json
@@ -1,0 +1,222 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "ADEO",
+  "modelid": "LDSENK08",
+  "vendor": "Adeo",
+  "product": "Smart Zigbee Door Window Contact and vibration",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_OPEN_CLOSE_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0006"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0402",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x0500"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+           "name":"state/tampered"
+        },
+        {
+          "name": "config/checkin"
+        },
+        {
+          "name": "config/enrolled",
+          "public": false
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/pending"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "config/battery",
+          "awake": true,
+          "parse": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "eval": "Item.val = Attr.val / 2"
+          }
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/lowbattery"
+        },
+        {
+          "name": "state/open",
+          "parse": {
+            "fn": "ias:zonestatus",
+            "mask": "alarm1"
+          }
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_VIBRATION_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0500"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0402",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x0500"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+           "name":"state/tampered"
+        },
+        {
+          "name": "config/checkin"
+        },
+        {
+          "name": "config/enrolled",
+          "public": false
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/pending"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "config/battery",
+          "awake": true,
+          "parse": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "eval": "Item.val = Attr.val / 2"
+          }
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/lowbattery"
+        },
+        {
+          "name": "state/vibration",
+          "parse": {
+            "fn": "ias:zonestatus",
+            "mask": "alarm2"
+          }
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 60,
+          "max": 3600,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0500",
+      "report": [
+        {
+          "at": "0x0002",
+          "dt": "0x19",
+          "min": 60,
+          "max": 3600
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/6717
The DDF create a fake endpoint for the door sensor (both are using same cluster)

So the DDF is working but I m not sure for some things.
The device use 1 mask for the door detection and 1 mask for the vibration detection, do we need to use the enrollment stuff on both ?
It seem the device work better if we make a report on the cluster 0x0500, there is no error on logs, but it's not something "classic".