### PR TITLE
DDF clone for Tuya Mercator 1-gang switch module (_TZ3000_7jsk6lxz)

### DIFF
--- a/devices/tuya/_TZ3000_TS0011_1gang_switch_module.json
+++ b/devices/tuya/_TZ3000_TS0011_1gang_switch_module.json
@@ -1,7 +1,7 @@
 {
   "schema": "devcap1.schema.json",
-  "manufacturername": ["_TZ3000_txpirhfq","_TZ3000_qmi1cfuq", "_TZ3000_ji4araar","_TZ3000_v7sopte0","_TYZB01_qeqvmvti"],
-  "modelid": ["TS0011", "TS0011", "TS0011","TS0011","TS0011"],
+  "manufacturername": ["_TZ3000_txpirhfq","_TZ3000_qmi1cfuq", "_TZ3000_ji4araar","_TZ3000_v7sopte0","_TYZB01_qeqvmvti","_TZ3000_7jsk6lxz"],
+  "modelid": ["TS0011", "TS0011", "TS0011","TS0011","TS0011","TS0011"],
   "product": "1 gang switch module",
   "sleeper": false,
   "status": "Gold",


### PR DESCRIPTION
To support [https://www.ikuu.com.au/product/switch-mechanism/](Mercator 1 gang switch mechanism), add additional new manufacturername to the existing DDF for tuya 1 gang TS0011 switches.

This resolves #7363.
