### PR TITLE
Force DDF supported presence sensors to state false during start

### DIFF
--- a/device_ddf_init.cpp
+++ b/device_ddf_init.cpp
@@ -243,6 +243,12 @@ bool DEV_InitDeviceFromDescription(Device *device, const DeviceDescription &ddf)
             {
                 continue;
             }
+            
+            if (item->descriptor().suffix == RStatePresence && item->toBool())
+            {
+                DBG_Printf(DBG_DDF, "sub-device: %s, presence state is true, reverting to false\n", qPrintable(uniqueId));
+                item->setValue(false);
+            }
 
             if (!ddfItem.defaultValue.isNull() && !ddfItem.writeParameters.isNull())
             {


### PR DESCRIPTION
For legacy sensors, `state/presence` was automatically reset while loading resource values from the DB. With DDF supported sensors, that particular function isn't called and the item keeps its (incorrect) value.

The PR ensures the item is similarly forced to `false` directly after it is loaded from the DB using the new load approach.