### PR TITLE
DDF for IKEA TRADFRI Signal Repeater

### DIFF
--- a/devices/ikea/tradfri_signal_repeater.json
+++ b/devices/ikea/tradfri_signal_repeater.json
@@ -1,0 +1,77 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": [
+    "$MF_IKEA",
+    "$MF_IKEA"
+  ],
+  "modelid": [
+    "TRADFRI Signal Repeater",
+    "TRADFRI signal repeater"
+  ],
+  "product": "TRADFRI Signal Repeater",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_RANGE_EXTENDER",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/productid",
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A",
+            "eval": "Item.val = Attr.val"
+          },
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x000A"
+          },
+          "refresh.interval": 86400
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert",
+          "default": "none"
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    }
+  ]
+}

--- a/devices/ikea/tradfri_signal_repeater.json
+++ b/devices/ikea/tradfri_signal_repeater.json
@@ -65,6 +65,9 @@
           "name": "attr/uniqueid"
         },
         {
+          "name": "cap/groups/not_supported"
+        },
+        {
           "name": "state/alert",
           "default": "none"
         },


### PR DESCRIPTION
Not the most useful device to expose over the API, but now you can also see the `productid`, next to renaming and identifying it.  Note that there's two variants of the `modelid`, even though they share the same `productid` and firmware image and version.  The do have different values for _Date Code_ (which is supposed to be the hardware manufacturing date, not the firmware date, although it's mostly used for the latter).

```
{
  "capabilities": {
    "alerts": [
      "none",
      "select",
      "lselect"
    ]
  },
  "etag": "f9ba728ddedfb37d0b534e02d61ccb01",
  "hascolor": false,
  "lastannounced": null,
  "lastseen": "2023-09-17T14:12Z",
  "manufacturername": "IKEA of Sweden",
  "modelid": "TRADFRI Signal Repeater",
  "name": "Range extender 15",
  "productid": "E1746",
  "state": {
    "alert": "none",
    "reachable": true
  },
  "swversion": "2.3.086",
  "type": "Range extender",
  "uniqueid": "84:71:27:ff:fe:30:e1:37-01"
}
```