### PR TITLE
Fix deprecated and other warnings

### DIFF
--- a/backup.cpp
+++ b/backup.cpp
@@ -134,7 +134,7 @@ bool BAK_ExportConfiguration(deCONZ::ApsController *apsCtrl)
         if (configFile.open(QIODevice::ReadWrite))
         {
             QTextStream stream(&configFile);
-            stream << saveString << endl;
+            stream << saveString << "\n";
             configFile.close();
         }
     }
@@ -235,7 +235,21 @@ bool BAK_ExportConfiguration(deCONZ::ApsController *apsCtrl)
             logfilesDirectories += QLatin1String("homebridge-install-logfiles");
         }
 
-        archProcess.start("tar -cf " + path + "/deCONZ.tar -C " + path + " deCONZ.conf zll.db session.default " + FirstFileName + " " + SecondFileName + " " + logfilesDirectories);
+        {
+            QStringList args;
+            args.append("-cf");
+            args.append(path + "/deCONZ.tar");
+            args.append("-C");
+            args.append(path);
+            args.append("deCONZ.conf");
+            args.append("zll.db");
+            args.append("session.default");
+            args.append(FirstFileName);
+            args.append(SecondFileName);
+            args.append(logfilesDirectories);
+
+            archProcess.start("tar", args);
+        }
 #endif
         archProcess.waitForFinished(EXT_PROCESS_TIMEOUT);
         DBG_Printf(DBG_INFO, "%s\n", qPrintable(archProcess.readAllStandardOutput()));
