### PR TITLE
Fix battery not reported for Tuya 4-gang  remote _TZ3000_TS0044_4gang_remote.json

### DIFF
--- a/devices/tuya/_TZ3000_TS0044_4gang_remote.json
+++ b/devices/tuya/_TZ3000_TS0044_4gang_remote.json
@@ -1,7 +1,27 @@
 {
   "schema": "devcap1.schema.json",
-  "manufacturername": ["_TZ3000_ygvf9xzp", "_TZ3000_ee8nrt2l", "_TZ3000_dziaict4", "_TZ3000_mh9px7cq", "_TZ3000_b7bxojrg", "_TZ3000_ufhtxr59", "_TZ3000_abci1hiu",  "_TZ3000_wkai4ga5", "_TZ3000_uaa99arv"],
-  "modelid": ["TS0044", "TS0044", "TS0044", "TS0044", "TS0044", "TS0044", "TS0044", "TS0044", "TS0044"],
+  "manufacturername": [
+    "_TZ3000_ygvf9xzp",
+    "_TZ3000_ee8nrt2l",
+    "_TZ3000_dziaict4",
+    "_TZ3000_mh9px7cq",
+    "_TZ3000_b7bxojrg",
+    "_TZ3000_ufhtxr59",
+    "_TZ3000_abci1hiu",
+    "_TZ3000_wkai4ga5",
+    "_TZ3000_uaa99arv"
+  ],
+  "modelid": [
+    "TS0044",
+    "TS0044",
+    "TS0044",
+    "TS0044",
+    "TS0044",
+    "TS0044",
+    "TS0044",
+    "TS0044",
+    "TS0044"
+  ],
   "product": "Tuya remote 4 gangs",
   "sleeper": true,
   "status": "Gold",
@@ -35,8 +55,19 @@
         },
         {
           "name": "attr/swversion",
-          "parse": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001", "script": "tuya_swversion.js"},
-          "read": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001"}
+          "parse": {
+            "fn": "zcl",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x0001",
+            "script": "tuya_swversion.js"
+          },
+          "read": {
+            "fn": "zcl",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x0001"
+          }
         },
         {
           "name": "attr/type"
@@ -47,7 +78,12 @@
         {
           "name": "config/battery",
           "refresh.interval": 86400,
-          "awake": true,
+          "read": {
+            "fn": "zcl",
+            "ep": 1,
+            "cl": "0x0001",
+            "at": "0x0021"
+          },
           "parse": {
             "at": "0x0021",
             "cl": "0x0001",
@@ -77,6 +113,20 @@
       "src.ep": 1,
       "dst.ep": 1,
       "cl": "0x0006"
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 64500,
+          "max": 65500,
+          "change": "0x00000002"
+        }
+      ]
     },
     {
       "bind": "unicast",


### PR DESCRIPTION
Battery % didn't report anymore since last modification, and missing "read" in "config/battery".

Fix #7048

Replace PR #7050 cause of conflicting changes