### PR TITLE
DDF for Moes vibration sensor (_TZ3000_bmfw9ykl)

### DIFF
--- a/devices/tuya/_TZ3000_bmfw9ykl_vibration_sensor.json
+++ b/devices/tuya/_TZ3000_bmfw9ykl_vibration_sensor.json
@@ -1,0 +1,122 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "_TZ3000_bmfw9ykl",
+  "modelid": "TS0210",
+  "vendor": "Tuya",
+  "product": "Moes vibration sensor",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "ZHAPresence",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0500"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0402",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x0500"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "awake": true,
+          "parse": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "eval": "Item.val = Attr.val / 2"
+          },
+          "default": 0
+        },
+        {
+          "name": "config/duration",
+          "default": 1
+        },
+        {
+          "name": "config/enrolled",
+          "public": false
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/pending"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/lowbattery",
+          "awake": true
+        },
+        {
+          "name": "state/presence",
+          "awake": true,
+          "default": false
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 60,
+          "max": 3600,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0500"
+    }
+  ]
+}


### PR DESCRIPTION
- Product name: Moes vibration sensor
- Manufacturer: _TZ3000_bmfw9ykl
- Model identifier: TS0210

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/6270

WARNING: this device is a vibration sensor, but used as ZHAPresence. The users prefer this mode for the "auto return to false"