### PR TITLE
DDF for generic Tuya smart curtain motor

### DIFF
--- a/devices/tuya/_TZE200_r0jdjrvi_covering.json
+++ b/devices/tuya/_TZE200_r0jdjrvi_covering.json
@@ -1,0 +1,80 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "_TZE200_r0jdjrvi",
+  "modelid": "TS0601",
+  "vendor": "Tuya",
+  "product": "Smart Curtain Controller",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_WINDOW_COVERING_DEVICE",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0xef00"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/reachable"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/open",
+          "write": { "fn": "tuya", "dpid": 1, "dt": "0x30", "eval": "if (Item.val) { 0 } else { 2 };" },
+          "parse": { "fn": "tuya", "dpid": 5, "eval": "if (Attr.val == 0) { true } else { false };" } 
+        },
+        {
+          "name": "state/lift",
+	  "range": [0,100],
+          "write": { "fn": "tuya", "dpid": 2, "dt": "0x2b", "eval": "Item.val;" },
+	  "parse": { "fn": "tuya", "dpid": 3, "eval": "Item.val = Attr.val;" },
+          "read": { "fn": "tuya" },
+          "refresh.interval": 300
+        },
+        {
+          "name": "config/motor_direction",
+          "write": { "fn": "tuya", "dpid": 4, "dt": "0x30", "eval": "Item.val;" }
+        },
+        {
+          "name": "config/lift_direction",
+          "write": { "fn": "tuya", "dpid": 6, "dt": "0x30", "eval": "Item.val;" }
+        },
+        {
+          "name": "state/error",
+          "parse": { "fn": "tuya", "dpid": 7, "eval": "Item.val;" }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Manufacturername is _TZE200_r0jdjrvi. (https://www.aliexpress.com/item/1005003796260309.html)

With this DDF I can successfully see the curtain state using the "lift" item. I can also open and close the curtains with those dpid's through the deconz GUI. I can't control them from the rest api however. As far as I understand window covering is treated specially in rest_lights.cpp bypassing the UseTuyaCluster? It also seems the DDF write function is only used for "config" items and not for "state" items in rest_lights.cpp. In short, I don't understand the code well enough to tackle it.
