### PR TITLE
DDF for IKEA TRADFRI motion sensor

### DIFF
--- a/devices/ikea/0006_presence.js
+++ b/devices/ikea/0006_presence.js
@@ -1,0 +1,5 @@
+/* global Item, R, ZclFrame */
+
+Item.val = true
+R.item('state/dark').val = (ZclFrame.at(0) & 0x01) === 0x00
+R.item('config/duration').val = Math.round((ZclFrame.at(1) | ZclFrame.at(2) << 8) / 10)

--- a/devices/ikea/tradfri_motion_sensor.json
+++ b/devices/ikea/tradfri_motion_sensor.json
@@ -1,0 +1,153 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "$MF_IKEA",
+  "modelid": "TRADFRI motion sensor",
+  "product": "TRADFRI motion sensor - E1525, E1745",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_PRESENCE_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0006"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0850",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x1000"
+        ],
+        "out": [
+          "0x0006"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/productid",
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A",
+            "eval": "Item.val = Attr.val"
+          },
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A"
+          },
+          "refresh.interval": 86400
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/alert"
+        },
+        {
+          "name": "config/battery",
+          "awake": true,
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0001",
+            "at": "0x0021",
+            "eval": "Item.val = Attr.val"
+          },
+          "default": 0,
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0001",
+            "at": "0x0021"
+          },
+          "refresh.interval": 86400
+        },
+        {
+          "name": "config/duration",
+          "default": 60
+        },
+        {
+          "name": "config/group",
+          "default": "auto"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/dark"
+        },
+        {
+          "name": "state/presence",
+          "awake": true,
+          "parse": {
+            "fn": "zcl:cmd",
+            "ep": 1,
+            "cl": "0x0006",
+            "cmd": "0x42",
+            "script": "0006_presence.js"
+          }
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "groupcast",
+      "config.group": 0,
+      "src.ep": 1,
+      "cl": "0x0006"
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 300,
+          "max": 2700,
+          "change": "0x01"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
New DDF, in line with DDFs for other IKEA controllers (!).

The DDF handles both the gen-1 (E1525) and gen-2 (E1745) motion sensors.  They use the same `modelid`; but the `productid` to tell them apart.

Note that these are indeed controllers (not sensors), sending _On with Timed Off_ on detecting motion.  Light can be controlled directly (without deCONZ running) by adding them to the associated group.

The sensors won't detect next motion for the period from _On Time_, so we set `config.duration` based on that parameter.  This is a change with respect to the C++ code, that used `config.delay` for that.  However the DDF logic to reset `state/presence` only works for `config/duration`, and it should be set to `0` (so the C++ code used `config/delay` instead) or to the `config/delay` value anyways.

The duration can set between 60 and 600 seconds on the gen-1 model, using the dial on the device, and is fixed to 180 seconds on the gen-2 model.  The day/night setting on the device needs to be on night, or `state/dark` will always be reported as `true`.

Note that the C++ code will still add `config/delay` when motion is detected, but this is removed when deCONZ restarts.

```
{
  "config": {
    "alert": "none",
    "battery": 100,
    "delay": 60,
    "duration": 60,
    "group": "10461",
    "on": true,
    "reachable": true
  },
  "ep": 1,
  "etag": "292eb36a4d8bea64772e663dde57870f",
  "lastannounced": null,
  "lastseen": "2023-09-16T23:03Z",
  "manufacturername": "IKEA of Sweden",
  "modelid": "TRADFRI motion sensor",
  "name": "TRADFRI motion sensor",
  "productid": "E1525",
  "state": {
    "dark": false,
    "lastupdated": "2023-09-16T23:04:46.969",
    "presence": true
  },
  "swversion": "1.2.214",
  "type": "ZHAPresence",
  "uniqueid": "00:0b:57:ff:fe:22:cf:5f-01-0006"
}
```

```
{
  "config": {
    "alert": "none",
    "battery": 100,
    "delay": 180,
    "duration": 180,
    "group": "20004",
    "on": true,
    "reachable": true
  },
  "ep": 1,
  "etag": "0a91afd665efbbe9544fb2810405f52a",
  "lastannounced": null,
  "lastseen": "2023-09-16T23:04Z",
  "manufacturername": "IKEA of Sweden",
  "modelid": "TRADFRI motion sensor",
  "name": "Presence 130",
  "productid": "E1745",
  "state": {
    "dark": true,
    "lastupdated": "2023-09-16T23:04:45.342",
    "presence": true
  },
  "swversion": "2.0.022",
  "type": "ZHAPresence",
  "uniqueid": "14:b4:57:ff:fe:3e:ad:28-01-0006"
}
```