### PR TITLE
Fix missing battery resource item for Bosch thermostat II

### DIFF
--- a/devices/bosch/thermostat2.json
+++ b/devices/bosch/thermostat2.json
@@ -60,6 +60,23 @@
           "name": "attr/uniqueid"
         },
         {
+          "name": "config/battery",
+          "refresh.interval": 3660,
+          "parse": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "eval": "Item.val = Attr.val / 2;",
+            "fn": "zcl"
+          },
+          "read": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "fn": "zcl"
+          }
+        },
+        {
           "name": "config/checkin",
           "public": false,
           "refresh.interval": 3600


### PR DESCRIPTION
Apparently, this got simply overlooked. Binding was already there, but the resource item was not exposed by the DDF.