### PR TITLE
Updated DDF for IKEA STARKVIND Air Purifier

### DIFF
--- a/devices/ikea/starkvind_air_purifier.json
+++ b/devices/ikea/starkvind_air_purifier.json
@@ -26,9 +26,6 @@
         "device": "0x0007",
         "in": [
           "0x0000",
-          "0x0003",
-          "0x0004",
-          "0x0005",
           "0xFC7D"
         ],
         "out": [
@@ -68,6 +65,23 @@
           "name": "attr/name"
         },
         {
+          "name": "attr/productid",
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A",
+            "eval": "Item.val = Attr.val"
+          },
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A"
+          },
+          "refresh.interval": 86400
+        },
+        {
           "name": "attr/swversion"
         },
         {
@@ -79,27 +93,27 @@
         {
           "name": "config/filterlifetime",
           "parse": {
-            "at": "0x0002",
-            "cl": "0xfc7d",
+            "fn": "zcl:attr",
             "ep": 1,
-            "fn": "zcl",
-            "mf": "0x117c",
+            "cl": "0xFC7D",
+            "mf": "0x117C",
+            "at": "0x0002",
             "eval": "Item.val = Attr.val"
           },
           "read": {
-            "fn": "zcl",
+            "fn": "zcl:attr",
             "ep": 1,
-            "cl": "0xfc7d",
-            "at": "0x0002",
-            "mf": "0x117c"
+            "cl": "0xFC7D",
+            "mf": "0x117C",
+            "at": "0x0002"
           },
           "write": {
-            "at": "0x0002",
-            "cl": "0xfc7d",
-            "dt": "0x23",
+            "fn": "zcl:attr",
             "ep": 1,
-            "fn": "zcl",
-            "mf": "0x117c",
+            "cl": "0xFC7D",
+            "mf": "0x117C",
+            "at": "0x0002",
+            "dt": "0x23",
             "eval": "Item.val"
           },
           "refresh.interval": 360
@@ -107,27 +121,27 @@
         {
           "name": "config/ledindication",
           "parse": {
-            "at": "0x0003",
-            "cl": "0xfc7d",
+            "fn": "zcl:attr",
             "ep": 1,
-            "fn": "zcl",
-            "mf": "0x117c",
+            "cl": "0xFC7D",
+            "mf": "0x117C",
+            "at": "0x0003",
             "eval": "Item.val = !Attr.val"
           },
           "read": {
-            "fn": "zcl",
+            "fn": "zcl:attr",
             "ep": 1,
-            "cl": "0xfc7d",
-            "at": "0x0003",
-            "mf": "0x117c"
+            "cl": "0xFC7D",
+            "mf": "0x117C",
+            "at": "0x0003"
           },
           "write": {
-            "at": "0x0003",
-            "cl": "0xfc7d",
-            "dt": "0x10",
+            "fn": "zcl:attr",
             "ep": 1,
-            "fn": "zcl",
-            "mf": "0x117c",
+            "cl": "0xFC7D",
+            "mf": "0x117C",
+            "at": "0x0003",
+            "dt": "0x10",
             "eval": "!Item.val"
           },
           "refresh.interval": 360,
@@ -136,27 +150,27 @@
         {
           "name": "config/locked",
           "parse": {
-            "at": "0x0005",
-            "cl": "0xfc7d",
+            "fn": "zcl:attr",
             "ep": 1,
-            "fn": "zcl",
-            "mf": "0x117c",
+            "cl": "0xFC7D",
+            "mf": "0x117C",
+            "at": "0x0005",
             "eval": "Item.val = Attr.val"
           },
           "read": {
-            "fn": "zcl",
+            "fn": "zcl:attr",
             "ep": 1,
-            "cl": "0xfc7d",
-            "at": "0x0005",
-            "mf": "0x117c"
+            "cl": "0xFC7D",
+            "mf": "0x117C",
+            "at": "0x0005"
           },
           "write": {
-            "at": "0x0005",
-            "cl": "0xfc7d",
-            "dt": "0x10",
+            "fn": "zcl:attr",
             "ep": 1,
-            "fn": "zcl",
-            "mf": "0x117c",
+            "cl": "0xFC7D",
+            "mf": "0x117C",
+            "at": "0x0005",
+            "dt": "0x10",
             "eval": "Item.val"
           },
           "refresh.interval": 360
@@ -194,26 +208,27 @@
             ]
           ],
           "parse": {
-            "at": "0x0006",
-            "cl": "0xfc7d",
+            "fn": "zcl:attr",
             "ep": 1,
-            "fn": "zcl",
-            "mf": "0x117c",
+            "cl": "0xFC7D",
+            "mf": "0x117C",
+            "at": "0x0006",
             "script": "starkvind_parse_target_mode.js"
           },
           "read": {
-            "fn": "zcl",
+            "fn": "zcl:attr",
             "ep": 1,
-            "cl": "0xfc7d",
-            "at": "0x0006",
-            "mf": "0x117c"
+            "cl": "0xFC7D",
+            "mf": "0x117C",
+            "at": "0x0006"
           },
           "write": {
-            "at": "0x0006",
-            "cl": "0xfc7d",
-            "dt": "0x20",
+            "fn": "zcl:attr",
             "ep": 1,
-            "mf": "0x117c",
+            "cl": "0xFC7D",
+            "mf": "0x117C",
+            "at": "0x0006",
+            "dt": "0x20",
             "script": "starkvind_write_target_mode.js"
           },
           "refresh.interval": 360,
@@ -228,38 +243,38 @@
         {
           "name": "state/deviceruntime",
           "parse": {
-            "at": "0x0008",
-            "cl": "0xfc7d",
+            "fn": "zcl:attr",
             "ep": 1,
-            "fn": "zcl",
-            "mf": "0x117c",
+            "cl": "0xFC7D",
+            "mf": "0x117C",
+            "at": "0x0008",
             "eval": "Item.val = Attr.val"
           },
           "read": {
-            "fn": "zcl",
+            "fn": "zcl:attr",
             "ep": 1,
-            "cl": "0xfc7d",
-            "at": "0x0008",
-            "mf": "0x117c"
+            "cl": "0xFC7D",
+            "mf": "0x117C",
+            "at": "0x0008"
           },
           "refresh.interval": 360
         },
         {
           "name": "state/filterruntime",
           "parse": {
-            "at": "0x0000",
-            "cl": "0xfc7d",
+            "fn": "zcl:attr",
             "ep": 1,
-            "fn": "zcl",
-            "mf": "0x117c",
+            "cl": "0xFC7D",
+            "mf": "0x117C",
+            "at": "0x0000",
             "eval": "Item.val = Attr.val"
           },
           "read": {
-            "fn": "zcl",
+            "fn": "zcl:attr",
             "ep": 1,
-            "cl": "0xfc7d",
-            "at": "0x0000",
-            "mf": "0x117c"
+            "cl": "0xFC7D",
+            "mf": "0x117C",
+            "at": "0x0000"
           },
           "refresh.interval": 360
         },
@@ -269,19 +284,19 @@
         {
           "name": "state/replacefilter",
           "parse": {
-            "at": "0x0001",
-            "cl": "0xfc7d",
+            "fn": "zcl:attr",
             "ep": 1,
-            "fn": "zcl",
-            "mf": "0x117c",
+            "cl": "0xFC7D",
+            "mf": "0x117C",
+            "at": "0x0001",
             "eval": "Item.val = Attr.val !== 0"
           },
           "read": {
-            "fn": "zcl",
+            "fn": "zcl:attr",
             "ep": 1,
-            "cl": "0xfc7d",
-            "at": "0x0001",
-            "mf": "0x117c"
+            "cl": "0xFC7D",
+            "mf": "0x117C",
+            "at": "0x0001"
           },
           "refresh.interval": 360
         },
@@ -289,19 +304,19 @@
           "name": "state/speed",
           "access": "R",
           "parse": {
-            "at": "0x0007",
-            "cl": "0xfc7d",
+            "fn": "zcl:attr",
             "ep": 1,
-            "fn": "zcl",
-            "mf": "0x117c",
+            "cl": "0xFC7D",
+            "mf": "0x117C",
+            "at": "0x0007",
             "script": "starkvind_parse_speed.js"
           },
           "read": {
-            "fn": "zcl",
+            "fn": "zcl:attr",
             "ep": 1,
-            "cl": "0xfc7d",
-            "at": "0x0007",
-            "mf": "0x117c"
+            "cl": "0xFC7D",
+            "mf": "0x117C",
+            "at": "0x0007"
           },
           "refresh.interval": 360,
           "default": 0
@@ -309,19 +324,24 @@
       ]
     },
     {
-      "type": "$TYPE_AIR_QUALITY_SENSOR",
+      "type": "$TYPE_PARTICULATEMATTER_SENSOR",
       "restapi": "/sensors",
       "uuid": [
         "$address.ext",
         "0x01",
         "0x042a"
+
       ],
       "fingerprint": {
         "endpoint": "0x01",
         "profile": "0x0104",
         "device": "0x0007",
         "in": [
-          "0x042A"
+          "0x0000",
+          "0xFC7D"
+        ],
+        "out": [
+          "0x0019"
         ]
       },
       "items": [
@@ -335,22 +355,64 @@
           "name": "attr/lastseen"
         },
         {
-          "name": "attr/manufacturername"
+          "name": "attr/manufacturername",
+          "read": {
+            "fn": "none"
+          }
         },
         {
-          "name": "attr/modelid"
+          "name": "attr/modelid",
+          "read": {
+            "fn": "none"
+          }
         },
         {
           "name": "attr/name"
         },
         {
-          "name": "attr/swversion"
+          "name": "attr/productid",
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A",
+            "eval": "Item.val = Attr.val"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "attr/swversion",
+          "read": {
+            "fn": "none"
+          }
         },
         {
           "name": "attr/type"
         },
         {
           "name": "attr/uniqueid"
+        },
+        {
+          "name": "cap/measured_value/max",
+          "static": 999
+        },
+        {
+          "name": "cap/measured_value/min",
+          "static": 0
+        },
+        {
+          "name": "cap/measured_value/quantity",
+          "static": "density"
+        },
+        {
+          "name": "cap/measured_value/substance",
+          "static": "pm2.5"
+        },
+        {
+          "name": "cap/measured_value/unit",
+          "static": "µg/m³"
         },
         {
           "name": "config/on"
@@ -362,35 +424,57 @@
           "name": "state/lastupdated"
         },
         {
-          "name": "state/pm2_5",
+          "name": "state/measured_value",
           "parse": {
-            "at": "0x0004",
-            "cl": "0xfc7d",
+            "fn": "zcl:attr",
             "ep": 1,
-            "fn": "zcl",
-            "mf": "0x117c",
+            "cl": "0xFC7D",
+            "mf": "0x117C",
+            "at": "0x0004",
             "eval": "Item.val = Attr.val"
           },
           "read": {
-            "fn": "zcl",
+            "fn": "zcl:attr",
             "ep": 1,
-            "cl": "0xfc7d",
-            "at": "0x0004",
-            "mf": "0x117c"
+            "cl": "0xFC7D",
+            "mf": "0x117C",
+            "at": "0x0004"
           },
           "refresh.interval": 360
         },
         {
+          "name": "state/pm2_5",
+          "deprecated": "2023-09-17",
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0xFC7D",
+            "mf": "0x117C",
+            "at": "0x0004",
+            "eval": "Item.val = Attr.val"
+          }
+        },
+        {
           "name": "state/airquality",
           "parse": {
-            "at": "0x0004",
-            "cl": "0xfc7d",
-            "ep": 1,
-            "fn": "zcl",
-            "mf": "0x117c",
-            "script": "starkvind_parse_pm2_5.js"
-          },
-          "default": "unknown"
+            "fn": "numtostr",
+            "srcitem": "state/measured_value",
+            "op": "le",
+            "to": [
+              10,
+              "excellent",
+              20,
+              "good",
+              25,
+              "moderate",
+              50,
+              "poor",
+              75,
+              "unhealthy",
+              65535,
+              "out of scale"
+            ]
+          }
         }
       ]
     }
