### PR TITLE
DDf add support for _TZE200_dwcarsat Smart Air House keepe

### DIFF
--- a/devices/tuya/_TZE200_dwcarsat_air_sensor.json
+++ b/devices/tuya/_TZE200_dwcarsat_air_sensor.json
@@ -1,0 +1,212 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "_TZE200_dwcarsat",
+  "modelid": "TS0601",
+  "vendor": "Tuya",
+  "product": "Smart Air House keeper",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_HUMIDITY_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0511"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/humidity",
+          "read": {
+            "fn": "none"
+          },
+          "parse": {
+            "dpid": 19,
+            "eval": "Item.val = (10 * Attr.val);",
+            "fn": "tuya"
+          },
+          "default": 0
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_AIR_QUALITY_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0512"
+      ],
+      "items": [
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/airqualityco2",
+          "read": {
+            "fn": "none"
+          },
+          "parse": {
+            "dpid": 22,
+            "eval": "Item.val = Attr.val;",
+            "fn": "tuya"
+          },
+          "default": 0
+        },
+        {
+          "name": "state/airqualityformaldehyd",
+          "read": {
+            "fn": "none"
+          },
+          "parse": {
+            "dpid": 20,
+            "eval": "Item.val = Attr.val;",
+            "fn": "tuya"
+          },
+          "default": 0
+        },
+        {
+          "name": "state/airqualityppb",
+          "read": {
+            "fn": "none"
+          },
+          "parse": {
+            "dpid": 21,
+            "eval": "Item.val = Attr.val;",
+            "fn": "tuya"
+          },
+          "default": 0
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/pm2_5",
+          "read": {
+            "fn": "none"
+          },
+          "parse": {
+            "dpid": 2,
+            "eval": "Item.val = Attr.val;",
+            "fn": "tuya"
+          },
+          "default": 0
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_TEMPERATURE_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0514"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/temperature",
+          "read": {
+            "fn": "none"
+          },
+          "parse": {
+            "dpid": 18,
+            "eval": "Item.val = (10 * Attr.val);",
+            "fn": "tuya"
+          },
+          "default": 0
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
With the @m4k2k  help.
This PR need this one first to have missing field https://github.com/dresden-elektronik/deconz-rest-plugin/pull/6673

- Product name: Smart Air House keeper
- Manufacturer: _TZE200_dwcarsat
- Model identifier: TS0601

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/5889

Can be improved, but will be later, this part is working fine.