### PR TITLE
Fix LIDL smart watering timer missing ZHAOpenClose state/open item (_TZE200_htnnfasr)

### DIFF
--- a/devices/tuya/_TZE200_htnnfasr_water_valve.json
+++ b/devices/tuya/_TZE200_htnnfasr_water_valve.json
@@ -102,7 +102,7 @@
         {
           "name": "attr/uniqueid"
         },
-		    {
+        {
           "name": "config/battery",
           "parse": {
             "dpid": 11,
@@ -113,7 +113,6 @@
         },
         {
           "name": "config/duration",
-          "description": "The duration the valve stays open.",
           "write": {
             "dpid": 5,
             "dt": "0x2b",
@@ -128,7 +127,6 @@
         },
         {
           "name": "config/locked",
-          "description": "Read: frost lock status. Write: frost lock reset.",
           "write": {
             "dpid": 109,
             "dt": "0x10",
@@ -143,6 +141,15 @@
           "default": 0
         },
         {
+          "name": "state/open",
+          "read": {"fn": "none"},
+          "parse": {
+            "dpid": 1,
+            "eval": "Item.val = Attr.val;",
+            "fn": "tuya"
+          }
+        },
+        {
           "name": "config/reachable"
         },
         {
@@ -150,7 +157,6 @@
         },
         {
           "name": "state/seconds_remaining",
-          "description": "The remaining time the valve is open in seconds.",
           "parse": {
             "dpid": 6,
             "eval": "Item.val = Attr.val * 60;",

--- a/devices/tuya/_TZE200_htnnfasr_water_valve.json
+++ b/devices/tuya/_TZE200_htnnfasr_water_valve.json
@@ -113,6 +113,7 @@
         },
         {
           "name": "config/duration",
+          "description": "The duration the valve stays open.",
           "write": {
             "dpid": 5,
             "dt": "0x2b",
@@ -127,6 +128,7 @@
         },
         {
           "name": "config/locked",
+          "description": "Read: frost lock status. Write: frost lock reset.",
           "write": {
             "dpid": 109,
             "dt": "0x10",
@@ -157,6 +159,7 @@
         },
         {
           "name": "state/seconds_remaining",
+          "description": "The remaining time the valve is open in seconds.",
           "parse": {
             "dpid": 6,
             "eval": "Item.val = Attr.val * 60;",


### PR DESCRIPTION
The actual DDF can cause issue on third app if they look for a state/open in the created ZHAOpenClose device.
See https://github.com/home-assistant/core/issues/94921