### PR TITLE
Add API and websocket support for `state/measured_value` and corresponding `cap` items.

### DIFF
--- a/devices/generic/items/cap_measured_value_quantity.json
+++ b/devices/generic/items/cap_measured_value_quantity.json
@@ -1,0 +1,8 @@
+{
+  "schema": "resourceitem1.schema.json",
+  "id": "cap/measured_value/quantity",
+  "datatype": "String",
+  "access": "R",
+  "public": true,
+  "description": "Quantity of measured_value."
+}

--- a/resource.cpp
+++ b/resource.cpp
@@ -133,6 +133,7 @@ const char *RStateLocaltime = "state/localtime";
 const char *RStateLockState = "state/lockstate";
 const char *RStateLowBattery = "state/lowbattery";
 const char *RStateLux = "state/lux";
+const char *RStateMeasuredValue = "state/measured_value";
 const char *RStateMoisture = "state/moisture";
 const char *RStateMountingModeActive = "state/mountingmodeactive";
 const char *RStateMusicSync = "state/music_sync";
@@ -215,6 +216,11 @@ const char *RCapColorXyRedX = "cap/color/xy/red_x";
 const char *RCapColorXyRedY = "cap/color/xy/red_y";
 const char *RCapGroup = "cap/group";
 const char *RCapGroupsNotSupported = "cap/groups/not_supported";
+const char *RCapMeasuredValueMax = "cap/measured_value/max";
+const char *RCapMeasuredValueMin = "cap/measured_value/min";
+const char *RCapMeasuredValueQuantity = "cap/measured_value/quantity";
+const char *RCapMeasuredValueSubstance = "cap/measured_value/substance";
+const char *RCapMeasuredValueUnit = "cap/measured_value/unit";
 const char *RCapOnOffWithEffect = "cap/on/off_with_effect";
 const char *RCapSleeper = "cap/sleeper";
 const char *RCapTransitionBlock = "cap/transition_block";
@@ -438,6 +444,7 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, QVariant::String, RStateLockState));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, QVariant::Bool, RStateLowBattery));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt32, QVariant::Double, RStateLux));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeReal, QVariant::Double, RStateMeasuredValue));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeInt16, QVariant::Double, RStateMoisture));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, QVariant::Bool, RStateMountingModeActive));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, QVariant::Bool, RStateMusicSync));
@@ -506,6 +513,11 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, QVariant::Double, RCapColorXyRedY));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, QVariant::String, RCapGroup));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, QVariant::Bool, RCapGroupsNotSupported));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeReal, QVariant::Double, RCapMeasuredValueMax));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeReal, QVariant::Double, RCapMeasuredValueMin));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, QVariant::String, RCapMeasuredValueQuantity));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, QVariant::String, RCapMeasuredValueSubstance));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, QVariant::String, RCapMeasuredValueUnit));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, QVariant::Bool, RCapOnOffWithEffect));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, QVariant::Bool, RCapSleeper));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeBool, QVariant::Bool, RCapTransitionBlock));
@@ -1182,7 +1194,7 @@ bool ResourceItem::setValue(const QVariant &val, ValueSource source)
     {
         if (m_rid->type == DataTypeReal)
         {
-            DBG_Printf(DBG_ERROR, "todo handle DataTypeReal in %s", __FUNCTION__);
+            DBG_Printf(DBG_ERROR, "todo handle DataTypeReal in %s\n", __FUNCTION__);
         }
 
         bool ok = false;

--- a/resource.h
+++ b/resource.h
@@ -112,8 +112,8 @@ extern const char *RActionScene;
 extern const char *RStateAction;
 extern const char *RStateAirQuality;
 extern const char *RStateAirQualityBis;
-extern const char *RStateAirQualityPpb;
-extern const char *RStateAirQualityPpbBis;
+extern const char *RStateAirQualityPpb; // Deprecated
+extern const char *RStateAirQualityPpbBis; // Deprecated
 extern const char *RStateAlarm;
 extern const char *RStateAlert;
 extern const char *RStateAllOn;
@@ -162,6 +162,7 @@ extern const char *RStateLocaltime;
 extern const char *RStateLockState;
 extern const char *RStateLowBattery;
 extern const char *RStateLux;
+extern const char *RStateMeasuredValue;
 extern const char *RStateMoisture;
 extern const char *RStateMountingModeActive;
 extern const char *RStateMusicSync;
@@ -171,7 +172,7 @@ extern const char *RStateOpenBis;
 extern const char *RStateOrientationX;
 extern const char *RStateOrientationY;
 extern const char *RStateOrientationZ;
-extern const char *RStatePM2_5;
+extern const char *RStatePM2_5; // Deprecated
 extern const char *RStatePanel;
 extern const char *RStatePower;
 extern const char *RStatePresence;
@@ -229,6 +230,11 @@ extern const char *RCapColorXyRedX;
 extern const char *RCapColorXyRedY;
 extern const char *RCapGroup;
 extern const char *RCapGroupsNotSupported;
+extern const char *RCapMeasuredValueMax;
+extern const char *RCapMeasuredValueMin;
+extern const char *RCapMeasuredValueQuantity;
+extern const char *RCapMeasuredValueSubstance;
+extern const char *RCapMeasuredValueUnit;
 extern const char *RCapOnOffWithEffect;
 extern const char *RCapSleeper;
 extern const char *RCapTransitionBlock;
@@ -509,6 +515,8 @@ private:
     quint16 m_flags = 0; // bitmap of ResourceItem::ItemFlags
     qint64 m_num = 0;
     qint64 m_numPrev = 0;
+    double m_double = 0.0;
+    double m_doublePrev = 0.0;
     deCONZ::SteadyTimeRef m_lastZclReport;
 
     BufStringCacheHandle m_strHandle; // for strings which don't fit into \c m_istr

--- a/resource.h
+++ b/resource.h
@@ -515,8 +515,6 @@ private:
     quint16 m_flags = 0; // bitmap of ResourceItem::ItemFlags
     qint64 m_num = 0;
     qint64 m_numPrev = 0;
-    double m_double = 0.0;
-    double m_doublePrev = 0.0;
     deCONZ::SteadyTimeRef m_lastZclReport;
 
     BufStringCacheHandle m_strHandle; // for strings which don't fit into \c m_istr


### PR DESCRIPTION
- Add JSON for `cap/measured_value/quantity`.  Note that `substance` specifies about what the measurement is (e.g. `air`)`quantity` specifies what is measured (e.g. `temperature`); and `unit` specifies in what units the measurement is done (e.g, `°C`);
- Add support for `state/measured_value` and `cap/measured_value/*` in API and web socket notifications;