### PR TITLE
Refactor gateway password code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ set(PLUGIN_INCLUDE_FILES
     colorspace.h
     connectivity.h
     crypto/mmohash.h
+    crypto/password.h
     crypto/random.h
     crypto/scrypt.h
     database.h
@@ -141,6 +142,7 @@ add_library(${PROJECT_NAME} SHARED
     colorspace.cpp
     connectivity.cpp
     crypto/mmohash.cpp
+    crypto/password.cpp
     crypto/random.cpp
     crypto/scrypt.cpp
     database.cpp
@@ -254,6 +256,7 @@ target_compile_definitions(${PROJECT_NAME}
     PRIVATE
     USE_WEBSOCKETS=1
     USE_DUKTAPE_JS_ENGINE=1
+    USE_ULIB_SHARED=1
 
     GW_SW_VERSION="\"\"${PROJECT_VERSION}\"\""
     GW_SW_DATE=${GIT_DATE}

--- a/crypto/password.cpp
+++ b/crypto/password.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ */
+
+#include "password.h"
+#include <deconz/dbg_trace.h>
+#include <deconz/u_library.h>
+
+typedef char *(*lib_crypt_fn)(const char *phrase, const char *setting);
+static lib_crypt_fn crypt_fn = nullptr;
+
+// TODO(mpi): CRYPTO_ScryptPassword() is much stronger and available on all platforms.
+//            Need to figure out a upgrade path.
+
+/*! Encrypts a string with using crypt() MD5 + salt. (unix only)
+    \param str the input string
+    \return the encrypted string on success or the unchanged input string on fail
+ */
+std::string CRYPTO_EncryptGatewayPassword(const std::string &str)
+{
+#ifndef _WIN32
+    const char *pwsalt = "$1$8282jdkmskwiu29291"; // $1$ for MD5
+
+    if (!crypt_fn)
+    {
+        void *lib = U_library_open("libcrypt");
+
+        if (lib)
+        {
+            crypt_fn = reinterpret_cast<lib_crypt_fn>(U_library_symbol(lib, "crypt"));
+        }
+        else
+        {
+            DBG_Printf(DBG_ERROR, "failed to load libcrypt\n");
+        }
+    }
+
+    // encrypt and salt the hash
+    if (crypt_fn)
+    {
+        const char *enc = crypt_fn(str.c_str(), pwsalt);
+
+        if (enc)
+        {
+            return enc;
+        }
+        // else: fall through and return str
+    }
+
+#endif // ! _WIN32
+    return str;
+}

--- a/crypto/password.h
+++ b/crypto/password.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ */
+
+ #ifndef U_PASSWORD_H
+ #define U_PASSWORD_H
+
+#include <string>
+
+std::string CRYPTO_EncryptGatewayPassword(const std::string &str);
+
+ #endif /* U_PASSWORD_H */

--- a/database.cpp
+++ b/database.cpp
@@ -1492,7 +1492,7 @@ static int sqliteLoadConfigCallback(void *user, int ncols, char **colval , char 
         if (!val.isEmpty())
         {
             d->gwConfig["gwpassword"] = val;
-            d->gwAdminPasswordHash = val;
+            d->gwAdminPasswordHash = val.toStdString();
         }
     }
     else if (strcmp(colval[0], "uuid") == 0)
@@ -4862,7 +4862,7 @@ void DeRestPluginPrivate::saveDb()
         gwConfig["zigbeechannel"] = gwZigbeeChannel;
         gwConfig["group0"] = gwGroup0;
         gwConfig["gwusername"] = gwAdminUserName;
-        gwConfig["gwpassword"] = gwAdminPasswordHash;
+        gwConfig["gwpassword"] = QString::fromStdString(gwAdminPasswordHash);
         gwConfig["homebridge"] = gwHomebridge;
         gwConfig["homebridgeversion"] = gwHomebridgeVersion;
         gwConfig["homebridgeupdateversion"] = gwHomebridgeUpdateVersion;

--- a/de_web.pro
+++ b/de_web.pro
@@ -121,6 +121,7 @@ HEADERS  = bindings.h \
            connectivity.h \
            colorspace.h \
            crypto/mmohash.h \
+           crypto/password.h \
            crypto/random.h \
            crypto/scrypt.h \
            database.h \
@@ -195,6 +196,7 @@ SOURCES  = air_quality.cpp \
            connectivity.cpp \
            colorspace.cpp \
            crypto/mmohash.cpp \
+           crypto/password.cpp \
            crypto/random.cpp \
            crypto/scrypt.cpp \
            database.cpp \

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1083,7 +1083,6 @@ public:
     void initAuthentication();
     bool allowedToCreateApikey(const ApiRequest &req, ApiResponse &rsp, QVariantMap &map);
     void authorise(ApiRequest &req, ApiResponse &rsp);
-    QString encryptString(const QString &str);
 
     // REST API gateways
     int handleGatewaysApi(const ApiRequest &req, ApiResponse &rsp);
@@ -1714,7 +1713,7 @@ public:
     size_t apiAuthCurrent;
     std::vector<ApiAuth> apiAuths;
     QString gwAdminUserName;
-    QString gwAdminPasswordHash;
+    std::string gwAdminPasswordHash;
 
     struct SwUpdateState {
      QString noUpdate;


### PR DESCRIPTION
The main goal was to dynamically load *libcrypt* with `dlopen`. The release build on Debian buster doesn't work Ubuntu Jammy, because it has a different version of the library.

Further the code was separated from `DeRestPluginPrivate` into the `crypto/password.cpp` module not using Qt and be testable.

TODO: Move away from libcrypt and use the stronger scrypt functionality which we already have on each platform.