### PR TITLE
Fix ZCLDB wrong « Neutral current » attribute number

### DIFF
--- a/general.xml
+++ b/general.xml
@@ -3966,7 +3966,7 @@ Note: It does not clear or delete previous weekly schedule programming configura
 	<attribute-set id="0x0200" description="DC Formatting">
 	  <attribute id="0x0200" name="DC Voltage Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
 	  <attribute id="0x0201" name="DC Voltage Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
-          <attribute id="0x0202 je" name="DC Current Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
+          <attribute id="0x0202" name="DC Current Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
           <attribute id="0x0203" name="DC Current Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
 	  <attribute id="0x0204" name="DC Power Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
 	  <attribute id="0x0205" name="DC Power Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>

--- a/general.xml
+++ b/general.xml
@@ -3966,7 +3966,7 @@ Note: It does not clear or delete previous weekly schedule programming configura
 	<attribute-set id="0x0200" description="DC Formatting">
 	  <attribute id="0x0200" name="DC Voltage Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
 	  <attribute id="0x0201" name="DC Voltage Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
-          <attribute id="0x0202" name="DC Current Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
+          <attribute id="0x0202 je" name="DC Current Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
           <attribute id="0x0203" name="DC Current Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
 	  <attribute id="0x0204" name="DC Power Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
 	  <attribute id="0x0205" name="DC Power Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
@@ -3975,7 +3975,7 @@ Note: It does not clear or delete previous weekly schedule programming configura
           <attribute id="0x0300" name="AC Frequency" type="u16" access="r" required="o" default="0xFFFF"></attribute>
 	  <attribute id="0x0301" name="AC Frequency Min" type="u16" access="r" required="o" default="0xFFFF"></attribute>
 	  <attribute id="0x0302" name="AC Frequency Max" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-	  <attribute id="0x0300" name="Neutral current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+	  <attribute id="0x0303" name="Neutral current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
           <attribute id="0x0304" name="Total Active Power" type="s32" access="r" required="o"></attribute>
           <attribute id="0x0305" name="Total Reactive Power" type="s32" access="r" required="o"></attribute>
           <attribute id="0x0306" name="Total Apparent Power" type="u32" access="r" required="o"></attribute>


### PR DESCRIPTION
Changed duplicate 0x0300 wrong attribute number for Neutral current to right number 0x0303 in Electrical measurement cluster.