### PR TITLE
Add support for latest Hue firmware

### DIFF
--- a/devices/philips/fc03_state.js
+++ b/devices/philips/fc03_state.js
@@ -46,13 +46,19 @@ if (attrid === 0x0002) {
             R.item('state/effect').val = 'fireplace'
             break
           case 0x8003:
-            R.item('state/effect').val = 'loop'
+            R.item('state/effect').val = 'prism'
             break
           case 0x8009:
             R.item('state/effect').val = 'sunrise'
             break
           case 0x800a:
             R.item('state/effect').val = 'sparkle'
+            break
+          case 0x800b:
+            R.item('state/effect').val = 'opal'
+            break
+          case 0x800c:
+            R.item('state/effect').val = 'glisten'
             break
           default:
             R.item('state/effect').val = '0x' + effect.toString(16)

--- a/devices/philips/light_zb3_C.json
+++ b/devices/philips/light_zb3_C.json
@@ -359,8 +359,8 @@
               "fireplace dynamic effect"
             ],
             [
-              "\"loop\"",
-              "colorloop dynamic effect"
+              "\"prism\"",
+              "prism dynamic effect"
             ]
           ],
           "parse": {

--- a/devices/philips/light_zb3_C_festavia.json
+++ b/devices/philips/light_zb3_C_festavia.json
@@ -296,8 +296,8 @@
               "fireplace dynamic effect"
             ],
             [
-              "\"loop\"",
-              "colorloop dynamic effect"
+              "\"prism\"",
+              "prism dynamic effect"
             ],
             [
               "\"sunrise\"",
@@ -306,6 +306,14 @@
             [
               "\"sparkle\"",
               "sparkle dynamic effect"
+            ],
+            [
+              "\"opal\"",
+              "opal dynamic effect"
+            ],
+            [
+              "\"glisten\"",
+              "glisten dynamic effect"
             ]
           ],
           "parse": {

--- a/devices/philips/light_zb3_C_gradient.json
+++ b/devices/philips/light_zb3_C_gradient.json
@@ -331,8 +331,8 @@
               "fireplace dynamic effect"
             ],
             [
-              "\"loop\"",
-              "colorloop dynamic effect"
+              "\"prism\"",
+              "prism dynamic effect"
             ],
             [
               "\"sunrise\"",

--- a/devices/philips/light_zll_C.json
+++ b/devices/philips/light_zll_C.json
@@ -224,7 +224,7 @@
             "ep": "0x0b",
             "cl": "0x0300",
             "at": "0x4001",
-            "eval": "if (Attr.val <= 3) Item.val = ['hs', 'xy', 'ct', 'xy'][Attr.val]"
+            "eval": "if (Item.val !== 'effect' && Attr.val <= 3) Item.val = ['hs', 'xy', 'ct', 'xy'][Attr.val]"
           },
           "read": {
             "fn": "zcl:attr",
@@ -241,6 +241,35 @@
         },
         {
           "name": "state/effect",
+          "values": [
+            [
+              "\"none\"",
+              "no effect is active"
+            ],
+            [
+              "\"colorloop\"",
+              "colorloop through hue values"
+            ],
+            [
+              "\"candle\"",
+              "candlelight dynamic effect"
+            ],
+            [
+              "\"fireplace\"",
+              "fireplace dynamic effect"
+            ],
+            [
+              "\"prism\"",
+              "prism dynamic effect"
+            ]
+          ],
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": "0x0b",
+            "cl": "0x0300",
+            "at": "0x4002",
+            "eval": "if (Item.val === 'none' || Item.val === 'colorloop') Item.val = Attr.val ? 'colorloop' : 'none'"
+          },
           "read": {
             "fn": "none"
           }

--- a/devices/philips/light_zll_C.json
+++ b/devices/philips/light_zll_C.json
@@ -130,6 +130,9 @@
           "name": "cap/color/ct/min"
         },
         {
+          "name": "cap/color/effects"
+        },
+        {
           "name": "cap/color/gamut_type"
         },
         {

--- a/hue.cpp
+++ b/hue.cpp
@@ -20,7 +20,7 @@ code effects[] = {
     { 0x09, QLatin1String("sunrise") },
     { 0x0a, QLatin1String("sparkle") },
     { 0x0b, QLatin1String("opal") },
-    { 0x0b, QLatin1String("glisten") }
+    { 0x0c, QLatin1String("glisten") }
 };
 
 quint8 effectNameToValue(QString &effectName)

--- a/hue.cpp
+++ b/hue.cpp
@@ -16,9 +16,11 @@ struct code {
 code effects[] = {
     { 0x01, QLatin1String("candle") },
     { 0x02, QLatin1String("fireplace") },
-    { 0x03, QLatin1String("loop") },
+    { 0x03, QLatin1String("prism") },
     { 0x09, QLatin1String("sunrise") },
-    { 0x0a, QLatin1String("sparkle") }
+    { 0x0a, QLatin1String("sparkle") },
+    { 0x0b, QLatin1String("opal") },
+    { 0x0b, QLatin1String("glisten") }
 };
 
 quint8 effectNameToValue(QString &effectName)


### PR DESCRIPTION
Add support for latest [Hue firmware](https://www.philips-hue.com/en-us/support/release-notes/lamps):
- Rename `loop` effect to `prism` (now visible in the Hue app);
- Add support for new effects `opal` and `glisten` (Hue Festavia, requires firmware 1.107.1);
- Add support for effects on gamut-C ZLL lights (requires firmware 1.108.5).

Note that the DDFs list the possible `effect` values to generate the documentation, but, depending on the firmware versions, the light might not support all of these.
`capabilities/color/effects` lists the actual supported effects, as reported by the light firmware.