### PR TITLE
DDF add variant for Develco ZHEMI101 external meter

### DIFF
--- a/devices/develco/zhemi101_external_meter_interface.json
+++ b/devices/develco/zhemi101_external_meter_interface.json
@@ -1,7 +1,7 @@
 {
   "schema": "devcap1.schema.json",
-  "manufacturername": ["Develco Products A/S", "frient A/S"],
-  "modelid": ["ZHEMI101", "ZHEMI101"],
+  "manufacturername": ["Develco Products A/S", "frient A/S", "Develco"],
+  "modelid": ["ZHEMI101", "ZHEMI101", "ZHEMI101"],
   "vendor": "Develco products",
   "product": "External meter interface ZHEMI101",
   "sleeper": false,


### PR DESCRIPTION
For my sensor the manufacturername is just "Develco"