@@ -243,8 +257,8 @@ bool BAK_ExportConfiguration(deCONZ::ApsController *apsCtrl)
         //create .tar.gz
         {
             QProcess zipProcess;
-#ifdef Q_OS_WIN
             QStringList args;
+#ifdef Q_OS_WIN
             QString cmd = appPath + "/7za.exe";
 
             args.append("a");
@@ -253,7 +267,10 @@ bool BAK_ExportConfiguration(deCONZ::ApsController *apsCtrl)
             zipProcess.start(cmd, args);
 #endif
 #ifdef Q_OS_LINUX
-            zipProcess.start("gzip -k -f " + path + "/deCONZ.tar");
+            args.append("-k");
+            args.append("-f");
+            args.append(path + "/deCONZ.tar");
+            zipProcess.start("gzip", args);
 #endif
             zipProcess.waitForFinished(EXT_PROCESS_TIMEOUT);
             DBG_Printf(DBG_INFO, "%s\n", qPrintable(zipProcess.readAllStandardOutput()));
@@ -316,11 +333,11 @@ bool BAK_ImportConfiguration(deCONZ::ApsController *apsCtrl)
     {
         // decompress .tar.gz
         QProcess archProcess;
+        QStringList args;
 
 #ifdef Q_OS_WIN
         const QString appPath = qApp->applicationDirPath();
         const QString cmd = appPath + "/7za.exe";
-        QStringList args;
         args.append("e");
         args.append("-y");
         args.append(path + "/deCONZ.tar.gz");
@@ -328,7 +345,9 @@ bool BAK_ImportConfiguration(deCONZ::ApsController *apsCtrl)
         archProcess.start(cmd, args);
 #endif
 #ifdef Q_OS_LINUX
-        archProcess.start("gzip -df " + path + "/deCONZ.tar.gz");
+        args.append("-df");
+        args.append(path + "/deCONZ.tar.gz");
+        archProcess.start("gzip", args);
 #endif
         archProcess.waitForFinished(EXT_PROCESS_TIMEOUT);
         DBG_Printf(DBG_INFO, "%s\n", qPrintable(archProcess.readAllStandardOutput()));
@@ -338,10 +357,10 @@ bool BAK_ImportConfiguration(deCONZ::ApsController *apsCtrl)
     {
         // unpack .tar
         QProcess zipProcess;
+        QStringList args;
 #ifdef Q_OS_WIN
         const  QString appPath = qApp->applicationDirPath();
         const QString cmd = appPath + "/7za.exe";
-        QStringList args;
         args.append("e");
         args.append("-y");
         args.append(path + "/deCONZ.tar");
@@ -349,7 +368,11 @@ bool BAK_ImportConfiguration(deCONZ::ApsController *apsCtrl)
         zipProcess.start(cmd, args);
 #endif
 #ifdef Q_OS_LINUX
-        zipProcess.start("tar -xf " + path + "/deCONZ.tar -C " + path);
+        args.append("-xf");
+        args.append(path + "/deCONZ.tar");
+        args.append("-C");
+        args.append(path);
+        zipProcess.start("tar", args);
 #endif
         zipProcess.waitForFinished(EXT_PROCESS_TIMEOUT);
         DBG_Printf(DBG_INFO, "%s\n", qPrintable(zipProcess.readAllStandardOutput()));

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -13,6 +13,7 @@
 #include "device.h"
 #include "device_descriptions.h"
 #include "utils/utils.h"
+#include "zdp/zdp.h"
 
 #define MAX_ACTIVE_BINDING_TASKS 3
 
@@ -677,7 +678,7 @@ bool DeRestPluginPrivate::sendBindRequest(BindingTask &bt)
     stream.setByteOrder(QDataStream::LittleEndian);
 
     // generate and remember a new ZDP transaction sequence number
-    bt.zdpSeqNum = (uint8_t)qrand();
+    bt.zdpSeqNum = ZDP_NextSequenceNumber();
 
     stream << bt.zdpSeqNum; // ZDP transaction sequence number
 

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -4749,7 +4749,9 @@ void DeRestPluginPrivate::bindingTableReaderTimerFired()
             i->apsReq.setClusterId(ZDP_MGMT_BIND_REQ_CLID);
             i->apsReq.setDstEndpoint(ZDO_ENDPOINT);
             i->apsReq.setSrcEndpoint(ZDO_ENDPOINT);
+#if QT_VERSION < QT_VERSION_CHECK(5,15,0)
             i->apsReq.setTxOptions(0);
+#endif
             i->apsReq.setRadius(0);
 
             QDataStream stream(&apsReq.asdu(), QIODevice::WriteOnly);

--- a/change_channel.cpp
+++ b/change_channel.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "de_web_plugin_private.h"
+#include "zdp/zdp.h"
 
 #define CC_CHANNELCHANGE_WAIT_TIME         1000
 #define CC_CHANNELCHANGE_WAIT_CONFIRM_TIME 10000
@@ -146,7 +147,7 @@ void DeRestPluginPrivate::changeChannel(quint8 channel)
             {
                 nwkUpdateId = 1;
             }
-            const quint8 zdpSeq = (qrand() % 255);
+            const quint8 zdpSeq = ZDP_NextSequenceNumber();
             const quint32 scanChannels = (1 << static_cast<uint>(channel));
             const quint8 scanDuration = 0xfe; //special value = channel change
 

--- a/change_channel.cpp
+++ b/change_channel.cpp
@@ -157,7 +157,9 @@ void DeRestPluginPrivate::changeChannel(quint8 channel)
 
             deCONZ::ApsDataRequest req;
 
+#if QT_VERSION < QT_VERSION_CHECK(5,15,0)
             req.setTxOptions(nullptr);
+#endif
             req.setDstEndpoint(ZDO_ENDPOINT);
             req.setDstAddressMode(deCONZ::ApsNwkAddress);
             req.dstAddress().setNwk(deCONZ::BroadcastRxOnWhenIdle);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -11455,7 +11455,9 @@ bool DeRestPluginPrivate::callScene(Group *group, uint8_t sceneId)
     TaskItem task;
     task.taskType = TaskCallScene;
 
+#if QT_VERSION < QT_VERSION_CHECK(5,15,0)
     task.req.setTxOptions(0);
+#endif
     task.req.setDstEndpoint(0xFF);
     task.req.setDstAddressMode(deCONZ::ApsGroupAddress);
     task.req.dstAddress().setGroup(group->address());

--- a/green_power.cpp
+++ b/green_power.cpp
@@ -156,7 +156,9 @@ bool GP_SendProxyCommissioningMode(deCONZ::ApsController *apsCtrl, quint8 zclSeq
     req.setClusterId(GREEN_POWER_CLUSTER_ID);
     req.setDstEndpoint(GREEN_POWER_ENDPOINT);
     req.setSrcEndpoint(GREEN_POWER_ENDPOINT);
+#if QT_VERSION < QT_VERSION_CHECK(5,15,0)
     req.setTxOptions(nullptr);
+#endif
     req.setRadius(0);
 
     QDataStream stream(&req.asdu(), QIODevice::WriteOnly);
@@ -210,7 +212,9 @@ bool GP_SendPairing(quint32 gpdSrcId, quint16 sinkGroupId, quint8 deviceId, quin
     req.setClusterId(GREEN_POWER_CLUSTER_ID);
     req.setDstEndpoint(GREEN_POWER_ENDPOINT);
     req.setSrcEndpoint(GREEN_POWER_ENDPOINT);
+#if QT_VERSION < QT_VERSION_CHECK(5,15,0)
     req.setTxOptions(nullptr);
+#endif
     req.setRadius(0);
 
     QDataStream stream(&req.asdu(), QIODevice::WriteOnly);

--- a/permitJoin.cpp
+++ b/permitJoin.cpp
@@ -132,7 +132,9 @@ void DeRestPluginPrivate::permitJoinTimerFired()
         apsReq.setClusterId(ZDP_MGMT_PERMIT_JOINING_REQ_CLID);
         apsReq.setDstEndpoint(ZDO_ENDPOINT);
         apsReq.setSrcEndpoint(ZDO_ENDPOINT);
+#if QT_VERSION < QT_VERSION_CHECK(5,15,0)
         apsReq.setTxOptions(0);
+#endif
         apsReq.setRadius(0);
 
         QDataStream stream(&apsReq.asdu(), QIODevice::WriteOnly);

--- a/reset_device.cpp
+++ b/reset_device.cpp
@@ -71,7 +71,9 @@ void DeRestPluginPrivate::checkResetState()
 
                 deCONZ::ApsDataRequest req;
 
+#if QT_VERSION < QT_VERSION_CHECK(5,15,0)
                 req.setTxOptions(0);
+#endif
                 req.setDstEndpoint(ZDO_ENDPOINT);
                 req.setDstAddressMode(deCONZ::ApsExtAddress);
                 req.dstAddress().setExt(i->address().ext());
@@ -135,7 +137,9 @@ void DeRestPluginPrivate::checkResetState()
 
                 deCONZ::ApsDataRequest req;
 
+#if QT_VERSION < QT_VERSION_CHECK(5,15,0)
                 req.setTxOptions(0);
+#endif
                 req.setDstEndpoint(ZDO_ENDPOINT);
                 req.setDstAddressMode(deCONZ::ApsExtAddress);
                 req.dstAddress().setExt(si->address().ext());

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -950,6 +950,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                 else if (rid.suffix == RConfigLat || rid.suffix == RConfigLong) // String
                 {
                     double coordinate = data.string.toDouble(&ok);
+                    Q_UNUSED(coordinate);
                     if (!ok || data.string.isEmpty())
                     {
                         rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/sensors/%1/config/%2").arg(id).arg(pi.key()),
@@ -2400,7 +2401,7 @@ int DeRestPluginPrivate::changeSensorState(const ApiRequest &req, ApiResponse &r
                         val = val.toInt() + item2->toNumber();
                         if (rid.suffix == RStateHumidity)
                         {
-                            val = val < 0 ? 0 : val > 10000 ? 10000 : val;
+                            val = val.toInt() < 0 ? 0 : val.toInt() > 10000 ? 10000 : val;
                         }
                     }
                 }

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -86,7 +86,7 @@ constexpr KeyValMapAirQuality invalidValue(KeyValMapAirQuality) { return KeyValM
 template <typename K, typename Cont, typename V = typename Cont::value_type>
 decltype(auto) matchKeyValue(const K &key, const Cont &cont)
 {
-    V ret = invalidValue(ret);
+    V ret = invalidValue(V{});
     const auto res = std::find_if(cont.cbegin(), cont.cend(), [&key](const auto &i){ return i.key == key; });
     if (res != cont.cend())
     {
@@ -99,7 +99,7 @@ decltype(auto) matchKeyValue(const K &key, const Cont &cont)
 template <typename K, typename Cont, typename V = typename Cont::value_type>
 decltype(auto) lessThenKeyValue(const K &key, const Cont &cont)
 {
-    V ret = invalidValue(ret);
+    V ret = invalidValue(V{});
     const auto res = std::find_if(cont.cbegin(), cont.cend(), [&key](const auto &i){ return key <= i.key; });
     if (res != cont.cend())
     {


### PR DESCRIPTION
Since Qt 5.15.x various functions are deprecated.
More `qrand()` warnings will be fixed in the next release by replacing it with new deCONZ library `U_rand32()` function.