### PR TITLE
DDF for LIDL Smart watering timer (_TZE200_htnnfasr)

### DIFF
--- a/devices/tuya/_TZE200_htnnfasr_water_valve
+++ b/devices/tuya/_TZE200_htnnfasr_water_valve
@@ -5,7 +5,7 @@
   "vendor": "LIDL",
   "product": "Smart watering timer",
   "sleeper": false,
-  "status": "Bronze",
+  "status": "Silver",
   "subdevices": [
     {
       "type": "$TYPE_ON_OFF_OUTPUT",
@@ -34,69 +34,13 @@
           "name": "attr/name"
         },
         {
-          "name": "attr/swversion",
-          "refresh.interval": 84000,
-          "read": {
-            "at": "0x0001",
-            "cl": "0x0000",
-            "ep": 1,
-            "fn": "zcl"
-          },
-          "parse": {
-            "at": "0x0001",
-            "cl": "0x0000",
-            "ep": 1,
-            "fn": "zcl",
-            "script": "tuya_swversion.js"
-          }
+          "name": "attr/swversion"
         },
         {
           "name": "attr/type"
         },
         {
           "name": "attr/uniqueid"
-        },
-        {
-          "name": "config/battery",
-          "parse": {
-            "dpid": 11,
-            "eval": "Item.val = Attr.val * 50;",
-            "fn": "tuya"
-          },
-          "default": 0
-        },
-        {
-          "name": "config/duration",
-          "parse": {
-            "dpid": 5,
-            "eval": "Item.val = Attr.val;",
-            "fn": "tuya"
-          }
-        },
-        {
-          "name": "config/lock",
-          "parse": {
-            "dpid": 109,
-            "eval": "Item.val = Attr.val;",
-            "fn": "tuya"
-          }
-        },
-        {
-          "name": "config/mode",
-          "parse": {
-            "dpid": 108,
-            "eval": "Item.val = Attr.val;",
-            "fn": "tuya"
-          }
-        },
-        {
-          "name": "state/deviceruntime",
-          "parse": {
-            "dpid": 6,
-            "eval": "Item.val = Attr.val;",
-            "fn": "tuya"
-          },
-          "default": 0
         },
         {
           "name": "state/on",
@@ -118,6 +62,88 @@
         },
         {
           "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_OPEN_CLOSE_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0500"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+		{
+          "name": "config/battery",
+          "parse": {
+            "dpid": 11,
+            "eval": "Item.val = Attr.val * 50;",
+            "fn": "tuya"
+          },
+          "default": 100
+        },
+        {
+          "name": "config/duration",
+          "write": {
+            "dpid": 5,
+            "dt": "0x02",
+            "eval": "Attr.val = Item.val;",
+            "fn": "tuya"
+          },
+          "parse": {
+            "dpid": 6,
+            "eval": "Item.val = Attr.val;",
+            "fn": "tuya"
+          }
+        },
+        {
+          "name": "config/locked",
+          "write": {
+            "dpid": 109,
+            "dt": "0x01",
+            "eval": "Item.val == 1 ? 1 : 0;",
+            "fn": "tuya"
+          },
+          "parse": {
+            "dpid": 108,
+            "eval": "Item.val == 1 ? 0 : 1;",
+            "fn": "tuya"
+          },
+          "default": false
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/lastupdated"
         }
       ]
     }

--- a/devices/tuya/_TZE200_htnnfasr_water_valve
+++ b/devices/tuya/_TZE200_htnnfasr_water_valve
@@ -5,7 +5,7 @@
   "vendor": "LIDL",
   "product": "Smart watering timer",
   "sleeper": false,
