### PR TITLE
DDF for LIDL Silvercrest Smart USB Extension Lead

### DIFF
--- a/devices/lidl/hg06338.json
+++ b/devices/lidl/hg06338.json
@@ -47,7 +47,7 @@
                         "ep": "0x01",
                         "cl": "0x0000",
                         "at": "0x0001",
-                        "eval": "Attr.val = Item.val"
+                        "eval": "Item.val = Attr.val"
                     },
                     "read": {
                         "fn": "zcl",
@@ -107,7 +107,7 @@
                         "ep": "0x01",
                         "cl": "0x0000",
                         "at": "0x0001",
-                        "eval": "Attr.val = Item.val"
+                        "eval": "Item.val = Attr.val"
                     },
                     "refresh.interval": 0
 
@@ -162,7 +162,7 @@
                         "ep": "0x01",
                         "cl": "0x0000",
                         "at": "0x0001",
-                        "eval": "Attr.val = Item.val"
+                        "eval": "Item.val = Attr.val"
                     },
                     "refresh.interval": 0
 

--- a/devices/lidl/hg06338.json
+++ b/devices/lidl/hg06338.json
@@ -112,7 +112,6 @@
                     "read": {
                         "fn": "none"
                     }
-
                 },
                 {
                     "name": "attr/type"
@@ -166,8 +165,9 @@
                         "at": "0x0001",
                         "eval": "Item.val = Attr.val"
                     },
-                    "refresh.interval": 0
-
+                    "read": {
+                        "fn": "none"
+                    }
                 },
                 {
                     "name": "attr/type"

--- a/devices/lidl/hg06338.json
+++ b/devices/lidl/hg06338.json
@@ -1,0 +1,227 @@
+{
+    "schema": "devcap1.schema.json",
+    "manufacturername": [
+        "LIDL Silvercrest",
+        "_TZ3000_1obwwnmq"
+    ],
+    "modelid": [
+        "HG06338",
+        "TS011F"
+    ],
+    "product": "LIDL Silvercrest Smart USB Extension Lead",
+    "sleeper": false,
+    "status": "Gold",
+    "subdevices": [
+        {
+            "type": "$TYPE_ON_OFF_PLUGIN_UNIT",
+            "restapi": "/lights",
+            "uuid": [
+                "$address.ext",
+                "0x01"
+            ],
+            "items": [
+                {
+                    "name": "attr/id"
+                },
+                {
+                    "name": "attr/lastannounced"
+                },
+                {
+                    "name": "attr/lastseen"
+                },
+                {
+                    "name": "attr/manufacturername",
+                    "static": "LIDL Silvercrest"
+                },
+                {
+                    "name": "attr/modelid",
+                    "static": "HG06338"
+                },
+                {
+                    "name": "attr/name"
+                },
+                {
+                    "name": "attr/swversion",
+                    "parse": {
+                        "fn": "zcl",
+                        "ep": "0x01",
+                        "cl": "0x0000",
+                        "at": "0x0001",
+                        "eval": "Attr.val = Item.val"
+                    },
+                    "read": {
+                        "fn": "zcl",
+                        "ep": "0x01",
+                        "cl": "0x0000",
+                        "at": "0x0001"
+                    },
+                    "refresh.interval": 86400
+                },
+                {
+                    "name": "attr/type"
+                },
+                {
+                    "name": "attr/uniqueid"
+                },
+                {
+                    "name": "state/on",
+                    "refresh.interval": 360
+                },
+                {
+                    "name": "state/reachable"
+                }
+            ]
+        },
+        {
+            "type": "$TYPE_ON_OFF_PLUGIN_UNIT",
+            "restapi": "/lights",
+            "uuid": [
+                "$address.ext",
+                "0x02"
+            ],
+            "items": [
+                {
+                    "name": "attr/id"
+                },
+                {
+                    "name": "attr/lastannounced"
+                },
+                {
+                    "name": "attr/lastseen"
+                },
+                {
+                    "name": "attr/manufacturername",
+                    "static": "LIDL Silvercrest"
+                },
+                {
+                    "name": "attr/modelid",
+                    "static": "HG06338"
+                },
+                {
+                    "name": "attr/name"
+                },
+                {
+                    "name": "attr/swversion",
+                    "parse": {
+                        "fn": "zcl",
+                        "ep": "0x01",
+                        "cl": "0x0000",
+                        "at": "0x0001",
+                        "eval": "Attr.val = Item.val"
+                    },
+                    "refresh.interval": 0
+
+                },
+                {
+                    "name": "attr/type"
+                },
+                {
+                    "name": "attr/uniqueid"
+                },
+                {
+                    "name": "state/on",
+                    "refresh.interval": 360
+                },
+                {
+                    "name": "state/reachable"
+                }
+            ]
+        },
+        {
+            "type": "$TYPE_ON_OFF_PLUGIN_UNIT",
+            "restapi": "/lights",
+            "uuid": [
+                "$address.ext",
+                "0x03"
+            ],
+            "items": [
+                {
+                    "name": "attr/id"
+                },
+                {
+                    "name": "attr/lastannounced"
+                },
+                {
+                    "name": "attr/lastseen"
+                },
+                {
+                    "name": "attr/manufacturername",
+                    "static": "LIDL Silvercrest"
+                },
+                {
+                    "name": "attr/modelid",
+                    "static": "HG06338"
+                },
+                {
+                    "name": "attr/name"
+                },
+                {
+                    "name": "attr/swversion",
+                    "parse": {
+                        "fn": "zcl",
+                        "ep": "0x01",
+                        "cl": "0x0000",
+                        "at": "0x0001",
+                        "eval": "Attr.val = Item.val"
+                    },
+                    "refresh.interval": 0
+
+                },
+                {
+                    "name": "attr/type"
+                },
+                {
+                    "name": "attr/uniqueid"
+                },
+                {
+                    "name": "state/on",
+                    "refresh.interval": 360
+                },
+                {
+                    "name": "state/reachable"
+                }
+            ]
+        }
+    ],
+    "bindings": [
+        {
+            "bind": "unicast",
+            "src.ep": 1,
+            "cl": "0x0006",
+            "report": [
+                {
+                    "at": "0x0000",
+                    "dt": "0x10",
+                    "min": 1,
+                    "max": 300
+                }
+            ]
+        },
+        {
+            "bind": "unicast",
+            "src.ep": 2,
+            "cl": "0x0006",
+            "report": [
+                {
+                    "at": "0x0000",
+                    "dt": "0x10",
+                    "min": 1,
+                    "max": 300
+                }
+            ]
+        },
+        {
+            "bind": "unicast",
+            "src.ep": 3,
+            "cl": "0x0006",
+            "report": [
+                {
+                    "at": "0x0000",
+                    "dt": "0x10",
+                    "min": 1,
+                    "max": 300
+                }
+            ]
+        }
+    ]
+}

--- a/devices/lidl/hg06338.json
+++ b/devices/lidl/hg06338.json
@@ -109,7 +109,9 @@
                         "at": "0x0001",
                         "eval": "Item.val = Attr.val"
                     },
-                    "refresh.interval": 0
+                    "read": {
+                        "fn": "none"
+                    }
 
                 },
                 {


### PR DESCRIPTION
Pretty straightforward, with following remarks:
- Forcing `manufacturername` and `modelid`to `LIDL Silvercrest` and `HG06338` from Tuya non-sensical names;
- Removed `state.alert`, as device doesn't blink any LED on _Identify_ (from any endpoint);
- Map `swversion` to _Application Version_, as devices supports neither _SW Build ID_, nor _Date Code_.
- Note: this DDF is tested with the old model, which works out of the box.