### PR TITLE
Fix TRÅDFRI Shortcut button sent 1004 instead 2004 event

### DIFF
--- a/button_maps.json
+++ b/button_maps.json
@@ -291,7 +291,7 @@
                 [1, "0x01", "ONOFF", "ON", "0", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "On"],
                 [1, "0x01", "LEVEL_CONTROL", "MOVE_WITH_ON_OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_HOLD", "Move up (with on/off)"],
                 [1, "0x01", "LEVEL_CONTROL", "STOP_WITH_ON_OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_LONG_RELEASED", "Stop (with on/off)"],
-                [1, "0x01", "ONOFF", "OFF", "0", "S_BUTTON_2", "S_BUTTON_ACTION_DOUBLE_PRESS", "Off"]
+                [1, "0x01", "ONOFF", "OFF", "0", "S_BUTTON_1", "S_BUTTON_ACTION_DOUBLE_PRESS", "Off"]
             ]
         },
         "ikeaOpenCloseMap": {


### PR DESCRIPTION
Bug fix: TRADFRI SHORTCUT Button sent 2004 on double press.  See https://github.com/ebaauw/homebridge-deconz/issues/163.  Obviously, this should be 1004, as the device only has one physical button.