### PR TITLE
Remove FLS-NB, ubisys C++ code and rule "BIND" support

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2017-2023 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -358,18 +358,8 @@ void DeRestPluginPrivate::handleMgmtBindRspIndication(const deCONZ::ApsDataIndic
                 continue;
             }
 
-            if (std::find(bindingToRuleQueue.begin(), bindingToRuleQueue.end(), bnd) == bindingToRuleQueue.end())
-            {
-                DBG_Printf(DBG_ZDP, "add binding to check rule queue size: %d\n", static_cast<int>(bindingToRuleQueue.size()));
-                bindingToRuleQueue.push_back(bnd);
-            }
-            else
-            {
-                DBG_Printf(DBG_ZDP, "binding already in binding to rule queue\n");
-            }
-
-            std::list<BindingTask>::iterator i = bindingQueue.begin();
-            std::list<BindingTask>::iterator end = bindingQueue.end();
+            auto i = bindingQueue.begin();
+            auto end = bindingQueue.end();
 
             for (;i != end; ++i)
             {
@@ -424,11 +414,6 @@ void DeRestPluginPrivate::handleMgmtBindRspIndication(const deCONZ::ApsDataIndic
                 }
             }
         }
-    }
-
-    if (!bindingToRuleTimer->isActive() && !bindingToRuleQueue.empty())
-    {
-        bindingToRuleTimer->start();
     }
 }
 
