### PR TITLE
DDF add support for Aeotec Range Extender Zi

### DIFF
--- a/devices/aeotec/WG001-Z01_range_extender.json
+++ b/devices/aeotec/WG001-Z01_range_extender.json
@@ -1,0 +1,50 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "AL001",
+  "modelid": "WG001-Z01",
+  "product": "Aeotec Range Extender Zi",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_RANGE_EXTENDER",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/6785

- Product name: Range Extender Zi
- Manufacturer: AL001
- Model identifier: WG001-Z01