### PR TITLE
Add generic measured_value items

### DIFF
--- a/devices/generic/items/cap_measured_value_max.json
+++ b/devices/generic/items/cap_measured_value_max.json
@@ -1,0 +1,9 @@
+{
+  "schema": "resourceitem1.schema.json",
+  "id": "cap/measured_value/max",
+  "datatype": "Double",
+  "access": "R",
+  "public": true,
+  "default": 0,
+  "description": "Maximum value of state/measured_value."
+}

--- a/devices/generic/items/cap_measured_value_min.json
+++ b/devices/generic/items/cap_measured_value_min.json
@@ -1,0 +1,9 @@
+{
+  "schema": "resourceitem1.schema.json",
+  "id": "cap/measured_value/min",
+  "datatype": "Double",
+  "access": "R",
+  "public": true,
+  "default": 0,
+  "description": "Minimum value of state/measured_value."
+}

--- a/devices/generic/items/cap_measured_value_unit.json
+++ b/devices/generic/items/cap_measured_value_unit.json
@@ -1,0 +1,14 @@
+{
+  "schema": "resourceitem1.schema.json",
+  "id": "cap/measured_value/unit",
+  "datatype": "String",
+  "access": "R",
+  "public": true,
+  "default": "",
+  "description": "The unit of state/measured_value. To be defined by static in DDF",
+  "values": [
+    ["ug/m^3", "microgram per cubic meter"],
+    ["PPM", "parts per million"],
+    ["PPB", "parts per billion"]
+  ]
+}

--- a/devices/generic/items/state_measured_value_item.json
+++ b/devices/generic/items/state_measured_value_item.json
@@ -1,0 +1,9 @@
+{
+  "schema": "resourceitem1.schema.json",
+  "id": "state/measured_value",
+  "datatype": "Double",
+  "access": "R",
+  "public": true,
+  "default": 0,
+  "description": "Represents the concentration as a fraction of 1."
+}


### PR DESCRIPTION
Related to https://github.com/dresden-elektronik/deconz-rest-plugin/pull/6673#issuecomment-1635627969

The main item `state/measured_value` provides a generic way to expose a measurement as floating point value e.g a temperature. The related `cap/measured_value/*` items describe the details — unit, min and max — about the value.

`state/measured_value`
`cap/measured_value/min`
`cap/measured_value/max`
`cap/measured_value/unit`