### PR TITLE
DDF for HZC S900W-ZG water leak sensor

### DIFF
--- a/devices/hzc_electric/s900w-zg_water_leak_sensor.json
+++ b/devices/hzc_electric/s900w-zg_water_leak_sensor.json
@@ -1,0 +1,118 @@
+{
+    "schema": "devcap1.schema.json",
+    "manufacturername": "Shyugj",
+    "modelid": "WaterLeakageSensor-ZB3.0",
+    "vendor": "HZC electric",
+    "product": "S900W-ZG Water leak sensor",
+    "sleeper": true,
+    "status": "Silver",
+    "subdevices": [
+      {
+        "type": "$TYPE_WATER_LEAK_SENSOR",
+        "restapi": "/sensors",
+        "uuid": [
+          "$address.ext",
+          "0x01",
+          "0x0500"
+        ],
+        "fingerprint": {
+          "profile": "0x0104",
+          "device": "0x0402",
+          "endpoint": "0x01",
+          "in": [
+            "0x0000",
+            "0x0001",
+            "0x0003",
+            "0x0020",
+            "0x0500",
+            "0x0B05"
+          ]
+        },
+        "items": [
+          {
+            "name": "attr/id"
+          },
+          {
+            "name": "attr/lastannounced"
+          },
+          {
+            "name": "attr/lastseen"
+          },
+          {
+            "name": "attr/manufacturername"
+          },
+          {
+            "name": "attr/modelid"
+          },
+          {
+            "name": "attr/name"
+          },
+          {
+            "name": "attr/swversion"
+          },
+          {
+            "name": "attr/type"
+          },
+          {
+            "name": "attr/uniqueid"
+          },
+          {
+            "name": "config/battery",
+            "awake": true,
+            "parse": {
+              "cl": "0x0001",
+              "at": "0x0021",
+              "ep": 1,
+              "eval": "Item.val = Attr.val / 2"
+            }
+          },
+          {
+            "name": "config/enrolled"
+          },
+          {
+            "name": "config/on"
+          },
+          {
+            "name": "config/pending"
+          },
+          {
+            "name": "config/reachable"
+          },
+          {
+            "name": "state/lastupdated"
+          },
+          {
+            "name": "state/lowbattery",
+            "awake": true
+          },
+          {
+            "name": "state/water",
+            "awake": true
+          }
+        ]
+      }
+    ],
+    "bindings": [
+      {
+        "bind": "unicast",
+        "src.ep": 1,
+        "dst.ep": 1,
+        "cl": "0x0001",
+        "report": [
+          {
+            "at": "0x0021",
+            "dt": "0x20",
+            "min": 3600,
+            "max": 14400,
+            "change": "0x00000001"
+          }
+        ]
+      },
+      {
+        "bind": "unicast",
+        "src.ep": 1,
+        "dst.ep": 1,
+        "cl": "0x0500"
+      }
+    ]
+  }


### PR DESCRIPTION
Copied DDF from bosch water leak sensor and modified for this sensor.

These entities popped up in Home Assistant for the sensor (after a restart of HA):
![image](https://user-images.githubusercontent.com/47948035/228659454-478ac7f6-cdc4-4234-9e36-bd365877e16e.png)

Confirmed that `binary_sensor.water_x` works
Haven't confirmed the rest of the sensors.
`sensor.water_x_battery` is still 100% so can't be sure it works.
Not sure if `tampered` is relevant for this sensor. How could that trigger?

fixes #6831