### PR TITLE
Fix ZCLDB On/Off cluster attribute compliance

### DIFF
--- a/general.xml
+++ b/general.xml
@@ -779,9 +779,9 @@
             <value name="On" value="1"></value>
             <value name="Off" value="0"></value>
           </attribute>
-          <attribute id="0x4000" name="GlobalSceneControl" type="bool" access="r" default="0" required="o"></attribute>
-          <attribute id="0x4001" name="OnTime" type="u16" access="r" default="0" required="o"></attribute>
-          <attribute id="0x4002" name="OffWaitTime" type="u16" access="r" default="0" required="o"></attribute>
+          <attribute id="0x4000" name="GlobalSceneControl" type="bool" access="r" default="0x01" required="o"></attribute>
+          <attribute id="0x4001" name="OnTime" type="u16" access="rw" default="0" required="o"></attribute>
+          <attribute id="0x4002" name="OffWaitTime" type="u16" access="rw" default="0" required="o"></attribute>
           <attribute id="0x4003" name="StartUp OnOff" type="enum8" access="rw" default="0x01" required="o">
             <value name="Off" value="0x00"></value>
             <value name="On" value="0x01"></value>


### PR DESCRIPTION
Update On/Off Cluster (0x0006) to be complinant with Zigbee Cluster library specifications : 
- Default value for `GlobalSceneControl` should be 0x01
- `OnTime` and `OffWaitTime` should be writeable

Close #4642 and fix #6888 