### PR TITLE
Bug fix: wrong value for `state/open` on Window Covering devices

### DIFF
--- a/devices/ikea/blind.json
+++ b/devices/ikea/blind.json
@@ -71,6 +71,9 @@
           "name": "cap/groups/not_supported"
         },
         {
+          "name": "state/alert"
+        },
+        {
           "name": "state/lift"
         },
         {
@@ -161,6 +164,9 @@
         },
         {
           "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/alert"
         },
         {
           "name": "config/on"

--- a/devices/ikea/blind.json
+++ b/devices/ikea/blind.json
@@ -80,7 +80,7 @@
             "ep": 1,
             "cl": "0x0102",
             "at": "0x0008",
-            "eval": "Item.val = Attr.val === 0"
+            "eval": "Item.val = Attr.val < 100"
           },
           "read": {
             "fn": "none"

--- a/devices/ikea/fyrtur_block-out_roller_blind.json
+++ b/devices/ikea/fyrtur_block-out_roller_blind.json
@@ -52,7 +52,7 @@
             "ep": 1,
             "cl": "0x0102",
             "at": "0x0008",
-            "eval": "Item.val = Attr.val === 0"
+            "eval": "Item.val = Attr.val < 100"
           },
           "read": {
             "fn": "none"

--- a/devices/iluminize/roller_shutter_actuator_mini.json
+++ b/devices/iluminize/roller_shutter_actuator_mini.json
@@ -81,7 +81,7 @@
             "at": "0x0008",
             "cl": "0x0102",
             "ep": 1,
-            "eval": "Item.val = Attr.val === 100",
+            "eval": "Item.val = Attr.val < 100",
             "fn": "zcl:attr"
           }
         },

--- a/devices/merten/meg5113-0300_cover_controller.json
+++ b/devices/merten/meg5113-0300_cover_controller.json
@@ -71,7 +71,7 @@
             "at": "0x0008",
             "cl": "0x0102",
             "ep": 5,
-            "eval": "if(Attr.val == 100) { Item.val = false; } else { Item.val = true; }",
+            "eval": "Item.val = Attr.val < 100",
             "fn": "zcl:attr"
           }
         },

--- a/devices/ubisys/j1_5502.json
+++ b/devices/ubisys/j1_5502.json
@@ -77,7 +77,7 @@
             "at": "0x0008",
             "cl": "0x0102",
             "ep": 1,
-            "eval": "if (Attr.val == 100) { Item.val = false; } else { Item.val = true; }",
+            "eval": "Item.val = Attr.val < 100",
             "fn": "zcl:attr"
           },
           "read": {

--- a/devices/ubisys/j1r_5602.json
+++ b/devices/ubisys/j1r_5602.json
@@ -77,7 +77,7 @@
             "at": "0x0008",
             "cl": "0x0102",
             "ep": 1,
-            "eval": "if (Attr.val == 100) { Item.val = false; } else { Item.val = true; }",
+            "eval": "Item.val = Attr.val < 100",
             "fn": "zcl:attr"
           },
           "read": {

--- a/devices/wiser/wall_switch_shutter.json
+++ b/devices/wiser/wall_switch_shutter.json
@@ -60,7 +60,7 @@
                         "at": "0x0008",
                         "cl": "0x0102",
                         "ep": 5,
-                        "eval": "Item.val = Attr.val != 0",
+                        "eval": "Item.val = Attr.val < 100",
                         "fn": "zcl:attr"
                     },
                     "awake": true,

--- a/devices/xiaomi/lumi_curtain.json
+++ b/devices/xiaomi/lumi_curtain.json
@@ -79,7 +79,7 @@
             "ep": 1,
             "cl": "0x0102",
             "at": "0x0008",
-            "eval": "Item.val = Attr.val === 100"
+            "eval": "Item.val = Attr.val > 0"
           },
           "read": {
             "fn": "none"

--- a/devices/xiaomi/lumi_curtain_acn002.json
+++ b/devices/xiaomi/lumi_curtain_acn002.json
@@ -126,7 +126,7 @@
             "ep": 1,
             "cl": "0x000D",
             "at": "0x0055",
-            "eval": "Item.val = Attr.val === 100"
+            "eval": "Item.val = Attr.val > 0"
           },
           "read": {
             "fn": "none"


### PR DESCRIPTION
Should be `false` only when fully closed (`state.lift === 100`), see #7313 .

Also added `state/alert` and `config/alert` for IKEA blinds (as they do support _Identify_).