### PR TITLE
Fix errors reported by DDF validator

### DIFF
--- a/devices/aubess/aubess_multi_sensor_TZ3000_bguser20.json
+++ b/devices/aubess/aubess_multi_sensor_TZ3000_bguser20.json
@@ -35,7 +35,7 @@
           "name": "attr/name"
         },
         {
-          "name": "attr/swversion",                   
+          "name": "attr/swversion",
           "parse": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001", "script": "../tuya/tuya_swversion.js"},
           "read": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001"}
         },
@@ -48,7 +48,7 @@
         {
           "name": "config/battery",
           "awake": true,
-          "refresh.interval": 3600,
+          "refresh.interval": 3665,
           "read": {
             "at": "0x0021",
             "cl": "0x0001",
@@ -111,10 +111,10 @@
           "name": "attr/name"
         },
         {
-          "name": "attr/swversion",                   
+          "name": "attr/swversion",
           "refresh.interval": 86400,
           "parse": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001", "script": "../tuya/tuya_swversion.js"},
-          "read": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001"}          
+          "read": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001"}
         },
         {
           "name": "attr/type"
@@ -125,7 +125,7 @@
         {
           "name": "config/battery",
           "awake": true,
-          "refresh.interval": 3600,
+          "refresh.interval": 3665,
           "read": {
             "at": "0x0021",
             "cl": "0x0001",
@@ -171,8 +171,8 @@
         {
           "at": "0x0021",
           "dt": "0x20",
-          "min": 3600,
-          "max": 84600,
+          "min": 3200,
+          "max": 3600,
           "change": "0x00000002"
         }
       ]

--- a/devices/aubess/aubess_plug_TZ3000_hdopuwv6.json
+++ b/devices/aubess/aubess_plug_TZ3000_hdopuwv6.json
@@ -46,7 +46,7 @@
         },
         {
           "name": "state/on",
-          "refresh.interval": 5
+          "refresh.interval": 365
         },
         {
           "name": "state/reachable"
@@ -118,7 +118,7 @@
             "ep": 1,
             "eval": "Item.val = Attr.val"
           },
-          "refresh.interval": 100
+          "refresh.interval": 365
         },
         {
           "name": "state/lastupdated"
@@ -137,7 +137,7 @@
             "ep": 1,
             "eval": "Item.val = Attr.val"
           },
-          "refresh.interval": 100
+          "refresh.interval": 365
         },
         {
           "name": "state/voltage",
@@ -153,7 +153,7 @@
             "ep": 1,
             "eval": "Item.val = Attr.val"
           },
-          "refresh.interval": 100
+          "refresh.interval": 365
         }
       ]
     },
@@ -222,7 +222,7 @@
             "ep": 0,
             "eval": "Item.val = Attr.val * 10"
           },
