### PR TITLE
IKEA bulbs: add `productid`

### DIFF
--- a/devices/ikea/tradfri_bulb_e27_cws_opal_600lm.json
+++ b/devices/ikea/tradfri_bulb_e27_cws_opal_600lm.json
@@ -32,6 +32,23 @@
           "name": "attr/name"
         },
         {
+          "name": "attr/productid",
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A",
+            "eval": "Item.val = Attr.val"
+          },
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A"
+          },
+          "refresh.interval": 86400
+        },
+        {
           "name": "attr/swversion"
         },
         {

--- a/devices/ikea/tradfri_bulb_e27_cws_opal_806lm.json
+++ b/devices/ikea/tradfri_bulb_e27_cws_opal_806lm.json
@@ -33,6 +33,23 @@
           "name": "attr/name"
         },
         {
+          "name": "attr/productid",
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A",
+            "eval": "Item.val = Attr.val"
+          },
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A"
+          },
+          "refresh.interval": 86400
+        },
+        {
           "name": "attr/swversion"
         },
         {

--- a/devices/ikea/tradfri_bulb_e27_w_opal_1000lm.json
+++ b/devices/ikea/tradfri_bulb_e27_w_opal_1000lm.json
@@ -33,6 +33,23 @@
           "name": "attr/name"
         },
         {
+          "name": "attr/productid",
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A",
+            "eval": "Item.val = Attr.val"
+          },
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A"
+          },
+          "refresh.interval": 86400
+        },
+        {
           "name": "attr/swversion"
         },
         {

--- a/devices/ikea/tradfri_bulb_e27_ws_opal_980lm.json
+++ b/devices/ikea/tradfri_bulb_e27_ws_opal_980lm.json
@@ -33,6 +33,23 @@
           "name": "attr/name"
         },
         {
+          "name": "attr/productid",
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A",
+            "eval": "Item.val = Attr.val"
+          },
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A"
+          },
+          "refresh.interval": 86400
+        },
+        {
           "name": "attr/swversion"
         },
         {

--- a/devices/ikea/tradfri_control_outlet.json
+++ b/devices/ikea/tradfri_control_outlet.json
@@ -33,6 +33,23 @@
           "name": "attr/name"
         },
         {
+          "name": "attr/productid",
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A",
+            "eval": "Item.val = Attr.val"
+          },
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A"
+          },
+          "refresh.interval": 86400
+        },
+        {
           "name": "attr/swversion"
         },
         {


### PR DESCRIPTION
I only did the DDFs for the bulbs I possess, but I'm pretty sure all IKEA bulbs support 0x0000/0x000A.

E.g. the CWS 806lm now exposes as:
```
{
  "capabilities": {
    "alerts": [
      "none",
      "select",
      "lselect"
    ],
    "color": {
      "ct": {
        "computes_xy": true,
        "max": 454,
        "min": 250
      },
      "effects": [
        "none",
        "colorloop"
      ],
      "modes": [
        "ct",
        "effect",
        "hs",
        "xy"
      ],
      "xy": {
        "blue": [
          0.13,
          0.04
        ],
        "green": [
          0.11,
          0.82
        ],
        "red": [
          0.68,
          0.31
        ]
      }
    }
  },
  "colorcapabilities": 31,
  "config": {
    "bri": {
      "execute_if_off": true,
      "on_level": "previous",
      "startup": "previous"
    },
    "color": {
      "ct": {
        "startup": "previous"
      },
      "execute_if_off": true
    },
    "groups": [
      "0"
    ],
    "on": {
      "startup": false
    }
  },
  "ctmax": 454,
  "ctmin": 250,
  "etag": "ce840e90b610b475e245fef6bbe8f3a0",
  "hascolor": true,
  "lastannounced": null,
  "lastseen": "2023-09-17T07:05Z",
  "manufacturername": "IKEA of Sweden",
  "modelid": "TRADFRI bulb E27 CWS 806lm",
  "name": "Trådfri CWS",
  "productid": "LED1924G9",
  "state": {
    "alert": "none",
    "bri": 1,
    "colormode": "ct",
    "ct": 370,
    "effect": "none",
    "hue": 0,
    "on": false,
    "reachable": true,
    "sat": 201,
    "xy": [
      0.458,
      0.41
    ]
  },
  "swversion": "1.0.021",
  "type": "Extended color light",
  "uniqueid": "ec:1b:bd:ff:fe:ad:45:44-01"
}
```