@@ -399,77 +483,77 @@
     {
       "bind": "unicast",
       "src.ep": 1,
-      "cl": "0xfc7d",
+      "cl": "0xFC7D",
       "report": [
         {
+          "mf": "0x117C",
           "at": "0x0000",
           "dt": "0x23",
-          "mf": "0x117c",
           "min": 1,
           "max": 300,
-          "change": "0x0001"
+          "change": "0x00000001"
         },
         {
+          "mf": "0x117C",
           "at": "0x0001",
           "dt": "0x20",
-          "mf": "0x117c",
           "min": 1,
           "max": 300,
-          "change": "0x0001"
+          "change": "0x01"
         },
         {
+          "mf": "0x117C",
           "at": "0x0002",
           "dt": "0x23",
-          "mf": "0x117c",
           "min": 1,
           "max": 300,
-          "change": "0x0001"
+          "change": "0x00000001"
         },
         {
+          "mf": "0x117C",
           "at": "0x0003",
           "dt": "0x10",
-          "mf": "0x117c",
           "min": 1,
           "max": 300
         },
         {
+          "mf": "0x117C",
           "at": "0x0004",
           "dt": "0x21",
-          "mf": "0x117c",
           "min": 1,
           "max": 300,
           "change": "0x0001"
         },
         {
+          "mf": "0x117C",
           "at": "0x0005",
           "dt": "0x10",
-          "mf": "0x117c",
           "min": 1,
           "max": 300
         },
         {
+          "mf": "0x117C",
           "at": "0x0006",
           "dt": "0x20",
-          "mf": "0x117c",
           "min": 1,
           "max": 300,
-          "change": "0x0001"
+          "change": "0x01"
         },
         {
+          "mf": "0x117C",
           "at": "0x0007",
           "dt": "0x20",
-          "mf": "0x117c",
           "min": 1,
           "max": 300,
-          "change": "0x0001"
+          "change": "0x01"
         },
         {
+          "mf": "0x117C",
           "at": "0x0008",
           "dt": "0x23",
-          "mf": "0x117c",
           "min": 1,
           "max": 300,
-          "change": "0x0001"
+          "change": "0x00000001"
         }
       ]
     }

