### PR TITLE
New IKEA firmware

### DIFF
--- a/devices/ikea/blind.json
+++ b/devices/ikea/blind.json
@@ -176,7 +176,7 @@
             "ep": 1,
             "cl": "0x0001",
             "at": "0x0021",
-            "eval": "Item.val = Attr.val"
+            "eval": "Item.val = Math.round(Attr.val/(R.item('attr/swversion').val.startsWith('24.') ? 2 : 1))"
           }
         },
         {

--- a/devices/ikea/blind.json
+++ b/devices/ikea/blind.json
@@ -176,7 +176,7 @@
             "ep": 1,
             "cl": "0x0001",
             "at": "0x0021",
-            "eval": "Item.val = Math.round(Attr.val/(R.item('attr/swversion').val.startsWith('24.') ? 2 : 1))"
+            "eval": "Item.val = Math.round(Attr.val/(R.item('attr/swversion').val.split('.')[0] >= 24 ? 2 : 1))"
           }
         },
         {

--- a/devices/ikea/tradfri_on_off_switch.json
+++ b/devices/ikea/tradfri_on_off_switch.json
@@ -84,7 +84,7 @@
             "ep": 1,
             "cl": "0x0001",
             "at": "0x0021",
-            "eval": "Item.val = Attr.val"
+            "eval": "Item.val = Math.round(Attr.val/(R.item('attr/swversion').val.split('.')[0] >= 24 ? 2 : 1))"
           },
           "default": 0,
           "read": {

--- a/devices/ikea/tradfri_open_close_remote.json
+++ b/devices/ikea/tradfri_open_close_remote.json
@@ -83,7 +83,7 @@
             "ep": 1,
             "cl": "0x0001",
             "at": "0x0021",
-            "eval": "Item.val = Attr.val"
+            "eval": "Item.val = Math.round(Attr.val/(R.item('attr/swversion').val.split('.')[0] >= 24 ? 2 : 1))"
           },
           "default": 0,
           "read": {

--- a/devices/ikea/tradfri_remote_control.json
+++ b/devices/ikea/tradfri_remote_control.json
@@ -85,7 +85,7 @@
             "ep": 1,
             "cl": "0x0001",
             "at": "0x0021",
-            "eval": "Item.val = Attr.val"
+            "eval": "Item.val = Math.round(Attr.val/(R.item('attr/swversion').val.split('.')[0] >= 24 ? 2 : 1))"
           },
           "default": 0,
           "read": {

--- a/devices/ikea/tradfri_shortcut_button.json
+++ b/devices/ikea/tradfri_shortcut_button.json
@@ -84,7 +84,7 @@
             "ep": 1,
             "cl": "0x0001",
             "at": "0x0021",
-            "eval": "Item.val = Attr.val"
+            "eval": "Item.val = Math.round(Attr.val/(R.item('attr/swversion').val.split('.')[0] >= 24 ? 2 : 1))"
           },
           "default": 0,
           "read": {


### PR DESCRIPTION
Lastest IKEA firmware v24.x.x reports _Battery Percentage Remaining_ in 0.5%, in line with ZCL standard.  Older firmware versions reported full %.  This PR updates the DDFs for impacted devices, supporting both older and newer firmware versions.  This is against my better judgement; I'd rather support only the latest version and tell people to upgrade.

See also #7245.

Note that the 24.x.x  firmware versions aren't yet listed on https://github.com/Koenkk/zigbee-OTA, but IKEA did publish them to http://fw.ota.homesmart.ikea.net/, where the `ikea-ota-download.py` script downloads them from.