### PR TITLE
Adjusting swversion to a whole day refresh

### DIFF
--- a/devices/generic/items/attr_swversion_item.json
+++ b/devices/generic/items/attr_swversion_item.json
@@ -8,5 +8,5 @@
 	"description": "Firmware version of the device.",
 	"parse": {"fn": "zcl", "ep": 255, "cl": "0x0000", "at": "0x4000", "eval": "Item.val = Attr.val"},
 	"read": {"fn": "zcl", "ep": 0, "cl": "0x0000", "at": "0x4000"},
-	"refresh.interval": 84000
+	"refresh.interval": 86400
 }


### PR DESCRIPTION
Why 8400 sec instead of a whole day ?