### PR TITLE
Refactor MMO hash function

### DIFF
--- a/crypto/mmohash.cpp
+++ b/crypto/mmohash.cpp
@@ -39,7 +39,51 @@ static bool aesMmoHash(unsigned &length, unsigned char *result, unsigned char *d
     return true;
 }
 
-bool getMmoHashFromInstallCode(std::string hexString, std::vector<unsigned char> &result)
+#define CRC_POLY 0x8408
+static unsigned short ccit_crc16(unsigned char *data_p, unsigned short length)
+{
+    unsigned char i;
+    unsigned int data;
+    unsigned long crc;
+
+    crc = 0xFFFF;
+
+    if (length == 0)
+        return (~crc);
+
+    do {
+        for (i = 0, data = (unsigned int)0xff & *data_p++;
+             i < 8;
+             i++, data >>= 1) {
+            if ((crc & 0x0001) ^ (data & 0x0001))
+                crc = (crc >> 1) ^ CRC_POLY;
+            else
+                crc >>= 1;
+        }
+    } while (--length);
+
+    crc = ~crc;
+
+    return crc;
+}
+
+/*
+    Verification of offical alliance example:
+
+    curl -XPUT -H "Content-type: application/json" -d '{"installcode": "83FED3407A939723A5C639FF4C12"}' '127.0.0.1/api/12345/devices/999/installcode'
+
+    [
+      {
+        "success": {
+          "installcode": "83FED3407A939723A5C639FF4C12",
+          "mmohash": "58C1828CF7F1C3FE29E7B1024AD84BFA"
+        }
+      }
+    ]
+
+    TODO(mpi): add more test cases for all IC lengths and test code
+*/
+bool getMmoHashFromInstallCode(const std::string &hexString, std::vector<unsigned char> &result)
 {
 #ifdef Q_OS_WIN
     QLibrary libCrypto(QLatin1String("libcrypto-1_1.dll"));
@@ -55,29 +99,70 @@ bool getMmoHashFromInstallCode(std::string hexString, std::vector<unsigned char>
         return false;
     }
 
-    std::vector<unsigned char> data;
-
-    for (std::string::size_type i = 0; i < hexString.length(); i += 2)
+    if ((hexString.length() & 1) == 1)
     {
-        std::string byteString = hexString.substr(i, 2);
-        unsigned char byte = static_cast<unsigned char>(std::stoul(byteString, nullptr, 16));
-        data.push_back(byte);
+        return false; // must be even number
+    }
+
+    unsigned icLength = (unsigned)hexString.length() / 2;
+    // test valid IC sizes (plus 2 bytes for CRC)
+    if (!(icLength == (6 + 2) || icLength == (8 + 2) || icLength == (12 + 2) || icLength == (16 + 2)))
+    {
+        return false; // valid IC sizes according https://wiki.st.com/stm32mcu/wiki/Connectivity:Zigbee_Install_Code
+    }
+
+    unsigned char data[16 + 2]; // IC + CRC16
+    unsigned dataLength = 0;
+
+    for (unsigned i = 0; i + 1 < icLength * 2; i += 2)
+    {
+        char ch = 0;
+        unsigned char byte = 0;
+
+        for (int j = 0; j < 2; j++)
+        {
+            ch = hexString.at(i + j);
+
+            if      (ch >= '0' && ch <= '9') { ch = ch - '0'; }
+            else if (ch >= 'A' && ch <= 'F') { ch = ch - 'A' + 10; }
+            else if (ch >= 'a' && ch <= 'f') { ch = ch - 'a' + 10; }
+            else
+            {
+                return false; // not a hex digit
+            }
+
+            byte <<= 4;
+            byte |= ch & 0xF;
+        }
+
+        data[dataLength] = byte;
+        dataLength++;
+    }
+
+    {   // Check that crc is correct. There have been devices out
+        // there where the crc is invalid or byte-swapped.
+        // Don't fail in that case but auto correct.
+        unsigned short crc = ccit_crc16(&data[0], dataLength - 2);
+        unsigned char crc_lo = crc & 0xFF;
+        unsigned char crc_hi = (crc >> 8) & 0xFF;
+
+        if (data[dataLength - 1] != crc_hi || data[dataLength - 2] != crc_lo)
+        {
+            data[dataLength - 1] = crc_hi;
+            data[dataLength - 2] = crc_lo;
+        }
     }
 
     unsigned char hashResult[AES_BLOCK_SIZE] = {0};
     unsigned char temp[AES_BLOCK_SIZE] = {0};
     unsigned hashResultLength = 0;
     unsigned lengthRemaining = 0;
-    unsigned dataLength = data.size();
 
-    if (data.size() > 0)
+    lengthRemaining = dataLength & (AES_BLOCK_SIZE - 1);
+
+    if (dataLength >= AES_BLOCK_SIZE)
     {
-        lengthRemaining = dataLength & (AES_BLOCK_SIZE - 1);
-
-        if (dataLength >= AES_BLOCK_SIZE)
-        {
-            aesMmoHash(hashResultLength, hashResult, &data[0], dataLength);
-        }
+        aesMmoHash(hashResultLength, hashResult, &data[0], dataLength);
     }
 
     for (unsigned i = 0; i < lengthRemaining; i++)

--- a/crypto/mmohash.cpp
+++ b/crypto/mmohash.cpp
@@ -2,11 +2,10 @@
   #error "OpenSSL required"
 #endif
 
-#include <vector>
-#include <string>
-#include <QByteArray>
 #include <QLibrary>
 #include <openssl/evp.h>
+
+#include "crypto/mmohash.h"
 
 #define AES_BLOCK_SIZE 16
 
@@ -99,7 +98,7 @@ static unsigned short ccit_crc16(unsigned char *data_p, unsigned short length)
 
     TODO(mpi): add more test cases for all IC lengths and test code
 */
-bool getMmoHashFromInstallCode(const std::string &hexString, std::vector<unsigned char> &result)
+bool CRYPTO_GetMmoHashFromInstallCode(const std::string &hexString, std::vector<unsigned char> &result)
 {
 #ifdef Q_OS_WIN
     QLibrary libCrypto(QLatin1String("libcrypto-1_1.dll"));

--- a/crypto/mmohash.cpp
+++ b/crypto/mmohash.cpp
@@ -12,10 +12,10 @@
 
 static EVP_CIPHER_CTX *(*lib_EVP_CIPHER_CTX_new)(void);
 static void (*lib_EVP_EncryptInit)(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type, const unsigned char *key, const unsigned char *iv);
-static int (*lib_EVP_CIPHER_CTX_ctrl)(EVP_CIPHER_CTX *ctx, int cmd, int p1, void *p2);
 static int (*lib_EVP_EncryptUpdate)(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);
 static int (*lib_EVP_EncryptFinal_ex)(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl);
 static void (*lib_EVP_CIPHER_CTX_free)(EVP_CIPHER_CTX *ctx);
+static const EVP_CIPHER *(*lib_EVP_aes_128_ecb)(void);
 
 static bool aesMmoHash(unsigned char *result, unsigned char *data, unsigned dataSize)
 {
@@ -27,7 +27,7 @@ static bool aesMmoHash(unsigned char *result, unsigned char *data, unsigned data
         if (!lib_ctx)
             return false;
 
-        lib_EVP_EncryptInit(lib_ctx, EVP_aes_128_ecb(), result, NULL);
+        lib_EVP_EncryptInit(lib_ctx, lib_EVP_aes_128_ecb(), result, NULL);
 
         unsigned char block[AES_BLOCK_SIZE];
         unsigned char encrypted_block[AES_BLOCK_SIZE * 2] = {0};
@@ -109,12 +109,12 @@ bool getMmoHashFromInstallCode(const std::string &hexString, std::vector<unsigne
 
     lib_EVP_CIPHER_CTX_new = (EVP_CIPHER_CTX *(*)(void))libCrypto.resolve("EVP_CIPHER_CTX_new");
     lib_EVP_EncryptInit = (void (*)(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type, const unsigned char *key, const unsigned char *iv))libCrypto.resolve("EVP_EncryptInit");
-    lib_EVP_CIPHER_CTX_ctrl = (int (*)(EVP_CIPHER_CTX *ctx, int cmd, int p1, void *p2))libCrypto.resolve("EVP_CIPHER_CTX_ctrl");
     lib_EVP_EncryptUpdate = (int (*)(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl))libCrypto.resolve("EVP_EncryptUpdate");
     lib_EVP_EncryptFinal_ex = (int (*)(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl))libCrypto.resolve("EVP_EncryptFinal_ex");
     lib_EVP_CIPHER_CTX_free = (void (*)(EVP_CIPHER_CTX *ctx))libCrypto.resolve("EVP_CIPHER_CTX_free");
+    lib_EVP_aes_128_ecb = (const EVP_CIPHER *(*)(void))libCrypto.resolve("EVP_aes_128_ecb");
 
-    if (!lib_EVP_CIPHER_CTX_new || !lib_EVP_EncryptInit || !lib_EVP_CIPHER_CTX_ctrl || !lib_EVP_EncryptUpdate || !lib_EVP_EncryptFinal_ex || !lib_EVP_CIPHER_CTX_free)
+    if (!lib_EVP_CIPHER_CTX_new || !lib_EVP_EncryptInit || !lib_EVP_EncryptUpdate || !lib_EVP_EncryptFinal_ex || !lib_EVP_CIPHER_CTX_free | !lib_EVP_aes_128_ecb)
     {
         return false;
     }

--- a/crypto/mmohash.cpp
+++ b/crypto/mmohash.cpp
@@ -88,7 +88,7 @@ bool getMmoHashFromInstallCode(const std::string &hexString, std::vector<unsigne
 #ifdef Q_OS_WIN
     QLibrary libCrypto(QLatin1String("libcrypto-1_1.dll"));
 #else
-    QLibrary libCrypto(QLatin1String("crypto"));
+    QLibrary libCrypto("crypto", "1.1");
 #endif
 
     lib_AES_set_encrypt_key = reinterpret_cast<int (*)(const unsigned char *userKey, const int bits, AES_KEY *key)>(libCrypto.resolve("AES_set_encrypt_key"));

--- a/crypto/mmohash.cpp
+++ b/crypto/mmohash.cpp
@@ -1,0 +1,111 @@
+#ifndef HAS_OPENSSL
+  #error "OpenSSL required"
+#endif
+
+#include <openssl/aes.h>
+#include <vector>
+#include <string>
+#include <QByteArray>
+#include <QLibrary>
+
+static int (*lib_AES_set_encrypt_key)(const unsigned char *userKey, const int bits, AES_KEY *key);
+static void (*lib_AES_encrypt)(const unsigned char *in, unsigned char *out, const AES_KEY *key);
+
+// Below 2 functions are an adaptation/port from https://github.com/zigpy/zigpy/blob/dev/zigpy/util.py (aes_mmo_hash_update() and aes_mmo_hash())
+static bool aesMmoHash(unsigned &length, unsigned char *result, unsigned char *data, unsigned dataSize)
+{
+    while (dataSize >= AES_BLOCK_SIZE)
+    {
+        AES_KEY aes_key;
+        lib_AES_set_encrypt_key(result, 128, &aes_key);
+
+        unsigned char block[AES_BLOCK_SIZE];
+        unsigned char encrypted_block[AES_BLOCK_SIZE];
+
+        memcpy(&block[0], &data[0], AES_BLOCK_SIZE);
+
+        lib_AES_encrypt(&block[0], &encrypted_block[0], &aes_key);
+
+        for (int i = 0; i < AES_BLOCK_SIZE; i++)
+        {
+            result[i] = encrypted_block[i] ^ block[i];
+        }
+
+        data += AES_BLOCK_SIZE;
+        dataSize -= AES_BLOCK_SIZE;
+        length += AES_BLOCK_SIZE;
+    }
+
+    return true;
+}
+
+bool getMmoHashFromInstallCode(std::string hexString, std::vector<unsigned char> &result)
+{
+#ifdef Q_OS_WIN
+    QLibrary libCrypto(QLatin1String("libcrypto-1_1.dll"));
+#else
+    QLibrary libCrypto(QLatin1String("crypto"));
+#endif
+
+    lib_AES_set_encrypt_key = reinterpret_cast<int (*)(const unsigned char *userKey, const int bits, AES_KEY *key)>(libCrypto.resolve("AES_set_encrypt_key"));
+    lib_AES_encrypt = reinterpret_cast<void (*)(const unsigned char *in, unsigned char *out, const AES_KEY *key)>(libCrypto.resolve("AES_encrypt"));
+
+    if (!lib_AES_set_encrypt_key || !lib_AES_encrypt)
+    {
+        return false;
+    }
+
+    std::vector<unsigned char> data;
+
+    for (std::string::size_type i = 0; i < hexString.length(); i += 2)
+    {
+        std::string byteString = hexString.substr(i, 2);
+        unsigned char byte = static_cast<unsigned char>(std::stoul(byteString, nullptr, 16));
+        data.push_back(byte);
+    }
+
+    unsigned char hashResult[AES_BLOCK_SIZE] = {0};
+    unsigned char temp[AES_BLOCK_SIZE] = {0};
+    unsigned hashResultLength = 0;
+    unsigned lengthRemaining = 0;
+    unsigned dataLength = data.size();
+
+    if (data.size() > 0)
+    {
+        lengthRemaining = dataLength & (AES_BLOCK_SIZE - 1);
+
+        if (dataLength >= AES_BLOCK_SIZE)
+        {
+            aesMmoHash(hashResultLength, hashResult, &data[0], dataLength);
+        }
+    }
+
+    for (unsigned i = 0; i < lengthRemaining; i++)
+    {
+        temp[i] = data[i];
+    }
+
+    temp[lengthRemaining] = 0x80;
+    hashResultLength += lengthRemaining;
+
+    if (AES_BLOCK_SIZE - lengthRemaining < 3)
+    {
+        aesMmoHash(hashResultLength, hashResult, &temp[0], AES_BLOCK_SIZE);
+        hashResultLength -= AES_BLOCK_SIZE;
+        memset(&temp[0], 0x00, sizeof(temp));
+    }
+
+    uint bit_size = hashResultLength * 8;
+    temp[AES_BLOCK_SIZE - 2] = (bit_size >> 8) & 0xFF;
+    temp[AES_BLOCK_SIZE - 1] = (bit_size) & 0xFF;
+
+    aesMmoHash(hashResultLength, hashResult, &temp[0], AES_BLOCK_SIZE);
+
+    result.resize(AES_BLOCK_SIZE);
+    for (unsigned i = 0; i < AES_BLOCK_SIZE; i++)
+    {
+        result[i] = hashResult[i];
+    }
+
+    return true;
+}

--- a/crypto/mmohash.h
+++ b/crypto/mmohash.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ */
+#ifndef MMO_HASH_H
+#define MMO_HASH_H
+
+#include <string>
+#include <vector>
+
+bool CRYPTO_GetMmoHashFromInstallCode(const std::string &hexString, std::vector<unsigned char> &result);
+
+#endif // MMO_HASH_H

--- a/de_web.pro
+++ b/de_web.pro
@@ -121,6 +121,7 @@ HEADERS  = bindings.h \
            button_maps.h \
            connectivity.h \
            colorspace.h \
+           crypto/mmohash.h \
            crypto/random.h \
            crypto/scrypt.h \
            database.h \

--- a/de_web.pro
+++ b/de_web.pro
@@ -64,7 +64,7 @@ macx {
 unix:LIBS +=  -L../.. -ldeCONZ
 
 unix:!macx {
-    LIBS += -lcrypt -lssl -lcrypto
+    LIBS += -lcrypt
 }
 
 TEMPLATE        = lib
@@ -194,6 +194,7 @@ SOURCES  = air_quality.cpp \
            change_channel.cpp \
            connectivity.cpp \
            colorspace.cpp \
+           crypto/mmohash.cpp \
            crypto/random.cpp \
            crypto/scrypt.cpp \
            database.cpp \
@@ -291,7 +292,7 @@ SOURCES  = air_quality.cpp \
 
 win32 {
 
-    OPENSSL_PATH = E:/Qt/Tools/OpenSSL/Win_x86
+    OPENSSL_PATH = C:/Qt/Tools/OpenSSL/Win_x86
 
     exists($$OPENSSL_PATH) {
         message(OpenSLL detected $$OPENSSL_PATH)

--- a/rest_devices.cpp
+++ b/rest_devices.cpp
@@ -16,6 +16,7 @@
 #include "product_match.h"
 #include "device_descriptions.h"
 #include "rest_devices.h"
+#include "crypto/mmohash.h"
 #include "utils/ArduinoJson.h"
 #include "utils/utils.h"
 
@@ -1052,7 +1053,7 @@ int RestDevices::putDeviceInstallCode(const ApiRequest &req, ApiResponse &rsp)
             char mmoHashHex[128] = {0};
             std::vector<unsigned char> mmoHash;
 
-            if (!getMmoHashFromInstallCode(installCode, mmoHash))
+            if (!CRYPTO_GetMmoHashFromInstallCode(installCode, mmoHash))
             {
                 rsp.list.append(errorToMap(ERR_INTERNAL_ERROR, QLatin1String("/devices"), QLatin1String("internal error, failed to calc mmo hash, occured")));
                 rsp.httpStatus = HttpStatusServiceUnavailable;

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -116,6 +116,4 @@ unsigned endpointFromUniqueId(const QString &uniqueId);
 bool copyString(char *dst, size_t dstSize, const char *src, ssize_t srcSize = -1);
 inline bool isEmptyString(const char *str) { return str && str[0] == '\0'; }
 
-bool getMmoHashFromInstallCode(const std::string &hexString, std::vector<unsigned char> &result);
-
 #endif // UTILS_H

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -116,7 +116,6 @@ unsigned endpointFromUniqueId(const QString &uniqueId);
 bool copyString(char *dst, size_t dstSize, const char *src, ssize_t srcSize = -1);
 inline bool isEmptyString(const char *str) { return str && str[0] == '\0'; }
 
-void aesMmoHash(uint &length, std::vector<unsigned char> &result, std::vector<unsigned char> &data);
-QByteArray getMmoHashFromInstallCode(std::string hexString);
+bool getMmoHashFromInstallCode(std::string hexString, std::vector<unsigned char> &result);
 
 #endif // UTILS_H

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -116,6 +116,6 @@ unsigned endpointFromUniqueId(const QString &uniqueId);
 bool copyString(char *dst, size_t dstSize, const char *src, ssize_t srcSize = -1);
 inline bool isEmptyString(const char *str) { return str && str[0] == '\0'; }
 
-bool getMmoHashFromInstallCode(std::string hexString, std::vector<unsigned char> &result);
+bool getMmoHashFromInstallCode(const std::string &hexString, std::vector<unsigned char> &result);
 
 #endif // UTILS_H


### PR DESCRIPTION
- Load OpenSSL function dynamically to not hard link the library.
- Replaced various std::vectors with simple C arrays.
- Move code from utils.cpp to crypto/mmohash.cpp
- Verify that that install code has valid sizes of 6, 8, 12, 16 plus two bytes CRC and contains actual hex data.
- Test if the CRC is valid and auto correct if not (there are some devices with invalid/twisted CRC)
- Verified against Zigbee Alliance test vectors.
- On Windows include msvcr100.dll to deCONZ installer, required for the OpenSSL libraries and might be missing on the host system.

This was also needed to get it compile for v2.22.0-beta Windows release (which didn't work out).