### PR TITLE
Bug fix: fp1 triggerdistance not updated from special atttribute

### DIFF
--- a/devices/xiaomi/lumi_motion_ac01.json
+++ b/devices/xiaomi/lumi_motion_ac01.json
@@ -274,7 +274,7 @@
           "parse": {
             "fn": "xiaomi:special",
             "at": "0x00F7",
-            "idx": "0x66",
+            "idx": "0x69",
             "eval": "R.item('config/triggerdistance').val = ['far', 'medium', 'near'][Attr.val]"
           }
         },


### PR DESCRIPTION
Typo (wrong tag) in handling `config/triggerdistance` for Aqara FP1 from Xioami special attribute, resulting in errors "failed to evaluate expression for 54:ef:44:10:00:4d:7b:c1-01-0406/config/triggerdistance_bis: R.item('config/triggerdistance').val = ['far', 'medium', 'near'][Attr.val], err: TypeError: failed to set Item.val".

(Re-submit of #7073)