### PR TITLE
DDF add supprt for the Heiman HS3AQ carbondioxide detector

### DIFF
--- a/devices/heiman/HS3AQ_air_quality_sensor.json
+++ b/devices/heiman/HS3AQ_air_quality_sensor.json
@@ -2,7 +2,7 @@
   "schema": "devcap1.schema.json",
   "manufacturername": "HEIMAN",
   "modelid": "HS3AQ-EFA-3.0",
-  "product": "HS3AQ-EFA-3.0",
+  "product": "HHS3AQ carbondioxide detector",
   "sleeper": false,
   "status": "Gold",
   "subdevices": [
@@ -44,6 +44,7 @@
         },
         {
           "name": "config/battery",
+          "refresh.interval": 86400,
           "awake": true,
           "parse": {
             "at": "0x0021",
@@ -112,6 +113,7 @@
         },
         {
           "name": "config/battery",
+          "refresh.interval": 86400,
           "awake": true,
           "parse": {
             "at": "0x0021",
@@ -181,6 +183,7 @@
         {
           "name": "config/battery",
           "awake": true,
+          "refresh.interval": 86400,
           "parse": {
             "at": "0x0021",
             "cl": "0x0001",

--- a/devices/heiman/HS3AQ_air_quality_sensor.json
+++ b/devices/heiman/HS3AQ_air_quality_sensor.json
@@ -1,0 +1,285 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "HEIMAN",
+  "modelid": "HS3AQ-EFA-3.0",
+  "product": "HS3AQ-EFA-3.0",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_TEMPERATURE_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0402"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "awake": true,
+          "parse": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "eval": "Item.val = Attr.val / 2;",
+            "fn": "zcl"
+          },
+          "default": 0
+        },
+        {
+          "name": "config/offset",
+          "default": 0
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/temperature",
+          "awake": true,
+          "default": 0
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_HUMIDITY_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0405"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "awake": true,
+          "parse": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "eval": "Item.val = Attr.val / 2;",
+            "fn": "zcl"
+          },
+          "default": 0
+        },
+        {
+          "name": "config/offset",
+          "default": 0
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/humidity",
+          "awake": true,
+          "default": 0
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_AIR_QUALITY_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x040D"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "awake": true,
+          "parse": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "eval": "Item.val = Attr.val / 2;",
+            "fn": "zcl"
+          },
+          "default": 0
+        },
+        {
+          "name": "config/offset",
+          "default": 0
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/airqualityppb",
+          "awake": true,
+          "parse": {
+            "at": "0x0000",
+            "cl": "0x040D",
+            "ep": 1,
+            "eval": "Item.val = Attr.val * 1000000;",
+            "fn": "zcl"
+          },
+          "read": {
+            "at": "0x0000",
+            "cl": "0x040D",
+            "ep": 1,
+            "fn": "zcl"
+          },
+          "default": 0
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 60,
+          "max": 3600,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0402",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x29",
+          "min": 60,
+          "max": 300,
+          "change": "0x00000064"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0405",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x21",
+          "min": 60,
+          "max": 300,
+          "change": "0x00000064"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x040D",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x39",
+          "min": 60,
+          "max": 300,
+          "change": "0x00000064"
+        }
+      ]
+    }
+  ]
+}

--- a/general.xml
+++ b/general.xml
@@ -3275,6 +3275,20 @@ Note: It does not clear or delete previous weekly schedule programming configura
       </client>
     </cluster>
 
+    <cluster id="0x040D" name="Carbon dioxyde measurement">
+      <description></description>
+      <server>
+        <attribute-set id="0x0000" description="Relative Carbon Dioxyde Information">
+          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+        </attribute-set>
+      </server>
+      <client>
+      </client>
+    </cluster>
+
     <cluster id="0x0b04" name="Electrical Measurement">
       <description>Provides a mechanism for querying data about the electrical properties as measured by the device.</description>
       <server>


### PR DESCRIPTION
- Product name: Carbon Dioxide Detector Heiman HS3AQ
- Manufacturer: HEIMAN
- Model identifier: HS3AQ-EFA-3.0

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/6396