### PR TITLE
DDF for Tuya 2-channel switch module (_TZ3000_zmy4lslw)

### DIFF
--- a/devices/tuya/_TZ3000_zmy4lslw_2channel_module.json
+++ b/devices/tuya/_TZ3000_zmy4lslw_2channel_module.json
@@ -1,0 +1,105 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "_TZ3000_zmy4lslw",
+  "modelid": "TS0002",
+  "product": "Tuya 2 output module",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_ON_OFF_OUTPUT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",                   
+          "refresh.interval": 86400,
+          "parse": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001", "script": "tuya_swversion.js"},
+          "read": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001"}
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/on"
+        },
+        {
+          "name": "state/reachable"
+        },
+        {
+          "name": "config/tuya_unlock"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_ON_OFF_OUTPUT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x02"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",                   
+          "refresh.interval": 86400,
+          "parse": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001", "script": "tuya_swversion.js"},
+          "read": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001"}
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/on"
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/6446

- Product name: 2CH Zigbee Switch Module (Tuya Smart ZigBee 3.0 Switch Module)
- Manufacturer: _TZ3000_zmy4lslw
- Model identifier: TS0002
- Device type : 2 gang/ch Switch