### PR TITLE
New DDF for all IKEA blinds

### DIFF
--- a/devices/ikea/blind.json
+++ b/devices/ikea/blind.json
@@ -1,0 +1,216 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "$MF_IKEA",
+  "modelid": [
+    "FYRTUR block-out roller blind",
+    "KADRILJ roller blind",
+    "PRAKTLYSING cellular blind",
+    "TREDANSEN block-out cellul blind"
+  ],
+  "vendor": [
+    "IKEA of Sweden",
+    "IKEA of Sweden",
+    "IKEA of Sweden",
+    "IKEA of Sweden"
+  ],
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_WINDOW_COVERING_DEVICE",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/productid",
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A",
+            "eval": "Item.val = Attr.val"
+          },
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A"
+          },
+          "refresh.interval": 86400
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/lift"
+        },
+        {
+          "name": "state/open",
+          "parse": {
+            "fn": "zcl",
+            "ep": 1,
+            "cl": "0x0102",
+            "at": "0x0008",
+            "eval": "Item.val = Attr.val === 0"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_BATTERY_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0001"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0202",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x0102"
+        ],
+        "out": [
+          "0x0019"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername",
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "attr/modelid",
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/productid",
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A",
+            "eval": "Item.val = Attr.val"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "attr/swversion",
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/battery",
+          "refresh.interval": 3660,
+          "parse": {
+            "fn": "zcl",
+            "ep": 1,
+            "cl": "0x0001",
+            "at": "0x0021",
+            "eval": "Item.val = Attr.val"
+          }
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0102",
+      "report": [
+        {
+          "at": "0x0008",
+          "dt": "0x20",
+          "min": 1,
+          "max": 300,
+          "change": "0x01"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 1,
+          "max": 3600,
+          "change": "0x01"
+        }
+      ]
+    }
+  ]
+}

--- a/devices/ikea/blind.json
+++ b/devices/ikea/blind.json
@@ -1,17 +1,16 @@
 {
   "schema": "devcap1.schema.json",
-  "manufacturername": "$MF_IKEA",
+  "manufacturername": [
+    "$MF_IKEA",
+    "$MF_IKEA",
+    "$MF_IKEA",
+    "$MF_IKEA"
+  ],
   "modelid": [
     "FYRTUR block-out roller blind",
     "KADRILJ roller blind",
     "PRAKTLYSING cellular blind",
     "TREDANSEN block-out cellul blind"
-  ],
-  "vendor": [
-    "IKEA of Sweden",
-    "IKEA of Sweden",
-    "IKEA of Sweden",
-    "IKEA of Sweden"
   ],
   "sleeper": false,
   "status": "Gold",
@@ -67,6 +66,9 @@
         },
         {
           "name": "attr/uniqueid"
+        },
+        {
+          "name": "cap/groups/not_supported"
         },
         {
           "name": "state/lift"

--- a/devices/ikea/fyrtur_block-out_roller_blind.json
+++ b/devices/ikea/fyrtur_block-out_roller_blind.json
@@ -5,7 +5,7 @@
   "vendor": "IKEA of Sweden",
   "product": "FYRTUR block-out roller blind",
   "sleeper": false,
-  "status": "Gold",
+  "status": "Draft",
   "subdevices": [
     {
       "type": "$TYPE_WINDOW_COVERING_DEVICE",

--- a/devices/ikea/kadrilj_blind.json
+++ b/devices/ikea/kadrilj_blind.json
@@ -5,7 +5,7 @@
   "manufacturername": "$MF_IKEA",
   "modelid": "KADRILJ roller blind",
   "product": "KADRILJ roller blind (E1752-140)",
-  "status": "Bronze",
+  "status": "Draft",
   "supportsMgmtBind": true,
   "sleeper": false,
   "subdevices": [

--- a/devices/ikea/tredansen_block-out_cellul_blind.json
+++ b/devices/ikea/tredansen_block-out_cellul_blind.json
@@ -10,7 +10,7 @@
   ],
   "product": "PRAKTLYSING/TREDANSEN cellular blind",
   "sleeper": false,
-  "status": "Gold",
+  "status": "Draft",
   "subdevices": [
     {
       "type": "$TYPE_WINDOW_COVERING_DEVICE",


### PR DESCRIPTION
This new DDF exposes the IKEA FYRTUR, KADRILJ, PRAKTLYSING, and TREDANSEN blinds from one DDF.
It replacing the individual DDFs for FYRTUR, and for KADRILJ and the combined DDF for PRAKTLYSING and TREDANSEN.

I've only been able to test it on the FYRTUR as I don't posses any of the other blinds
I've downgraded the existing DDFs to status `Draft`, instead of deleting them.
This way, there's an easy fallback in case the new DDF doesn't work: mark it `Draft` and set the old DDF to `Gold`.
Once the new DDF has been confirmed to work with the other blinds, the existing DDFs can be deleted.
Note that the DDF for the KADRILJ was set to `Silver`.

Changes:
- Add `productid`;
- Add `cap/groups/not_supported`.  While the blinds support the _Groups_ cluster, deCONZ cannot send groupcasts to these, as it sends groupcasts to the _Receiver On When Idle_ broadcast address and the blinds don't have this.  With the latest firmware, the TRADFRI open/close remote no longer supports groupcasts either.
- Remove long deprecated `state/bri` and `state/on` from the KADRILJ, PRAKTLYSING, and TREDANSEN.  They were already removed from the FYRTUR;
- Change the order of bindings to bind the _Window Covering_ cluster before the _Power Configuration_ cluster;
- `state/battery`: Standardise on attribute reporting settings of 1/3600/0x01, with refresh interval of 3660;
- Don't read the `attr` items on the ZHABattery, as they're already read for the _Window covering device_

```
{
  "etag": "087d96ca9e2219df5961bfc4b81d2feb",
  "hascolor": false,
  "lastannounced": null,
  "lastseen": "2023-09-17T08:09Z",
  "manufacturername": "IKEA of Sweden",
  "modelid": "FYRTUR block-out roller blind",
  "name": "Bathroom Blind",
  "productid": "E1757-140",
  "state": {
    "lift": 0,
    "open": true,
    "reachable": true
  },
  "swversion": "2.3.088",
  "type": "Window covering device",
  "uniqueid": "84:fd:27:ff:fe:e1:01:61-01"
}
```
Note the `-140` in the `productid`, which indicates the width of the blind.