### PR TITLE
Fix heavy bogus database writes

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -4210,7 +4210,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             }
         }
 
-        if (extAddr != 0)
+        if (extAddr != 0 && endpoint != 0xFF)
         {
             const QString uid = generateUniqueId(extAddr, endpoint, clusterId);
 

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2583,10 +2583,9 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
         { }
         else if (node->nodeDescriptor().manufacturerCode() == VENDOR_NONE || (node->nodeDescriptor().manufacturerCode() == VENDOR_EMBER))
         {
+            // TODO(mpi): this needs to go in favor of DDF
             if (manufacturer.isEmpty())
             {
-                DBG_Printf(DBG_INFO_L2, "Tuya debug 7 : Missing manufacture name for 0x%016llx\n", node->address().ext());
-
                 //searching in DB
                 openDb();
                 manufacturer = loadDataForLightNodeFromDb(generateUniqueId(node->address().ext(),0,0));
@@ -2599,18 +2598,14 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
                     if (sensor && !sensor->manufacturer().isEmpty())
                     {
                         manufacturer = sensor->manufacturer();
+                        lightNode.setNeedSaveDatabase(true);
                     }
                 }
 
-				if (manufacturer.isEmpty())
-				{
-					DBG_Printf(DBG_INFO_L2, "Tuya debug 7 : Missing manufacture name, till missing in DB.\n");
-				}
-            }
-            if (!manufacturer.isEmpty())
-            {
-                lightNode.setManufacturerName(manufacturer);
-                lightNode.setNeedSaveDatabase(true);
+                if (!manufacturer.isEmpty())
+                {
+                    lightNode.setManufacturerName(manufacturer);
+                }
             }
         }
 
@@ -15886,6 +15881,9 @@ void DeRestPlugin::appAboutToQuit()
         d->openDb();
         d->saveDb();
 
+        // TODO(mpi): Following is really heavy and already done previously
+        //            storing items needs to get more explicit with dirty flags
+#if 0
         for (const auto &dev : d->m_devices)
         {
             if (dev->managed())
@@ -15896,6 +15894,7 @@ void DeRestPlugin::appAboutToQuit()
                 }
             }
         }
+#endif
 
         d->ttlDataBaseConnection = 0;
         d->closeDb();

--- a/device_compat.cpp
+++ b/device_compat.cpp
@@ -86,6 +86,7 @@ static Resource *DEV_InitSensorNodeFromDescription(Device *device, const DeviceD
         else
         {
             sensor.setId(QString::number(getFreeSensorId()));
+            sensor.setNeedSaveDatabase(true);
         }
     }
 
@@ -103,10 +104,10 @@ static Resource *DEV_InitSensorNodeFromDescription(Device *device, const DeviceD
                 friendlyName = friendlyName.mid(3);
             }
             sensor.setName(QString("%1 %2").arg(friendlyName, sensor.id()));
+            sensor.setNeedSaveDatabase(true);
         }
     }
 
-    sensor.setNeedSaveDatabase(true);
     sensor.rx();
 
     auto *r = DEV_AddResource(sensor);
@@ -192,6 +193,7 @@ static Resource *DEV_InitLightNodeFromDescription(Device *device, const DeviceDe
         else
         {
             lightNode.setId(QString::number(getFreeLightId()));
+            lightNode.setNeedSaveDatabase(true);
         }
     }
 
@@ -204,6 +206,7 @@ static Resource *DEV_InitLightNodeFromDescription(Device *device, const DeviceDe
         else
         {
             lightNode.setName(QString("%1 %2").arg(lightNode.type(), lightNode.id()));
+            lightNode.setNeedSaveDatabase(true);
         }
     }
 
@@ -242,7 +245,6 @@ static Resource *DEV_InitLightNodeFromDescription(Device *device, const DeviceDe
     lightNode.removeItem(RStateSat);
     lightNode.removeItem(RStateAlert);
 
-    lightNode.setNeedSaveDatabase(true);
     lightNode.rx();
 
     auto *r = DEV_AddResource(lightNode);


### PR DESCRIPTION
Currently there are some database writes after startup and closing deCONZ which are very heavy and just write already present entries. The change prevents these writes.

Also fixes trying to change a valid sensor `uniqueid` to one with invalid endpoint 0xFF.