### PR TITLE
IKEA Styrbar firmware 2.4.5.

### DIFF
--- a/button_maps.json
+++ b/button_maps.json
@@ -351,6 +351,7 @@
                 [1, "0x01", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ (with on/off)"],
                 [1, "0x01", "ONOFF", "OFF", "0", "S_BUTTON_2", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],
                 [1, "0x01", "LEVEL_CONTROL", "MOVE", "1", "S_BUTTON_2", "S_BUTTON_ACTION_HOLD", "Move down"],
+                [1, "0x01", "LEVEL_CONTROL", "STOP", "1", "S_BUTTON_2", "S_BUTTON_ACTION_LONG_RELEASED", "Stop"],
                 [1, "0x01", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "1", "S_BUTTON_2", "S_BUTTON_ACTION_LONG_RELEASED", "Stop_ (with on/off)"],
                 [1, "0x01", "SCENES", "IKEA_STEP_CT", "1", "S_BUTTON_3", "S_BUTTON_ACTION_SHORT_RELEASED", "Step ct colder"],
                 [1, "0x01", "SCENES", "IKEA_MOVE_CT", "1", "S_BUTTON_3", "S_BUTTON_ACTION_HOLD", "Move ct colder"],

--- a/devices/ikea/styrbar_remote_control.json
+++ b/devices/ikea/styrbar_remote_control.json
@@ -1,0 +1,118 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "$MF_IKEA",
+  "modelid": "Remote Control N2",
+  "product": "STYRBAR remote control",
+  "sleeper": true,
+  "status": "Gold",
+  "path": "/devices/styrbar_remote_control.json",
+  "subdevices": [
+    {
+      "type": "$TYPE_SWITCH",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x1000"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0820",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x1000"
+        ],
+        "out": [
+          "0x0006",
+          "0x0008",
+          "0x0005"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "parse": {
+            "fn": "zcl",
+            "ep": 1,
+            "cl": "0x0001",
+            "at": "0x0021",
+            "eval": "Item.val = Math.round(Attr.val / 2)"
+          },
+          "default": 0
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/buttonevent"
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 300,
+          "max": 2700,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0006"
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0008"
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0005"
+    }
+  ]
+}

--- a/devices/ikea/styrbar_remote_control.json
+++ b/devices/ikea/styrbar_remote_control.json
@@ -5,7 +5,6 @@
   "product": "STYRBAR remote control",
   "sleeper": true,
   "status": "Gold",
-  "path": "/devices/styrbar_remote_control.json",
   "subdevices": [
     {
       "type": "$TYPE_SWITCH",


### PR DESCRIPTION
See #6761.

The API still exposes `config/group` and creates a corresponding `/groups` resource.  I suppose the legacy code handling _ZLL Commissioning_ (0x1000) doesn't check for managed devices?