### PR TITLE
DDF for Tuya Avatto radiator actuator (_TZE200_bvu2wnxz)

### DIFF
--- a/devices/tuya/_TZE200_bvu2wnxz_trv.json
+++ b/devices/tuya/_TZE200_bvu2wnxz_trv.json
@@ -1,0 +1,94 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": ["_TZE200_bvu2wnxz", "_TZE200_6rdj8dzm", "_TZE200_gd4rvykv"],
+  "modelid": ["TS0601", "TS0601", "TS0601"],
+  "vendor": "Tuya",
+  "product": "Tuya TRV",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_THERMOSTAT",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0xef00"
+      ],
+      "meta": {
+        "values": {
+          "config/mode": {"auto": 0, "heat": 1, "off": 2}
+        }
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/lowbattery",
+          "parse": {"fn": "tuya", "dpid": 35, "eval": "Item.val = Attr.val != 0"},
+          "read": {"fn": "none"}
+        },
+        {
+          "name": "config/heatsetpoint",
+          "parse": {"fn": "tuya", "dpid": 4, "eval": "Item.val = Attr.val * 10;"},
+          "write": {"fn": "tuya", "dpid": 4, "dt": "0x2b", "eval": "Item.val / 10;"},
+          "read": {"fn": "tuya"}
+        },
+        {
+          "name": "config/locked",
+          "parse": {"fn": "tuya", "dpid": 7, "eval": "Item.val = Attr.val;"},
+          "write": {"fn": "tuya", "dpid": 7, "dt": "0x10", "eval": "Item.val;"},
+          "read": {"fn": "none"}
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "config/mode",
+          "values": [
+              ["auto", 0], ["heat", 1], ["off", 2]
+          ],
+          "parse": {"fn": "tuya", "dpid": 2, "eval": "if (Attr.val == 0) { Item.val = 'auto' } else if (Attr.val == 1) { Item.val = 'heat' } else { Item.val = 'off' }"},
+          "write": {"fn": "tuya", "dpid": 2, "dt": "0x30", "eval": "if (Item.val == 'auto') { 0 } else if (Item.val == 'heat') { 1 } else { 2 }"},
+          "read": {"fn": "none"}
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/temperature",
+          "parse": {"fn": "tuya", "dpid": 5, "eval": "Item.val = Attr.val * 10;"},
+          "read": {"fn": "none"}
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/6883

- Product name: Avatto Tuya Zigbee Radiator Actuator
- Manufacturer: _TZE200_6rdj8dzm
- Model identifier: TS0601

And 2 clones.