-  "status": "Silver",
+  "status": "Gold",
   "subdevices": [
     {
       "type": "$TYPE_ON_OFF_OUTPUT",
@@ -58,7 +58,8 @@
             "dpid": 1,
             "eval": "Item.val = Attr.val;",
             "fn": "tuya"
-          }
+          },
+	  "default": 0
         },
         {
           "name": "state/reachable"
@@ -105,13 +106,14 @@
           "name": "config/battery",
           "parse": {
             "dpid": 11,
-            "eval": "Item.val = Attr.val * 50;",
+            "eval": "Item.val = Attr.val;",
             "fn": "tuya"
           },
           "default": 100
         },
         {
           "name": "config/duration",
+          "description": "The duration the valve stays open.",
           "write": {
             "dpid": 5,
             "dt": "0x2b",
@@ -119,13 +121,14 @@
             "fn": "tuya"
           },
           "parse": {
-            "dpid": 6,
+            "dpid": 5,
             "eval": "Item.val = Attr.val;",
             "fn": "tuya"
           }
         },
         {
           "name": "config/locked",
+          "description": "Read: frost lock status. Write: frost lock reset.",
           "write": {
             "dpid": 109,
             "dt": "0x10",
@@ -137,13 +140,22 @@
             "eval": "Item.val == 1 ? 0 : 1;",
             "fn": "tuya"
           },
-          "default": false
+          "default": 0
         },
         {
           "name": "config/reachable"
         },
         {
           "name": "state/lastupdated"
+        },
+        {
+          "name": "state/seconds_remaining",
+          "description": "The remaining time the valve is open in seconds.",
+          "parse": {
+            "dpid": 6,
+            "eval": "Item.val = Attr.val * 60;",
+            "fn": "tuya"
+          }
         }
       ]
     }

--- a/devices/tuya/_TZE200_htnnfasr_water_valve
+++ b/devices/tuya/_TZE200_htnnfasr_water_valve
@@ -114,7 +114,7 @@
           "name": "config/duration",
           "write": {
             "dpid": 5,
-            "dt": "0x02",
+            "dt": "0x2b",
             "eval": "Attr.val = Item.val;",
             "fn": "tuya"
           },
@@ -128,7 +128,7 @@
           "name": "config/locked",
           "write": {
             "dpid": 109,
-            "dt": "0x01",
+            "dt": "0x10",
             "eval": "Item.val == 1 ? 1 : 0;",
             "fn": "tuya"
           },

--- a/devices/tuya/_TZE200_htnnfasr_water_valve
+++ b/devices/tuya/_TZE200_htnnfasr_water_valve
@@ -1,0 +1,155 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "_TZE200_htnnfasr",
+  "modelid": "TS0601",
+  "vendor": "LIDL",
+  "product": "Smart watering timer",
+  "sleeper": false,
+  "status": "Bronze",
+  "subdevices": [
+    {
+      "type": "$TYPE_ON_OFF_OUTPUT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "refresh.interval": 84000,
+          "read": {
+            "at": "0x0001",
+            "cl": "0x0000",
+            "ep": 1,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0x0001",
+            "cl": "0x0000",
+            "ep": 1,
+            "fn": "zcl",
+            "script": "tuya_swversion.js"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "parse": {
+            "dpid": 11,
+            "eval": "Item.val = Attr.val * 50;",
+            "fn": "tuya"
+          },
+          "default": 0
+        },
+        {
+          "name": "config/duration",
+          "parse": {
+            "dpid": 5,
+            "eval": "Item.val = Attr.val;",
+            "fn": "tuya"
+          }
+        },
+        {
+          "name": "config/lock",
+          "parse": {
+            "dpid": 109,
+            "eval": "Item.val = Attr.val;",
+            "fn": "tuya"
+          }
+        },
+        {
+          "name": "config/mode",
+          "parse": {
+            "dpid": 108,
+            "eval": "Item.val = Attr.val;",
+            "fn": "tuya"
+          }
+        },
+        {
+          "name": "state/deviceruntime",
+          "parse": {
+            "dpid": 6,
+            "eval": "Item.val = Attr.val;",
+            "fn": "tuya"
+          },
+          "default": 0
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 300,
+          "read": {
+            "fn": "tuya"
+          },
+          "write": {
+            "dpid": 1,
+            "dt": "0x10",
+            "eval": "Item.val == 1 ? 1 : 0;",
+            "fn": "tuya"
+          },
+          "parse": {
+            "dpid": 1,
+            "eval": "Item.val = Attr.val;",
+            "fn": "tuya"
+          }
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0006",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 300
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0006",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 300
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- On/Off and swversion are working
- make battery, frostlock and valve open duration available via RestAPI in separate sensor object (wrong values / no impact on actual device)