### PR TITLE
Create dimmer_module.json

### DIFF
--- a/devices/wiser/dimmer_module.json
+++ b/devices/wiser/dimmer_module.json
@@ -1,0 +1,91 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "Schneider Electric",
+  "modelid": "CH/DIMMER/1",
+  "product": "40/300-Series Module Dimmer",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$DIMMABLE_LIGHT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x03"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert",
+          "default": "none"
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 5
+        },
+        {
+          "name": "state/bri",
+          "refresh.interval": 5
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 3,
+      "cl": "0x0006",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 600
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 3,
+      "cl": "0x0008",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x20",
+          "min": 1,
+          "max": 300,
+          "change": "0x01"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- Product name : Schneider Electric Wiser 40/300-Series Module Dimmer
- Manufacturer : Schneider Electric
- Model identifier : CH/DIMMER/1

Nothing special, but there is latency used with legacy code (no problem with DDF)
See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7275