### PR TITLE
DDF for Xiaomi Aqara Smart Curtain Controller

### DIFF
--- a/devices/xiaomi/lumi_curtain.json
+++ b/devices/xiaomi/lumi_curtain.json
@@ -1,0 +1,95 @@
+{
+    "schema": "devcap1.schema.json",
+    "manufacturername": "$MF_LUMI",
+    "modelid": "lumi.curtain",
+    "product": "Xiaomi Aqara Smart Curtain Controller",
+    "sleeper": false,
+    "status": "Gold",
+    "subdevices": [
+        {
+            "type": "$TYPE_WINDOW_COVERING_DEVICE",
+            "restapi": "/lights",
+            "uuid": [
+                "$address.ext",
+                "0x01"
+            ],
+            "items": [
+                {
+                    "name": "attr/id"
+                },
+                {
+                    "name": "attr/lastannounced"
+                },
+                {
+                    "name": "attr/lastseen"
+                },
+                {
+                    "name": "attr/manufacturername"
+                },
+                {
+                    "name": "attr/modelid"
+                },
+                {
+                    "name": "attr/name"
+                },
+                {
+                    "name": "attr/swversion",
+                    "parse": {
+                        "fn": "zcl",
+                        "ep": "0x01",
+                        "cl": "0x0000",
+                        "at": "0x0006",
+                        "eval": "Item.val = Attr.val"
+                    },
+                    "read": {
+                        "fn": "zcl",
+                        "ep": "0x01",
+                        "cl": "0x0000",
+                        "at": "0x0006"
+                    },
+                    "refresh.interval": 86400
+                },
+                {
+                    "name": "attr/type"
+                },
+                {
+                    "name": "attr/uniqueid"
+                },
+                {
+                    "name": "state/lift",
+                    "parse": {
+                        "fn": "zcl",
+                        "ep": 1,
+                        "cl": "0x0102",
+                        "at": "0x0008",
+                        "eval": "Item.val = Attr.val"
+                    },
+                    "read": {
+                        "fn": "zcl",
+                        "ep": 1,
+                        "cl": "0x0102",
+                        "at": "0x0008",
+                        "eval": "Item.val = Attr.val"
+                    },
+                    "refresh.interval": 300
+                },
+                {
+                    "name": "state/open",
+                    "parse": {
+                        "fn": "zcl",
+                        "ep": 1,
+                        "cl": "0x0102",
+                        "at": "0x0008",
+                        "eval": "Item.val = Attr.val === 100"
+                    },
+                    "read": {
+                        "fn": "none"
+                    }
+                },
+                {
+                    "name": "state/reachable"
+                }
+            ]
+        }
+    ]
+}

--- a/devices/xiaomi/lumi_curtain.json
+++ b/devices/xiaomi/lumi_curtain.json
@@ -62,14 +62,13 @@
                         "ep": 1,
                         "cl": "0x0102",
                         "at": "0x0008",
-                        "eval": "Item.val = Attr.val"
+                        "eval": "Item.val = 100 - Attr.val"
                     },
                     "read": {
                         "fn": "zcl",
                         "ep": 1,
                         "cl": "0x0102",
-                        "at": "0x0008",
-                        "eval": "Item.val = Attr.val"
+                        "at": "0x0008"
                     },
                     "refresh.interval": 300
                 },


### PR DESCRIPTION
This is the original mains-powered `lumi.curtain` from around 2017.

The DDF is pretty straightforward, but note:
- `state.on` and `state.bri` are no longer exposed.  These have been deprecated for _Window Covering_ devices since 2020/04/08, so over three years now.
- No bindings, but the device reports _Current Position Lift Percentage_ to the coordinator out-of-the-box.
- The device doesn't support _DW Build ID_, so `swversion` is based on _Date Code_.
- The device also reports the current position as _Present Value_ on the _Analog Output (Basic)_ cluster.  The legacy C++ code also considers this, but the DDF currently ignores it.  I don't think I've ever seen a report from _Analog Output_ without one on _Window Covering_.
- The device supports a _Reversed_ configuration setting, but this is currently not exposed, as the corresponding resource item (`config/reversed`?) hasn't been defined yet.
- And, last but not least, `state.lift` reports % closed, as per ZCL spec.  So 0 is fully open (in which case `state.open` is true, and 100 is fully closed.  The device reports % open instead.