### PR TITLE
DDF for Tuya bidirectional energy meter (_TZE204_ac0fhfiq)

### DIFF
--- a/device_access_fn.cpp
+++ b/device_access_fn.cpp
@@ -719,6 +719,12 @@ bool parseTuyaData(Resource *r, ResourceItem *item, const deCONZ::ApsDataIndicat
         switch (dataType)
         {
         case TuyaDataTypeRaw:
+        {
+            // Not setting value because need to much ressource.
+            zclDataType = deCONZ::ZclCharacterString;
+        }
+        break;
+            
         case TuyaDataTypeString:
             return result; // TODO implement?
 

--- a/devices/generic/items/state_direction_item.json
+++ b/devices/generic/items/state_direction_item.json
@@ -1,7 +1,0 @@
-{
-	"schema": "resourceitem1.schema.json",
-	"id": "state/direction",
-	"datatype": "String",
-	"access": "R",
-	"public": true
-}

--- a/devices/generic/items/state_direction_item.json
+++ b/devices/generic/items/state_direction_item.json
@@ -1,0 +1,7 @@
+{
+	"schema": "resourceitem1.schema.json",
+	"id": "state/direction",
+	"datatype": "String",
+	"access": "R",
+	"public": true
+}

--- a/devices/tuya/_TZE204_ac0fhfiq_energy_meter.json
+++ b/devices/tuya/_TZE204_ac0fhfiq_energy_meter.json
@@ -153,7 +153,7 @@
           },
           "parse": {
             "dpid": 6,
-            "eval": "eval": "Item.val = ((ZclFrame.at(11) << 16) | (ZclFrame.at(12) << 8) | ZclFrame.at(13)) / 1000;",
+            "eval": "Item.val = ((ZclFrame.at(11) << 16) | (ZclFrame.at(12) << 8) | ZclFrame.at(13)) / 1000;",
             "fn": "tuya"
           },
           "default": 0

--- a/devices/tuya/_TZE204_ac0fhfiq_energy_meter.json
+++ b/devices/tuya/_TZE204_ac0fhfiq_energy_meter.json
@@ -39,13 +39,13 @@
             "at":"0x0001",
             "cl":"0x0000",
             "ep":1,
-            "fn":"zcl"
+            "fn": "zcl:attr"
           },
           "parse":{
             "at":"0x0001",
             "cl":"0x0000",
             "ep":1,
-            "fn":"zcl",
+            "fn": "zcl:attr",
             "script":"tuya_swversion.js"
           }
         },
@@ -123,13 +123,13 @@
             "at":"0x0001",
             "cl":"0x0000",
             "ep":1,
-            "fn":"zcl"
+            "fn": "zcl:attr"
           },
           "parse":{
             "at":"0x0001",
             "cl":"0x0000",
             "ep":1,
-            "fn":"zcl",
+            "fn": "zcl:attr",
             "script":"tuya_swversion.js"
           }
         },

--- a/devices/tuya/_TZE204_ac0fhfiq_energy_meter.json
+++ b/devices/tuya/_TZE204_ac0fhfiq_energy_meter.json
@@ -158,14 +158,6 @@
           "default": 0
         },
         {
-          "name": "state/direction",
-          "parse": {
-            "dpid": 102,
-            "eval": "if (Attr.val == 0) { Item.val = 'consuming' } else { Item.val = 'producing' };",
-            "fn": "tuya"
-          }
-        },
-        {
           "name": "state/lastupdated"
         },
         {

--- a/devices/tuya/_TZE204_ac0fhfiq_energy_meter.json
+++ b/devices/tuya/_TZE204_ac0fhfiq_energy_meter.json
@@ -147,13 +147,12 @@
         },
         {
           "name": "state/current",
-          "refresh.interval": 300,
           "read": {
             "fn": "none"
           },
           "parse": {
             "dpid": 6,
-            "eval": "Item.val = ((ZclFrame.at(11) << 16) | (ZclFrame.at(12) << 8) | ZclFrame.at(13)) / 1000;",
+            "eval": "Item.val = ((ZclFrame.at(8) << 16) | (ZclFrame.at(9) << 8) | ZclFrame.at(10)) / 1000;",
             "fn": "tuya"
           },
           "default": 0

--- a/devices/tuya/_TZE204_ac0fhfiq_energy_meter.json
+++ b/devices/tuya/_TZE204_ac0fhfiq_energy_meter.json
@@ -1,0 +1,199 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "_TZE204_ac0fhfiq",
+  "modelid": "TS0601",
+  "product": "BiDirectional ZigBee Energy Meter",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_CONSUMPTION_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0702"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name":"attr/swversion",
+          "read":{
+            "at":"0x0001",
+            "cl":"0x0000",
+            "ep":1,
+            "fn":"zcl"
+          },
+          "parse":{
+            "at":"0x0001",
+            "cl":"0x0000",
+            "ep":1,
+            "fn":"zcl",
+            "script":"tuya_swversion.js"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/consumption",
+          "read": {
+            "fn": "tuya"
+          },
+          "parse": {
+            "dpid": 1,
+            "eval": "Item.val = Attr.val * 10;",
+            "fn": "tuya"
+          },
+          "default": 0
+        },
+        {
+          "name": "state/consumption_2",
+          "read": {
+            "fn": "none"
+          },
+          "parse": {
+            "dpid": 2,
+            "eval": "Item.val = Attr.val * 10;",
+            "fn": "tuya"
+          },
+          "default": 0
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_POWER_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0b04"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name":"attr/swversion",
+          "read":{
+            "at":"0x0001",
+            "cl":"0x0000",
+            "ep":1,
+            "fn":"zcl"
+          },
+          "parse":{
+            "at":"0x0001",
+            "cl":"0x0000",
+            "ep":1,
+            "fn":"zcl",
+            "script":"tuya_swversion.js"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/current",
+          "refresh.interval": 300,
+          "read": {
+            "fn": "none"
+          },
+          "parse": {
+            "dpid": 6,
+            "eval": "eval": "Item.val = ((ZclFrame.at(11) << 16) | (ZclFrame.at(12) << 8) | ZclFrame.at(13)) / 1000;",
+            "fn": "tuya"
+          },
+          "default": 0
+        },
+        {
+          "name": "state/direction",
+          "parse": {
+            "dpid": 102,
+            "eval": "if (Attr.val == 0) { Item.val = 'consuming' } else { Item.val = 'producing' };",
+            "fn": "tuya"
+          }
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/power",
+          "read": {
+            "fn": "none"
+          },
+          "parse": {
+            "dpid": 101,
+            "eval": "Item.val = Attr.val;",
+            "fn": "tuya"
+          },
+          "default": 0
+        },
+        {
+          "name": "state/voltage",
+          "read": {
+            "fn": "none"
+          },
+          "parse": {
+            "dpid": 6,
+            "eval": "Item.val = ((ZclFrame.at(6) << 8) | ZclFrame.at(7)) / 10;",
+            "fn": "tuya"
+          },
+          "default": 0
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
With the @decrouxtom help, See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7151

-    Product name: Tuya BiDirectional ZigBee Energy Meter with 150A Clamp Current Sensor
-    Manufacturer: _TZE204_ac0fhfiq
-    Model identifier: TS0601

We have added an item state/direction, can be used later by covering.