### PR TITLE
Add sub device for ZHACarbonMonoxide

### DIFF
--- a/devices/generic/constants.json
+++ b/devices/generic/constants.json
@@ -16,6 +16,7 @@
         "$TYPE_AIR_PURIFIER": "ZHAAirPurifier",
         "$TYPE_AIR_QUALITY_SENSOR": "ZHAAirQuality",
         "$TYPE_CARBONDIOXIDE_SENSOR": "ZHACarbonDioxide",
+        "$TYPE_CARBONMONOXIDE_SENSOR": "ZHACarbonMonoxide",
         "$TYPE_FORMALDEHYDE_SENSOR": "ZHAFormaldehyde",
         "$TYPE_PARTICULATEMATTER_SENSOR": "ZHAParticulateMatter",
         "$TYPE_ALARM_SENSOR": "ZHAAlarm",

--- a/devices/generic/subdevices/carbonmonoxide_sensor.json
+++ b/devices/generic/subdevices/carbonmonoxide_sensor.json
@@ -1,0 +1,14 @@
+{
+    "schema": "subdevice1.schema.json",
+    "type": "$TYPE_CARBONMONOXIDE_SENSOR",
+    "name": "ZHACarbonMonoxide",
+    "restapi": "/sensors",
+    "order": 20,
+    "uuid": ["$address.ext", "0x01", "0x0500"],
+    "items": [
+        "config/on",
+        "config/reachable",
+        "state/carbonmonoxide",
+        "state/lastupdated"
+    ]
+}


### PR DESCRIPTION
To shut up DDF validation errors, on `xiaomi/xiaomi_jtqj-bf-01lm_gas_leak_detector.json`
```
Error: 1 validation error in file devices/xiaomi/xiaomi_jtqj-bf-01lm_gas_leak_detector.json at subdevices/0/items
Error: The device is missing the device definition for the type "ZHACarbonMonoxide"
```