### PR TITLE
DDF Add support for Paulmann Zigbee Switch 501.34

### DIFF
--- a/button_maps.json
+++ b/button_maps.json
@@ -1425,6 +1425,35 @@
                 [1, "0x02", "LEVEL_CONTROL", "STOP", "1", "S_BUTTON_4", "S_BUTTON_ACTION_LONG_RELEASED", "Dimm down stop"]
             ]
         },
+        "PaulmannMap": {
+            "vendor": "Paulmann LichtGmbH",
+            "doc": "On off remote",
+            "modelids": ["501.34"],
+            "buttons": [
+                {"S_BUTTON_1": "ON Left"},
+                {"S_BUTTON_2": "OFF Left"},
+                {"S_BUTTON_3": "ON Right"},
+                {"S_BUTTON_4": "OFF Right"},
+                {"S_BUTTON_5": "ON Left long"},
+                {"S_BUTTON_6": "OFF Left long"},
+                {"S_BUTTON_7": "ON Right long"},
+                {"S_BUTTON_8": "OFF Right long"}
+            ],
+            "map": [
+                [1, "0x01", "ONOFF", "ON", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "ON Left"],
+                [1, "0x01", "ONOFF", "OFF", "0", "S_BUTTON_2", "S_BUTTON_ACTION_SHORT_RELEASED", "OFF Left"],
+                [1, "0x02", "ONOFF", "ON", "0", "S_BUTTON_3", "S_BUTTON_ACTION_SHORT_RELEASED", "ON Right"],
+                [1, "0x02", "ONOFF", "OFF", "0", "S_BUTTON_4", "S_BUTTON_ACTION_SHORT_RELEASED", "OFF Right"],
+                [1, "0x01", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "0", "S_BUTTON_5", "S_BUTTON_ACTION_SHORT_RELEASED", "Dim Up Left"],
+                [1, "0x01", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "0", "S_BUTTON_5", "S_BUTTON_ACTION_SHORT_RELEASED", "Stop Dim"],
+                [1, "0x01", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "1", "S_BUTTON_6", "S_BUTTON_ACTION_SHORT_RELEASED", "Dim Down Left"],
+                [1, "0x01", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "1", "S_BUTTON_6", "S_BUTTON_ACTION_SHORT_RELEASED", "Stop Dim"],
+                [1, "0x02", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "0", "S_BUTTON_7", "S_BUTTON_ACTION_SHORT_RELEASED", "Dim Up Right"],
+                [1, "0x02", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "0", "S_BUTTON_7", "S_BUTTON_ACTION_SHORT_RELEASED", "Stop Dim"],
+                [1, "0x02", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "1", "S_BUTTON_8", "S_BUTTON_ACTION_SHORT_RELEASED", "Dim Down Right"],
+                [1, "0x02", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "1", "S_BUTTON_8", "S_BUTTON_ACTION_SHORT_RELEASED", "Stop Dim"]
+            ]
+        }
         "aqaraOpple6Map": {
             "vendor": "Xiaomi",
             "doc": "Aqara Opple switches",

--- a/button_maps.json
+++ b/button_maps.json
@@ -1453,7 +1453,7 @@
                 [1, "0x02", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "1", "S_BUTTON_8", "S_BUTTON_ACTION_SHORT_RELEASED", "Dim Down Right"],
                 [1, "0x02", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "1", "S_BUTTON_8", "S_BUTTON_ACTION_SHORT_RELEASED", "Stop Dim"]
             ]
-        }
+        },
         "aqaraOpple6Map": {
             "vendor": "Xiaomi",
             "doc": "Aqara Opple switches",

--- a/devices/paulmann/501_34_battery_switch.json
+++ b/devices/paulmann/501_34_battery_switch.json
@@ -1,0 +1,91 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "Paulmann LichtGmbH",
+  "modelid": "501.34",
+  "product": "Paulmann Battery Switch",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_SWITCH",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0006"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/buttonevent"
+        },
+        {
+          "name": "config/battery"
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 60,
+          "max": 3600,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0006"
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0008"
+    }
+  ]
+}


### PR DESCRIPTION
See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/6102


-    Product name: Zigbee Wandschalter On/Off/Dimm
-    Manufacturer: Paulman LichtGmbH
-    Model identifier: 501.34
-    Device type : Switch
