### PR TITLE
DDF for Heiman SmartPlug

### DIFF
--- a/devices/heiman/smartplug.json
+++ b/devices/heiman/smartplug.json
@@ -1,0 +1,309 @@
+{
+    "schema": "devcap1.schema.json",
+    "manufacturername": "Heiman",
+    "modelid": "SmartPlug",
+    "product": "SmartPlug",
+    "sleeper": false,
+    "status": "Gold",
+    "subdevices": [
+        {
+            "type": "$TYPE_SMART_PLUG",
+            "restapi": "/lights",
+            "uuid": [
+                "$address.ext",
+                "0x01"
+            ],
+            "items": [
+                {
+                    "name": "attr/id"
+                },
+                {
+                    "name": "attr/lastannounced"
+                },
+                {
+                    "name": "attr/lastseen"
+                },
+                {
+                    "name": "attr/manufacturername"
+                },
+                {
+                    "name": "attr/modelid"
+                },
+                {
+                    "name": "attr/name"
+                },
+                {
+                    "name": "attr/swversion",
+                    "parse": {
+                        "fn": "zcl",
+                        "ep": "0x01",
+                        "cl": "0x0000",
+                        "at": "0x0006",
+                        "eval": "Item.val = Attr.val"
+                    },
+                    "read": {
+                        "fn": "zcl",
+                        "ep": "0x01",
+                        "cl": "0x0000",
+                        "at": "0x0006"
+                    },
+                    "refresh.interval": 86400
+                },
+                {
+                    "name": "attr/type"
+                },
+                {
+                    "name": "attr/uniqueid"
+                },
+                {
+                    "name": "state/alert"
+                },
+                {
+                    "name": "state/on",
+                    "refresh.interval": 360
+                },
+                {
+                    "name": "state/reachable"
+                }
+            ]
+        },
+        {
+            "type": "$TYPE_CONSUMPTION_SENSOR",
+            "restapi": "/sensors",
+            "uuid": [
+                "$address.ext",
+                "0x01",
+                "0x0702"
+            ],
+            "fingerprint": {
+                "profile": "0x0104",
+                "device": "0x0051",
+                "endpoint": "0x01",
+                "in": [
+                    "0x0000",
+                    "0x0006",
+                    "0x0702"
+                ],
+                "out": [
+                    "0x0019"
+                ]
+            },
+            "items": [
+                {
+                    "name": "attr/id"
+                },
+                {
+                    "name": "attr/lastannounced"
+                },
+                {
+                    "name": "attr/lastseen"
+                },
+                {
+                    "name": "attr/manufacturername"
+                },
+                {
+                    "name": "attr/modelid"
+                },
+                {
+                    "name": "attr/name"
+                },
+                {
+                    "name": "attr/swversion",
+                    "parse": {
+                        "fn": "zcl",
+                        "ep": "0x01",
+                        "cl": "0x0000",
+                        "at": "0x0006",
+                        "eval": "Item.val = Attr.val"
+                    }
+                },
+                {
+                    "name": "attr/type"
+                },
+                {
+                    "name": "attr/uniqueid"
+                },
+                {
+                    "name": "config/on"
+                },
+                {
+                    "name": "config/reachable"
+                },
+                {
+                    "name": "state/consumption",
+                    "description": "The measured consumption (in Wh).",
+                    "parse": {
+                        "fn": "zcl",
+                        "ep": "0x01",
+                        "cl": "0x0702",
+                        "at": "0x0000",
+                        "eval": "Item.val = Math.round(Attr.val / 10)"
+                    },
+                    "refresh.interval": 360,
+                    "default": 0
+                },
+                {
+                    "name": "state/lastupdated"
+                }
+            ]
+        },
+        {
+            "type": "$TYPE_POWER_SENSOR",
+            "restapi": "/sensors",
+            "uuid": [
+                "$address.ext",
+                "0x01",
+                "0x0b04"
+            ],
+            "fingerprint": {
+                "profile": "0x0104",
+                "device": "0x0051",
+                "endpoint": "0x01",
+                "in": [
+                    "0x0B04"
+                ]
+            },
+            "items": [
+                {
+                    "name": "attr/id"
+                },
+                {
+                    "name": "attr/lastannounced"
+                },
+                {
+                    "name": "attr/lastseen"
+                },
+                {
+                    "name": "attr/manufacturername"
+                },
+                {
+                    "name": "attr/modelid"
+                },
+                {
+                    "name": "attr/name"
+                },
+                {
+                    "name": "attr/swversion",
+                    "parse": {
+                        "fn": "zcl",
+                        "ep": "0x01",
+                        "cl": "0x0000",
+                        "at": "0x0006",
+                        "eval": "Item.val = Attr.val"
+                    }
+                },
+                {
+                    "name": "attr/type"
+                },
+                {
+                    "name": "attr/uniqueid"
+                },
+                {
+                    "name": "config/on"
+                },
+                {
+                    "name": "config/reachable"
+                },
+                {
+                    "name": "state/current",
+                    "description": "The measured current (in mA).",
+                    "parse": {
+                        "fn": "zcl",
+                        "ep": "0x01",
+                        "cl": "0x0B04",
+                        "at": "0x0508",
+                        "eval": "Item.val = Math.round(Attr.val / 100)"
+                    },
+                    "refresh.interval": 360,
+                    "default": 0
+                },
+                {
+                    "name": "state/lastupdated"
+                },
+                {
+                    "name": "state/power",
+                    "description": "The measured power (in W).",
+                    "parse": {
+                        "fn": "zcl",
+                        "ep": "0x01",
+                        "cl": "0x0B04",
+                        "at": "0x050B",
+                        "eval": "Item.val = Math.round(Attr.val / 10)"
+                    },
+                    "refresh.interval": 360,
+                    "default": 0
+                },
+                {
+                    "name": "state/voltage",
+                    "description": "The measured voltage (in V).",
+                    "parse": {
+                        "fn": "zcl",
+                        "ep": "0x01",
+                        "cl": "0x0B04",
+                        "at": "0x0505",
+                        "eval": "Item.val = Math.round(Attr.val / 100)"
+                    },
+                    "refresh.interval": 360,
+                    "default": 0
+                }
+            ]
+        }
+    ],
+    "bindings": [
+        {
+            "bind": "unicast",
+            "src.ep": 1,
+            "cl": "0x0006",
+            "report": [
+                {
+                    "at": "0x0000",
+                    "dt": "0x10",
+                    "min": 1,
+                    "max": 300
+                }
+            ]
+        },
+        {
+            "bind": "unicast",
+            "src.ep": 1,
+            "cl": "0x0702",
+            "report": [
+                {
+                    "at": "0x0000",
+                    "dt": "0x25",
+                    "min": 1,
+                    "max": 300,
+                    "change": "0x0A"
+                }
+            ]
+        },
+        {
+            "bind": "unicast",
+            "src.ep": 1,
+            "cl": "0x0B04",
+            "report": [
+                {
+                    "at": "0x0505",
+                    "dt": "0x21",
+                    "min": 1,
+                    "max": 300,
+                    "change": "0x64"
+                },
+                {
+                    "at": "0x0508",
+                    "dt": "0x21",
+                    "min": 1,
+                    "max": 300,
+                    "change": "0x64"
+                },
+                {
+                    "at": "0x050B",
+                    "dt": "0x29",
+                    "min": 1,
+                    "max": 300,
+                    "change": "0x0A"
+                }
+            ]
+        }
+    ]
+}

