### PR TITLE
Fix Aubess multi sensor config/battery parse function

### DIFF
--- a/devices/aubess/aubess_multi_sensor_TZ3000_bguser20.json
+++ b/devices/aubess/aubess_multi_sensor_TZ3000_bguser20.json
@@ -59,7 +59,8 @@
             "at": "0x0021",
             "cl": "0x0001",
             "ep": 1,
-            "fn": "zcl"
+            "fn": "zcl",
+            "eval": "Item.val = Attr.val / 2"
           },
           "default": 0
         },


### PR DESCRIPTION
`parse.eval` was missing. Reported by validator.