### PR TITLE
Enable usage of zigbee install codes

### DIFF
--- a/de_web.pro
+++ b/de_web.pro
@@ -64,7 +64,7 @@ macx {
 unix:LIBS +=  -L../.. -ldeCONZ
 
 unix:!macx {
-    LIBS += -lcrypt
+    LIBS += -lcrypt -lssl -lcrypto
 }
 
 TEMPLATE        = lib

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -116,4 +116,7 @@ unsigned endpointFromUniqueId(const QString &uniqueId);
 bool copyString(char *dst, size_t dstSize, const char *src, ssize_t srcSize = -1);
 inline bool isEmptyString(const char *str) { return str && str[0] == '\0'; }
 
+std::pair<uint, std::vector<unsigned char>> aesMmoHash(uint rlength, const std::vector<unsigned char>& result, std::vector<unsigned char>& data);
+QByteArray getMmoHashFromInstallCode(std::string hexString);
+
 #endif // UTILS_H

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -116,7 +116,7 @@ unsigned endpointFromUniqueId(const QString &uniqueId);
 bool copyString(char *dst, size_t dstSize, const char *src, ssize_t srcSize = -1);
 inline bool isEmptyString(const char *str) { return str && str[0] == '\0'; }
 
-std::pair<uint, std::vector<unsigned char>> aesMmoHash(uint rlength, const std::vector<unsigned char>& result, std::vector<unsigned char>& data);
+void aesMmoHash(uint &length, std::vector<unsigned char> &result, std::vector<unsigned char> &data);
 QByteArray getMmoHashFromInstallCode(std::string hexString);
 
 #endif // UTILS_H


### PR DESCRIPTION
As deconz was missing a native way to use zigbee install codes, this PR adds the respective capability. The code to derive the required hash is ported from the zigpy implementation.

It has been tested with the reference codes from zigbee smart energy standard and also with some device codes on Ubuntu 20.04 LTS. Also, A Bosch Thermostat II has been successfully paired.

It is important to include the CRC for the correct calculation, so all characters of the code are required.

![grafik](https://user-images.githubusercontent.com/4005212/224163078-8a7cc0c7-1c92-45e0-9a08-c21bbec887a0.png)



![grafik](https://user-images.githubusercontent.com/4005212/224052906-542f01b1-89f8-4e9a-bd15-49950ff81965.png)
