### PR TITLE
Create lumi.switch.b1laus01.json

### DIFF
--- a/devices/xiaomi/lumi.switch.b1laus01.json
+++ b/devices/xiaomi/lumi.switch.b1laus01.json
@@ -1,0 +1,169 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "$MF_LUMI",
+  "modelid": "lumi.switch.b1laus01",
+  "vendor": "Xiaomi",
+  "product": "Aqara smart wall switch (no neutral wire) WS-USC01",
+  "sleeper": false,
+  "status": "Bronze",
+  "subdevices": [
+    {
+      "type": "$TYPE_ON_OFF_LIGHT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {
+            "at": "0x00f7",
+            "ep": 1,
+            "fn": "xiaomi:special",
+            "idx": "0x0d",
+            "script": "xiaomi_swversion.js"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert"
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 300
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_SWITCH",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x29",
+        "0x0012"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0100",
+        "endpoint": "0x29",
+        "in": [
+          "0x0012"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {
+            "at": "0x00f7",
+            "ep": 1,
+            "fn": "xiaomi:special",
+            "idx": "0x0d",
+            "script": "xiaomi_swversion.js"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/clickmode",
+          "refresh.interval": 300,
+          "read": {
+            "at": "0x0200",
+            "cl": "0xfcc0",
+            "ep": 1,
+            "fn": "zcl:attr",
+            "mf": "0x115f"
+          },
+          "parse": {
+            "at": "0x0200",
+            "cl": "0xfcc0",
+            "ep": 1,
+            "eval": "if (Attr.val == 0) { Item.val = 'decoupled' } else if (Attr.val == 1) { Item.val = 'coupled' } else { Item.val = 'unknown' }",
+            "fn": "zcl:attr",
+            "mf": "0x115f"
+          },
+          "write": {
+            "at": "0x0200",
+            "cl": "0xfcc0",
+            "dt": "0x20",
+            "ep": 1,
+            "eval": "if (Item.val == 'decoupled') { 0 } else if (Item.val == 'coupled') { 1 } else { 'unknown' }",
+            "fn": "zcl:attr",
+            "mf": "0x115f"
+          },
+          "values": [
+            ["\"decoupled\"", "Decoupled Mode"],
+            ["\"coupled\"", "Coupled Mode"] 
+          ],
+          "default": "coupled"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/buttonevent"
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Create a DDF for `lumi.switch.b1laus01`, which is the US [no-neutral Aqara switch](https://www.amazon.com/dp/B081ZQWX1F?psc=1&ref=ppx_yo2ov_dt_b_product_details). It's currently missing a couple config options, namely:

- Flip LED status indicator
- Switch "mode" between "quick" and "anti-flicker"

Both are [exposed in Z2M](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/xiaomi.ts#L1006), though I'm not familiar enough with the DDF structure to implement those endpoints. This does make the switch work, however, so that's nice.