### PR TITLE
DDF for GLEDOPTO RGBW

### DIFF
--- a/devices/gledopto/gledopto.json
+++ b/devices/gledopto/gledopto.json
@@ -53,10 +53,12 @@
                     "name": "cap/color/capabilities"
                 },
                 {
-                    "name": "cap/color/ct/max"
+                    "name": "cap/color/ct/max",
+                    "static": 500
                 },
                 {
-                    "name": "cap/color/ct/min"
+                    "name": "cap/color/ct/min",
+                    "static": 153
                 },
                 {
                     "name": "cap/color/xy/blue_x",

--- a/devices/gledopto/gledopto.json
+++ b/devices/gledopto/gledopto.json
@@ -1,7 +1,13 @@
 {
     "schema": "devcap1.schema.json",
-    "manufacturername": "GLEDOPTO",
-    "modelid": "GLEDOPTO",
+    "manufacturername": [
+        "GLEDOPTO",
+        "GLEDOPTO"
+    ],
+    "modelid": [
+        "GLEDOPTO",
+        "RGBW"
+    ],
     "matchexpr": "R.endpoints.indexOf(0x0a) !== -1 && R.endpoints.indexOf(0x0b) !== -1",
     "product": "GLEDOPTO floodlight",
     "sleeper": false,

--- a/devices/gledopto/gledopto.json
+++ b/devices/gledopto/gledopto.json
@@ -1,0 +1,205 @@
+{
+    "schema": "devcap1.schema.json",
+    "manufacturername": "GLEDOPTO",
+    "modelid": "GLEDOPTO",
+    "matchexpr": "R.endpoints.indexOf(0x0a) !== -1 && R.endpoints.indexOf(0x0b) !== -1",
+    "product": "GLEDOPTO floodlight",
+    "sleeper": false,
+    "status": "Gold",
+    "subdevices": [
+        {
+            "type": "$TYPE_EXTENDED_COLOR_LIGHT",
+            "restapi": "/lights",
+            "uuid": [
+                "$address.ext",
+                "0x0b"
+            ],
+            "items": [
+                {
+                    "name": "attr/id"
+                },
+                {
+                    "name": "attr/lastannounced"
+                },
+                {
+                    "name": "attr/lastseen"
+                },
+                {
+                    "name": "attr/manufacturername"
+                },
+                {
+                    "name": "attr/modelid",
+                    "static": "RGBW"
+                },
+                {
+                    "name": "attr/name"
+                },
+                {
+                    "name": "attr/swversion"
+                },
+                {
+                    "name": "attr/type"
+                },
+                {
+                    "name": "attr/uniqueid"
+                },
+                {
+                    "name": "cap/color/capabilities"
+                },
+                {
+                    "name": "cap/color/ct/max"
+                },
+                {
+                    "name": "cap/color/ct/min"
+                },
+                {
+                    "name": "cap/color/xy/blue_x",
+                    "static": 9896
+                },
+                {
+                    "name": "cap/color/xy/blue_y",
+                    "static": 1488
+                },
+                {
+                    "name": "cap/color/xy/green_x",
+                    "static": 9090
+                },
+                {
+                    "name": "cap/color/xy/green_y",
+                    "static": 53398
+                },
+                {
+                    "name": "cap/color/xy/red_x",
+                    "static": 45914
+                },
+                {
+                    "name": "cap/color/xy/red_y",
+                    "static": 19615
+                },
+                {
+                    "name": "state/alert"
+                },
+                {
+                    "name": "state/bri"
+                },
+                {
+                    "name": "state/colormode",
+                    "parse": {
+                        "fn": "zcl",
+                        "ep": "0x0b",
+                        "cl": "0x0300",
+                        "at": "0x4001",
+                        "eval": "if (Attr.val <= 3) Item.val = ['hs', 'xy', 'ct', 'xy'][Attr.val]"
+                    },
+                    "read": {
+                        "fn": "zcl",
+                        "ep": "0x0b",
+                        "cl": "0x0300",
+                        "at": [
+                            "0x4001",
+                            "0x0003",
+                            "0x0004",
+                            "0x0007",
+                            "0x4002",
+                            "0x4000",
+                            "0x0001"
+                        ]
+                    },
+                    "refresh.interval": 60
+                },
+                {
+                    "name": "state/ct",
+                    "read": {
+                        "fn": "none"
+                    }
+                },
+                {
+                    "name": "state/effect",
+                    "read": {
+                        "fn": "none"
+                    }
+                },
+                {
+                    "name": "state/hue",
+                    "read": {
+                        "fn": "none"
+                    }
+                },
+                {
+                    "name": "state/on"
+                },
+                {
+                    "name": "state/reachable"
+                },
+                {
+                    "name": "state/sat",
+                    "read": {
+                        "fn": "none"
+                    }
+                },
+                {
+                    "name": "state/x",
+                    "read": {
+                        "fn": "none"
+                    }
+                },
+                {
+                    "name": "state/y",
+                    "read": {
+                        "fn": "none"
+                    }
+                }
+            ]
+        },
+        {
+            "type": "$TYPE_DIMMABLE_LIGHT",
+            "restapi": "/lights",
+            "uuid": [
+                "$address.ext",
+                "0x0a"
+            ],
+            "items": [
+                {
+                    "name": "attr/id"
+                },
+                {
+                    "name": "attr/lastannounced"
+                },
+                {
+                    "name": "attr/lastseen"
+                },
+                {
+                    "name": "attr/manufacturername"
+                },
+                {
+                    "name": "attr/modelid",
+                    "static": "RGBW"
+                },
+                {
+                    "name": "attr/name"
+                },
+                {
+                    "name": "attr/swversion"
+                },
+                {
+                    "name": "attr/type"
+                },
+                {
+                    "name": "attr/uniqueid"
+                },
+                {
+                    "name": "state/alert"
+                },
+                {
+                    "name": "state/bri"
+                },
+                {
+                    "name": "state/on"
+                },
+                {
+                    "name": "state/reachable"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
DDF for my GLEDOPTO flood light, to eliminate the need to whitelist this device in Homebridge deCONZ.

The older GLEDOPTO devices all used `GLEDOPTO` for _Manufacturer Name_ and _Model Identifier_, but they would expose different endpoints.  This is for the RGBW lights, that expose a dimmable light on endpoint 0x0A and an extended color light on endpoint 0x0B, like the flood light that I have on my balcony.  I have some other devices (controllers) whitelisted in Homebridge Hue, but I'm not sure if I still have these.

Notes:
- I want to add a check for _SW Build ID_ of `1.0.2`, but that's currently not possible in a DDF.
- The max/min `ct` values are assumed; unfortunately, the light does not report the actual `ct`.  Note that `ct` is emulated using the RGB channels.