--- a/devices/ikea/starkvind_air_purifier.json
+++ b/devices/ikea/starkvind_air_purifier.json
@@ -412,7 +412,7 @@
         },
         {
           "name": "cap/measured_value/unit",
-          "static": "µg/m³"
+          "static": "ug/m^3"
         },
         {
           "name": "config/on"

--- a/devices/ikea/starkvind_air_purifier.json
+++ b/devices/ikea/starkvind_air_purifier.json
@@ -408,7 +408,7 @@
         },
         {
           "name": "cap/measured_value/substance",
-          "static": "pm2.5"
+          "static": "PM2.5"
         },
         {
           "name": "cap/measured_value/unit",

--- a/devices/ikea/starkvind_parse_pm2_5.js
+++ b/devices/ikea/starkvind_parse_pm2_5.js
@@ -1,9 +1,0 @@
-/* global Attr, Item */
-
-if (Attr.val === 65535) Item.val = 'unknown'
-else if (Attr.val <= 10) Item.val = 'excellent'
-else if (Attr.val <= 20) Item.val = 'good'
-else if (Attr.val <= 25) Item.val = 'moderate'
-else if (Attr.val <= 50) Item.val = 'poor'
-else if (Attr.val <= 75) Item.val = 'unhealthy'
-else Item.val = 'out of scale'


### PR DESCRIPTION
The air purifier uses the IKEA-specific 0xFC7D cluster for both the Air Purifier and PM2.5 density sensor features.  We expose the latter as a separate resource, faking a standard 0x042A cluster.

This PR makes the following changes:

### ZHAAirPurifier
- Add `productid`;
- Adjust `change` values in bindings to match data type.
```
{
  "config": {
    "filterlifetime": 259200,
    "ledindication": true,
    "locked": false,
    "mode": "auto",
    "on": true,
    "reachable": true
  },
  "ep": 1,
  "etag": "d21eaa7d4c887ebfd431ef2a85d7203a",
  "lastannounced": null,
  "lastseen": "2023-09-23T14:07Z",
  "manufacturername": "IKEA of Sweden",
  "modelid": "STARKVIND Air purifier",
  "name": "AirPurifier 141",
  "productid": "E2007",
  "state": {
    "deviceruntime": 858341,
    "filterruntime": 21843,
    "lastupdated": "2023-09-23T14:07:42.513",
    "replacefilter": false,
    "speed": 20
  },
  "swversion": "1.1.001",
  "type": "ZHAAirPurifier",
  "uniqueid": "cc:86:ec:ff:fe:6d:30:11-01-fc7d"
}
```

### ZHAParticulateMatter
- Change `type` to ZHAParticulateMatter (was ZHAAirQuality);
- Don't read `attr` items, as they're already read from the ZHAAirPurifier;
- Add `productid`
- Add `state/measured_value`, as float value in µg/m³. Unfortunately, the sensor's granularity is limited to integer values;
- Add corresponding `cap/measured_value` items.  All are defined in the DDF.  The `min` and `max` values are taken from the VINDSTYRKA;
- Derive `state/airquality` from `state/measured_value`, using `numtostr`;
- Deprecate `state/pm2_5`;
- Delete script file `starkvind_parse_pm2_5.js`.
```
{
  "capabilities": {
    "measured_value": {
      "max": 999,
      "min": 0,
      "quantity": "density",
      "substance": "PM2.5",
      "unit": "ug/m^3"
    }
  },
  "config": {
    "on": true,
    "reachable": true
  },
  "ep": 1,
  "etag": "bbbe4c0a08efaea80d9edb22e0adc97e",
  "lastannounced": null,
  "lastseen": "2023-09-23T14:09Z",
  "manufacturername": "IKEA of Sweden",
  "modelid": "STARKVIND Air purifier",
  "name": "ParticulateMatter 142",
  "productid": "E2007",
  "state": {
    "airquality": "excellent",
    "lastupdated": "2023-09-23T14:10:00.054",
    "measured_value": 6,
    "pm2_5": 6
  },
  "swversion": "1.1.001",
  "type": "ZHAParticulateMatter",
  "uniqueid": "cc:86:ec:ff:fe:6d:30:11-01-042a"
}
```