### PR TITLE
Update DDF for H2L-ZBPH-RS roller shutter

### DIFF
--- a/devices/home2link/H2L-ZBPH-RS.json
+++ b/devices/home2link/H2L-ZBPH-RS.json
@@ -1,0 +1,82 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "H2L-ZBPH-RS",
+  "modelid": "H2L-ZBPH-RS",
+  "product": "H2L-ZBPH-RS",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_WINDOW_COVERING_DEVICE",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/lift",
+          "refresh.interval": 60,
+          "default": 0
+        },
+        {
+          "name": "state/open",
+          "parse": {
+            "at": "0x0008",
+            "cl": "0x0102",
+            "ep": 0,
+            "eval": "Item.val = Attr.val < 100",
+            "fn": "zcl"
+          }
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0102",
+      "report": [
+        {
+          "at": "0x0008",
+          "dt": "0x20",
+          "min": 1,
+          "max": 100,
+          "change": "0x00000001"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This device was placed under manufacturer Philips. It's actually a Hue shutter which was branded H2L-ZBPH-RS, just like the model ID. It's from the Dutch webshop Home2Link. The DDF was not working (anymore) with manufacturer Philips.