### PR TITLE
Support setting ZCL frame control (optional) in "zcl:cmd"

### DIFF
--- a/device_access_fn.cpp
+++ b/device_access_fn.cpp
@@ -207,6 +207,16 @@ static ZCL_Param getZclParam(const QVariantMap &param)
         result.hasCommandId = 0;
     }
 
+    if (param.contains(QLatin1String("fc"))) // optional
+    {
+        result.frameControl = (uint8_t)variantToUint(param["fc"], UINT8_MAX, &ok);
+        result.hasFrameControl = ok ? 1 : 0;
+    }
+    else
+    {
+        result.hasFrameControl = 0;
+    }
+
     const auto ignoreSeqno = QLatin1String("noseq");
     if (param.contains(ignoreSeqno))
     {
@@ -1796,15 +1806,25 @@ bool writeZclAttribute(const Resource *r, const ResourceItem *item, deCONZ::ApsC
 /*! A generic function to send a cluster-specific ZCL command.
     The \p cmdParameters is expected to contain one object (given in the device description file).
 
-    { "fn": "zcl:cmd", "ep": endpoint, "cl": clusterId, "mf": manufacturerCode, "cmd": commandId, "eval": expression }
+    { "fn": "zcl:cmd", "ep": endpoint, "cl": clusterId, "mf": manufacturerCode, "cmd": commandId, "fc": frameControl, "eval": expression }
 
     - endpoint: the destination endpoint, use 0 for auto endpoint (from the uniqueid)
     - clusterId: string hex value
     - manufacturerCode: (optional) string hex value
     - commandId: string hex value
+    - frameControl: (optional) string hex value, OR combined 8-bit bitmap to overwrite ZCL frame control
+
+          ZclFCProfileCommand          = 0x00,
+          ZclFCClusterCommand          = 0x01,
+          ZclFCManufacturerSpecific    = 0x04,
+          ZclFCDirectionServerToClient = 0x08,
+          ZclFCDirectionClientToServer = 0x00,
+          ZclFCEnableDefaultResponse   = 0x00,
+          ZclFCDisableDefaultResponse  = 0x10
+
     - expression: (optional) to transform the item value to the command payload as hex string value
 
-    Example: "read": {"fn": "zcl:cmd", "ep": "0x0b", "cl": "0x0000", "mf": "0x100b", "cmd": "0xc0",  "eval": "'002d00000040'"}
+    Example: "read": {"fn": "zcl:cmd", "ep": "0x0b", "cl": "0x0000", "mf": "0x100b", "cmd": "0xc0", "eval": "'002d00000040'"}
  */
 static DA_ReadResult sendZclCommand(const Resource *r, const ResourceItem *item, deCONZ::ApsController *apsCtrl, const QVariant &cmdParameters)
 {

--- a/device_ddf_init.cpp
+++ b/device_ddf_init.cpp
@@ -260,7 +260,7 @@ bool DEV_InitDeviceFromDescription(Device *device, const DeviceDescription &ddf)
                     writeFunction = writeParam.value(QLatin1String("fn")).toString();
                 }
 
-                if (writeFunction.isEmpty() || writeFunction == QLatin1String("zcl"))
+                if (writeFunction.isEmpty() || writeFunction.startsWith(QLatin1String("zcl")))
                 {
                     bool ok;
 

--- a/zcl/zcl.cpp
+++ b/zcl/zcl.cpp
@@ -224,6 +224,11 @@ ZCL_Result ZCL_SendCommand(const ZCL_Param &param, quint64 extAddress, quint16 n
                                       deCONZ::ZclFCDisableDefaultResponse);
     }
 
+    if (param.hasFrameControl)
+    {
+        zclFrame.setFrameControl(param.frameControl);
+    }
+
     { // payload
         QDataStream stream(&zclFrame.payload(), QIODevice::WriteOnly);
         stream.setByteOrder(QDataStream::LittleEndian);

--- a/zcl/zcl.h
+++ b/zcl/zcl.h
@@ -34,9 +34,9 @@ struct ZCL_Param
         uint8_t hasCommandId : 1;
         uint8_t attributeCount : 4;
         uint8_t ignoreResponseSeq: 1;
-        uint8_t _pad0 : 1;
+        uint8_t hasFrameControl : 1;
     };
-    uint8_t _pad1;
+    uint8_t frameControl = 0;
 };
 
 struct ZCL_Result


### PR DESCRIPTION
The DDF `zcl:cmd` function allows sending arbitrary commands. By specifying the frame control field we can control the whole ZCL frame.

I'm using this to send ZCL structured read/write attributes commands to the ubisys C4 *Device Setup Cluster (0xFC00)*.
These commands are ZCL profile wide and need respective bit 0x01 to be set to 0.

Background: There will be a separate PR for the ubisys devices in question like C4 and Sunricher SR-ZG2833PAC-C4 rebrand  https://github.com/dresden-elektronik/deconz-rest-plugin/issues/4703#issuecomment-813414935 structured write attribute is needed because writing the full array of elements to configure larger amounts of input actions (attribute 0x0001) can't be done with one write attribute request, so the C4 can't be configured to let all 4 buttons send press/hold/release events. With the very latest ubisys firmware version this is now possible due  addition of structured read/write attributes support.