### PR TITLE
Remove some legacy device code

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1836,7 +1836,6 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
                  modelId == QLatin1String("TS0202") || // Tuya sensor
                  modelId == QLatin1String("3AFE14010402000D") || // Konke presence sensor
                  modelId == QLatin1String("3AFE28010402000D") || // Konke presence sensor
-                 modelId == QLatin1String("lumi.airmonitor.acn01") ||      // Xiaomi Aqara TVOC Air Quality Monitor
                  modelId.startsWith(QLatin1String("GZ-PIR02")) ||          // Sercomm motion sensor
                  modelId.startsWith(QLatin1String("SZ-WTD02N_CAR")) ||     // Sercomm water sensor
                  modelId.startsWith(QLatin1String("3300")) ||          // Centralite contatc sensor
@@ -2280,43 +2279,6 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
 
         return sendConfigureReportingRequest(bt, {rq});
     }
-    else if (bt.binding.clusterId == VENDOR_CLUSTER_ID)
-    {
-        if (modelId == QLatin1String("de_spect")) // dresden elektronik spectral sensor
-        {
-            rq.dataType = deCONZ::Zcl8BitUint;
-            rq.attributeId = 0x0000; // sensor enabled
-            rq.minInterval = 1;
-            rq.maxInterval = 120;
-            rq.reportableChange8bit = 1;
-
-            ConfigureReportingRequest rq2;
-            rq2 = ConfigureReportingRequest();
-            rq2.dataType = deCONZ::Zcl16BitUint;
-            rq2.attributeId = 0x0001; // spectral x
-            rq2.minInterval = 1;
-            rq2.maxInterval = 300;
-            rq2.reportableChange16bit = 200;
-
-            ConfigureReportingRequest rq3;
-            rq3 = ConfigureReportingRequest();
-            rq3.dataType = deCONZ::Zcl16BitUint;
-            rq3.attributeId = 0x0002; // spectral x
-            rq3.minInterval = 1;
-            rq3.maxInterval = 300;
-            rq3.reportableChange16bit = 200;
-
-            ConfigureReportingRequest rq4;
-            rq4 = ConfigureReportingRequest();
-            rq4.dataType = deCONZ::Zcl16BitUint;
-            rq4.attributeId = 0x0003; // spectral x
-            rq4.minInterval = 1;
-            rq4.maxInterval = 300;
-            rq4.reportableChange16bit = 200;
-
-            return sendConfigureReportingRequest(bt, {rq, rq2, rq3, rq4});
-        }
-    }
 
     return false;
 }
@@ -2687,8 +2649,6 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId().startsWith(QLatin1String("3323")) ||
         sensor->modelId().startsWith(QLatin1String("3326-L")) ||
         sensor->modelId().startsWith(QLatin1String("3157100")) ||
-        // dresden elektronik
-        (sensor->manufacturer() == QLatin1String("dresden elektronik") && sensor->modelId() == QLatin1String("de_spect")) ||
         // GE
         (sensor->manufacturer() == QLatin1String("Jasco Products") && sensor->modelId() == QLatin1String("45856")) ||
         // NYCE
@@ -2711,7 +2671,6 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         // IKEA
         sensor->modelId().startsWith(QLatin1String("TRADFRI")) ||
         sensor->modelId().startsWith(QLatin1String("Remote Control N2")) || // STYRBAR
-        sensor->modelId().startsWith(QLatin1String("FYRTUR")) ||
         sensor->modelId().startsWith(QLatin1String("KADRILJ")) ||
         sensor->modelId().startsWith(QLatin1String("SYMFONISK")) ||
         // OSRAM
@@ -2795,7 +2754,6 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId().startsWith(QLatin1String("FLSZB-1")) ||   // water leak sensor
         sensor->modelId().startsWith(QLatin1String("MOSZB-1")) ||   // motion sensor
         sensor->modelId().startsWith(QLatin1String("ZHMS101")) ||   // Wattle (Develco) magnetic sensor
-        sensor->modelId() == QLatin1String("ZHEMI101") ||           // Wattle (Develco) External Meter Interface
         sensor->modelId().startsWith(QLatin1String("EMIZB-1")) ||   // EMI Norwegian HAN
         sensor->modelId().startsWith(QLatin1String("SMRZB-3")) ||   // Smart Relay DIN
         sensor->modelId().startsWith(QLatin1String("SMRZB-1")) ||   // Smart Cable
@@ -2883,7 +2841,6 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId().startsWith(QLatin1String("RH3052")) ||
         // Xiaomi
         sensor->modelId().startsWith(QLatin1String("lumi.switch.b1naus01")) ||
-        sensor->modelId() == QLatin1String("lumi.airmonitor.acn01") ||
         sensor->modelId() == QLatin1String("lumi.sensor_magnet.agl02") ||
         sensor->modelId() == QLatin1String("lumi.motion.agl04") ||
         sensor->modelId() == QLatin1String("lumi.flood.agl02") ||
