### PR TITLE
Fix DDF validation errors for samjin_multi_sensor.json

### DIFF
--- a/devices/samsung/samjin_multi_sensor.json
+++ b/devices/samsung/samjin_multi_sensor.json
@@ -44,7 +44,7 @@
                     "awake": true,
                     "parse": {"fn": "zcl", "ep": 1, "cl": "0x0001", "at": "0x0021", "eval": "Item.val = Attr.val / 2"},
                     "read": {"fn": "zcl", "ep": 1, "cl": "0x0001", "at": "0x0021"},
-                    "refresh.interval": 3600
+                    "refresh.interval": 3660
                 },
                 {
                     "name": "config/on"
@@ -100,7 +100,7 @@
                     "name": "config/battery",
                     "parse": {"fn": "zcl", "ep": 1, "cl": "0x0001", "at": "0x0021", "eval": "Item.val = Attr.val / 2"},
                     "read": {"fn": "zcl", "ep": 1, "cl": "0x0001", "at": "0x0021"},
-                    "refresh.interval": 3600
+                    "refresh.interval": 3660
                 },
                 {
                     "name": "config/offset"
@@ -152,7 +152,7 @@
                     "name": "config/battery",
                     "parse": {"fn": "zcl", "ep": 1, "cl": "0x0001", "at": "0x0021", "eval": "Item.val = Attr.val / 2"},
                     "read": {"fn": "zcl", "ep": 1, "cl": "0x0001", "at": "0x0021"},
-                    "refresh.interval": 3600
+                    "refresh.interval": 3660
                 },
                 {
                     "name": "config/on"

--- a/devices/samsung/samjin_multi_sensor.json
+++ b/devices/samsung/samjin_multi_sensor.json
@@ -161,10 +161,6 @@
                     "name": "config/reachable"
                 },
                 {
-                    "name": "state/orientation",
-                    "description": "<p>The orientation as [X, Y, Z].</p> <p><b>Note:</b> These are the raw device values, it's not known what they represent, they are in range -1400&ndash;1400.</p>"
-                },
-                {
                     "name": "state/orientation_x",
                     "public": true,
                     "parse": {"fn": "zcl", "ep": 1, "cl": "0xfc02", "at": "0x0012", "mf": "0x1241", "eval": "Item.val = Attr.val"}


### PR DESCRIPTION
Fix DDF validation errors.
- Invalid item `state/orientation`;
- Invalid refresh interval for `config/battery` (3x).