-          "refresh.interval": 10
+          "refresh.interval": 365
         },
         {
           "name": "state/lastupdated"

--- a/devices/generic/subdevices/moisture_sensor.json
+++ b/devices/generic/subdevices/moisture_sensor.json
@@ -3,6 +3,7 @@
     "type": "$TYPE_MOISTURE_SENSOR",
     "name": "ZHAMoisture",
     "restapi": "/sensors",
+    "order": 23,
     "uuid": ["$address.ext", "0x01", "0x0408"],
     "items": [
         "config/on",

--- a/devices/ikea/cws_light.json
+++ b/devices/ikea/cws_light.json
@@ -144,11 +144,11 @@
         },
         {
           "name": "state/on",
-          "refresh.interval": 305
+          "refresh.interval": 365
         },
         {
           "name": "state/bri",
-          "refresh.interval": 305
+          "refresh.interval": 365
         },
         {
           "name": "state/colormode",
@@ -159,7 +159,7 @@
           "read": {
             "fn": "zcl", "ep": "0x01", "cl": "0x0300", "at": ["0x4001", "0x0003", "0x0004", "0x0007", "0x4002", "0x4000", "0x0001"]
           },
-          "refresh.interval": 305
+          "refresh.interval": 365
         },
         {
           "name": "state/x",

--- a/devices/lixee/zlinky_tic_histo_tri_hphc.json
+++ b/devices/lixee/zlinky_tic_histo_tri_hphc.json
@@ -51,7 +51,7 @@
         },
         {
           "name": "state/current",
-          "refresh.interval": 60,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0508",
             "cl": "0x0b04",
@@ -71,7 +71,7 @@
         },
         {
           "name": "state/power",
-          "refresh.interval": 60,
+          "refresh.interval": 365,
           "read": {
             "at": "0x050F",
             "cl": "0x0b04",
@@ -88,7 +88,7 @@
         },
         {
           "name": "state/voltage",
-          "refresh.interval": 60,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0505",
             "cl": "0x0b04",
@@ -152,7 +152,7 @@
         },
         {
           "name": "state/power",
-          "refresh.interval": 60,
+          "refresh.interval": 365,
           "read": {
             "at": "0x050B",
             "cl": "0x0b04",
@@ -213,7 +213,7 @@
         },
         {
           "name": "state/current",
-          "refresh.interval": 60,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0908",
             "cl": "0x0b04",
@@ -233,7 +233,7 @@
         },
         {
           "name": "state/power",
-          "refresh.interval": 60,
+          "refresh.interval": 365,
           "read": {
             "at": "0x090F",
             "cl": "0x0b04",
@@ -250,7 +250,7 @@
         },
         {
           "name": "state/voltage",
-          "refresh.interval": 60,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0905",
             "cl": "0x0b04",
@@ -311,7 +311,7 @@
         },
         {
           "name": "state/current",
-          "refresh.interval": 60,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0a08",
             "cl": "0x0b04",
@@ -331,7 +331,7 @@
         },
         {
           "name": "state/power",
-          "refresh.interval": 60,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0A0F",
             "cl": "0x0b04",
@@ -348,7 +348,7 @@
         },
         {
           "name": "state/voltage",
-          "refresh.interval": 60,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0a05",
             "cl": "0x0b04",
@@ -409,7 +409,7 @@
         },
         {
           "name": "state/consumption",
-          "refresh.interval": 10,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0100",
             "cl": "0x0702",
@@ -426,7 +426,7 @@
         },
         {
           "name": "state/consumption_2",
-          "refresh.interval": 10,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0102",
             "cl": "0x0702",
@@ -489,7 +489,7 @@
         },
         {
           "name": "state/alarm",
-          "refresh.interval": 300,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0005",
             "cl": "0xff66",

--- a/devices/lixee/zlinky_tic_historique_mono_base.json
+++ b/devices/lixee/zlinky_tic_historique_mono_base.json
@@ -50,7 +50,7 @@
         },
         {
           "name": "state/current",
-          "refresh.interval": 300,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0508",
             "cl": "0x0b04",
@@ -69,7 +69,7 @@
         },
         {
           "name": "state/power",
-          "refresh.interval": 300,
+          "refresh.interval": 365,
           "read": {
             "at": "0x050f",
             "cl": "0x0b04",
@@ -85,7 +85,7 @@
         },
         {
           "name": "state/voltage",
-          "refresh.interval": 300
+          "refresh.interval": 365
         }
       ]
     },
@@ -133,7 +133,7 @@
         },
         {
           "name": "state/consumption",
-          "refresh.interval": 300,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0100",
             "cl": "0x0702",
@@ -196,7 +196,7 @@
         },
         {
           "name": "state/alarm",
-          "refresh.interval": 300,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0005",
             "cl": "0xff66",

--- a/devices/lixee/zlinky_tic_historique_mono_hphc.json
+++ b/devices/lixee/zlinky_tic_historique_mono_hphc.json
@@ -51,7 +51,7 @@
         },
         {
           "name": "state/consumption",
-          "refresh.interval": 300,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0100",
             "cl": "0x0702",
@@ -67,7 +67,7 @@
         },
         {
           "name": "state/current",
-          "refresh.interval": 300,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0508",
             "cl": "0x0b04",
@@ -86,7 +86,7 @@
         },
         {
           "name": "state/power",
-          "refresh.interval": 300,
+          "refresh.interval": 365,
           "read": {
             "at": "0x050f",
             "cl": "0x0b04",
@@ -102,7 +102,7 @@
         },
         {
           "name": "state/voltage",
-          "refresh.interval": 300
+          "refresh.interval": 365
         }
       ]
     },
@@ -150,7 +150,7 @@
         },
         {
           "name": "state/consumption",
-          "refresh.interval": 300,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0102",
             "cl": "0x0702",
@@ -213,7 +213,7 @@
         },
         {
           "name": "state/alarm",
-          "refresh.interval": 300,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0005",
             "cl": "0xff66",
@@ -278,7 +278,7 @@
         },
         {
           "name": "state/consumption",
-          "refresh.interval": 300,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0100",
             "cl": "0x0702",

--- a/devices/lixee/zlinky_tic_standard_mono_base.json
+++ b/devices/lixee/zlinky_tic_standard_mono_base.json
@@ -50,7 +50,7 @@
         },
         {
           "name": "state/current",
-          "refresh.interval": 300,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0508",
             "cl": "0x0b04",
@@ -69,7 +69,7 @@
         },
         {
           "name": "state/power",
-          "refresh.interval": 300,
+          "refresh.interval": 365,
           "read": {
             "at": "0x050f",
             "cl": "0x0b04",
@@ -85,7 +85,7 @@
         },
         {
           "name": "state/voltage",
-          "refresh.interval": 300
+          "refresh.interval": 365
         }
       ]
     },
