### PR TITLE
Fix rand() deprecated warnings

### DIFF
--- a/light_node.cpp
+++ b/light_node.cpp
@@ -401,7 +401,7 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
                             item(RStateColorMode)->setValue(QVariant("ct")); // note due addItem() calls, pointer is different here
                         }
                     }
-                    [[clang::fallthrough]];
+                    // fall through
 
                     default:
                         break;

--- a/rest_schedules.cpp
+++ b/rest_schedules.cpp
@@ -12,9 +12,9 @@
 #include <QTcpSocket>
 #include <QVariantMap>
 #include <QRegExp>
-#include "de_web_plugin.h"
 #include "de_web_plugin_private.h"
 #include "json.h"
+#include "deconz/u_rand32.h"
 
 /*! Inits the schedules manager.
  */
@@ -440,14 +440,18 @@ int DeRestPluginPrivate::setScheduleAttributes(const ApiRequest &req, ApiRespons
                 QRegExp rnd("(\\d\\d):(\\d\\d):(\\d\\d)");
                 if (rnd.exactMatch(ls[1]))
                 {
+                    // TODO(mpi): the following code could use a refactor
                     randomMax = rnd.cap(1).toInt() * 60 * 60 + // h
                         rnd.cap(2).toInt() * 60 +   // m
                         rnd.cap(3).toInt(); // s
 
-                    if (randomMax == 0) {
+                    if (randomMax == 0)
+                    {
                         randomTime = 0;
-                    } else {
-                        randomTime = (qrand() % ((randomMax + 1) - 1) + 1);
+                    }
+                    else
+                    {
+                        randomTime = (U_rand32() % ((randomMax + 1) - 1) + 1);
                     }
                 }
                 else
@@ -900,10 +904,13 @@ bool DeRestPluginPrivate::jsonToSchedule(const QString &jsonString, Schedule &sc
                     rnd.cap(2).toInt() * 60 +   // m
                     rnd.cap(3).toInt(); // s
 
-                if (randomMax == 0) {
+                if (randomMax == 0)
+                {
                     randomTime = 0;
-                } else {
-                    randomTime = (qrand() % ((randomMax + 1) - 1) + 1);
+                }
+                else
+                {
+                    randomTime = (U_rand32() % ((randomMax + 1) - 1) + 1);
                 }
             }
             else
@@ -1294,10 +1301,13 @@ void DeRestPluginPrivate::scheduleTimerFired()
                             rnd.cap(2).toInt() * 60 +   // m
                             rnd.cap(3).toInt(); // s
 
-                        if (randomMax == 0) {
+                        if (randomMax == 0)
+                        {
                             randomTime = 0;
-                        } else {
-                            randomTime = (qrand() % ((randomMax + 1) - 1) + 1);
+                        }
+                        else
+                        {
+                            randomTime = (U_rand32() % ((randomMax + 1) - 1) + 1);
                         }
                     }
 

--- a/rest_touchlink.cpp
+++ b/rest_touchlink.cpp
@@ -12,9 +12,8 @@
 #include <QString>
 #include <QTcpSocket>
 #include <QVariantMap>
-#include "de_web_plugin.h"
 #include "de_web_plugin_private.h"
-#include "json.h"
+#include "deconz/u_rand32.h"
 
 // duration to wait for scan responses
 #define TL_SCAN_WAIT_TIME 250
@@ -124,7 +123,7 @@ int DeRestPluginPrivate::touchlinkScan(const ApiRequest &req, ApiResponse &rsp)
         return REQ_READY_SEND;
     }
 
-    uint32_t transactionId = qrand();
+    uint32_t transactionId = U_rand32();
 
     if (transactionId == 0)
     {
@@ -234,7 +233,7 @@ int DeRestPluginPrivate::identifyLight(const ApiRequest &req, ApiResponse &rsp)
         return REQ_READY_SEND;
     }
 
-    uint32_t transactionId = qrand();
+    uint32_t transactionId = U_rand32();
 
     if (transactionId == 0)
     {
@@ -298,7 +297,7 @@ int DeRestPluginPrivate::resetLight(const ApiRequest &req, ApiResponse &rsp)
         return REQ_READY_SEND;
     }
 
-    uint32_t transactionId = qrand();
+    uint32_t transactionId = U_rand32();
 
     if (transactionId == 0)
     {


### PR DESCRIPTION
Use deCONZ library `U_rand32()` instead.