### PR TITLE
Fix Sengled E12-N1E use cap/color/ct/[min | max]

### DIFF
--- a/devices/sengled/E12-N1E.json
+++ b/devices/sengled/E12-N1E.json
@@ -43,6 +43,12 @@
           "name": "attr/uniqueid"
         },
         {
+          "name": "cap/color/ct/max"
+        },
+        {
+          "name": "cap/color/ct/min"
+        },
+        {
           "name": "state/alert",
           "default": "none"
         },


### PR DESCRIPTION
Reported by validator, device didn't have even ctmin/ctmax before.