@@ -2922,7 +2879,6 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId() == QLatin1String("CCT593011_AS") ||
         sensor->modelId() == QLatin1String("CCT595011_AS") ||
         // Immax
-        sensor->modelId() == QLatin1String("Plug-230V-ZB3.0") ||
         sensor->modelId() == QLatin1String("4in1-Sensor-ZB3.0") ||
         sensor->modelId() == QLatin1String("DoorWindow-Sensor-ZB3.0") ||
         // Casa.IA
@@ -3129,9 +3085,7 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
             {
                 val = sensor->getZclValue(*i, 0x0035); // battery alarm mask
             }
-            else if (sensor->modelId().startsWith(QLatin1String("AQSZB-1")) ||
-                     sensor->modelId().startsWith(QLatin1String("WISZB-1")) ||
-                     sensor->modelId().startsWith(QLatin1String("MOSZB-1")) ||
+            else if (sensor->modelId().startsWith(QLatin1String("MOSZB-1")) ||
                      sensor->modelId().startsWith(QLatin1String("FLSZB-1")) ||
                      sensor->modelId().startsWith(QLatin1String("HMSZB-1")) ||
                      sensor->modelId() == QLatin1String("MotionSensor51AU") ||
@@ -3199,13 +3153,6 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
                     val.maxInterval = static_cast<quint16>(item->toNumber());
                     val.maxInterval -= 5; // report before going presence: false
                 }
-            }
-        }
-        else if (*i == VENDOR_CLUSTER_ID)
-        {
-            if (sensor->modelId() == QLatin1String("de_spect")) // dresden elektronik spectral sensor
-            {
-                val = sensor->getZclValue(*i, 0x0000, sensor->fingerPrint().endpoint); // sensor enabled per endpoint
             }
         }
         else if (*i == BOSCH_AIR_QUALITY_CLUSTER_ID && sensor->modelId() == QLatin1String("AIR"))

--- a/database.cpp
+++ b/database.cpp
@@ -3508,10 +3508,6 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             {
                 clusterId = clusterId ? clusterId : BOSCH_AIR_QUALITY_CLUSTER_ID;
             }
-            else if (sensor.fingerPrint().hasInCluster(DEVELCO_AIR_QUALITY_CLUSTER_ID))  // Develco air quality sensor
-            {
-                clusterId = clusterId ? clusterId : DEVELCO_AIR_QUALITY_CLUSTER_ID;
-            }
             item = sensor.addItem(DataTypeString, RStateAirQuality);
             item = sensor.addItem(DataTypeUInt16, RStateAirQualityPpb);
         }
@@ -3745,19 +3741,12 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     (sensor.modelId() != QLatin1String("TS0121")) &&
                     (!sensor.modelId().startsWith(QLatin1String("BQZ10-AU"))) &&
                     (!sensor.modelId().startsWith(QLatin1String("ROB_200"))) &&
-                    (!sensor.modelId().startsWith(QLatin1String("lumi.plug.ma"))) &&
-                    (sensor.modelId() != QLatin1String("Plug-230V-ZB3.0")) &&
                     (sensor.modelId() != QLatin1String("lumi.switch.b1naus01")) &&
                     (sensor.modelId() != QLatin1String("lumi.switch.n0agl1")) &&
                     (!sensor.modelId().startsWith(QLatin1String("SPW35Z"))))
                 {
                     item = sensor.addItem(DataTypeInt16, RStatePower);
                     item->setValue(0);
-                }
-                if (sensor.modelId() == QLatin1String("ZHEMI101"))
-                {
-                    sensor.addItem(DataTypeUInt8, RConfigInterfaceMode)->setValue(1);
-                    sensor.addItem(DataTypeUInt16, RConfigPulseConfiguration)->setValue(1000);
                 }
                 if (sensor.modelId().startsWith(QLatin1String("EMIZB-1")))
                 {
@@ -3787,7 +3776,6 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     // hasVoltage = false;
                 }
                 else if (sensor.modelId() == QLatin1String("ZB-ONOFFPlug-D0005") ||
-                         sensor.modelId() == QLatin1String("Plug-230V-ZB3.0") ||
                          sensor.modelId() == QLatin1String("lumi.switch.b1nacn02") ||
                          sensor.modelId() == QLatin1String("lumi.switch.b2nacn02") ||
                          sensor.modelId() == QLatin1String("lumi.switch.b1naus01") ||
@@ -4102,7 +4090,6 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             if (!sensor.modelId().startsWith(QLatin1String("lumi.ctrl_")) &&
                 !sensor.modelId().startsWith(QLatin1String("lumi.plug")) &&
                 sensor.modelId() != QLatin1String("lumi.curtain") &&
-                sensor.modelId() != QLatin1String("lumi.sensor_natgas") &&
                 !sensor.modelId().startsWith(QLatin1String("lumi.relay.c")) &&
                 !sensor.type().endsWith(QLatin1String("Battery")))
             {
@@ -4182,8 +4169,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                 item = sensor.addItem(DataTypeBool, RStateLowBattery);
                 // don't set value -> null until reported
             }
-            else if (sensor.modelId() == QLatin1String("lumi.sensor_natgas") ||
-                     sensor.modelId() == QLatin1String("Bell"))
+            else if (sensor.modelId() == QLatin1String("Bell"))
             {
                 // Don't expose battery resource item for this device
             }

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -177,7 +177,6 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_CENTRALITE, "3328-G", emberMacPrefix }, // Centralite micro motion sensor
     { VENDOR_CENTRALITE, "3323", emberMacPrefix }, // Centralite contact sensor
     { VENDOR_DATEK, "ID Lock 150", silabs4MacPrefix }, // ID-Lock
