### PR TITLE
Cleanup debug prints and remove addr.toStringExt() usage

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -284,16 +284,6 @@ void DeRestPluginPrivate::handleMgmtBindRspIndication(const deCONZ::ApsDataIndic
     stream >> seqNo;
     stream >> status;
 
-    if (btReader)
-    {
-        DBG_Printf(DBG_ZDP, "MgmtBind_rsp id: %d %s seq: %u, status 0x%02X \n", btReader->apsReq.id(),
-                   qPrintable(node->address().toStringExt()), seqNo, status);
-    }
-    else
-    {
-        DBG_Printf(DBG_ZDP, "MgmtBind_rsp (no BTR) %s seq: %u, status 0x%02X \n", qPrintable(node->address().toStringExt()), seqNo, status);
-    }
-
     if (status != deCONZ::ZdpSuccess)
     {
         if (status == deCONZ::ZdpNotPermitted ||
@@ -301,7 +291,6 @@ void DeRestPluginPrivate::handleMgmtBindRspIndication(const deCONZ::ApsDataIndic
         {
             if (node->mgmtBindSupported())
             {
-                DBG_Printf(DBG_ZDP, "MgmtBind_req/rsp %s not supported, deactivate \n", qPrintable(node->address().toStringExt()));
                 node->setMgmtBindSupported(false);
             }
         }
@@ -347,7 +336,7 @@ void DeRestPluginPrivate::handleMgmtBindRspIndication(const deCONZ::ApsDataIndic
             btReader->state = BindingTableReader::StateFinished;
         }
 
-        enqueueEvent({RDevices, REventBindingTable, status, ind.srcAddress().ext()});
+        enqueueEvent({RDevices, REventBindingTable, status, ind.srcAddress().ext()}); // TODO(mpi): I think this event is obsolete and should be removed
     }
 
     while (listCount && !stream.atEnd())

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2527,7 +2527,6 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
             if (lightNode2->node() != node)
             {
                 lightNode2->setNode(const_cast<deCONZ::Node*>(node));
-                DBG_Printf(DBG_INFO, "LightNode %s set node %s\n", qPrintable(lightNode2->id()), qPrintable(node->address().toStringExt()));
             }
 
             lightNode2->setManufacturerCode(node->nodeDescriptor().manufacturerCode());
@@ -2539,7 +2538,6 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
             {
                 // the node existed before
                 // refresh all with new values
-                DBG_Printf(DBG_INFO, "LightNode %u: %s updated\n", lightNode2->id().toUInt(), qPrintable(lightNode2->name()));
                 reachable->setValue(avail);
                 Event e(RLights, RStateReachable, lightNode2->id(), reachable);
                 enqueueEvent(e);
@@ -3354,7 +3352,6 @@ void DeRestPluginPrivate::nodeZombieStateChanged(const deCONZ::Node *node)
             if (i->node() != node)
             {
                 i->setNode(const_cast<deCONZ::Node*>(node));
-                DBG_Printf(DBG_INFO, "LightNode %s set node %s\n", qPrintable(i->id()), qPrintable(node->address().toStringExt()));
             }
 
             ResourceItem *item = i->item(RStateReachable);
@@ -3396,7 +3393,6 @@ void DeRestPluginPrivate::nodeZombieStateChanged(const deCONZ::Node *node)
                 if (i->node() != node)
                 {
                     i->setNode(const_cast<deCONZ::Node*>(node));
-                    DBG_Printf(DBG_INFO, "Sensor %s set node %s\n", qPrintable(i->id()), qPrintable(node->address().toStringExt()));
                 }
 
                 checkSensorNodeReachable(&(*i));
@@ -3438,7 +3434,6 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
     if (lightNode->node() != event.node())
     {
         lightNode->setNode(const_cast<deCONZ::Node*>(event.node()));
-        DBG_Printf(DBG_INFO, "LightNode %s set node %s\n", qPrintable(lightNode->id()), qPrintable(event.node()->address().toStringExt()));
     }
 
     if (lightNode->toBool(RStateReachable))
@@ -5568,7 +5563,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                 if (i->node() != node)
                 {
                     i->setNode(const_cast<deCONZ::Node*>(node));
-                    DBG_Printf(DBG_INFO, "SensorNode %s set node %s\n", qPrintable(i->id()), qPrintable(node->address().toStringExt()));
 
                     pushSensorInfoToCore(&*i);
 
@@ -5578,7 +5572,6 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const deCONZ::
                         auto *itemPending = i->item(RConfigPending);
                         if (itemPending)
                         {
-                            DBG_Printf(DBG_INFO, "Init Poll Control for %s\n", qPrintable(node->address().toStringExt()));
                             pollControlInitialized = true;
                             itemPending->setValue(itemPending->toNumber() | R_PENDING_WRITE_POLL_CHECKIN_INTERVAL | R_PENDING_SET_LONG_POLL_INTERVAL);
                         }
@@ -8437,7 +8430,6 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
         if (i->node() != event.node())
         {
             i->setNode(const_cast<deCONZ::Node*>(event.node()));
-            DBG_Printf(DBG_INFO, "Sensor %s set node %s\n", qPrintable(i->id()), qPrintable(event.node()->address().toStringExt()));
         }
 
         if (event.event() == deCONZ::NodeEvent::UpdatedClusterDataZclReport ||
@@ -12064,14 +12056,6 @@ void DeRestPluginPrivate::processTasks()
 
         if (!ok) // destination already busy
         {
-            if (i->req.dstAddressMode() == deCONZ::ApsExtAddress)
-            {
-                DBG_Printf(DBG_INFO_L2, "delay sending request %u ep: 0x%02X cluster 0x%04X to %s onAir %d\n", i->req.id(), i->req.dstEndpoint(), i->req.clusterId(), qPrintable(i->req.dstAddress().toStringExt()), onAir);
-            }
-            else if (i->req.dstAddressMode() == deCONZ::ApsGroupAddress)
-            {
-                DBG_Printf(DBG_INFO, "delay sending request %u - type: %d to group 0x%04X\n", i->req.id(), i->taskType, i->req.dstAddress().group());
-            }
         }
         else
         {
@@ -12247,7 +12231,6 @@ void DeRestPluginPrivate::nodeEvent(const deCONZ::NodeEvent &event)
 
     case deCONZ::NodeEvent::NodeZombieChanged:
     {
-        DBG_Printf(DBG_INFO, "Node zombie state changed %s\n", qPrintable(event.node()->address().toStringExt()));
         nodeZombieStateChanged(event.node());
     }
         break;
@@ -12327,8 +12310,6 @@ void DeRestPluginPrivate::nodeEvent(const deCONZ::NodeEvent &event)
                 return;
             }
         }
-
-        DBG_Printf(DBG_INFO_L2, "Node data %s profileId: 0x%04X, clusterId: 0x%04X\n", qPrintable(event.node()->address().toStringExt()), event.profileId(), event.clusterId());
 
         // filter for supported sensor clusters
         switch (event.clusterId())
@@ -12598,8 +12579,6 @@ void DeRestPluginPrivate::handleGroupClusterIndication(const deCONZ::ApsDataIndi
         lightNode->setGroupCapacity(capacity);
         lightNode->setGroupCount(count);
 
-//        DBG_Printf(DBG_INFO, "verified group capacity: %u and group count: %u of LightNode %s\n", capacity, count, qPrintable(lightNode->address().toStringExt()));
-
         QVector<quint16> responseGroups;
         for (uint i = 0; i < count; i++)
         {
@@ -12610,7 +12589,7 @@ void DeRestPluginPrivate::handleGroupClusterIndication(const deCONZ::ApsDataIndi
 
                 responseGroups.push_back(groupId);
 
-                DBG_Printf(DBG_INFO, "%s found group 0x%04X\n", qPrintable(lightNode->address().toStringExt()), groupId);
+                DBG_Printf(DBG_INFO, FMT_MAC " found group 0x%04X\n", (unsigned long long)lightNode->address().ext(), groupId);
 
                 foundGroup(groupId);
                 foundGroupMembership(lightNode, groupId);
@@ -12629,7 +12608,7 @@ void DeRestPluginPrivate::handleGroupClusterIndication(const deCONZ::ApsDataIndi
                 && !responseGroups.contains(i->id)
                 && i->state == GroupInfo::StateInGroup)
             {
-                    DBG_Printf(DBG_INFO, "restore group  0x%04X for lightNode %s\n", i->id, qPrintable(lightNode->address().toStringExt()));
+                    DBG_Printf(DBG_INFO, FMT_MAC " restore group 0x%04X for lightNode\n", (unsigned long long)lightNode->address().ext(), i->id);
                     i->actions &= ~GroupInfo::ActionRemoveFromGroup; // sanity
                     i->actions |= GroupInfo::ActionAddToGroup;
                     i->state = GroupInfo::StateInGroup;
@@ -12888,7 +12867,7 @@ void DeRestPluginPrivate::handleSceneClusterIndication(const deCONZ::ApsDataIndi
 
                 if (i != v.end())
                 {
-                    DBG_Printf(DBG_INFO, "Added/stored scene %u in node %s Response. Status: 0x%02X\n", sceneId, qPrintable(lightNode->address().toStringExt()), status);
+                    DBG_Printf(DBG_INFO, FMT_MAC " added/stored scene %u response status: 0x%02X\n", (unsigned long long)lightNode->address().ext(), sceneId, status);
                     groupInfo->addScenes.erase(i);
 
                     if (status == 0x00)
@@ -13148,8 +13127,7 @@ void DeRestPluginPrivate::handleSceneClusterIndication(const deCONZ::ApsDataIndi
 
                 if (i != v.end())
                 {
-                    DBG_Printf(DBG_INFO, "Modified scene %u in node %s status 0x%02X\n", sceneId, qPrintable(lightNode->address().toStringExt()), status);
-
+                    DBG_Printf(DBG_INFO, FMT_MAC " modified scene %u status 0x%02X\n", (unsigned long long)lightNode->address().ext(), sceneId, status);
                     if (status == deCONZ::ZclSuccessStatus)
                     {
                         groupInfo->modifyScenesRetries = 0;
@@ -13874,7 +13852,7 @@ void DeRestPluginPrivate::handleCommissioningClusterIndication(const deCONZ::Aps
         stream >> startIndex;
         stream >> count;
 
-        DBG_Printf(DBG_INFO, "Get group identifiers response of sensor %s. Count: %u\n", qPrintable(sensorNode->address().toStringExt()), count);
+        DBG_Printf(DBG_INFO, FMT_MAC " get ZLL group identifiers response: count: %u\n", (unsigned long long)sensorNode->address().ext(), unsigned(count));
 
         while (!stream.atEnd() && epIter < count)
         {

--- a/de_web_widget.cpp
+++ b/de_web_widget.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2020 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2013-2023 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -118,7 +118,6 @@ void DeRestWidget::readBindingTableTriggered()
 {
     if (m_selectedNodeAddress.hasExt())
     {
-
         auto *restNode = dynamic_cast<RestNodeBase*>(plugin->d->getLightNodeForAddress(m_selectedNodeAddress));
 
         if (!restNode)
@@ -129,7 +128,6 @@ void DeRestWidget::readBindingTableTriggered()
         if (restNode)
         {
             restNode->setMgmtBindSupported(true);
-            DBG_Printf(DBG_INFO, "read binding table for %s (%s) \n", qPrintable(m_selectedNodeAddress.toStringExt()), qPrintable(m_selectedNodeAddress.toStringNwk()));
             plugin->d->readBindingTable(restNode, 0);
         }
     }

--- a/reset_device.cpp
+++ b/reset_device.cpp
@@ -226,7 +226,7 @@ void DeRestPluginPrivate::handleMgmtLeaveRspIndication(const deCONZ::ApsDataIndi
         stream >> seqNo;    // use SeqNo ?
         stream >> status;
 
-        DBG_Printf(DBG_INFO, "MgmtLeave_rsp %s seq: %u, status 0x%02X \n", qPrintable(ind.srcAddress().toStringExt()), seqNo, status);
+        DBG_Printf(DBG_INFO, "MgmtLeave_rsp " FMT_MAC " seq: %u, status 0x%02X \n", (unsigned long long)ind.srcAddress().ext(), seqNo, status);
 
         if (status == deCONZ::ZdpSuccess || status == deCONZ::ZdpNotSupported)
         {

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1610,7 +1610,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
 
     if (!taskRef.lightNode->stateChanges().empty())
     {
-        DBG_Printf(DBG_INFO, "emit event/tick: %s\n", qPrintable(taskRef.lightNode->address().toStringExt()));
+        DBG_Printf(DBG_INFO, "emit event/tick: " FMT_MAC "\n", (unsigned long long)taskRef.lightNode->address().ext());
         enqueueEvent({taskRef.lightNode->prefix(), REventTick, taskRef.lightNode->uniqueId(), taskRef.lightNode->address().ext()});
     }
 

--- a/rest_touchlink.cpp
+++ b/rest_touchlink.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2016-2023 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -174,7 +174,7 @@ int DeRestPluginPrivate::getTouchlinkScanResults(const ApiRequest &req, ApiRespo
     for (; i != end; ++i)
     {
         QVariantMap item;
-        item["address"] = i->address.toStringExt();
+        item["address"] = QString("0x%1").arg(i->address.ext(), int(16), int(16), QChar('0'));
         item["factorynew"] = i->factoryNew;
         item["rssi"] = (double)i->rssi;
         item["channel"] = (double)i->channel;
@@ -793,8 +793,8 @@ void DeRestPluginPrivate::interpanDataIndication(const QByteArray &data)
             scanResponse.transactionId = touchlinkReq.transactionId();
             scanResponse.rssi = rssi;
 
-            DBG_Printf(DBG_TLINK, "scan response %s, fn=%u, channel=%u rssi=%d TrId=0x%08X in state=%d action=%d\n",
-                       qPrintable(scanResponse.address.toStringExt()),
+            DBG_Printf(DBG_TLINK, "scan response " FMT_MAC ", fn=%u, channel=%u rssi=%d TrId=0x%08X in state=%d action=%d\n",
+                       (unsigned long long)scanResponse.address.ext(),
                        scanResponse.factoryNew, touchlinkChannel, rssi, scanResponse.transactionId,
                        touchlinkState, touchlinkAction);
 

--- a/window_covering.cpp
+++ b/window_covering.cpp
@@ -69,9 +69,6 @@
  *    To leave calibration mode, clear bit #1 in the Mode attribute, e.g. write attribute 0x0017 as 0x00.
  */
 
-
-
-#include "de_web_plugin.h"
 #include "de_web_plugin_private.h"
 #include "product_match.h"
 
@@ -646,10 +643,10 @@ void DeRestPluginPrivate::calibrateWindowCoveringNextStep()
     TaskItem task;
     copyTaskReq(calibrationTask, task);
 
-    DBG_Printf(DBG_INFO, "ubisys NextStep calibrationStep = %d, task=%s calibrationTask = %s \n",
+    DBG_Printf(DBG_INFO, "ubisys NextStep calibrationStep = %d, task=" FMT_MAC " calibrationTask = " FMT_MAC "\n",
                calibrationStep,
-               qPrintable(task.req.dstAddress().toStringExt()),
-               qPrintable(calibrationTask.req.dstAddress().toStringExt()));
+               (unsigned long long)task.req.dstAddress().ext(),
+               (unsigned long long)calibrationTask.req.dstAddress().ext());
 
     switch(calibrationStep)
     {

--- a/zdp/zdp_handlers.cpp
+++ b/zdp/zdp_handlers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2021-2023 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -8,7 +8,6 @@
  *
  */
 
-#include "de_web_plugin.h"
 #include "de_web_plugin_private.h"
 #include "utils/utils.h"
 #include "zdp_handlers.h"
@@ -131,7 +130,7 @@ void DeRestPluginPrivate::handleDeviceAnnceIndication(const deCONZ::ApsDataIndic
                 updateEtag(gwConfigEtag);
             }
 
-            DBG_Printf(DBG_INFO, "DeviceAnnce of LightNode: %s Permit Join: %i\n", qPrintable(i->address().toStringExt()), gwPermitJoinDuration);
+            DBG_Printf(DBG_INFO, "DeviceAnnce of LightNode: " FMT_MAC " Permit Join: %i\n", (unsigned long long)i->address().ext(), gwPermitJoinDuration);
 
             // force reading attributes
             i->enableRead(READ_GROUPS | READ_SCENES);


### PR DESCRIPTION
The PR removes various legacy log outputs which I think aren't relevant anymore and superseeded by DDFs.

Further `QString deCONZ::Address::toStringExt()` is deprecated in first steps to create a QString alternative. Since it's a heavy method also which allocates memory on each call, change debug printing to plain numeric `printf`. It isn't pretty but will do for now. There will be a better method to print MAC addresses soon.