### PR TITLE
DDF clone for Tuya window sensor (_TZ3000_yxqnffam)

### DIFF
--- a/devices/tuya/_TZ3000_TS0203_door_sensor.json
+++ b/devices/tuya/_TZ3000_TS0203_door_sensor.json
@@ -1,7 +1,7 @@
 {
   "schema": "devcap1.schema.json",
-  "manufacturername": ["_TZ3000_n2egfsli", "_TZ3000_oxslv1c9", "_TZ3000_7tbsruql", "_TZ3000_7d8yme6f", "_TZ3000_rgchmad8", "_TZ3000_bzxlofth","_TZ3000_au1rjicn", "_TZ3000_4ugnzsli", "_TZ3000_decxrtwa", "_TZ3000_2mbfxlzr", "_TZ3000_6zvw8ham", "_TZ3000_v7chgqso"],
-  "modelid": ["TS0203", "TS0203", "TS0203", "TS0203", "TS0203", "TS0203","TS0203","TS0203","TS0203", "TS0203", "TS0203", "TS0203"],
+  "manufacturername": ["_TZ3000_n2egfsli", "_TZ3000_oxslv1c9", "_TZ3000_7tbsruql", "_TZ3000_7d8yme6f", "_TZ3000_rgchmad8", "_TZ3000_bzxlofth","_TZ3000_au1rjicn", "_TZ3000_4ugnzsli", "_TZ3000_decxrtwa", "_TZ3000_2mbfxlzr", "_TZ3000_6zvw8ham", "_TZ3000_v7chgqso", "_TZ3000_yxqnffam"],
+  "modelid": ["TS0203", "TS0203", "TS0203", "TS0203", "TS0203", "TS0203","TS0203","TS0203","TS0203", "TS0203", "TS0203", "TS0203", "TS0203"],
   "vendor": "Tuya",
   "product": "Smart Zigbee Door Window Contact",
   "sleeper": true,


### PR DESCRIPTION
- Manufacture name : _TZ3000_yxqnffam
- Model id : TS0203

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7318