-    { VENDOR_DDEL, "de_spect", silabs3MacPrefix }, // dresden elektronic spectral sensor
     { VENDOR_JASCO, "45856", celMacPrefix },
     { VENDOR_NONE, "FB56-DOS06HM1.3", tiMacPrefix }, // Feibit FB56-DOS06HM1.3 door/window sensor
     { VENDOR_NONE, "LM_",  tiMacPrefix },
@@ -210,7 +209,6 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_IKEA, "TRADFRI on/off switch", silabs1MacPrefix },
     { VENDOR_IKEA, "TRADFRI SHORTCUT Button", silabs4MacPrefix },
     { VENDOR_IKEA, "TRADFRI open/close remote", silabs1MacPrefix },
-    { VENDOR_IKEA, "FYRTUR", silabs1MacPrefix }, // smart blind
     { VENDOR_IKEA, "KADRILJ", silabs1MacPrefix }, // smart blind
     { VENDOR_IKEA, "KADRILJ", silabs4MacPrefix }, // smart blind
     { VENDOR_IKEA, "SYMFONISK", ikea2MacPrefix }, // sound controller
@@ -253,8 +251,6 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_JENNIC, "lumi.ctrl_neutral", jennicMacPrefix }, // Xiaomi Wall Switch (end-device)
     { VENDOR_JENNIC, "lumi.vibration", jennicMacPrefix }, // Xiaomi Aqara vibration/shock sensor
     { VENDOR_JENNIC, "lumi.sensor_wleak", jennicMacPrefix },
-    { VENDOR_JENNIC, "lumi.sensor_smoke", jennicMacPrefix },
-    { VENDOR_JENNIC, "lumi.sensor_natgas", jennicMacPrefix }, // Xiaomi Mija (HonneyWell) gas detector
     { VENDOR_JENNIC, "lumi.relay.c", jennicMacPrefix }, // Xiaomi Aqara LLKZMK11LM
     { VENDOR_JENNIC, "lumi.switch.b1lacn02", jennicMacPrefix }, // Xiaomi Aqara D1 1-gang (no neutral wire) QBKG21LM
     { VENDOR_JENNIC, "lumi.switch.b2lacn02", jennicMacPrefix }, // Xiaomi Aqara D1 2-gang (no neutral wire) QBKG22LM
@@ -265,7 +261,6 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_XIAOMI, "lumi.remote.b286opcn01", xiaomiMacPrefix }, // Xiaomi Aqara Opple WXCJKG11LM
     { VENDOR_XIAOMI, "lumi.remote.b486opcn01", xiaomiMacPrefix }, // Xiaomi Aqara Opple WXCJKG12LM
     { VENDOR_XIAOMI, "lumi.remote.b686opcn01", xiaomiMacPrefix }, // Xiaomi Aqara Opple WXCJKG13LM
-    { VENDOR_XIAOMI, "lumi.airmonitor.acn01", lumiMacPrefix}, // Xiaomi Aqara TVOC Air Quality Monitor VOCKQJK11LM
     { VENDOR_XIAOMI, "lumi.plug", xiaomiMacPrefix }, // Xiaomi smart plugs (router)
     { VENDOR_XIAOMI, "lumi.switch.b1naus01", xiaomiMacPrefix }, // Xiaomi Aqara ZB3.0 Smart Wall Switch Single Rocker WS-USC03
     // { VENDOR_XIAOMI, "lumi.curtain", jennicMacPrefix}, // Xiaomi curtain controller (router) - exposed only as light
@@ -349,7 +344,6 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_DEVELCO, "SMRZB-1", develcoMacPrefix }, // Develco Smart Cable
     { VENDOR_DEVELCO, "SIRZB-1", develcoMacPrefix }, // Develco siren
     { VENDOR_DEVELCO, "ZHMS101", develcoMacPrefix }, // Wattle (Develco) magnetic sensor
