### PR TITLE
Update fyrtur_block-out_roller_blind.json

### DIFF
--- a/devices/ikea/fyrtur_block-out_roller_blind.json
+++ b/devices/ikea/fyrtur_block-out_roller_blind.json
@@ -65,7 +65,7 @@
             "at": "0x0008",
             "cl": "0x0102",
             "ep": 1,
-            "eval": "if (Attr.val == 100) { Item.val = true; } else { Item.val = false; }",
+            "eval": "Item.val = Attr.val > 0",
             "fn": "zcl"
           },
           "read": {


### PR DESCRIPTION
Behaviour of command "state/on" differs from IKEA kadrilj device .
Also before implement that devices as DDF, it was different. 
"state/on" must be true, if "state/lift" > 0