### PR TITLE
Use Tuya unlock sequence for Moes 2-gang switch (_TZ3000_18ejxno0)

### DIFF
--- a/devices/moes/Moes_TZ3000_TS0012_2_gang_switches.json
+++ b/devices/moes/Moes_TZ3000_TS0012_2_gang_switches.json
@@ -4,7 +4,7 @@
   "modelid": "TS0012",
   "product": "2 gang switches",
   "sleeper": false,
-  "status": "Silver",
+  "status": "Gold",
   "subdevices": [
     {
       "type": "$TYPE_ON_OFF_LIGHT",

--- a/devices/moes/Moes_TZ3000_TS0012_2_gang_switches.json
+++ b/devices/moes/Moes_TZ3000_TS0012_2_gang_switches.json
@@ -2,7 +2,7 @@
   "schema": "devcap1.schema.json",
   "manufacturername": "_TZ3000_18ejxno0",
   "modelid": "TS0012",
-  "product": "Battery 2 gang switches",
+  "product": "2 gang switches",
   "sleeper": false,
   "status": "Silver",
   "subdevices": [
@@ -62,6 +62,9 @@
           "name": "state/on",
           "refresh.interval": 5
         },
+				{
+					"name": "config/tuya_unlock"
+				},
         {
           "name": "state/reachable"
         }

--- a/devices/moes/Moes_TZ3000_TS0012_2_gang_switches.json
+++ b/devices/moes/Moes_TZ3000_TS0012_2_gang_switches.json
@@ -62,9 +62,9 @@
           "name": "state/on",
           "refresh.interval": 5
         },
-				{
-					"name": "config/tuya_unlock"
-				},
+	{
+	 "name": "config/tuya_unlock"
+	},
         {
           "name": "state/reachable"
         }


### PR DESCRIPTION
1. It's not battery powered device but wired with or without neutral (changing name of the DDF file)
2. Newer version need tuya unlock sequence to toggle switch individualy.

Thx to @tosko in Discord to mention this.