### PR TITLE
DDF for innr PL 110 and innr UC 110

### DIFF
--- a/devices/innr/xx_110.json
+++ b/devices/innr/xx_110.json
@@ -1,0 +1,73 @@
+{
+    "schema": "devcap1.schema.json",
+    "manufacturername": [
+        "innr",
+        "innr"
+    ],
+    "modelid": [
+        "PL 110",
+        "UC 110"
+    ],
+    "product": "innr Puck Light and innr Under Cabinet light",
+    "sleeper": false,
+    "status": "Gold",
+    "subdevices": [
+        {
+            "type": "$TYPE_DIMMABLE_LIGHT",
+            "restapi": "/lights",
+            "uuid": [
+                "$address.ext",
+                "0x01"
+            ],
+            "items": [
+                {
+                    "name": "attr/id"
+                },
+                {
+                    "name": "attr/lastannounced"
+                },
+                {
+                    "name": "attr/lastseen"
+                },
+                {
+                    "name": "attr/manufacturername"
+                },
+                {
+                    "name": "attr/modelid"
+                },
+                {
+                    "name": "attr/name"
+                },
+                {
+                    "name": "attr/swversion"
+                },
+                {
+                    "name": "attr/type"
+                },
+                {
+                    "name": "attr/uniqueid"
+                },
+                {
+                    "name": "state/alert"
+                },
+                {
+                    "name": "config/bri/on_level"
+                },
+                {
+                    "name": "config/bri/onoff_transitiontime"
+                },
+                {
+                    "name": "state/bri",
+                    "refresh.interval": 5
+                },
+                {
+                    "name": "state/on",
+                    "refresh.interval": 5
+                },
+                {
+                    "name": "state/reachable"
+                }
+            ]
+        }
+    ]
+}

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -325,6 +325,7 @@ bool DeRestPluginPrivate::lightToMap(const ApiRequest &req, const LightNode *lig
         else if (rid.suffix == RConfigBriMax) { configBri["max"] = item->toNumber(); }
         else if (rid.suffix == RConfigBriMin) { configBri["min"] = item->toNumber(); }
         else if (rid.suffix == RConfigBriOnLevel) { configBri["on_level"] = item->toNumber() == 0xFF ? QVariant(QLatin1String("previous")) : item->toNumber(); }
+        else if (rid.suffix == RConfigBriOnOffTransitiontime) { configBri["onoff_transitiontime"] = item->toNumber(); }
         else if (rid.suffix == RConfigBriMin) { configBri["onoff_transition_time"] = item->toNumber(); }
         else if (rid.suffix == RConfigBriStartup) { configBri["startup"] = item->toNumber() == 0xFF ? QVariant(QLatin1String("previous")) : item->toNumber(); }
         else if (rid.suffix == RConfigColorCtStartup) { configColorCt["startup"] = item->toNumber() == 0xFFFF ? QVariant(QLatin1String("previous")) : item->toNumber(); }
@@ -4010,6 +4011,7 @@ void DeRestPluginPrivate::handleLightEvent(const Event &e)
                     else if (rid.suffix == RConfigBriMax) { configBri["max"] = item->toNumber(); }
                     else if (rid.suffix == RConfigBriMin) { configBri["min"] = item->toNumber(); }
                     else if (rid.suffix == RConfigBriOnLevel) { configBri["on_level"] = item->toNumber() == 0xFF ? QVariant(QLatin1String("previous")) : item->toNumber(); }
+                    else if (rid.suffix == RConfigBriOnOffTransitiontime) { configBri["onoff_transitiontime"] = item->toNumber(); }
                     else if (rid.suffix == RConfigBriMin) { configBri["onoff_transition_time"] = item->toNumber(); }
                     else if (rid.suffix == RConfigBriStartup) { configBri["startup"] = item->toNumber() == 0xFF ? QVariant(QLatin1String("previous")) : item->toNumber(); }
                     else if (rid.suffix == RConfigColorCtStartup) { configColorCt["startup"] = item->toNumber() == 0xFFFF ? QVariant(QLatin1String("previous")) : item->toNumber(); }


### PR DESCRIPTION
These are the old innr Puck Lights and Under Cabinet lights, which use the same control box.  I think there was a third light that used the same box as well, but can no longer find it.

Pretty dumb ZLL dimmable lights.  Technically, they support _Trigger Effect_, but the firmware hangs, requiring a power cycle, when receiving a _Stop_ while _Breathe_ is active.  So best not expose this.

They support _On Level_ and _OnOff Transitiontime_ on _Level Control_, which are now exposed on `config`.

Apparently, I forgot to report `config/bri/onoff_transitiontime` over the API and web socket notifications, but you can already change it through the API in v2.21.2.