### PR TITLE
Bug fix: false water detection for lumi_sensor_wleak_aq1

### DIFF
--- a/devices/xiaomi/lumi_sensor_wleak_aq1.json
+++ b/devices/xiaomi/lumi_sensor_wleak_aq1.json
@@ -100,17 +100,6 @@
             "fn": "ias:zonestatus",
             "mask": "alarm1"
           }
-        },
-        {
-          "name": "state/water_bis",
-          "awake": true,
-          "parse": {
-            "fn": "xiaomi:special",
-            "mf": "0x115F",
-            "at": "0xFF01",
-            "idx": "0x64",
-            "eval": "R.item('state/water').val = Attr.val"
-          }
         }
       ]
     }

--- a/devices/xiaomi/lumi_sensor_wleak_aq1.json
+++ b/devices/xiaomi/lumi_sensor_wleak_aq1.json
@@ -100,6 +100,17 @@
             "fn": "ias:zonestatus",
             "mask": "alarm1"
           }
+        },
+        {
+          "name": "state/water_bis",
+          "awake": true,
+          "parse": {
+            "fn": "xiaomi:special",
+            "mf": "0x115F",
+            "at": "0xFF01",
+            "idx": "0x64",
+            "eval": "R.item('state/water').val = false"
+          }
         }
       ]
     }

--- a/devices/xiaomi/lumi_sensor_wleak_aq1.json
+++ b/devices/xiaomi/lumi_sensor_wleak_aq1.json
@@ -109,7 +109,7 @@
             "mf": "0x115F",
             "at": "0xFF01",
             "idx": "0x64",
-            "eval": "R.item('state/water').val = false"
+            "eval": "R.item('state/water').val = R.item('state/water').val"
           }
         }
       ]


### PR DESCRIPTION
Remove `state/water_bis` as Xiaomi special attribute doesn't always reflect the water detected state, see #7061