### PR TITLE
DEV handle Mgmt_Bind_rsp NOT_PERMITTED status

### DIFF
--- a/device.cpp
+++ b/device.cpp
@@ -1037,9 +1037,13 @@ void DEV_BindingTableReadHandler(Device *device, const Event &event)
                 }
                 else
                 {
-                    if (status == deCONZ::ZdpNotSupported)
+                    if (status == deCONZ::ZdpNotSupported || status == deCONZ::ZdpNotPermitted)
                     {
                         d->binding.mgmtBindSupported = MGMT_BIND_NOT_SUPPORTED;
+                    }
+                    else
+                    {
+                        DBG_Printf(DBG_DEV, "ZDP read binding table error: 0x%016llX, status: 0x%02X (TODO handle?)\n", device->key(), status);
                     }
                     d->setState(DEV_BindingHandler, STATE_LEVEL_BINDING);
                 }


### PR DESCRIPTION
Seen for Sonoff multi sensor, the requests kept repeating forever. Handle the error, and fall back to "blindly" creating the bindings.

https://forum.phoscon.de/t/sonoff-sensors-ewelink-disconnected-and-not-sending-out-updates/3774/5