### PR TITLE
DDF set state to "Gold" from "Silver" for the Tuya Soil Sensor _TZE200_myd45weu

### DIFF
--- a/devices/tuya/_TZE200_myd45weu_soil_sensor.json
+++ b/devices/tuya/_TZE200_myd45weu_soil_sensor.json
@@ -4,7 +4,7 @@
   "modelid": "TS0601",
   "product": "Tuya Soil Sensor",
   "sleeper": true,
-  "status": "Silver",
+  "status": "Gold",
   "subdevices": [
     {
       "type": "$TYPE_TEMPERATURE_SENSOR",


### PR DESCRIPTION
Device is working, already tested by some users.
For exemple https://forum.phoscon.de/t/tuya-qt-07s-myd45qeu-soil-humidity-en-temp-sensor-always-reports-0-humidity/3727