### PR TITLE
DDF for WOOX Smart Smoke Alarm R7049

### DIFF
--- a/devices/bosch/bsd-2-smoke-alarm.json
+++ b/devices/bosch/bsd-2-smoke-alarm.json
@@ -1,0 +1,118 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "$MF_BOSCH",
+  "modelid": "RBSH-SD-ZB-EU",
+  "vendor": "Bosch",
+  "product": "Smoke Alarm II",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_FIRE_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0500"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0402",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x0500"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "parse": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "eval": "Item.val = Attr.val / 2",
+            "fn": "zcl"
+          },
+          "default": 0
+        },
+        {
+          "name": "config/enrolled",
+          "public": false
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/pending"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/fire",
+          "awake": true
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/lowbattery"
+        },
+        {
+          "name": "state/test",
+          "awake": true
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 600,
+          "max": 43200,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0500"
+    }
+  ]
+}

--- a/devices/bosch/bsd-2-smoke-alarm.json
+++ b/devices/bosch/bsd-2-smoke-alarm.json
@@ -60,9 +60,8 @@
             "cl": "0x0001",
             "ep": 1,
             "eval": "Item.val = Attr.val / 2",
-            "fn": "zcl"
-          },
-          "default": 0
+            "fn": "zcl:attr"
+          }
         },
         {
           "name": "config/enrolled",

--- a/devices/woox/Woox_smart_smoke_alarm_r7049.json
+++ b/devices/woox/Woox_smart_smoke_alarm_r7049.json
@@ -1,0 +1,103 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "_TZE200_aycxwiau",
+  "modelid": "TS0601",
+  "vendor": "WOOX",
+  "product": "Smart Smoke Alarm R7049",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_FIRE_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0xef00"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0051",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0xEF00"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "awake": true,
+          "parse": {"fn": "zcl:attr", "ep": 1, "cl": "0x0000", "at": "0x0001", "script": "tuya_swversion.js"},
+          "read": {"fn": "zcl:attr", "ep": 1, "cl": "0x0000", "at": "0x0001"}
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/errorcode",
+          "awake": true,
+          "parse": {
+            "dpid": 11,
+            "eval": "Item.val = String(Attr.val);",
+            "fn": "tuya"
+          }
+        },
+        {
+          "name": "state/fire",
+          "awake": true,
+          "parse": {"dpid": 1, "eval": "Item.val = (Attr.val == 0 ? true : false);","fn": "tuya" },
+          "default": false
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/lowbattery",
+          "parse": {"dpid": 14, "eval": "Item.val = (Attr.val == 0 ? true : false);", "fn": "tuya" },
+          "default": false
+        },
+        {
+          "name": "state/test",
+          "awake": true,
+          "parse": {"dpid": 8, "eval": "Item.val = (Attr.val == 0 ? false : true);", "fn": "tuya" },
+          "default": false
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0xEF00"
+    }
+  ]
+}


### PR DESCRIPTION
Replacing the legacy code for [this device](https://wooxhome.com/products-c10/security-c6/r7049-smoke-alarm-single-unit-discontinued-p70). Note that "lowbattery" check in tuya.cpp is in my opinion switched, it should deliver true if DPID 14 == 0. I did check with a voltmeter.