### PR TITLE
Fix Bosch thermostat  RBSH-TRV0-ZB-EU battery refresh interval

### DIFF
--- a/devices/bosch/thermostat2.json
+++ b/devices/bosch/thermostat2.json
@@ -61,7 +61,7 @@
         },
         {
           "name": "config/battery",
-          "refresh.interval": 3660,
+          "refresh.interval": 43265,
           "parse": {
             "at": "0x0021",
             "cl": "0x0001",


### PR DESCRIPTION
Reported by validator.