### PR TITLE
Add dynamic ResourceItemDescriptors

### DIFF
--- a/resource.cpp
+++ b/resource.cpp
@@ -630,8 +630,8 @@ const char *getResourcePrefix(const QString &str)
 
 bool getResourceItemDescriptor(const QString &str, ResourceItemDescriptor &descr)
 {
-    std::vector<ResourceItemDescriptor>::const_iterator i = rItemDescriptors.begin();
-    std::vector<ResourceItemDescriptor>::const_iterator end = rItemDescriptors.end();
+    auto i = rItemDescriptors.begin();
+    const auto end = rItemDescriptors.end();
 
     for (; i != end; ++i)
     {
@@ -640,6 +640,32 @@ bool getResourceItemDescriptor(const QString &str, ResourceItemDescriptor &descr
             descr = *i;
             return true;
         }
+    }
+
+    return false;
+}
+
+bool R_AddResourceItemDescriptor(const ResourceItemDescriptor &rid)
+{
+    if (rid.isValid())
+    {
+        QLatin1String str1(rid.suffix);
+
+        auto i = rItemDescriptors.begin();
+        const auto end = rItemDescriptors.end();
+
+        for (; i != end; ++i)
+        {
+            QLatin1String str2(i->suffix);
+
+            if (str1 == str2)
+            {
+                return false; //already known
+            }
+        }
+
+        rItemDescriptors.push_back(rid);
+        return true;
     }
 
     return false;

--- a/resource.h
+++ b/resource.h
@@ -394,16 +394,16 @@ public:
         type(t),
         qVariantType(v),
         suffix(s),
-        validMin(min),
-        validMax(max) { }
+        validMin((double)min),
+        validMax((double)max) { }
 
     bool isValid() const { return (type != DataTypeUnknown && suffix); }
     Access access = Access::Unknown;
     ApiDataType type = DataTypeUnknown;
     QVariant::Type qVariantType = QVariant::Invalid;
     const char *suffix = RInvalidSuffix;
-    qint64 validMin = 0;
-    qint64 validMax = 0;
+    double validMin = 0;
+    double validMax = 0;
     quint16 flags = 0;
 };
 
@@ -424,7 +424,8 @@ public:
         FlagPushOnSet       = 0x04, // events will be generated when item is set (even when value doesn't change)
         FlagPushOnChange    = 0x08, // events will be generated only when item changes
         FlagAwakeOnSet      = 0x10, // REventAwake will be generated when item is set after parse
-        FlagImplicit        = 0x20  // the item is always present for a specific resource type
+        FlagImplicit        = 0x20, // the item is always present for a specific resource type
+        FlagDynamicDescriptor = 0x40, // ResourceItemDescriptor is dynamic (not specified in code)
     };
 
     enum ValueSource
@@ -657,6 +658,8 @@ bool R_SetValueEventOnSet(Resource *r, const char *suffix, const V &val, Resourc
 
     return result;
 }
+
+bool R_AddResourceItemDescriptor(const ResourceItemDescriptor &rid);
 
 bool isValidRConfigGroup(const QString &str);
 

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -57,7 +57,7 @@ struct RestData
     int integer;
     uint uinteger;
     QString string;
-    float real;
+    double real;
     bool valid = false;
 };
 


### PR DESCRIPTION
Support creation of `ResourceItemsDescriptor` from `generic/items` JSON files. Works the same as the items defined in C++ code.

Dynamic items are only added if they aren't already registered. Later on we can remove items defined in C++ code, but need to reroute `const char*` suffix pointers like `RStateOn`.