### PR TITLE
Add DDF + Button Map for _TZ3000_ja5osu5g Tuya Smart Button

### DIFF
--- a/button_maps.json
+++ b/button_maps.json
@@ -1372,7 +1372,7 @@
         },
         "TuyaSmartButton": {
             "vendor": "Tuya",
-            "doc": "Smart Button with Scene Control (scene control not mapped)",
+            "doc": "Smart Button with two modes (remote mode not mapped)",
             "modelids": ["_TZ3000_ja5osu5g"],
             "map": [
                 [1, "0x01", "ONOFF", "0xfd", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "Short"],

--- a/button_maps.json
+++ b/button_maps.json
@@ -1370,6 +1370,16 @@
                 [1, "0x01", "LEVEL_CONTROL", "STOP", "1", "S_BUTTON_4", "S_BUTTON_ACTION_SHORT_RELEASED", "B4R"]
             ]
         },
+        "TuyaSmartButton": {
+            "vendor": "Tuya",
+            "doc": "Smart Button with Scene Control (scene control not mapped)",
+            "modelids": ["_TZ3000_ja5osu5g"],
+            "map": [
+                [1, "0x01", "ONOFF", "0xfd", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "Short"],
+                [1, "0x01", "ONOFF", "0xfd", "1", "S_BUTTON_1", "S_BUTTON_ACTION_DOUBLE_PRESS", "Double"],
+                [1, "0x01", "ONOFF", "0xfd", "2", "S_BUTTON_1", "S_BUTTON_ACTION_LONG_RELEASED", "Long"]
+            ]
+        },
         "legrandSceneRemote": {
             "vendor": "Legrand",
             "doc": "Pocket remote",

--- a/devices/tuya/_TZ3000_ja5osu5g_smart_button.json
+++ b/devices/tuya/_TZ3000_ja5osu5g_smart_button.json
@@ -1,0 +1,97 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "_TZ3000_ja5osu5g",
+  "modelid": "TS004F",
+  "vendor": "Tuya",
+  "product": "Wireless Smart Button",
+  "sleeper": true,
+  "status": "Silver",
+  "subdevices": [
+    {
+      "type": "$TYPE_SWITCH",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x1000"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001", "script": "tuya_swversion.js"},
+          "read": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001"}
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+            "name": "config/battery",
+            "parse": {
+                "ep": 1, "cl": "0x0001", "at": "0x0021",
+                "eval": "Item.val = Attr.val / 2"
+            },
+            "read": {
+                "ep": 1, "cl": "0x0001", "at": "0x0021"
+            },
+            "refresh.interval": 7300
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/buttonevent",
+          "awake": true
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 60,
+          "max": 3600,
+          "change": "0x01"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0006"
+    }
+  ]
+}


### PR DESCRIPTION
My Try at a DDF for a smart button I recently bought:

https://de.aliexpress.com/item/1005005238316199.html?spm=a2g0o.order_list.order_list_main.11.49a15c5fjVVmas&gatewayAdapt=glo2deu

This is a single button, battery powered (button cell).

The button has two modes, you can switch between them by 3xPressing the button very fast.

### Scenario Mode
![image](https://github.com/dresden-elektronik/deconz-rest-plugin/assets/5864045/8c31f08c-4066-4ed0-bf1a-70786100047d)

Single Press
Double Press
Long Press

**I added the button events for this mode. They are working very reliable.**

### Remote Mode
![image](https://github.com/dresden-elektronik/deconz-rest-plugin/assets/5864045/fd75fd68-5c56-42ef-829d-bffcd5b6b7b7)

_Not very much info yet._

Single Press to turn on, double to turn off.

When on: press and hold to dim.
It seems to increase, then decrease and cycle again.
I was not able to identify a "start" event for dimming, although a "LEVEL_CONTROL STOP" event was sent.

Single press when on: Seems to cycle between 4 Presets of Level & Color Control based on the received button events (When on) I have no dimmable light to test this using a direct binding.
Could also just be some kind of Tuya-Magic.
The button can be bound directly to a plug to control on/off (tested)

### Notes
Testing is quite challenging. When playing aroung with bindings, I managed to put the button in some kind of state, that prevented the mode switch by 3x pressing the button.
Even after re-pairing this state remained.
Only after I brute-force played around with the unbinding in the GUI I managed to revert it backt to its initial behaviour.
