### PR TITLE
Refactor switch selection to emit button events

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1384,125 +1384,26 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
             !(zclFrame.frameControl() & deCONZ::ZclFCDirectionServerToClient) ||
             (zclFrame.isProfileWideCommand() && zclFrame.commandId() == deCONZ::ZclReportAttributesId))
         {
-            Sensor *sensorNode = getSensorNodeForAddressEndpointAndCluster(ind.srcAddress(), ind.srcEndpoint(), ind.clusterId());
+            Sensor *sensorNode = nullptr;
+            quint8 count = 0;
 
-            if (!sensorNode)
+            for (Sensor &sensor: sensors)
             {
-                quint8 count = 0;
+                if (sensor.deletedState() != Sensor::StateNormal || !sensor.node())                             { continue; }
+                if (!isSameAddress(sensor.address(), ind.srcAddress()))                                         { continue; }
+                if (sensor.type() != QLatin1String("ZHASwitch"))                                                { continue; }
 
-                for (Sensor &sensor: sensors)
-                {
-                    if (sensor.deletedState() != Sensor::StateNormal || !sensor.node())                             { continue; }
-                    if (!isSameAddress(sensor.address(), ind.srcAddress()))                                         { continue; }
-                    if (sensor.type() != QLatin1String("ZHASwitch"))                                                { continue; }
+                sensorNode = &sensor;
+                count++;
+            }
 
-                    sensorNode = &sensor;
-                    count++;
-                }
-
-
-                if (count == 1)
-                {
-                    // Only 1 switch resource for the indication address found
-                }
-                else
-                {
-                    // No sensorNode found for endpoint - check for multiple endpoints mapped to the same resource
-                    sensorNode = getSensorNodeForAddress(ind.srcAddress());
-
-                    if (sensorNode && device && device->subDevices().size() == 1)
-                    {
-                        // no need to string match if there is only one sub-device
-                        DBG_Printf(DBG_INFO_L2, "Only 1 subdevice found\n");
-                    }
-                    else if (sensorNode)
-                    {
-                        quint16 mfCode = sensorNode->node() ? sensorNode->node()->nodeDescriptor().manufacturerCode() : 0;
-                        if (mfCode == VENDOR_SCHNEIDER)
-                        {  }
-                        else if (sensorNode->modelId().startsWith(QLatin1String("C4")) || // ubisys
-                                 sensorNode->modelId().startsWith(QLatin1String("RC 110")) || // innr RC 110
-                                 sensorNode->modelId().startsWith(QLatin1String("ICZB-RM")) || // icasa remote
-                                 sensorNode->modelId().startsWith(QLatin1String("ZGR904-S")) || // Envilar remote
-                                 sensorNode->modelId().startsWith(QLatin1String("ZGRC-KEY")) || // Sunricher remote
-                                 sensorNode->modelId().startsWith(QLatin1String("ZG2833PAC")) || // Sunricher C4
-                                 sensorNode->modelId() == QLatin1String("4512705") || // Namron remote control
-                                 sensorNode->modelId() == QLatin1String("4512726") || // Namron rotary switch
-                                 sensorNode->modelId().startsWith(QLatin1String("S57003")) || // SLC 4 ch remote switch
-                                 sensorNode->modelId().startsWith(QLatin1String("Lightify Switch Mini")) ||  // Osram 3 button remote
-                                 sensorNode->modelId().startsWith(QLatin1String("Switch 4x EU-LIGHTIFY")) || // Osram 4 button remote
-                                 sensorNode->modelId().startsWith(QLatin1String("Switch 4x-LIGHTIFY")) || // Osram 4 button remote
-                                 sensorNode->modelId().startsWith(QLatin1String("Switch-LIGHTIFY")) || // Osram 4 button remote
-                                 sensorNode->modelId().endsWith(QLatin1String("86opcn01")) ||          //Aqara Opple enable events from all multistate clusters
-                                 sensorNode->modelId() == QLatin1String("lumi.remote.b28ac1") ||    // Aqara wireless remote switch H1 (double rocker)
-                                 sensorNode->modelId() == QLatin1String("lumi.remote.b286acn01") || // Xiaomi dual button wall switch WXKG02LM 2018
-                                 sensorNode->modelId() == QLatin1String("lumi.remote.b286acn02") ||   // Xiaomi dual button wall switch WXKG02LM 2020
-                                 sensorNode->manufacturer() == QLatin1String("_TZ3000_bi6lpsew") ||
-                                 sensorNode->manufacturer() == QLatin1String("_TZ3400_keyjhapk") ||
-                                 sensorNode->manufacturer() == QLatin1String("_TYZB02_key8kk7r") ||
-                                 sensorNode->manufacturer() == QLatin1String("_TZ3400_keyjqthh") ||
-                                 sensorNode->manufacturer() == QLatin1String("_TZ3400_key8kk7r") ||
-                                 sensorNode->manufacturer() == QLatin1String("_TZ3000_rrjr1q0u") ||
-                                 sensorNode->manufacturer() == QLatin1String("_TZ3000_abci1hiu") ||
-                                 sensorNode->manufacturer() == QLatin1String("_TZ3000_vp6clf9d") ||
-                                 sensorNode->manufacturer() == QLatin1String("_TZ3000_wkai4ga5") ||
-                                 sensorNode->manufacturer() == QLatin1String("_TZ3000_peszejy7") ||
-                                 sensorNode->manufacturer() == QLatin1String("_TZ3000_qzjcsmar") ||
-                                 sensorNode->manufacturer() == QLatin1String("_TZ3000_owgcnkrh") ||
-                                 sensorNode->manufacturer() == QLatin1String("_TZ3000_adkvzooy") ||
-                                 sensorNode->manufacturer() == QLatin1String("_TZ3000_arfwfgoa") ||
-                                 sensorNode->manufacturer() == QLatin1String("_TZ3000_a7ouggvs") ||
-                                 sensorNode->manufacturer() == QLatin1String("_TZ3000_dfgbtub0") ||
-                                 sensorNode->manufacturer() == QLatin1String("_TZ3000_xabckq1v") ||
-                                 sensorNode->manufacturer() == QLatin1String("_TYZB02_keyjqthh"))
-                        {
-                            sensorNode = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), 0x01);
-                        }
-                        else if (sensorNode->modelId().startsWith(QLatin1String("D1")) || // ubisys
-                                 sensorNode->modelId().startsWith(QLatin1String("S1-R")))   // ubisys
-                        {
-                            sensorNode = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), 0x02);
-                        }
-                        else if (sensorNode->modelId().startsWith(QLatin1String("S2")))
-                        {
-                            sensorNode = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), 0x03);
-                        }
-                        else if ((ind.srcEndpoint() == 0x05 || ind.srcEndpoint() == 0x06) &&
-                                (sensorNode->modelId() == QLatin1String("lumi.switch.b1lacn02") || sensorNode->modelId() == QLatin1String("lumi.switch.b2lacn02")))
-                        {
-                            sensorNode = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), 0x04);
-                        }
-                        else if ((ind.srcEndpoint() == 0x06 || ind.srcEndpoint() == 0x07) && sensorNode->modelId() == QLatin1String("lumi.ctrl_ln2.aq1"))
-                        {
-                            // TODO Button maps should express one ZHASwitch is related to multiple endpoints.
-                            //      Or search for one ZHASwitch resource inside sensors.
-                            sensorNode = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), 0x05);
-                        }
-                        else if (sensorNode->modelId() == QLatin1String("lumi.switch.b1nacn02") || sensorNode->modelId() == QLatin1String("lumi.switch.b2nacn02"))
-                        {
-                            sensorNode = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), 0x05);
-                        }
-                        else if (sensorNode->modelId() == QLatin1String("RM01"))
-                        {
-                            sensorNode = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), 0x0A);
-                        }
-                        else if (sensorNode->modelId() == QLatin1String("lumi.switch.l2aeu1") || sensorNode->modelId() == QLatin1String("lumi.switch.n2aeu1"))
-                        {
-                            sensorNode = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), 0x29);
-                        }
-                        else
-                        {
-                            sensorNode = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), ind.srcEndpoint());
-
-                            if (sensorNode)
-                            {
-                                DBG_Printf(DBG_INFO_L2, "[WARNING] - Missing cluster in sensor fingerprint: 0x%016llX - 0x%04X (%s), endpoint: 0x%02X, cluster: 0x%04X, payload: %s, zclSeq: %u\n",
-                                            ind.srcAddress().ext(), ind.srcAddress().nwk(), qPrintable(sensorNode->modelId()), ind.srcEndpoint(), ind.clusterId(), qPrintable(zclFrame.payload().toHex().toUpper()), zclFrame.sequenceNumber());
-                            }
-                        }
-                    }
-                }
-
+            if (count == 1)
+            {
+                // Only 1 switch resource for the indication address found
+            }
+            else
+            {
+                sensorNode = getSensorNodeForAddressAndEndpoint(ind.srcAddress(), ind.srcEndpoint());
             }
 
             if (sensorNode)


### PR DESCRIPTION
This PR is enhancement and fix at the same time.

**Fix**
When already supported switches shall be exposed by 1 resource only (and previsouly had 2 or more resources), they would not work properly, if the model ID is not explicitly hardcoded. That's required so that all relevant events are redirected to a predefined endpoint used by the switch resource.

The new code only requires existence of a single switch resource, which is then automatically selected. Potential events do not get lost anymore.

**Enhancement**
The new code reduces complexity and processing time. Additionally, only `ZHASwitch` resources are now considered as allowed.
Instead of typically 3 sensor selection loops, there should only be 1 in most cases. The hardcoded model IDs are also not required anymore. If just 1 switch resource exists, it gets just selected. In case there are more switch resources, they are chosen by endpoint. Clusters are not considered to make the selection process independent from the sensor fingerprint.

The code has been tested with 2 switches, which originally had 1 resource for multiple endpoints and a hardcoded model ID. For the test, the sensor for 1 switch remained untouched. For the 2nd switch, it has been ensured that 1 resource per endpoint (3 in total) was available.