### PR TITLE
DDF for Zemismart Tuya 2-gang no neutral switch (_TZ3000_lupfd8zu)

### DIFF
--- a/devices/tuya/_TS0012_2gangs_wired_no_neutral_not_locked.json
+++ b/devices/tuya/_TS0012_2gangs_wired_no_neutral_not_locked.json
@@ -1,0 +1,124 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "_TZ3000_lupfd8zu",
+  "modelid": "TS0012",
+  "product": "Tuya 2 gangs wired without neutral",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_ON_OFF_LIGHT ",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "refresh.interval": 86400,
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x0001",
+            "script": "tuya_swversion.js"
+          },
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x0001"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/on"
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_ON_OFF_OUTPUT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x02"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "refresh.interval": 86400,
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x0001",
+            "script": "tuya_swversion.js"
+          },
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x0001"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/on"
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    }
+  ]
+}

--- a/devices/tuya/_TS0012_2gangs_wired_no_neutral_not_locked.json
+++ b/devices/tuya/_TS0012_2gangs_wired_no_neutral_not_locked.json
@@ -7,7 +7,7 @@
   "status": "Gold",
   "subdevices": [
     {
-      "type": "$TYPE_ON_OFF_LIGHT ",
+      "type": "$TYPE_ON_OFF_LIGHT",
       "restapi": "/lights",
       "uuid": [
         "$address.ext",
@@ -64,7 +64,7 @@
       ]
     },
     {
-      "type": "$TYPE_ON_OFF_OUTPUT",
+      "type": "$TYPE_ON_OFF_LIGHT",
       "restapi": "/lights",
       "uuid": [
         "$address.ext",


### PR DESCRIPTION
Product name : Zemismart Tuya 2 gang no neutral switch
Manufacturer : _TZ3000_lupfd8zu
Model identifier : TS0012

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7301

Nothing special, just an unlocked version.