@@ -133,7 +133,7 @@
         },
         {
           "name": "state/consumption",
-          "refresh.interval": 300,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0100",
             "cl": "0x0702",
@@ -196,7 +196,7 @@
         },
         {
           "name": "state/alarm",
-          "refresh.interval": 300,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0005",
             "cl": "0xff66",

--- a/devices/lonsonho/_TZ3000_TS011F_smart_plug.json
+++ b/devices/lonsonho/_TZ3000_TS011F_smart_plug.json
@@ -126,7 +126,7 @@
             "ep": 1,
             "eval": "Item.val = Attr.val"
           },
-          "refresh.interval": 100
+          "refresh.interval": 365
         },
         {
           "name": "state/lastupdated"
@@ -145,7 +145,7 @@
             "ep": 1,
             "eval": "Item.val = Attr.val"
           },
-          "refresh.interval": 100
+          "refresh.interval": 365
         },
         {
           "name": "state/voltage",
@@ -161,7 +161,7 @@
             "ep": 1,
             "eval": "Item.val = Attr.val"
           },
-          "refresh.interval": 100
+          "refresh.interval": 365
         }
       ]
     },
@@ -233,7 +233,7 @@
             "ep": 0,
             "eval": "Item.val = Attr.val * 10"
           },
-          "refresh.interval": 10
+          "refresh.interval": 365
         },
         {
           "name": "state/lastupdated"

--- a/devices/mli/zbt-extendedcolor.json
+++ b/devices/mli/zbt-extendedcolor.json
@@ -103,11 +103,11 @@
         },
         {
           "name": "state/on",
-          "refresh.interval": 305
+          "refresh.interval": 365
         },
         {
           "name": "state/bri",
-          "refresh.interval": 305
+          "refresh.interval": 365
         },
         {
           "name": "state/colormode",
@@ -124,7 +124,7 @@
           "read": {
             "fn": "zcl", "ep": "0x01", "cl": "0x0300", "at": ["0x4001", "0x0007", "0x0003", "0x0004", "0x4002", "0x0000", "0x0001"]
           },
-          "refresh.interval": 305
+          "refresh.interval": 365
         },
         {
           "name": "state/ct",

--- a/devices/moes/Moes_TZ3000_TS0201_temp_hum_with_LCD.json
+++ b/devices/moes/Moes_TZ3000_TS0201_temp_hum_with_LCD.json
@@ -46,7 +46,7 @@
         {
           "name": "config/battery",
           "awake": true,
-          "refresh.interval": 3600,
+          "refresh.interval": 3665,
           "read": {
             "at": "0x0021",
             "cl": "0x0001",
@@ -121,7 +121,7 @@
         {
           "name": "config/battery",
           "awake": true,
-          "refresh.interval": 3600,
+          "refresh.interval": 3665,
           "read": {
             "at": "0x0021",
             "cl": "0x0001",

--- a/devices/nexentro/nexentro_blinds_actuator_mini.json
+++ b/devices/nexentro/nexentro_blinds_actuator_mini.json
@@ -67,7 +67,7 @@
         },
         {
           "name": "state/lift",
-          "refresh.interval": 300,
+          "refresh.interval": 365,
           "parse": {
             "at": "0x0008",
             "cl": "0x0102",
@@ -90,7 +90,7 @@
         },
         {
           "name": "state/tilt",
-          "refresh.interval": 300,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0009",
             "cl": "0x0102",

--- a/devices/sonoff/snzb-02-multisensor.json
+++ b/devices/sonoff/snzb-02-multisensor.json
@@ -70,7 +70,7 @@
         {
           "name": "config/battery",
           "awake": true,
-          "refresh.interval": 3600,
+          "refresh.interval": 7265,
           "read": {
             "at": "0x0021",
             "cl": "0x0001",
@@ -168,7 +168,7 @@
         {
           "name": "config/battery",
           "awake": true,
-          "refresh.interval": 3600,
+          "refresh.interval": 7265,
           "read": {
             "at": "0x0021",
             "cl": "0x0001",

--- a/devices/terncy/terncy_dc01_contact_sensor.json
+++ b/devices/terncy/terncy_dc01_contact_sensor.json
@@ -44,7 +44,7 @@
         },
         {
           "name": "config/battery",
-          "refresh.interval": 3600,
+          "refresh.interval": 3665,
           "read": {
             "at": "0x0021",
             "cl": "0x0001",

--- a/devices/third_reality/3RTHS24BZ_multi_sensor.json
+++ b/devices/third_reality/3RTHS24BZ_multi_sensor.json
@@ -46,7 +46,7 @@
             {
                "name":"config/battery",
                "awake":true,
-               "refresh.interval":3600,
+               "refresh.interval": 7265,
                "read":{
                   "at":"0x0021",
                   "cl":"0x0001",
@@ -118,7 +118,7 @@
             {
                "name":"config/battery",
                "awake":true,
-               "refresh.interval":3600,
+               "refresh.interval": 7265,
                "read":{
                   "at":"0x0021",
                   "cl":"0x0001",

--- a/devices/tuya/_TZ3000_cehuw1lw_smartplug_EU.json
+++ b/devices/tuya/_TZ3000_cehuw1lw_smartplug_EU.json
@@ -100,7 +100,7 @@
           "name": "state/consumption",
           "read": {"at": "0x0000", "cl": "0x0702", "ep": 1, "fn": "zcl" },
           "parse": {"at": "0x0000", "cl": "0x0702", "ep": 1, "eval": "Item.val = Attr.val * 10"},
-          "refresh.interval": 300
+          "refresh.interval": 365
         },
           {
             "name": "state/lastupdated"

--- a/devices/ubisys/s1_5501.json
+++ b/devices/ubisys/s1_5501.json
@@ -289,7 +289,7 @@
         },
         {
           "name": "state/power",
-          "refresh.interval": 305,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0400",
             "cl": "0x0702",

--- a/devices/ubisys/s2_5502.json
+++ b/devices/ubisys/s2_5502.json
@@ -338,7 +338,7 @@
         },
         {
           "name": "state/power",
-          "refresh.interval": 305,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0400",
             "cl": "0x0702",

--- a/devices/ubisys/s2r_5602.json
+++ b/devices/ubisys/s2r_5602.json
@@ -338,7 +338,7 @@
         },
         {
           "name": "state/power",
-          "refresh.interval": 305,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0400",
             "cl": "0x0702",

--- a/devices/wiser/contact_sensor_cct591011_as.json
+++ b/devices/wiser/contact_sensor_cct591011_as.json
@@ -56,7 +56,7 @@
         {
           "name": "config/battery",
           "awake": true,
-          "refresh.interval": 3700,
+          "refresh.interval": 3665,
           "read": {
             "at": "0x0021",
             "cl": "0x0001",
@@ -119,8 +119,8 @@
         {
           "at": "0x0021",
           "dt": "0x20",
-          "min": 3600,
-          "max": 43200,
+          "min": 3400,
+          "max": 3600,
           "change": "0x00000001"
         }
       ]

--- a/devices/wiser/socket-outlet-double-16A-connected.json
+++ b/devices/wiser/socket-outlet-double-16A-connected.json
@@ -47,7 +47,7 @@
         },
         {
           "name": "state/on",
-          "refresh.interval": 5,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0000",
             "cl": "0x0006",
@@ -111,7 +111,7 @@
         },
         {
           "name": "state/current",
-          "refresh.interval": 300,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0508",
             "cl": "0x0b04",
@@ -130,7 +130,7 @@
         },
         {
           "name": "state/power",
-          "refresh.interval": 300,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0400",
             "cl": "0x0702",
@@ -146,7 +146,7 @@
         },
         {
           "name": "state/voltage",
-          "refresh.interval": 300,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0505",
             "cl": "0x0b04",
@@ -206,7 +206,7 @@
         },
         {
           "name": "state/consumption",
-          "refresh.interval": 300,
+          "refresh.interval": 365,
           "read": {
             "at": "0x0000",
             "cl": "0x0702",

--- a/devices/xiaomi/lumi_sensor_wleak_aq1.json
+++ b/devices/xiaomi/lumi_sensor_wleak_aq1.json
@@ -8,7 +8,7 @@
   "status": "Gold",
   "subdevices": [
     {
-      "type": "$TYPE_WATER_SENSOR",
+      "type": "$TYPE_WATER_LEAK_SENSOR",
       "restapi": "/sensors",
       "uuid": [
         "$address.ext",


### PR DESCRIPTION
The PR contains several commits to better keep an overview and be able to revert or modify if needed.
The majority fixes are for refresh.interval vs reporting interval, if the refresh interval is too low, reporting can't be utilized optimally.

There are some power measurement plugs affected by this which had very small refresh.interval compared to the reporting configuration. The PR raised the refresh.interval in favor of the reporting intervals, some users might not be happy with that, here the max reporting intervals should be lowered, but I strongly advise against max reporting < 60 seconds as it scales poorly.

