### PR TITLE
DDF, add a clone for Woox Smart Remote Control R7054

### DIFF
--- a/button_maps.json
+++ b/button_maps.json
@@ -1228,7 +1228,7 @@
         "TuyaKeyfobMap": {
             "vendor": "Woox",
             "doc": "4 button remotes from Woox and Nedis",
-            "modelids": ["_TZ3000_0zrccfgx", "_TZ3000_fsiepnrh"],
+            "modelids": ["_TZ3000_0zrccfgx", "_TZ3000_fsiepnrh", "_TZ3000_p6ju8myv"],
             "map": [
                 [1, "0x01", "IAS_ACE", "ARM", "1", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "Arm day/home zones only"],
                 [1, "0x01", "IAS_ACE", "ARM", "0", "S_BUTTON_2", "S_BUTTON_ACTION_SHORT_RELEASED", "Disarm"],

--- a/devices/woox/woox_r7054_remote.json
+++ b/devices/woox/woox_r7054_remote.json
@@ -1,7 +1,7 @@
 {
    "schema":"devcap1.schema.json",
-   "manufacturername":"_TZ3000_0zrccfgx",
-   "modelid":"TS0215A",
+   "manufacturername":["_TZ3000_0zrccfgx", "_TZ3000_p6ju8myv"],
+   "modelid":["TS0215A", "TS0215A"],
    "vendor":"Woox",
    "product":"R7054 4 gang",
    "sleeper":true,
@@ -73,7 +73,8 @@
                "name":"state/lastupdated"
             },
             {
-               "name":"state/lowbattery"
+               "name": "state/lowbattery",
+               "default": false
             }
          ]
       }


### PR DESCRIPTION
- manufacturername: _TZ3000_p6ju8myv
- modelid: TS0215A

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7312