-    { VENDOR_DEVELCO, "ZHEMI101", develcoMacPrefix }, // Wattle (Develco) External Meter Interface
     { VENDOR_DEVELCO, "MotionSensor51AU", develcoMacPrefix }, // Aurora (Develco) motion sensor
     { VENDOR_DEVELCO, "Smart16ARelay51AU", develcoMacPrefix }, // Aurora (Develco) smart plug
     { VENDOR_DATEK_WIRLESS, "PoP", konkeMacPrefix }, // Apex Smart Plug
@@ -475,7 +469,6 @@ static const SupportedDevice supportedDevices[] = {
     { VENDOR_SENGLED_OPTOELEC, "E1D-", zhejiangMacPrefix }, // Sengled contact sensor
     { VENDOR_SENGLED_OPTOELEC, "E1E-", zhejiangMacPrefix }, // Sengled Smart Light Switch
     { VENDOR_SENGLED_OPTOELEC, "Z01-A19", zhejiangMacPrefix }, // Sengled SMART LED Z01-A19NAE26
-    { VENDOR_JENNIC, "Plug-230V-ZB3.0", silabs2MacPrefix }, // Immax NEO ZB3.0 smart plug
     { VENDOR_JENNIC, "4in1-Sensor-ZB3.0", emberMacPrefix }, // Immax NEO ZB3.0 4 in 1 sensor
     { VENDOR_JENNIC, "DoorWindow-Sensor-ZB3.0", emberMacPrefix }, // Immax NEO ZB3.0 window/door sensor 07045L
     { VENDOR_WAXMAN, "leakSMART Water Sensor V2", celMacPrefix }, // WAXMAN LeakSMART v2
@@ -3346,8 +3339,7 @@ void DeRestPluginPrivate::setLightNodeStaticCapabilities(LightNode *lightNode)
         lightNode->addItem(DataTypeUInt8, RStateSat);
         lightNode->addItem(DataTypeString, RStateEffect)->setValue(RStateEffectValues[R_EFFECT_NONE]);
     }
-    else if (modelId.startsWith(QLatin1String("KADRILJ")) ||
-             modelId.startsWith(QLatin1String("FYRTUR")))
+    else if (modelId.startsWith(QLatin1String("KADRILJ")))
     {
         item = lightNode->addItem(DataTypeBool, RCapSleeper);
         if (item)
@@ -5816,11 +5808,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     {
                         fpWaterSensor.inClusters.push_back(IAS_ZONE_CLUSTER_ID);
                     }
-                    else if (node->nodeDescriptor().manufacturerCode() == VENDOR_JENNIC &&
-                             modelId.startsWith(QLatin1String("lumi.sensor_smoke")))
-                    {
-                        fpFireSensor.inClusters.push_back(IAS_ZONE_CLUSTER_ID);
-                    }
                     else if (node->nodeDescriptor().manufacturerCode() == VENDOR_SINOPE &&
                              modelId.startsWith(QLatin1String("WL4200")))
                     {
@@ -5830,11 +5817,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                              modelId.endsWith(QLatin1String("86opcn01")))   // Aqara Opple switches
                     {
                         fpSwitch.inClusters.push_back(MULTISTATE_INPUT_CLUSTER_ID);
-                    }
-                    else if (node->nodeDescriptor().manufacturerCode() == VENDOR_JENNIC &&
-                             modelId.startsWith(QLatin1String("lumi.sensor_natgas")))
-                    {
-                        fpCarbonMonoxideSensor.inClusters.push_back(IAS_ZONE_CLUSTER_ID);
                     }
                     else if (isTuyaManufacturerName(manufacturer))
                     {
@@ -5913,8 +5895,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                 {
                     fpAirQualitySensor.inClusters.push_back(ci->id());
                     fpAlarmSensor.inClusters.push_back(ci->id());
-                    if (node->nodeDescriptor().manufacturerCode() == VENDOR_IKEA &&
-                        (modelId.startsWith(QLatin1String("FYRTUR")) || modelId.startsWith(QLatin1String("KADRILJ"))))
+                    if (node->nodeDescriptor().manufacturerCode() == VENDOR_IKEA && modelId.startsWith(QLatin1String("KADRILJ")))
                     {
                         fpBatterySensor.inClusters.push_back(ci->id());
                     }
@@ -6045,8 +6026,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                         fpAncillaryControlSensor.inClusters.push_back(ci->id());
                     }
                     else if (modelId.startsWith(QLatin1String("CO_")) ||                   // Heiman CO sensor
-                        modelId.startsWith(QLatin1String("COSensor")) ||              // Heiman CO sensor (newer model)
-                        modelId.startsWith(QLatin1String("lumi.sensor_natgas")))      // Xiaomi Mi gas detector
+                             modelId.startsWith(QLatin1String("COSensor")))                // Heiman CO sensor (newer model)
                     {
                         fpCarbonMonoxideSensor.inClusters.push_back(ci->id());
                     }
@@ -6109,7 +6089,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                              modelId == QLatin1String("358e4e3e03c644709905034dae81433e") || // Orvibo Combustible Gas Sensor
                              modelId == QLatin1String("c3442b4ac59b4ba1a83119d938f283ab") || // ORVIBO SF30 smoke sensor
                              modelId.startsWith(QLatin1String("LH05121")) ||                 // iHorn smoke detector
-                             modelId.startsWith(QLatin1String("lumi.sensor_smoke")) ||       // Xiaomi Mi smoke sensor
                              modelId.startsWith(QLatin1String("TS0204")) ||                  // Tuya gas sensor
                              modelId.startsWith(QLatin1String("TS0205")) ||                  // Tuya smoke sensor
                              modelId == QLatin1String("SD8SC_00.00.03.09TC") ||              // Centralite smoke sensor
@@ -6321,10 +6300,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     {
                         fpConsumptionSensor.inClusters.push_back(ci->id());
                     }
-                    else if (modelId == QLatin1String("lumi.airmonitor.acn01"))
-                    {
-                        fpAirQualitySensor.inClusters.push_back(ci->id());
-                    }
                 }
                     break;
 
