### PR TITLE
DDF for IKEA TRADFRI wireless dimmer

### DIFF
--- a/devices/ikea/tradfri_wireless_dimmer.json
+++ b/devices/ikea/tradfri_wireless_dimmer.json
@@ -1,0 +1,129 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "$MF_IKEA",
+  "modelid": "TRADFRI wireless dimmer",
+  "product": "TRADFRI wireless dimmer - E1724",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_SWITCH",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x1000"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0820",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x1000"
+        ],
+        "out": [
+          "0x0008"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/productid",
+          "static": "E1724",
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/alert"
+        },
+        {
+          "name": "config/battery",
+          "awake": true,
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0001",
+            "at": "0x0021",
+            "eval": "Item.val = Attr.val"
+          },
+          "default": 0,
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0001",
+            "at": "0x0021"
+          },
+          "refresh.interval": 86400
+        },
+        {
+          "name": "config/group",
+          "default": "auto"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/buttonevent",
+          "awake": true
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "groupcast",
+      "config.group": 0,
+      "src.ep": 1,
+      "cl": "0x0008"
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 300,
+          "max": 2700,
+          "change": "0x01"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
New DDF, in line with DDFs for other IKEA controllers.

This is the cursed, old, round wireless dimmer.  It insists on sending multiple groupcasts from _Level Control_ when turning it, completely flooding the Zigbee network.  It won't honour any unicast binding for _Level Control_ (even though it does for _Power Configuration_).  When you delete the group binding, it continues to send groupcasts to group 0x0000.

I think the device should have been exposed with only a ZHARelativeRotary resource, since it only supports turning and has no buttons.  This might be challenging to do in JSON and Javascript, as it sends three different commands, _Move_, _Move (with On/Off)_, and _Move to Level (with On/Off)_, that need to be considered for rotary events.  For now it's still exposed as ZHASwitch, as I doubt the change would be worth the effort, since the device is hardly usable anyways.  The main benefit of this DDF is to be able to get rid of whitelisting IKEA devices in the C++ code.

```
{
  "config": {
    "alert": "none",
    "battery": 87,
    "group": "4",
    "on": true,
    "reachable": true
  },
  "ep": 1,
  "etag": "39cccb7e96bc5b2a615b02d8b1686862",
  "lastannounced": "2023-09-16T20:42:15Z",
  "lastseen": "2023-09-16T21:11Z",
  "manufacturername": "IKEA of Sweden",
  "mode": 1,
  "modelid": "TRADFRI wireless dimmer",
  "name": "Switch 128",
  "productid": "E1724",
  "state": {
    "buttonevent": 1003,
    "lastupdated": "2023-09-16T21:11:46.062"
  },
  "swversion": "2.3.028",
  "type": "ZHASwitch",
  "uniqueid": "00:0b:57:ff:fe:88:b9:a0-01-1000"
}
```