### PR TITLE
Fix ubisys J1 auto calibration

### DIFF
--- a/devices/generic/items/config_windowcoveringtype_item.json
+++ b/devices/generic/items/config_windowcoveringtype_item.json
@@ -5,6 +5,7 @@
 	"access": "RW",
 	"public": true,
 	"description": "The window cover type.",
+	"default" : 0,
 	"values": [
 		[0, "Roller Shade"],
 		[1, "Roller Shade two motors"],

--- a/devices/ubisys/j1_5502.json
+++ b/devices/ubisys/j1_5502.json
@@ -160,8 +160,7 @@
           "name": "config/reachable"
         },
         {
-          "name": "config/windowcoveringtype",
-          "default" : 0
+          "name": "config/windowcoveringtype"
         },
         {
           "name": "state/buttonevent"
@@ -333,6 +332,12 @@
           "min": 1,
           "max": 300,
           "change": "0x00000001"
+        },
+        {
+          "at": "0x000A",
+          "dt": "0x18",
+          "min": 1,
+          "max": 600
         }
       ]
     },

--- a/devices/ubisys/j1r_5602.json
+++ b/devices/ubisys/j1r_5602.json
@@ -160,8 +160,7 @@
           "name": "config/reachable"
         },
         {
-          "name": "config/windowcoveringtype",
-          "default" : 0
+          "name": "config/windowcoveringtype"
         },
         {
           "name": "state/buttonevent"
@@ -333,6 +332,12 @@
           "min": 1,
           "max": 300,
           "change": "0x00000001"
+        },
+        {
+          "at": "0x000A",
+          "dt": "0x18",
+          "min": 1,
+          "max": 600
         }
       ]
     },

--- a/general.xml
+++ b/general.xml
@@ -2004,6 +2004,10 @@
           </attribute>
           <attribute id="0x0008" name="Current Position Lift Percentage" type="u8" default="0x00" access="r" required="o" range="0,0x64"></attribute>
           <attribute id="0x0009" name="Current Position Tilt Percentage" type="u8" default="0x00" access="r" required="o" range="0,0x64"></attribute>
+          <attribute id="0x000a" name="Operational Status" type="bmp8" required="m" access="r">
+            <value name="Covering is opening" value="0"></value>
+            <value name="Covering is closing" value="1"></value>
+          </attribute>
         </attribute-set>
         <attribute-set id="0x0010" description="Window Covering Settings">
           <attribute id="0x0010" name="Installed Open Limit – Lift" type="u16" default="0x0000" access="r" required="o"></attribute>
@@ -2057,9 +2061,19 @@
             <value name="Unknown (7)" value="7"></value>
           </attribute>
           <attribute id="0xe014" name="Cover run time (open)" type="u16" default="0" required="m" access="rw" mfcode="0x105e"> </attribute>
-			    <attribute id="0xe015" name="Cover run time (close)" type="u16" default="0" required="m" access="rw" mfcode="0x105e"> </attribute>
+          <attribute id="0xe015" name="Cover run time (close)" type="u16" default="0" required="m" access="rw" mfcode="0x105e"> </attribute>
           <attribute id="0xe016" name="Unknown" type="u16" default="0" required="m" access="rw" mfcode="0x105e"> </attribute>
           <attribute id="0xe017" name="Unknown" type="u8" default="0" required="m" access="rw" mfcode="0x105e"> </attribute>
+        </attribute-set>
+        <attribute-set id="0x1000" description="Ubisys specific" mfcode="0x10f2">
+          <attribute id="0x1000" name="Turnaround Guard Time" type="u8" default="0" required="m" access="rw" mfcode="0x10f2"></attribute>
+          <attribute id="0x1001" name="Lift to Tilt Transition Steps" type="u16" default="0" required="m" access="rw" mfcode="0x10f2"></attribute>
+          <attribute id="0x1002" name="Total Steps" type="u16" default="0" required="m" access="rw" mfcode="0x10f2"></attribute>
+          <attribute id="0x1003" name="Lift to Tilt Transition Steps 2" type="u16" default="0" required="m" access="rw" mfcode="0x10f2"></attribute>
+          <attribute id="0x1004" name="Total Steps 2" type="u16" default="0" required="m" access="rw" mfcode="0x10f2"></attribute>
+          <attribute id="0x1005" name="Additional Steps" type="u8" default="0" required="m" access="rw" mfcode="0x10f2"></attribute>
+          <attribute id="0x1006" name="Inactive Power Threshold" type="u16" default="0" required="m" access="rw" mfcode="0x10f2"></attribute>
+          <attribute id="0x1007" name="Startup Steps" type="u16" default="0" required="m" access="rw" mfcode="0x10f2"></attribute>
         </attribute-set>
         <command id="0x00" dir="recv" name="Up / Open" required="m"></command>
         <command id="0x01" dir="recv" name="Down / Close" required="m"></command>

--- a/window_covering.cpp
+++ b/window_covering.cpp
@@ -661,7 +661,7 @@ void DeRestPluginPrivate::calibrateWindowCoveringNextStep()
 
     case 4:
         calibrationStep = 5;
-        QTimer::singleShot(2000, this, SLOT(calibrateWindowCoveringNextStep()));
+        QTimer::singleShot(4000, this, SLOT(calibrateWindowCoveringNextStep()));
         addTaskWindowCovering(task, 0x00 /*move up*/, 0, 0);
         break;
 
@@ -671,7 +671,7 @@ void DeRestPluginPrivate::calibrateWindowCoveringNextStep()
             calibrationStep = 6;
             addTaskWindowCovering(task, 0x01 /*move down*/, 0, 0);
         }
-        QTimer::singleShot(4000, this, SLOT(calibrateWindowCoveringNextStep()));
+        QTimer::singleShot(30000, this, SLOT(calibrateWindowCoveringNextStep()));
         break;
 
     case 6:
@@ -680,7 +680,7 @@ void DeRestPluginPrivate::calibrateWindowCoveringNextStep()
             calibrationStep = 7;
             addTaskWindowCovering(task, 0x00 /*move up*/, 0, 0);
         }
-        QTimer::singleShot(4000, this, SLOT(calibrateWindowCoveringNextStep()));
+        QTimer::singleShot(30000, this, SLOT(calibrateWindowCoveringNextStep()));
         break;
 
     case 7:
@@ -688,7 +688,7 @@ void DeRestPluginPrivate::calibrateWindowCoveringNextStep()
         {
             calibrationStep = 8;
         }
-        QTimer::singleShot(4000, this, SLOT(calibrateWindowCoveringNextStep()));
+        QTimer::singleShot(30000, this, SLOT(calibrateWindowCoveringNextStep()));
         break;
 
     case 8:


### PR DESCRIPTION
While the legacy code was able to check every couple of seconds if the cover is still moving, this code doesn't work anymore while using DDFs. As a quick workaround, it is assumed full open/close doesn't last longer than 30 secs.

With the amended time spans, auto calibration has been successfully tested. All in all not pretty, but easily implemented and functional.