@@ -6457,18 +6432,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                     if(modelId != QLatin1String("VOC_Sensor"))
                     {
                         fpThermostatSensor.inClusters.push_back(ci->id());
-                    }
-                }
-                    break;
-
-                case VENDOR_CLUSTER_ID:
-                {
-                    if (node->nodeDescriptor().manufacturerCode() == VENDOR_DDEL && modelId == QLatin1String("de_spect"))
-                    {
-                        if (i->endpoint() <= 0x03)
-                        {
-                            fpSpectralSensor.inClusters.push_back(ci->id());
-                        }
                     }
                 }
                     break;
@@ -7248,8 +7211,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             sensorNode.addItem(DataTypeBool, RStateLowBattery);
             // don't set value -> null until reported
         }
-        else if (sensorNode.modelId() == QLatin1String("lumi.sensor_natgas") ||
-                 sensorNode.modelId() == QLatin1String("Bell"))
+        else if (sensorNode.modelId() == QLatin1String("Bell"))
         {
             // Don't expose battery resource item for this device
         }
@@ -7338,23 +7300,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
         item->setValue(R_THOLDDARK_DEFAULT);
         item = sensorNode.addItem(DataTypeUInt16, RConfigTholdOffset);
         item->setValue(R_THOLDOFFSET_DEFAULT);
-    }
-    else if (sensorNode.type().endsWith(QLatin1String("Spectral")))
-    {
-        if (sensorNode.fingerPrint().hasInCluster(VENDOR_CLUSTER_ID))
-        {
-            clusterId = VENDOR_CLUSTER_ID;
-        }
-
-        if (modelId == QLatin1String("de_spect"))
-        {
-            item = sensorNode.item(RConfigOn); // default off
-            item->setValue(false);
-        }
-
-        sensorNode.addItem(DataTypeUInt16, RStateSpectralX);
-        sensorNode.addItem(DataTypeUInt16, RStateSpectralY);
-        sensorNode.addItem(DataTypeUInt16, RStateSpectralZ);
     }
     else if (sensorNode.type().endsWith(QLatin1String("Temperature")))
     {
@@ -7558,8 +7503,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                 (modelId != QLatin1String("TS0121")) &&
                 (!modelId.startsWith(QLatin1String("BQZ10-AU"))) &&
                 (!modelId.startsWith(QLatin1String("ROB_200"))) &&
-                (!modelId.startsWith(QLatin1String("lumi.plug.ma"))) &&
-                (modelId != QLatin1String("Plug-230V-ZB3.0")) &&
                 (modelId != QLatin1String("lumi.switch.b1nacn02")) &&
                 (modelId != QLatin1String("lumi.switch.b2nacn02")) &&
                 (modelId != QLatin1String("lumi.switch.b1naus01")) &&
@@ -7567,11 +7510,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                 (!modelId.startsWith(QLatin1String("SPW35Z"))))
             {
                 item = sensorNode.addItem(DataTypeInt16, RStatePower);
-            }
-            if (modelId == QLatin1String("ZHEMI101"))
-            {
-                sensorNode.addItem(DataTypeUInt8, RConfigInterfaceMode)->setValue(1);
-                sensorNode.addItem(DataTypeUInt16, RConfigPulseConfiguration)->setValue(1000);
             }
             if (modelId.startsWith(QLatin1String("EMIZB-1")))
             {
@@ -7592,7 +7530,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             item = sensorNode.addItem(DataTypeInt16, RStatePower);
             if ( (!modelId.startsWith(QLatin1String("Plug"))) &&
                  (!modelId.startsWith(QLatin1String("ZB-ONOFFPlug-D0005"))) &&
-                 (modelId != QLatin1String("Plug-230V-ZB3.0")) &&
                  (modelId != QLatin1String("lumi.switch.b1naus01")) &&
                  (modelId != QLatin1String("lumi.switch.b1nacn02")) &&
                  (modelId != QLatin1String("lumi.switch.b2nacn02")) &&
@@ -7607,11 +7544,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
         {
             clusterId = ANALOG_INPUT_CLUSTER_ID;
             item = sensorNode.addItem(DataTypeInt16, RStatePower);
-            if (modelId.startsWith(QLatin1String("lumi.plug.mm"))) // Only available for new ZB3.0 Mi smart plugs?
-            {
-                item = sensorNode.addItem(DataTypeUInt16, RStateVoltage);
-                item = sensorNode.addItem(DataTypeUInt16, RStateCurrent);
-            }
         }
     }
     else if (sensorNode.type().endsWith(QLatin1String("Thermostat")))
@@ -7872,8 +7804,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             clusterId = ANALOG_INPUT_CLUSTER_ID;
         }
 
