### PR TITLE
Fix resource item `config/heatsetpoint` not having a default write function

### DIFF
--- a/devices/generic/items/config_heatsetpoint_item.json
+++ b/devices/generic/items/config_heatsetpoint_item.json
@@ -8,5 +8,6 @@
 	"description": "Target temperature of a thermostat.",
 	"parse": {"at": "0x0012", "cl": "0x0201", "ep": 0, "eval": "Item.val = Attr.val;", "fn": "zcl"},
 	"read": {"at": "0x0012", "cl": "0x0201", "ep": 0, "fn": "zcl"},
+	"write": {"at": "0x0012", "cl": "0x0201", "dt": "0x29", "ep": 0, "eval": "Item.val;", "fn": "zcl"},
 	"range": [500, 3200]
 }


### PR DESCRIPTION
Some thermostat DDFs only have added the resource item `config/heatsetpoint` in its generic form, most notably the Namron and Xiaomi Thermostats. However, it only offers a read and parse function. The required write function to set temperature via attribute 0x0012 is not available and the respective legacy code is not entered for DDF supported devices.

As for the Xiaomi thermostat, it cannot be ensured that the temperature can/must be set this way, the device is not available for testing.