--- a/devices/heiman/smartplug.json
+++ b/devices/heiman/smartplug.json
@@ -212,7 +212,7 @@
                         "ep": "0x01",
                         "cl": "0x0B04",
                         "at": "0x0508",
-                        "eval": "Item.val = Math.round(Attr.val / 100)"
+                        "eval": "Item.val = Attr.val * 10"
                     },
                     "refresh.interval": 360,
                     "default": 0
@@ -294,7 +294,7 @@
                     "dt": "0x21",
                     "min": 1,
                     "max": 300,
-                    "change": "0x64"
+                    "change": "0x01"
                 },
                 {
                     "at": "0x050B",


### PR DESCRIPTION
I have two of these models, an older one that exposes neither _SW Version ID_ nor _Date Code_ and a newer one with _Date Code_ of `2018.1.11`.  So `swversion` is based on the date code, and `null` for the older model.

The fingerprints in this DDF should get rid of all the "Missing cluster in sensor fingerprint" messages.

I've removed the `state.power` from the ZHAConsumption resource.  This was completely redundant, as it was also exposed on the ZHAPower resource.  The ZHAConsumption `power` was based on the _Instantaneous Demand_ attribute of the _Simple Metering_ cluster; the ZHAPower on the _Active Power_ of _Electrical Management_.  The device reports the same value on both clusters.  
However, because the device only has room for attribute reporting for five attributes, _Instantaneous Demand_ had to be polled, and would run behind _Active Power_.  I really don't like deCONZ polling the attribute and it seems better to remove it altogether.