-        if (modelId == QLatin1String("lumi.airmonitor.acn01") ||    // Xiaomi Aqara TVOC Air Quality Monitor
-            (node->nodeDescriptor().manufacturerCode() == VENDOR_BOSCH2 && modelId == QLatin1String("AIR")))  // Bosch air quality sensor
+        if (node->nodeDescriptor().manufacturerCode() == VENDOR_BOSCH2 && modelId == QLatin1String("AIR"))  // Bosch air quality sensor
         {
             item = sensorNode.addItem(DataTypeString, RStateAirQuality);
             item = sensorNode.addItem(DataTypeUInt16, RStateAirQualityPpb);
@@ -8006,7 +7937,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
             !sensorNode.modelId().startsWith(QLatin1String("lumi.plug")) &&
             !sensorNode.modelId().startsWith(QLatin1String("lumi.relay.c")) &&
             sensorNode.modelId() != QLatin1String("lumi.curtain") &&
-            sensorNode.modelId() != QLatin1String("lumi.sensor_natgas") &&
             !sensorNode.type().endsWith(QLatin1String("Battery")))
         {
             sensorNode.addItem(DataTypeUInt8, RConfigBattery);
@@ -9448,39 +9378,6 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                         updateSensorEtag(&*i);
                                     }
                                 }
-                                else if (i->modelId() == QLatin1String("lumi.airmonitor.acn01"))
-                                {
-                                    quint16 level = static_cast<quint16>(ia->numericValue().real);
-                                    ResourceItem *item = i->item(RStateAirQualityPpb);
-
-                                    if (item && item->toNumber() != level)
-                                    {
-                                        item->setValue(level);
-                                        QString airQuality;
-
-                                        const auto match = lessThenKeyValue(level, RStateAirQualityVocLevelGer);
-
-                                        if (match.key)
-                                        {
-                                            airQuality = match.value;
-                                        }
-
-                                        ResourceItem *item = i->item(RStateAirQuality);
-
-                                        if (item && item->toString() != airQuality)
-                                        {
-                                            item->setValue(airQuality);
-                                            enqueueEvent(Event(RSensors, RStateAirQuality, i->id(), item));
-                                        }
-
-                                        i->updateStateTimestamp();
-                                        i->setNeedSaveDatabase(true);
-                                        enqueueEvent(Event(RSensors, RStateAirQualityPpb, i->id(), item));
-                                        enqueueEvent(Event(RSensors, RStateLastUpdated, i->id()));
-                                    }
-
-                                    updateSensorEtag(&*i);
-                                }
                             }
                         }
                     }
@@ -9809,68 +9706,6 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                 }
                             }
                         }
