### PR TITLE
DDF for IKEA SYMFONISK Sound Contoller

### DIFF
--- a/devices/generic/items/config_alert_item.json
+++ b/devices/generic/items/config_alert_item.json
@@ -5,6 +5,7 @@
   "access": "RW",
   "public": true,
   "description": "The currently active alert.",
+  "default": "none",
   "values": [
     [
       "\"none\"",

--- a/devices/ikea/0008_rotaryevent.js
+++ b/devices/ikea/0008_rotaryevent.js
@@ -1,0 +1,10 @@
+/* global Item, R, ZclFrame */
+
+const rotation = 30
+const duration = 1000
+const delta = new Date().getTime() - new Date(R.item('state/lastupdated').val).getTime()
+const expectedrotation = ZclFrame.at(0) === 0x00 ? rotation : -rotation
+const changed = expectedrotation !== R.item('state/expectedrotation').val
+Item.val = (changed || delta > duration) ? 1 : 2
+R.item('state/expectedeventduration').val = duration
+R.item('state/expectedrotation').val = ZclFrame.at(0) === 0x00 ? rotation : -rotation

--- a/devices/ikea/symfonisk_sound_contoller.json
+++ b/devices/ikea/symfonisk_sound_contoller.json
@@ -1,0 +1,246 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "$MF_IKEA",
+  "modelid": "SYMFONISK Sound Controller",
+  "product": "SYMFONISK Sound Controller - E1744",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_SWITCH",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x1000"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0006",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x1000"
+        ],
+        "out": [
+          "0x0006",
+          "0x0008"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/productid",
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A",
+            "eval": "Item.val = Attr.val"
+          },
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A"
+          },
+          "refresh.interval": 86400
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/alert"
+        },
+        {
+          "name": "config/battery",
+          "awake": true,
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0001",
+            "at": "0x0021",
+            "eval": "Item.val = Math.round(Attr.val / 2)"
+          },
+          "default": 0,
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0001",
+            "at": "0x0021"
+          },
+          "refresh.interval": 86400
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/buttonevent",
+          "awake": true
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_RELATIVE_ROTARY",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0008"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0006",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x1000"
+        ],
+        "out": [
+          "0x0006",
+          "0x0008"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/productid",
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A",
+            "eval": "Item.val = Attr.val"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/alert"
+        },
+        {
+          "name": "config/battery",
+          "awake": true,
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0001",
+            "at": "0x0021",
+            "eval": "Item.val = Math.round(Attr.val / 2)"
+          },
+          "default": 0
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/expectedeventduration"
+        },
+        {
+          "name": "state/expectedrotation"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/rotaryevent",
+          "awake": true,
+          "parse": {
+            "fn": "zcl:cmd",
+            "ep": 1,
+            "cl": "0x0008",
+            "cmd": "0x01",
+            "script": "0008_rotaryevent.js"
+          }
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0006"
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0008"
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 300,
+          "max": 2700,
+          "change": "0x01"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
New DDF, in line with DDFs for other IKEA controllers.

This is the old Symfonisk controller with one button and dial.

The button is functionally unchanged, but the ZHASwitch resource got some new attributes:
```
{
  "config": {
    "alert": "none",
    "battery": 50,
    "on": true,
    "reachable": true
  },
  "ep": 1,
  "etag": "af60abcc21af47ac5f0c04c35063063a",
  "lastannounced": null,
  "lastseen": "2023-09-16T19:27Z",
  "manufacturername": "IKEA of Sweden",
  "mode": 1,
  "modelid": "SYMFONISK Sound Controller",
  "name": "Symfonisk",
  "productid": "E1744",
  "state": {
    "buttonevent": 2003,
    "lastupdated": "2023-09-16T19:27:45.226"
  },
  "swversion": "2.3.080",
  "type": "ZHASwitch",
  "uniqueid": "14:b4:57:ff:fe:66:48:62-01-1000"
}
```
As before, the ZHASwitch supports single press (1002), double press (1004) and triple press (1005).  It also still reports right (2001/2003) and left (3001/3003) turn, as I haven't updated `buttonmap.json`.  Best consider this deprecated functionality.

The dial is now exposed as ZHARelativeRotary, implemented completely in JSON and JavaScript:
```
{
  "config": {
    "alert": "none",
    "battery": 50,
    "on": true,
    "reachable": true
  },
  "ep": 1,
  "etag": "e5fbd098a796dd381e7931cc03060c30",
  "lastannounced": null,
  "lastseen": "2023-09-16T19:27Z",
  "manufacturername": "IKEA of Sweden",
  "modelid": "SYMFONISK Sound Controller",
  "name": "RelativeRotary 126",
  "productid": "E1744",
  "state": {
    "expectedeventduration": 1000,
    "expectedrotation": 30,
    "lastupdated": "2023-09-16T19:27:44.929",
    "rotaryevent": 2
  },
  "swversion": "2.3.080",
  "type": "ZHARelativeRotary",
  "uniqueid": "14:b4:57:ff:fe:66:48:62-01-0008"
}
```
The `state` attributes are normalised after the Hue tap dial switch.  `expectedeventduration` is a constant in the JavaScript handling the _Move_ command.  1000 (ms) seems the right time to register repeat events (`rotaryevent` 2).  The `expectedrotation` is 30 for right turn and -30 for left turn.  The 30 is another constant in the JavaScript.
