### PR TITLE
Fix sensitivity for lumi_vibration_aq1

### DIFF
--- a/devices/xiaomi/lumi_vibration_aq1.json
+++ b/devices/xiaomi/lumi_vibration_aq1.json
@@ -92,7 +92,7 @@
             "cl": "0x0000",
             "mf": "0x115F",
             "at": "0xFF0D",
-            "eval": "Item.val = 2 - Math.floor(Attr.val / 10)"
+            "eval": "Item.val = 3 - Attr.val"
           },
           "read": {
             "fn": "zcl",
@@ -109,7 +109,7 @@
             "mf": "0x115F",
             "at": "0xFF0D",
             "dt": "0x20",
-            "eval": "10 * (2 - Item.val) + 1"
+            "eval": "3 - Item.val"
           },
           "values": [
             [

--- a/devices/xiaomi/lumi_vibration_aq1.json
+++ b/devices/xiaomi/lumi_vibration_aq1.json
@@ -101,7 +101,7 @@
             "mf": "0x115F",
             "at": "0xFF0D"
           },
-          "refresh.interval": 600,
+          "refresh.interval": 3600,
           "write": {
             "fn": "zcl",
             "ep": 1,
@@ -109,8 +109,10 @@
             "mf": "0x115F",
             "at": "0xFF0D",
             "dt": "0x20",
-            "eval": "3 - Item.val"
-          },
+            "eval": "3 - Item.val",
+            "state.timeout": 2,
+            "change.timeout": 3600
+            },
           "values": [
             [
               0,


### PR DESCRIPTION
See Discord, upon sniffing the Aqara app / Hub M2, it appears that the Xiaomi vibration sensor uses Zigbee values 1: High, 2: Medium, 3: Low.

The device seems to accept and report back any value, even higher then 21.  This was carried over from the C++ code when the sensor was supported initially, but, apparently, never verified.

See also:
- https://github.com/dresden-elektronik/deconz-rest-plugin/issues/1396#issuecomment-478644832
- https://github.com/dresden-elektronik/deconz-rest-plugin/issues/1935#issue-502937054
- https://github.com/dresden-elektronik/deconz-rest-plugin/pull/6919