-                        if (updated)
-                        {
-                            i->updateStateTimestamp();
-                            i->setNeedSaveDatabase(true);
-                            enqueueEvent(Event(RSensors, RStateLastUpdated, i->id()));
-                            updateSensorEtag(&*i);
-                        }
-                    }
-                    else if (event.clusterId() == VENDOR_CLUSTER_ID && i->modelId() == QLatin1String("de_spect"))
-                    {
-                        bool updated = false;
-
-                        if (event.endpoint() != i->fingerPrint().endpoint)
-                        {
-                            continue;
-                        }
-
-                        for (;ia != enda; ++ia)
-                        {
-                            if (std::find(event.attributeIds().begin(),
-                                          event.attributeIds().end(),
-                                          ia->id()) == event.attributeIds().end())
-                            {
-                                continue;
-                            }
-
-                            if (updateType != NodeValue::UpdateInvalid)
-                            {
-                                i->setZclValue(updateType, event.endpoint(), event.clusterId(), ia->id(), ia->numericValue());
-                            }
-
-                            if (ia->id() == 0x0000 && ia->dataType() == deCONZ::Zcl8BitUint) // sensor enabled / disabled
-                            {
-                                ResourceItem *item = i->item(RConfigOn);
-                                if (item)
-                                {
-                                    bool enabled = ia->numericValue().u8 > 0 ? true : false;
-                                    if (item->toBool() != enabled)
-                                    {
-                                        DBG_Printf(DBG_INFO, "0x%016llX: enabled state (%u) != config.on (%u)\n", event.node()->address().ext(), enabled, item->toBool());
-                                        deCONZ::ZclAttribute attr = *ia;
-                                        attr.setValue(static_cast<quint64>(enabled ? 0 : 1)); // toggle
-                                        writeAttribute(&*i, i->fingerPrint().endpoint, VENDOR_CLUSTER_ID, attr);
-                                        processTasks();
-                                    }
-                                }
-                            }
-                            else if (ia->id() >= 0x0001 && ia->id() <= 0x0003 && ia->dataType() == deCONZ::Zcl16BitUint) // Input actions
-                            {
-                                // 0x0001: X, 0x0002: Y, 0x0003: Z
-                                const char *r[] = { RStateSpectralX, RStateSpectralY, RStateSpectralZ };
-
-                                ResourceItem *item = i->item(r[ia->id() - 1]);
-                                if (item)
-                                {
-                                    item->setValue(ia->numericValue().u16);
-                                    enqueueEvent(Event(RSensors, r[ia->id() - 1], i->id(), item));
-                                    updated = true;
-                                }
-                            }
-                        }
-
                         if (updated)
                         {
                             i->updateStateTimestamp();

--- a/power_configuration.cpp
+++ b/power_configuration.cpp
@@ -124,7 +124,6 @@ void DeRestPluginPrivate::handlePowerConfigurationClusterIndication(const deCONZ
                 uint divider = 2;
 
                 if (sensor.modelId().startsWith(QLatin1String("TRADFRI")) || // IKEA
-                    sensor.modelId().startsWith(QLatin1String("FYRTUR")) || // IKEA
                     sensor.modelId().startsWith(QLatin1String("KADRILJ")) || // IKEA
                     sensor.modelId().startsWith(QLatin1String("SYMFONISK")) || // IKEA
                     sensor.modelId().startsWith(QLatin1String("Remote Control N2")) || // IKEA

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -1919,19 +1919,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                 {
                     if (!devManaged)
                     {
-                        if (sensor->modelId().startsWith(QLatin1String("ZHEMI101")))
-                        {
-                            const auto match = matchKeyValue(data.uinteger, RConfigInterfaceModeValuesZHEMI);
-
-                            if (match.key)
-                            {
-                                if (addTaskSimpleMeteringReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, METERING_ATTRID_INTERFACE_MODE, deCONZ::Zcl16BitEnum, match.value, VENDOR_DEVELCO))
-                                {
-                                    updated = true;
-                                }
-                            }
-                        }
-                        else if (sensor->modelId().startsWith(QLatin1String("EMIZB-1")))
+                        if (sensor->modelId().startsWith(QLatin1String("EMIZB-1")))
                         {
                             const auto match = matchKeyValue(data.uinteger, RConfigInterfaceModeValuesEMIZB);
 

--- a/simple_metering.cpp
+++ b/simple_metering.cpp
@@ -3,9 +3,6 @@
 #include "device_descriptions.h"
 #include "simple_metering.h"
 
-const std::array<KeyValMapInt, 8> RConfigInterfaceModeValuesZHEMI = { { {1, PULSE_COUNTING_ELECTRICITY}, {2, PULSE_COUNTING_GAS}, {3, PULSE_COUNTING_WATER},
-                                                                               {4, KAMSTRUP_KMP}, {5, LINKY}, {6, DLMS_COSEM}, {7, DSMR_23}, {8, DSMR_40} } };
-
 const std::array<KeyValMapInt, 5> RConfigInterfaceModeValuesEMIZB = { { {1, NORWEGIAN_HAN}, {2, NORWEGIAN_HAN_EXTRA_LOAD}, {3, AIDON_METER},
                                                                                {4, KAIFA_KAMSTRUP_METERS}, {5, AUTO_DETECT} } };
 
@@ -93,8 +90,7 @@ void DeRestPluginPrivate::handleSimpleMeteringClusterIndication(const deCONZ::Ap
                     consumption = static_cast<quint64>(round((double)consumption / 10.0)); // 0.1 Wh -> Wh
                     DDF_AnnoteZclParse(sensor, item, ind.srcEndpoint(), ind.clusterId(), attrId, "Item.val = Math.round(Attr.val / 10)");
                 }
-                else if (modelId == QLatin1String("Plug-230V-ZB3.0") ||           // Immax
-                         modelId == QLatin1String("Smart plug Zigbee PE") ||      // Niko Smart Plug 552-80699
+                else if (modelId == QLatin1String("Smart plug Zigbee PE") ||      // Niko Smart Plug 552-80699
                          modelId == QLatin1String("TS011F") ||                    // Tuya / Blitzwolf 
                          modelId == QLatin1String("TS0121"))                      // Tuya / Blitzwolf
                 {
@@ -129,26 +125,6 @@ void DeRestPluginPrivate::handleSimpleMeteringClusterIndication(const deCONZ::Ap
             }
                 break;
 
-            case METERING_ATTRID_PULSE_CONFIGURATION:
-            {
-                if (zclFrame.manufacturerCode() == VENDOR_DEVELCO && modelId == QLatin1String("ZHEMI101"))
-                {
-                    quint16 pulseConfiguration = attr.numericValue().u16;
-                    item = sensor->item(RConfigPulseConfiguration);
-
-                    DDF_AnnoteZclParse(sensor, item, ind.srcEndpoint(), ind.clusterId(), attrId, "Item.val = Attr.val");
-
-                    if (item && item->toNumber() != pulseConfiguration)
-                    {
-                        item->setValue(pulseConfiguration);
-                        enqueueEvent(Event(RSensors, RConfigPulseConfiguration, sensor->id(), item));
-                        configUpdated = true;
-                    }
-                }
-                sensor->setZclValue(updateType, ind.srcEndpoint(), METERING_CLUSTER_ID, attrId, attr.numericValue());
-            }
-                break;
-
             case METERING_ATTRID_INTERFACE_MODE:
             {
                 if (zclFrame.manufacturerCode() == VENDOR_DEVELCO)
@@ -157,18 +133,7 @@ void DeRestPluginPrivate::handleSimpleMeteringClusterIndication(const deCONZ::Ap
                     item = sensor->item(RConfigInterfaceMode);
                     quint8 mode = 0;
                     
-                    if(modelId == QLatin1String("ZHEMI101"))
-                    {
-                        if      (interfaceMode == PULSE_COUNTING_ELECTRICITY)   { mode = 1; }
-                        else if (interfaceMode == PULSE_COUNTING_GAS)           { mode = 2; }
-                        else if (interfaceMode == PULSE_COUNTING_WATER)         { mode = 3; }
-                        else if (interfaceMode == KAMSTRUP_KMP)                 { mode = 4; }
-                        else if (interfaceMode == LINKY)                        { mode = 5; }
-                        else if (interfaceMode == DLMS_COSEM)                   { mode = 6; }
-                        else if (interfaceMode == DSMR_23)                      { mode = 7; }
-                        else if (interfaceMode == DSMR_40)                      { mode = 8; }
-                    }
-                    else if (modelId.startsWith(QLatin1String("EMIZB-1")))
+                    if (modelId.startsWith(QLatin1String("EMIZB-1")))
                     {
                         if      (interfaceMode == NORWEGIAN_HAN)            { mode = 1; }
                         else if (interfaceMode == NORWEGIAN_HAN_EXTRA_LOAD) { mode = 2; }

--- a/simple_metering.h
+++ b/simple_metering.h
@@ -5,26 +5,16 @@
 
 //Attribute IDs
 #define METERING_ATTRID_CURRENT_SUMMATION_DELIVERED             0x0000
-#define METERING_ATTRID_PULSE_CONFIGURATION                     0x0300  // Develco specific
 #define METERING_ATTRID_INTERFACE_MODE                          0x0302  // Develco specific
 #define METERING_ATTRID_INSTANTANEOUS_DEMAND                    0x0400
 
 // Values for attribute Interface Mode (0x0302), Develco specific
-#define PULSE_COUNTING_ELECTRICITY      0x0000
-#define PULSE_COUNTING_GAS              0x0001
-#define PULSE_COUNTING_WATER            0x0002
-#define KAMSTRUP_KMP                    0x0100
-#define LINKY                           0x0101
-#define DLMS_COSEM                      0x0102
-#define DSMR_23                         0x0103
-#define DSMR_40                         0x0104
 #define NORWEGIAN_HAN                   0x0200
 #define NORWEGIAN_HAN_EXTRA_LOAD        0x0201
 #define AIDON_METER                     0x0202
 #define KAIFA_KAMSTRUP_METERS           0x0203
 #define AUTO_DETECT                     0x0204
 
-extern const std::array<KeyValMapInt, 8> RConfigInterfaceModeValuesZHEMI;
 extern const std::array<KeyValMapInt, 5> RConfigInterfaceModeValuesEMIZB;
 
 #endif // SIMPLE_METERING_H


### PR DESCRIPTION
Remove legacy device code for the following (DDF supported) devices:

- Develco external meter interface
- Xiaomi Aqara TVOC Air Quality Monitor
- IKEA Fyrtur
- Xiaomi Aqara H1 wireless switch
- Immax neo smart plug
- DE spectral sensor
- Xiaomi Honeywell smoke and gas sensor
- Xiaomi smart plugs