### PR TITLE
DDF add support for UEHK2AZ0 keypad

### DIFF
--- a/devices/xfinity/THK1_keypad.json
+++ b/devices/xfinity/THK1_keypad.json
@@ -1,8 +1,8 @@
 {
   "schema": "devcap1.schema.json",
-  "manufacturername": ["Technicolor","Universal Electronics Inc"],
-  "modelid": ["TKA105","URC4450BC0-X-R"],
-  "product": "XHK1 keypad",
+  "manufacturername": ["Technicolor","Universal Electronics Inc","Universal Electronics Inc"],
+  "modelid": ["TKA105","URC4450BC0-X-R","H34450BA00-00007"],
+  "product": "Xfinity security keypad",
   "sleeper": false,
   "status": "Silver",
   "subdevices": [


### PR DESCRIPTION
Update DDF for Universal Electronics Inc UEHK2AZ0 keypad support.