### PR TITLE
Fix Javascript crash when setting unsupported JS value to item

### DIFF
--- a/device_js/device_js_duktape.cpp
+++ b/device_js/device_js_duktape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2022-2023 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -21,17 +21,16 @@
 #include "resource.h"
 #include "utils/utils.h"
 
-// before v2.19.2-beta DBG_JS isn't defined, can be removed afterwards
-#ifndef DBG_JS
-  #define DBG_JS DBG_INFO_L2
-#endif
-
+#ifdef DECONZ_DEBUG_BUILD
 #if _MSC_VER
   #define U_ASSERT(c) if (!(c)) __debugbreak()
 #elif __GNUC__
   #define U_ASSERT(c) if (!(c)) __builtin_trap()
 #else
   #define U_ASSERT assert
+#endif
+#else // release build
+  #define U_ASSERT DBG_Assert
 #endif
 
 static DeviceJs *_djs = nullptr; // singleton
@@ -801,7 +800,9 @@ static duk_ret_t DJS_SetItemVal(duk_context *ctx)
         }
         else
         {
-            U_ASSERT(0 && "unhandled value");
+            const char *str = duk_safe_to_string(ctx, 0);
+            DBG_Printf(DBG_JS, "%s: failed to set %s --> '%s' (unsupported)\n", __FUNCTION__, item->descriptor().suffix, str);
+            duk_pop(ctx); /* conversion result*/
         }
 
         if (!ok)


### PR DESCRIPTION
The new code now prints the unsupported value. This can happen for example if NaN, null or undefined is returned, as well as JS objects and arrays.

@ebaauw this should prevent the crash in your network and give some info which item needs to be handled.

I'm not sure what we should do with NaN, null, or undefined in terms of setting a value suitable for a `ResourceItem`.