### PR TITLE
Fix battery updates not contributing to sensor availability

### DIFF
--- a/power_configuration.cpp
+++ b/power_configuration.cpp
@@ -167,11 +167,18 @@ void DeRestPluginPrivate::handlePowerConfigurationClusterIndication(const deCONZ
 
                 if (sensor.type().endsWith(QLatin1String("Battery")))
                 {
-                    if (sensor.setValue(RStateBattery, bat) || updateType == NodeValue::UpdateByZclReport)
-                    {
-                        sensor.updateStateTimestamp();
-                    }
                     item = sensor.item(RStateBattery);
+
+                    if (item)
+                    {
+                        item->setValue(bat);
+                        sensor.updateStateTimestamp();
+                        sensor.setNeedSaveDatabase(true);
+                        queSaveDb(DB_SENSORS, DB_HUGE_SAVE_DELAY);
+                        enqueueEvent(Event(RSensors, RStateBattery, sensor.id(), item));
+                        enqueueEvent(Event(RSensors, RStateLastUpdated, sensor.id()));
+                        updateSensorEtag(&sensor);
+                    }
                 }
                 else
                 {
@@ -182,7 +189,14 @@ void DeRestPluginPrivate::handlePowerConfigurationClusterIndication(const deCONZ
                         item = sensor.addItem(DataTypeUInt8, RConfigBattery);
                     }
 
-                    sensor.setValue(RConfigBattery, bat);
+                    if (item)
+                    {
+                        item->setValue(bat);
+                        enqueueEvent(Event(RSensors, RConfigBattery, sensor.id(), item));
+                        updateSensorEtag(&sensor);
+                        sensor.setNeedSaveDatabase(true);
+                        queSaveDb(DB_SENSORS, DB_SHORT_SAVE_DELAY);
+                    }
                 }
 
                 if (item)
@@ -287,8 +301,16 @@ void DeRestPluginPrivate::handlePowerConfigurationClusterIndication(const deCONZ
                 }
 
                 battery = calculateBatteryPercentageRemaining(&sensor, item, battery, vmin, vmax);
-
-                sensor.setValue(RConfigBattery, battery);
+                
+                if (item)
+                {
+                    item->setValue(battery);
+                    enqueueEvent(Event(RSensors, RConfigBattery, sensor.id(), item));
+                    updateSensorEtag(&sensor);
+                    sensor.setNeedSaveDatabase(true);
+                    queSaveDb(DB_SENSORS, DB_SHORT_SAVE_DELAY);
+                }
+                
                 sensor.setZclValue(updateType, ind.srcEndpoint(), POWER_CONFIGURATION_CLUSTER_ID, POWER_CONFIG_ATTRID_BATTERY_VOLTAGE, attr.numericValue());
             }
                 break;
@@ -304,11 +326,16 @@ void DeRestPluginPrivate::handlePowerConfigurationClusterIndication(const deCONZ
 
                 bool lowBat = (attr.numericValue().u8 & 0x01);
 
-                sensor.setValue(RConfigBattery, lowBat);
                 sensor.setZclValue(updateType, ind.srcEndpoint(), POWER_CONFIGURATION_CLUSTER_ID, POWER_CONFIG_ATTRID_BATTERY_ALARM_MASK, attr.numericValue());
 
                 if (item)
                 {
+                    item->setValue(lowBat);
+                    enqueueEvent(Event(RSensors, RConfigBattery, sensor.id(), item));
+                    updateSensorEtag(&sensor);
+                    sensor.setNeedSaveDatabase(true);
+                    queSaveDb(DB_SENSORS, DB_SHORT_SAVE_DELAY);
+
                     DDF_AnnoteZclParse(&sensor, item, ind.srcEndpoint(), ind.clusterId(), attrId, "Item.val = (Attr.val & 1) != 0");
                 }
             }


### PR DESCRIPTION
For `power_configuration.cpp`, setting the resource item value is changed from `resource::setValue()` back to `resourceItem::setValue()`, as it was prior to version 2.13.0. This will ensure internal resource item timestamps are updated upon reception of an attribute report, even upon no value change.

In the end, this will prevent certain sensors to go into `unreachable` state and bring back some previously seen websocket events.