### PR TITLE
DDF for TRADFRI open/close remote

### DIFF
--- a/devices/ikea/tradfri_open_close_remote.json
+++ b/devices/ikea/tradfri_open_close_remote.json
@@ -73,6 +73,9 @@
           "name": "attr/uniqueid"
         },
         {
+          "name": "config/alert"
+        },
+        {
           "name": "config/battery",
           "awake": true,
           "parse": {

--- a/devices/ikea/tradfri_open_close_remote.json
+++ b/devices/ikea/tradfri_open_close_remote.json
@@ -1,0 +1,131 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "$MF_IKEA",
+  "modelid": "TRADFRI open/close remote",
+  "product": "TRADFRI open/close remote - E1766",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_SWITCH",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0102"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0203",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x1000"
+        ],
+        "out": [
+          "0x0102"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/productid",
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A",
+            "eval": "Item.val = Attr.val"
+          },
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A"
+          },
+          "refresh.interval": 86400
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "awake": true,
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0001",
+            "at": "0x0021",
+            "eval": "Item.val = Attr.val"
+          },
+          "default": 0,
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0001",
+            "at": "0x0021"
+          },
+          "refresh.interval": 86400
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/buttonevent",
+          "awake": true
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0102"
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 300,
+          "max": 2700,
+          "change": "0x01"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
New DDF, in line with DDFs for other IKEA controllers.

Controller no longer supports groups.

```
{
  "config": {
    "alert": "none",
    "battery": 100,
    "on": true,
    "reachable": true
  },
  "ep": 1,
  "etag": "6edbf2215f774c46b5fa62561593d499",
  "lastannounced": "2023-09-16T15:02:20Z",
  "lastseen": "2023-09-16T15:02Z",
  "manufacturername": "IKEA of Sweden",
  "mode": 1,
  "modelid": "TRADFRI open/close remote",
  "name": "Open/Close",
  "productid": "E1766",
  "state": {
    "buttonevent": 1002,
    "lastupdated": "2023-09-16T11:26:15.709"
  },
  "swversion": "2.3.079",
  "type": "ZHASwitch",
  "uniqueid": "00:0d:6f:ff:fe:e3:f4:90-01-0102"
}
```