@@ -2264,10 +2249,7 @@ void DeRestPluginPrivate::checkLightBindingsForAttributeReporting(LightNode *lig
     if (gwReportingEnabled)
     {
         action = BindingTask::ActionBind;
-        if (lightNode->modelId().startsWith(QLatin1String("FLS-NB")))
-        {
-        }
-        else if (lightNode->manufacturer() == QLatin1String("OSRAM"))
+        if (lightNode->manufacturer() == QLatin1String("OSRAM"))
         {
         }
         else if (lightNode->manufacturer() == QLatin1String("LEDVANCE"))
@@ -2612,10 +2594,6 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId() == QLatin1String("YRD226/246 TSDB") ||
         sensor->modelId() == QLatin1String("YRD220/240 TSDB") ||
         sensor->modelId() == QLatin1String("easyCodeTouch_v1") ||
-        // ubisys
-        sensor->modelId().startsWith(QLatin1String("D1")) ||
-        sensor->modelId().startsWith(QLatin1String("S1-R")) ||
-        sensor->modelId().startsWith(QLatin1String("S2-R")) ||
         // IKEA
         sensor->modelId().startsWith(QLatin1String("TRADFRI")) ||
         sensor->modelId().startsWith(QLatin1String("Remote Control N2")) || // STYRBAR
@@ -2675,8 +2653,6 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
         sensor->modelId() == QLatin1String("3AFE14010402000D") ||
         sensor->modelId() == QLatin1String("3AFE220103020000") ||
         sensor->modelId() == QLatin1String("3AFE28010402000D") ||
-        // Nimbus
-        sensor->modelId().startsWith(QLatin1String("FLS-NB")) ||
         // Danalock support
         sensor->modelId().startsWith(QLatin1String("V3")) ||
         // Schlage support
@@ -2931,10 +2907,6 @@ bool DeRestPluginPrivate::checkSensorBindingsForAttributeReporting(Sensor *senso
     // whitelist by Model ID
     if (gwReportingEnabled)
     {
-//        if (sensor->modelId().startsWith(QLatin1String("FLS-NB")))
-//        {
-//            // temporary disable, delete bindings and use read attributes
-//        }
         if (deviceSupported)
         {
             action = BindingTask::ActionBind;
@@ -4009,81 +3981,6 @@ void DeRestPluginPrivate::deleteGroupsWithDeviceMembership(const QString &id)
     }
 }
 
-/*! Check existing bindings on ubisys devices. */
-void DeRestPluginPrivate::processUbisysBinding(Sensor *sensor, const Binding &bnd)
-{
-    if (!sensor)
-    {
-        return;
-    }
-
-    ResourceItem *item = 0;
-
-    if (sensor->type() == QLatin1String("ZHASwitch") && bnd.dstAddrMode == deCONZ::ApsGroupAddress)
-    {
-        item = sensor->item(RConfigGroup);
-
-        DBG_Assert(item != 0);
-        if (!item)
-        {
-            return;
-        }
-
-        if (bnd.clusterId != ONOFF_CLUSTER_ID && bnd.clusterId != LEVEL_CLUSTER_ID)
-        {
-            return;
-        }
-
-        int pos = -1; // index in config.group: "1,4"
-
-        if (sensor->modelId().startsWith(QLatin1String("D1")))
-        {
-            DBG_Assert(sensor->fingerPrint().endpoint == 0x02);
-
-            if       (bnd.srcEndpoint == 0x02) { pos = 0; }
-            else if  (bnd.srcEndpoint == 0x03) { pos = 1; }
-
-        }
-        else if (sensor->modelId().startsWith(QLatin1String("S1-R")))
-        {
-            DBG_Assert(sensor->fingerPrint().endpoint == 0x02);
-
-            if       (bnd.srcEndpoint == 0x02) { pos = 0; }
-            else if  (bnd.srcEndpoint == 0x03) { pos = 1; } // S1-R only
-        }
-        else if (sensor->modelId().startsWith(QLatin1String("S2-R")))
-        {
-            DBG_Assert(sensor->fingerPrint().endpoint == 0x03);
-
-            if       (bnd.srcEndpoint == 0x03) { pos = 0; }
-            else if  (bnd.srcEndpoint == 0x04) { pos = 1; }
-        }
-        else
-        {
-            return;
-        }
-
-        // remove group bindings which aren't configured via 'config.group'
-        QString dstGroup = QString::number(bnd.dstAddress.group);
-        QStringList gids = item->toString().split(',', SKIP_EMPTY_PARTS);
-
-        if (!gids.contains(dstGroup) || (pos == -1) || (gids.size() < (pos + 1)) || gids[pos] != dstGroup)
-        {
-            DBG_Printf(DBG_INFO, "0x%016llx remove old group binding group: %u, cluster: 0x%04X\n", bnd.srcAddress, bnd.dstAddress.group, bnd.clusterId);
-
-            BindingTask bindingTask;
-            bindingTask.state = BindingTask::StateIdle;
-            bindingTask.action = BindingTask::ActionUnbind;
-            bindingTask.binding = bnd;
-            queueBindingTask(bindingTask);
-            if (!bindingTimer->isActive())
-            {
-                bindingTimer->start();
-            }
-        }
-    }
-}
-
 /*! Process binding related tasks queue every one second. */
 void DeRestPluginPrivate::bindingTimerFired()
 {
@@ -4216,466 +4113,6 @@ void DeRestPluginPrivate::bindingTimerFired()
     if (!bindingQueue.empty())
     {
         bindingTimer->start(1000);
-    }
-}
-
-/*
-QString Binding::toString()
-{
-    //        QString dbg = QString("srcAddr: 0x%1 srcEp: %2 clusterId: %3")
-    //            .arg(i->srcAddress, 16, 16, QChar('0'))
-    //            .arg(i->srcEndpoint)
-    //            .arg(i->clusterId);
-
-    //        if (i->dstAddrMode == 0x01) // group address
-    //        {
-    //            dbg.append(QString(" dstGroup: 0x%1").arg(i->dstAddress.group, 2, 16, QChar('0')));
-    //        }
-    //        else if (i->dstAddrMode == 0x03) // ext address + dst endpoint
-    //        {
-    //            dbg.append(QString(" dstExt: 0x%1 dstEp: %2").arg(i->dstAddress.ext, 16, 16, QChar('0'))
-    //                                                         .arg(i->dstEndpoint));
-    //        }
-
-    //        DBG_Printf(DBG_INFO, "Binding %s\n", qPrintable(dbg));
-}
-*/
-
-/*! Process binding to rule conversion.
-    For bindings found via binding table query, check if there exists already
-    a rule representing it. If such a rule does not exist it will be created.
-*/
-void DeRestPluginPrivate::bindingToRuleTimerFired()
-{
-    if (bindingToRuleQueue.empty())
-    {
-        return;
-    }
-
-    Binding bnd = bindingToRuleQueue.front();
-    bindingToRuleQueue.pop_front();
-
-    if (!bindingToRuleQueue.empty())
-    {
-        bindingToRuleTimer->start();
-    }
-
-    if (!apsCtrl)
-    {
-        return;
-    }
-
-    int idx = 0;
-    bool found = false;
-    const deCONZ::Node *node = 0;
-    while (apsCtrl->getNode(idx, &node) == 0)
-    {
-        if (bnd.srcAddress == node->address().ext())
-        {
-            found = true;
-            break;
-        }
-        idx++;
-    }
-
-    // check if cluster does exist
-    if (found && node)
-    {
-        found = false;
-        for (const deCONZ::SimpleDescriptor &sd : node->simpleDescriptors())
-        {
-            if (sd.endpoint() != bnd.srcEndpoint)
-            {
-                continue;
-            }
-
-            for (const deCONZ::ZclCluster &cl : sd.inClusters())
-            {
-                if (cl.id() == bnd.clusterId)
-                {
-                    found = true;
-                    break;
-                }
-            }
-
-            for (const deCONZ::ZclCluster &cl : sd.outClusters())
-            {
-                if (cl.id() == ILLUMINANCE_MEASUREMENT_CLUSTER_ID && existDevicesWithVendorCodeForMacPrefix(node->address(), VENDOR_DDEL))
-                {
-                    continue; // ignore, binding only allowed for server cluster
-                }
-
-                if (cl.id() == bnd.clusterId)
-                {
-                    found = true;
-                    break;
-                }
-            }
-
-            if (found)
-            {
-                break;
-            }
-        }
-
-        if (!found)
-        {
-            DBG_Printf(DBG_INFO, "remove binding from 0x%016llX cluster 0x%04X due non existing cluster\n", bnd.srcAddress, bnd.clusterId);
-            BindingTask bindingTask;
-            bindingTask.state = BindingTask::StateIdle;
-            bindingTask.action = BindingTask::ActionUnbind;
-            bindingTask.binding = bnd;
-            queueBindingTask(bindingTask);
-            if (!bindingTimer->isActive())
-            {
-                bindingTimer->start();
-            }
-            return;
-        }
-    }
-
-    // binding table maintenance
-    // check if destination node exist and remove binding if not
-    if (bnd.dstAddrMode == deCONZ::ApsExtAddress)
-    {
-        idx = 0;
-        found = false;
-        node = nullptr;
-        while (apsCtrl->getNode(idx, &node) == 0)
-        {
-            if (bnd.dstAddress.ext == node->address().ext())
-            {
-                found = true;
-                break;
-            }
-            idx++;
-        }
-
-        if (!found)
-        {
-            DBG_Printf(DBG_INFO, "remove binding from 0x%016llX cluster 0x%04X to non existing node 0x%016llX\n", bnd.srcAddress, bnd.clusterId, bnd.dstAddress.ext);
-            BindingTask bindingTask;
-            bindingTask.state = BindingTask::StateIdle;
-            bindingTask.action = BindingTask::ActionUnbind;
-            bindingTask.binding = bnd;
-            queueBindingTask(bindingTask);
-            if (!bindingTimer->isActive())
-            {
-                bindingTimer->start();
-            }
-            return;
-        }
-    }
-
-
-    std::vector<Sensor>::iterator i = sensors.begin();
-    std::vector<Sensor>::iterator end = sensors.end();
-
-    Sensor *sensor = 0;
-
-    for (; i != end; ++i)
-    {
-        if (bnd.srcAddress != i->address().ext())
-        {
-            continue;
-        }
-
-        if (existDevicesWithVendorCodeForMacPrefix(bnd.srcAddress, VENDOR_UBISYS))
-        {
-            processUbisysBinding(&*i, bnd);
-            return;
-        }
-
-        if (!i->modelId().startsWith(QLatin1String("FLS-NB")))
-        {
-            continue;
-        }
-
-        if (bnd.srcEndpoint == i->fingerPrint().endpoint)
-        {
-            // match only valid sensors
-            switch (bnd.clusterId)
-            {
-            case ONOFF_CLUSTER_ID:
-            case LEVEL_CLUSTER_ID:
-            case SCENE_CLUSTER_ID:
-            {
-                if (i->type() == "ZHASwitch")
-                {
-                    sensor = &(*i);
-                }
-            }
-                break;
-
-            case ILLUMINANCE_MEASUREMENT_CLUSTER_ID:
-            {
-                if (i->type() == "ZHALightLevel")
-                {
-                    sensor = &(*i);
-                }
-            }
-                break;
-
-            case OCCUPANCY_SENSING_CLUSTER_ID:
-            {
-                if (i->type() == "ZHAPresence")
-                {
-                    sensor = &(*i);
-                }
-            }
-                break;
-
-            default:
-                break;
-            }
-        }
-
-        if (sensor)
-        {
-            break;
-        }
-    }
-
-    // only proceed if the sensor (binding source) is known
-    if (!sensor)
-    {
-//        deCONZ::Address addr;
-//        addr.setExt(bnd.srcAddress);
-//        DBG_Printf(DBG_INFO, "Binding to Rule unsupported sensor %s\n", qPrintable(addr.toStringExt()));
-        return;
-    }
-
-    Rule rule;
-    RuleCondition cond;
-    RuleAction action;
-
-    if (bnd.dstAddrMode == Binding::ExtendedAddressMode)
-    {
-        deCONZ::Address addr;
-        addr.setExt(bnd.dstAddress.ext);
-        LightNode *lightNode = getLightNodeForAddress(addr, bnd.dstEndpoint);
-
-        if (lightNode)
-        {
-            action.setAddress(QString("/lights/%1/state").arg(lightNode->id()));
-        }
-        else
-        {
-            DBG_Printf(DBG_INFO_L2, "Binding to Rule no LightNode found for dstAddress: %s\n",
-                       qPrintable(QString("0x%1").arg(bnd.dstAddress.ext, 16,16, QChar('0'))));
-            return;
-        }
-
-    }
-    else if (bnd.dstAddrMode == Binding::GroupAddressMode)
-    {
-        action.setAddress(QString("/groups/%1/action").arg(bnd.dstAddress.group));
-    }
-    else
-    {
-        DBG_Printf(DBG_INFO, "Binding to Rule unsupported dstAddrMode 0x%02X\n", bnd.dstAddrMode);
-        return;
-    }
-
-    action.setMethod("BIND");
-
-    QVariantMap body;
-    QString item;
-
-    if (bnd.clusterId == ONOFF_CLUSTER_ID)
-    {
-        body["on"] = true;
-        item = "buttonevent";
-    }
-    else if (bnd.clusterId == LEVEL_CLUSTER_ID)
-    {
-        body["bri"] = (double)1;
-        item = "buttonevent";
-    }
-    else if (bnd.clusterId == ILLUMINANCE_MEASUREMENT_CLUSTER_ID)
-    {
-        body["illum"] = QString("report");
-        item = "illuminance";
-    }
-    else if (bnd.clusterId == OCCUPANCY_SENSING_CLUSTER_ID)
-    {
-        body["occ"] = QString("report");
-        item = "presence";
-    }
-    else if (bnd.clusterId == SCENE_CLUSTER_ID)
-    {
-        body["scene"] = QString("S%1").arg(bnd.srcEndpoint);
-        item = "buttonevent";
-    }
-    else
-    {
-        return;
-    }
-
-    action.setBody(deCONZ::jsonStringFromMap(body));
-
-    cond.setAddress(QString("/sensors/%1/state/%2").arg(sensor->id()).arg(item));
-    cond.setOperator("eq");
-    cond.setValue(bnd.srcEndpoint);
-
-    // check if a rule for that binding already exists
-    bool foundRule = false;
-
-    std::vector<Rule>::const_iterator ri = rules.begin();
-    std::vector<Rule>::const_iterator rend = rules.end();
-
-    for (; !foundRule && (ri != rend); ++ri) // rule loop
-    {
-        std::vector<RuleCondition>::const_iterator ci = ri->conditions().begin();
-        std::vector<RuleCondition>::const_iterator cend = ri->conditions().end();
-        for (; !foundRule && (ci != cend); ++ci) // rule.conditions loop
-        {
-            // found matching condition
-            if ((ci->address()   == cond.address()) &&
-                (ci->ooperator() == cond.ooperator()) &&
-                (ci->value()     == cond.value()))
-            {
-                std::vector<RuleAction>::const_iterator ai = ri->actions().begin();
-                std::vector<RuleAction>::const_iterator aend = ri->actions().end();
-
-                for (; !foundRule && (ai != aend); ++ai) // rule.actions loop
-                {
-                    if ((ai->method() == action.method()) && (ai->address() == action.address()))
-                    {
-                        // search action body which covers the binding clusterId
-                        if (bnd.clusterId == ONOFF_CLUSTER_ID)
-                        {
-                            if (ai->body().contains("on"))
-                            {
-                                rule = *ri;
-                                foundRule = true;
-                            }
-                        }
-                        else if (bnd.clusterId == ILLUMINANCE_MEASUREMENT_CLUSTER_ID)
-                        {
-                            if (ai->body().contains("illum"))
-                            {
-                                rule = *ri;
-                                foundRule = true;
-                            }
-                        }
-                        else if (bnd.clusterId == OCCUPANCY_SENSING_CLUSTER_ID)
-                        {
-                            if (ai->body().contains("occ"))
-                            {
-                                rule = *ri;
-                                foundRule = true;
-                            }
-                        }
-                        else if (bnd.clusterId == LEVEL_CLUSTER_ID)
-                        {
-                            if (ai->body().contains("bri"))
-                            {
-                                rule = *ri;
-                                foundRule = true;
-                            }
-                        }
-                        else if (bnd.clusterId == SCENE_CLUSTER_ID)
-                        {
-                            if (ai->body().contains("scene"))
-                            {
-                                rule = *ri;
-                                foundRule = true;
-                            }
-                        }
-                        else
-                        {
-                            DBG_Printf(DBG_INFO, "Binding to Rule unhandled clusterId 0x%04X\n", bnd.clusterId);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    if (DBG_IsEnabled(DBG_INFO_L2))
-    {
-        DBG_Printf(DBG_INFO_L2, "cond.address: %s\n", qPrintable(cond.address()));
-        DBG_Printf(DBG_INFO_L2, "cond.value: %s\n", qPrintable(cond.value().toString()));
-        DBG_Printf(DBG_INFO_L2, "action.address: %s\n", qPrintable(action.address()));
-        DBG_Printf(DBG_INFO_L2, "action.body: %s\n", qPrintable(action.body()));
-    }
-
-    if (!foundRule)
-    {
-        if (sensor && sensor->item(RConfigOn)->toBool())
-        {
-            std::vector<RuleAction> actions;
-            std::vector<RuleCondition> conditions;
-
-            actions.push_back(action);
-            conditions.push_back(cond);
-
-            updateEtag(rule.etag);
-            rule.setOwner("deCONZ");
-            rule.setCreationtime(QDateTime::currentDateTimeUtc().toString("yyyy-MM-ddTHH:mm:ss"));
-            rule.setActions(actions);
-            rule.setConditions(conditions);
-
-            // create a new rule id // don't overwrite already existing rules
-            rule.setId("1");
-
-            bool ok;
-            do {
-                ok = true;
-                std::vector<Rule>::const_iterator i = rules.begin();
-                std::vector<Rule>::const_iterator end = rules.end();
-
-                for (; i != end; ++i)
-                {
-                    if (i->id() == rule.id())
-                    {
-                        rule.setId(QString::number(i->id().toInt() + 1));
-                        ok = false;
-                    }
-                }
-            } while (!ok);
-
-            rule.setName(QString("Rule %1").arg(rule.id()));
-            rules.push_back(rule);
-
-            queSaveDb(DB_RULES, DB_SHORT_SAVE_DELAY);
-
-            DBG_Printf(DBG_INFO, "Rule %s created from Binding\n", qPrintable(rule.id()));
-        }
-        else if (gwDeleteUnknownRules)
-        {
-
-            DBG_Printf(DBG_INFO, "Rule for Binding doesn't exists start unbind 0x%04X\n", bnd.clusterId);
-            BindingTask bt;
-            bt.state = BindingTask::StateIdle;
-            bt.restNode = sensor; // might be 0
-            bt.action = BindingTask::ActionUnbind;
-            bt.binding = bnd;
-            queueBindingTask(bt);
-        }
-    }
-    else
-    {
-        if (rule.state() == Rule::StateDeleted || rule.status() == "disabled")
-        {
-            DBG_Printf(DBG_INFO, "Rule for Binding already exists (inactive), start unbind 0x%04X\n", bnd.clusterId);
-            BindingTask bt;
-            bt.state = BindingTask::StateIdle;
-            bt.restNode = sensor; // might be 0
-            bt.action = BindingTask::ActionUnbind;
-            bt.binding = bnd;
-            queueBindingTask(bt);
-        }
-        else
-        {
-            DBG_Printf(DBG_INFO_L2, "Rule for Binding 0x%04X already exists\n", bnd.clusterId);
-        }
-    }
-
-    if (!bindingTimer->isActive())
-    {
-        bindingTimer->start();
     }
 }
 

--- a/database.cpp
+++ b/database.cpp
@@ -2894,29 +2894,6 @@ void DeRestPluginPrivate::loadLightNodeFromDb(LightNode *lightNode)
         }
     }
 
-    // check for old mac address only format
-    if (lightNode->id().isEmpty())
-    {
-        sql = QString("SELECT * FROM nodes WHERE mac='%1' COLLATE NOCASE AND state != 'deleted'").arg(lightNode->address().toStringExt());
-
-        DBG_Printf(DBG_INFO_L2, "sql exec %s\n", qPrintable(sql));
-        rc = sqlite3_exec(db, qPrintable(sql), sqliteLoadLightNodeCallback, &cb, &errmsg);
-
-        if (rc != SQLITE_OK)
-        {
-            if (errmsg)
-            {
-                DBG_Printf(DBG_ERROR_L2, "sqlite3_exec %s, error: %s\n", qPrintable(sql), errmsg);
-                sqlite3_free(errmsg);
-            }
-        }
-
-        if (!lightNode->id().isEmpty())
-        {
-            lightNode->setNeedSaveDatabase(true);
-        }
-    }
-
     if (lightNode->needSaveDatabase())
     {
         queSaveDb(DB_LIGHTS, DB_SHORT_SAVE_DELAY);

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1232,7 +1232,6 @@ public:
     int createRule(const ApiRequest &req, ApiResponse &rsp);
     int updateRule(const ApiRequest &req, ApiResponse &rsp);
     int deleteRule(const ApiRequest &req, ApiResponse &rsp);
-    void queueCheckRuleBindings(const Rule &rule);
     bool evaluateRule(Rule &rule, const Event &e, Resource *eResource, ResourceItem *eItem, QDateTime now, QDateTime previousNow);
     void indexRuleTriggers(Rule &rule);
     void triggerRule(Rule &rule);
@@ -1327,11 +1326,8 @@ public Q_SLOTS:
     void checkSensorGroup(Sensor *sensor);
     void checkOldSensorGroups(Sensor *sensor);
     void deleteGroupsWithDeviceMembership(const QString &id);
-    void processUbisysBinding(Sensor *sensor, const Binding &bnd);
     void bindingTimerFired();
-    void bindingToRuleTimerFired();
     void bindingTableReaderTimerFired();
-    void verifyRuleBindingsTimerFired();
     void indexRulesTriggers();
     void fastRuleCheckTimerFired();
     void webhookFinishedRequest(QNetworkReply *reply);
@@ -1456,7 +1452,6 @@ public:
     Rule *getRuleForName(const QString &name);
     void addSensorNode(const deCONZ::Node *node, const deCONZ::NodeEvent *event = 0);
     void addSensorNode(const deCONZ::Node *node, const SensorFingerprint &fingerPrint, const QString &type, const QString &modelId, const QString &manufacturer);
-    void checkUpdatedFingerPrint(const deCONZ::Node *node, quint8 endpoint, Sensor *sensorNode);
     void checkSensorNodeReachable(Sensor *sensor, const deCONZ::NodeEvent *event = 0);
     void checkSensorButtonEvent(Sensor *sensor, const deCONZ::ApsDataIndication &ind, const deCONZ::ZclFrame &zclFrame);
     void updateSensorNode(const deCONZ::NodeEvent &event);
@@ -2116,7 +2111,6 @@ public:
     std::vector<Sensor> sensors;
     std::list<TaskItem> tasks;
     std::list<TaskItem> runningTasks;
-    QTimer *verifyRulesTimer;
     QTimer *taskTimer;
     QTimer *groupTaskTimer;
     QTimer *checkSensorsTimer;
@@ -2132,12 +2126,9 @@ public:
     EventEmitter *eventEmitter = nullptr;
 
     // bindings
-    size_t verifyRuleIter;
     bool gwReportingEnabled;
-    QTimer *bindingToRuleTimer;
     QTimer *bindingTimer;
     QTimer *bindingTableReaderTimer;
-    std::list<Binding> bindingToRuleQueue; // check if rule exists for discovered bindings
     std::list<BindingTask> bindingQueue; // bind/unbind queue
     std::vector<BindingTableReader> bindingTableReaders;
 

--- a/electrical_measurement.cpp
+++ b/electrical_measurement.cpp
@@ -195,9 +195,7 @@ void DeRestPluginPrivate::handleElectricalMeasurementClusterIndication(const deC
                         modelId.startsWith(QLatin1String("Micro Smart Dimmer")) ||                // Sunricher Micro Smart Dimmer
                         modelId == QLatin1String("SMRZB-1") ||                                    // Develco smart cable
                         modelId == QLatin1String("PoP") ||                                        // Apex Smart Plug
-                        modelId == QLatin1String("TS011F") ||                                     // Tuya plugs
-                        modelId.startsWith(QLatin1String("S1-R")) ||                              // Ubisys S1-R
-                        modelId.startsWith(QLatin1String("D1")))                                  // Ubisys D1/D1-R
+                        modelId == QLatin1String("TS011F"))                                       // Tuya plugs
                     {
                         // already in mA
                         DDF_AnnoteZclParse(sensor, item, ind.srcEndpoint(), ind.clusterId(), attrId, "if (Attr.val != 65535) { Item.val = Attr.val; } ");

--- a/occupancy_sensing.cpp
+++ b/occupancy_sensing.cpp
@@ -120,9 +120,9 @@ void DeRestPluginPrivate::handleOccupancySensingClusterIndication(const deCONZ::
 
         case OCCUPIED_TO_UNOCCUPIED_DELAY:
         {
-            if (sensor->modelId().startsWith(QLatin1String("FLS-NB")) || sensor->modelId() == QLatin1String("LG IP65 HMS"))
+            if (sensor->modelId() == QLatin1String("LG IP65 HMS"))
             {
-                // TODO this if branch needs to be refactored or better removed later on
+                // TODO(mpi): this can be removed, I don't think there are any users of this device (large industrial light+sensor)
                 quint16 duration = attr.numericValue().u16;
                 item = sensor->item(RConfigDuration);
 

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -3336,21 +3336,6 @@ int DeRestPluginPrivate::setLightAttributes(const ApiRequest &req, ApiResponse &
             Q_Q(DeRestPlugin);
             q->nodeUpdated(lightNode->address().ext(), QLatin1String("name"), name);
 
-            if (lightNode->modelId().startsWith(QLatin1String("FLS-NB"))) // sync names
-            {
-                for (Sensor &s : sensors)
-                {
-                    if (s.address().ext() == lightNode->address().ext() &&
-                        s.name() != lightNode->name())
-                    {
-                        updateSensorEtag(&s);
-                        s.setName(lightNode->name());
-                        s.setNeedSaveDatabase(true);
-                        queSaveDb(DB_SENSORS, DB_SHORT_SAVE_DELAY);
-                    }
-                }
-            }
-
             QVariantMap rspItem;
             QVariantMap rspItemState;
             rspItemState[QString("/lights/%1/name").arg(id)] = map["name"];

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -177,12 +177,6 @@ int DeRestPluginPrivate::getAllSensors(const ApiRequest &req, ApiResponse &rsp)
             continue;
         }
 
-        // ignore sensors without attached node
-        if (i->modelId().startsWith(QLatin1String("FLS-NB")) && !i->node())
-        {
-            continue;
-        }
-
         if (i->modelId().isEmpty())
         {
             continue;
@@ -875,16 +869,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                 }
                 else if (rid.suffix == RConfigDuration) // Unsigned integer
                 {
-                    if (sensor->modelId().startsWith(QLatin1String("FLS-NB")))
-                    {
-                        DBG_Printf(DBG_INFO, "Force read of occupaction delay for sensor %s\n", qPrintable(sensor->address().toStringExt()));
-                        sensor->enableRead(READ_OCCUPANCY_CONFIG);
-                        sensor->setNextReadTime(READ_OCCUPANCY_CONFIG, queryTime.addSecs(1));
-                        queryTime = queryTime.addSecs(1);
-                        Q_Q(DeRestPlugin);
-                        q->startZclAttributeTimer(0);
-                    }
-                    else if (sensor->modelId() == QLatin1String("TRADFRI motion sensor"))
+                    if (sensor->modelId() == QLatin1String("TRADFRI motion sensor"))
                     {
                         if (data.uinteger < 1 || data.uinteger > 60)
                         {

--- a/rule.cpp
+++ b/rule.cpp
@@ -15,7 +15,6 @@ static int _ruleHandle = 1;
 
 /*! Constructor. */
 Rule::Rule() :
-    lastBindingVerify(0),
     m_state(StateNormal),
     //m_id(QLatin1String("none")),
     m_handle(-1),
@@ -334,15 +333,15 @@ const QString &RuleAction::address() const
 
 /*! Sets the action method.
     The HTTP method used to send the body to the given address.
-    Either "POST", "PUT", "BIND", "DELETE" for local addresses.
+    Either "POST", "PUT", "DELETE" for local addresses.
     \param method the action method
  */
 void RuleAction::setMethod(const QString &method)
 {
-    DBG_Assert(method == "POST" || method == "PUT" || method == "DELETE" || method == "BIND" || method == "GET");
-    if (!(method == "POST" || method == "PUT" || method == "DELETE" || method == "BIND" || method == "GET"))
+    DBG_Assert(method == "POST" || method == "PUT" || method == "DELETE" || method == "GET");
+    if (!(method == "POST" || method == "PUT" || method == "DELETE" || method == "GET"))
     {
-        DBG_Printf(DBG_INFO, "actions method must be either GET, POST, PUT, BIND or DELETE\n");
+        DBG_Printf(DBG_INFO, "actions method must be either GET, POST, PUT or DELETE\n");
         return;
     }
     m_method = method;

--- a/rule.h
+++ b/rule.h
@@ -87,11 +87,6 @@ public:
         StateDeleted
     };
 
-    enum Constants
-    {
-        MaxVerifyDelay = 300
-    };
-
     State state() const;
     void setState(State state);
     const QString &id() const;
@@ -125,7 +120,6 @@ public:
     QString etag;
     QDateTime lastVerify;
     QDateTime m_lastTriggered;
-    int lastBindingVerify; // copy of idleTotalCounter at last binding verification
 
 private:
     State m_state;


### PR DESCRIPTION
Most of this code was used by old FLS-NB units. It had quite an performance impact in general due all the string comparisons and loops.

The ubisys legacy code is also removed in favor for followup PR adding missing S1-R and D1-R as DDF.