### PR TITLE
DDF for Legrand / BTicino Master remote SW Home / Away

### DIFF
--- a/devices/legrand/Remote_switch_home_away.json
+++ b/devices/legrand/Remote_switch_home_away.json
@@ -1,0 +1,78 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "Legrand",
+  "modelid": "Master remote SW Home / Away",
+  "product": "Master remote SW Home / Away",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_SWITCH",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x000f"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "awake": true,
+          "parse": {
+            "at": "0x0020",
+            "cl": "0x0001",
+            "eval": "const vmin = 20; const vmax = 30; var bat = Attr.val; if (bat > vmax) { bat = vmax; } else if (bat < vmin) { bat = vmin; } bat = ((bat - vmin) / (vmax - vmin)) * 100; if (bat > 100) { bat = 100; } else if (bat <= 0)  { bat = 1; } Item.val = bat;"
+          },
+          "refresh.interval": 86400,
+          "default": 0
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/buttonevent",
+          "awake": true,
+          "parse": {
+            "cl": "0x0005",
+            "cmd": "0x05",
+            "ep": 1,
+            "eval": "const t={'-9':1002,'-10':2002,'247':1002,'246':2002};if(ZclFrame.at(0) in t){Item.val=t[ZclFrame.at(0)]}"
+          }
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7202

- Product name: BTicino Living Now K4570CW
- Manufacturer: Legrand
- Model identifier: Master remote SW Home / Away

The battery level is probably not working, due to a device specificity.