### PR TITLE
Hue gamut-A ZLL lights

### DIFF
--- a/devices/generic/items/cap_color_gamut_type_item.json
+++ b/devices/generic/items/cap_color_gamut_type_item.json
@@ -7,6 +7,6 @@
     "description": "Color gamut type for Hue lights.",
     "parse": {
         "fn": "zcl", "ep": 0, "cl": "0x0300", "at": "0x0032",
-        "eval": "Item.val = Attr.val === 45317 ? 'C' : Attr.val === 44236 ? 'B' : Attr.val === 46138 ? 'A' : null"
+        "eval": "Item.val = Attr.val === 45317 ? 'C' : Attr.val === 44236 ? 'B' : Attr.val === 46137 ? 'A' : ''"
     }
 }

--- a/devices/philips/fc03_state.js
+++ b/devices/philips/fc03_state.js
@@ -29,6 +29,9 @@ if (attrid === 0x0002) {
         R.item('state/y').val = ZclFrame.at(i + 3) << 8 | ZclFrame.at(i + 2)
         i += 4
         len -= 4
+        if (mode === 0x000B && R.item('state/colormode').val !== 'hs') {
+          R.item('state/colormode').val = 'xy'
+        }
       }
       if (mode === 0x00AB && len >= 2) {
         const effect = ZclFrame.at(i + 1) << 8 | ZclFrame.at(i)
@@ -55,6 +58,10 @@ if (attrid === 0x0002) {
             break
         }
         R.item('state/colormode').val = 'effect'
+      } else {
+        if (R.item('state/effect').val !== 'colorloop') {
+          R.item('state/effect').val = 'none'
+        }
       }
       if (mode === 0x014B && len >= 2) {
         const vLen = ZclFrame.at(i)

--- a/devices/philips/light_zll_A.json
+++ b/devices/philips/light_zll_A.json
@@ -113,10 +113,41 @@
                     "name": "state/alert"
                 },
                 {
-                    "name": "state/on"
+                    "name": "state/on",
+                    "parse": {
+                        "fn": "zcl",
+                        "ep": "0x0b",
+                        "cl": "0xfc03",
+                        "mf": "0x100b",
+                        "at": "0x0002",
+                        "script": "fc03_state.js"
+                    },
+                    "read": {
+                        "fn": "zcl",
+                        "ep": "0x0b",
+                        "cl": "0xfc03",
+                        "mf": "0x100b",
+                        "at": "0x0002"
+                    },
+                    "refresh.interval": 5
                 },
                 {
-                    "name": "state/bri"
+                    "name": "state/bri",
+                    "read": {
+                        "fn": "none"
+                    }
+                },
+                {
+                    "name": "state/x",
+                    "read": {
+                        "fn": "none"
+                    }
+                },
+                {
+                    "name": "state/y",
+                    "read": {
+                        "fn": "none"
+                    }
                 },
                 {
                     "name": "state/colormode",
@@ -133,26 +164,12 @@
                         "cl": "0x0300",
                         "at": [
                             "0x4001",
-                            "0x0003",
-                            "0x0004",
                             "0x4002",
                             "0x4000",
                             "0x0001"
                         ]
                     },
-                    "refresh.interval": 5
-                },
-                {
-                    "name": "state/x",
-                    "read": {
-                        "fn": "none"
-                    }
-                },
-                {
-                    "name": "state/y",
-                    "read": {
-                        "fn": "none"
-                    }
+                    "refresh.interval": 60
                 },
                 {
                     "name": "state/effect",

--- a/devices/philips/light_zll_B.json
+++ b/devices/philips/light_zll_B.json
@@ -57,10 +57,10 @@
                     "name": "cap/alert/trigger_effect"
                 },
                 {
-                    "name": "cap/bri/move_with_onoff"
+                    "name": "cap/bri/min_dim_level"
                 },
                 {
-                    "name": "cap/bri/min_dim_level"
+                    "name": "cap/bri/move_with_onoff"
                 },
                 {
                     "name": "cap/color/capabilities"

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -3943,6 +3943,15 @@ void DeRestPluginPrivate::handleLightEvent(const Event &e)
 
                 const ResourceItemDescriptor &rid = item->descriptor();
 
+                if (item->needPushChange())
+                {
+                    // TODO make declarative
+                    if (strncmp(rid.suffix, "attr/", 5) == 0) { pushAttr = true; }
+                    if (strncmp(rid.suffix, "cap/", 4) == 0) { pushCap = true; }
+                    if (strncmp(rid.suffix, "config/", 7) == 0) { pushConfig = true; }
+                    if (strncmp(rid.suffix, "state/", 6) == 0) { pushState = true; }
+                }
+
                 if      (rid.suffix == RCapColorCapabilities) { icc = item; }
                 else if (rid.suffix == RCapColorXyBlueX) { ibluex = item; }
                 else if (rid.suffix == RCapColorXyBlueY) { ibluey = item; }
@@ -4049,15 +4058,6 @@ void DeRestPluginPrivate::handleLightEvent(const Event &e)
                             }
                         }
                     }
-
-                    if (item->needPushChange())
-                    {
-                        // TODO make declarative
-                        if (strncmp(rid.suffix, "attr/", 5) == 0) { pushAttr = true; }
-                        if (strncmp(rid.suffix, "cap/", 4) == 0) { pushCap = true; }
-                        if (strncmp(rid.suffix, "config/", 7) == 0) { pushConfig = true; }
-                        if (strncmp(rid.suffix, "state/", 6) == 0) { pushState = true; }
-                    }
                     item->clearNeedPush();
                 }
             }
@@ -4108,7 +4108,6 @@ void DeRestPluginPrivate::handleLightEvent(const Event &e)
                     capabilitiesColorXy["blue"] = blue;
                     capabilitiesColorXy["green"] = green;
                     capabilitiesColorXy["red"] = red;
-                    pushCap = true;
                     ibluex->clearNeedPush();
                     ibluey->clearNeedPush();
                     igreenx->clearNeedPush();


### PR DESCRIPTION
- Leverage 0xFC03 cluster for Hue gamut-A ZLL lights;
- Fix crash of deCONZ v2.20.1, due to JavaScript called from DDF for Hue gamut-A ZLL light;
- Fix missing `state` web socket notification when only `xy` has changed;
- Fix superfluous `capabilities` web socket notification with `websocketnotifyall` and only non-`capabilities` attribute changes.
- Reset `colormode` to `xy` and `effect` to `"none"` from 0xFC03/0x0002 instead of waiting for _Color Control_ to be polled.