### PR TITLE
Bug fix: CLIP sensor's `config/battery` not restored

### DIFF
--- a/sensor.cpp
+++ b/sensor.cpp
@@ -542,6 +542,11 @@ void Sensor::jsonToConfig(const QString &json)
         map["lastchange_time"] = lct;
     }
 
+    if (map.contains("battery") && type().startsWith(QLatin1String("CLIP")))
+    {
+        addItem(DataTypeUInt8, RConfigBattery);
+    }
+
     QDateTime dt = QDateTime::currentDateTime().addSecs(-120);
 
     for (int i = 0; i < itemCount(); i++)


### PR DESCRIPTION
CLIP sensors might include `config/battery`, i.e. when the real, non-Zigbee sensor is battery-powered.  On creation of the CLIP sensor, `config/battery` can be specified.  However, the `RConfigBattery` item is not re-created on restart, as CLIP sensors don't get a fingerprint with a _Power Configuration_ cluster.

This PR re-creates the item while loading the CLIP sensor from the database, when the `config` column contains a key for `battery`.