### PR TITLE
Fix compiler warning for QLatin1String bounds

### DIFF
--- a/ui/ddf_editor.cpp
+++ b/ui/ddf_editor.cpp
@@ -413,7 +413,7 @@ void DDF_Editor::addSubDevice(const QString &name)
 
         std::sort(items.begin(), items.end(), [](const auto *a, const auto *b)
         {
-            return QLatin1String(a) < QLatin1String(b);
+            return strcmp(a, b) < 0;
         });
 
         for (const auto *suffix : items)

--- a/utils/bufstring.h
+++ b/utils/bufstring.h
@@ -171,9 +171,9 @@ public:
 };
 
 template<size_t T, size_t U>
-constexpr bool operator<(const BufString<T> &lhs, const BufString<U> &rhs)
+inline bool operator<(const BufString<T> &lhs, const BufString<U> &rhs)
 {
-    return static_cast<QLatin1String>(lhs) < static_cast<QLatin1String>(rhs);
+    return strcmp(lhs.c_str(), rhs.c_str()) < 0;
 }
 
 template <size_t Size>


### PR DESCRIPTION
Reported by GCC 13.2.1