### PR TITLE
Enable setting/viewing write functions in DDF editor

### DIFF
--- a/device_descriptions.cpp
+++ b/device_descriptions.cpp
@@ -208,6 +208,383 @@ DeviceDescriptions::DeviceDescriptions(QObject *parent) :
 
         d_ptr2->readFunctions.push_back(fn);
     }
+    
+    {  // Write function as shown in the DDF editor.
+        DDF_FunctionDescriptor fn;
+        fn.name = "zcl:attr";
+        fn.description = "Generic function to write ZCL attributes.";
+
+        DDF_FunctionDescriptor::Parameter param;
+
+        param.name = "Endpoint";
+        param.key = "ep";
+        param.description = "255 means any endpoint, 0 means auto selected from subdevice.";
+        param.dataType = DataTypeUInt8;
+        param.defaultValue = 0;
+        param.isOptional = 1;
+        param.isHexString = 0;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Cluster ID";
+        param.key = "cl";
+        param.description = "As string hex value";
+        param.dataType = DataTypeUInt16;
+        param.defaultValue = 0;
+        param.isOptional = 0;
+        param.isHexString = 1;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Attribute ID";
+        param.key = "at";
+        param.description = "As string hex value";
+        param.dataType = DataTypeUInt16;
+        param.defaultValue = 0;
+        param.isOptional = 0;
+        param.isHexString = 1;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+        
+        param.name = "Datatype";
+        param.key = "dt";
+        param.description = "Datatype of the data to be written.";
+        param.dataType = DataTypeUInt8;
+        param.defaultValue = 0;
+        param.isOptional = 0;
+        param.isHexString = 1;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Manufacturer code";
+        param.key = "mf";
+        param.description = "As string hex value.";
+        param.dataType = DataTypeUInt16;
+        param.defaultValue = 0;
+        param.isOptional = 1;
+        param.isHexString = 1;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Javascript file";
+        param.key = "script";
+        param.description = "Relative path of a Javascript .js file.";
+        param.dataType = DataTypeString;
+        param.defaultValue = {};
+        param.isOptional = 1;
+        param.isHexString = 0;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Expression";
+        param.key = "eval";
+        param.description = "Javascript expression to transform the raw value.";
+        param.dataType = DataTypeString;
+        param.defaultValue = QLatin1String("Item.val;");
+        param.isOptional = 1;
+        param.isHexString = 0;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        d_ptr2->writeFunctions.push_back(fn);
+    }
+    
+    {
+        DDF_FunctionDescriptor fn;
+        fn.name = "zcl:cmd";
+        fn.description = "Generic function to parse ZCL commands.";
+
+        DDF_FunctionDescriptor::Parameter param;
+
+        param.name = "Endpoint";
+        param.key = "ep";
+        param.description = "255 means any endpoint, 0 means auto selected from subdevice.";
+        param.dataType = DataTypeUInt8;
+        param.defaultValue = 0;
+        param.isOptional = 1;
+        param.isHexString = 0;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Cluster ID";
+        param.key = "cl";
+        param.description = "As string hex value.";
+        param.dataType = DataTypeUInt16;
+        param.defaultValue = 0;
+        param.isOptional = 0;
+        param.isHexString = 1;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Command ID";
+        param.key = "cmd";
+        param.description = "As string hex value.";
+        param.dataType = DataTypeUInt8;
+        param.defaultValue = 0;
+        param.isOptional = 0;
+        param.isHexString = 1;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Manufacturer code";
+        param.key = "mf";
+        param.description = "As string hex value.";
+        param.dataType = DataTypeUInt16;
+        param.defaultValue = 0;
+        param.isOptional = 1;
+        param.isHexString = 1;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Javascript file";
+        param.key = "script";
+        param.description = "Relative path of a Javascript .js file.";
+        param.dataType = DataTypeString;
+        param.defaultValue = {};
+        param.isOptional = 1;
+        param.isHexString = 0;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Expression";
+        param.key = "eval";
+        param.description = "Javascript expression to transform the raw value.";
+        param.dataType = DataTypeString;
+        param.defaultValue = 0;
+        param.isOptional = 1;
+        param.isHexString = 0;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        d_ptr2->parseFunctions.push_back(fn);
+    }
+    
+    {
+        DDF_FunctionDescriptor fn;
+        fn.name = "zcl:cmd";
+        fn.description = "Generic function to read ZCL commands.";
+
+        DDF_FunctionDescriptor::Parameter param;
+
+        param.name = "Endpoint";
+        param.key = "ep";
+        param.description = "255 means any endpoint, 0 means auto selected from subdevice.";
+        param.dataType = DataTypeUInt8;
+        param.defaultValue = 255;
+        param.isOptional = 0;
+        param.isHexString = 0;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Cluster ID";
+        param.key = "cl";
+        param.description = "As string hex value.";
+        param.dataType = DataTypeUInt16;
+        param.defaultValue = 0;
+        param.isOptional = 0;
+        param.isHexString = 1;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Command ID";
+        param.key = "cmd";
+        param.description = "As string hex value.";
+        param.dataType = DataTypeUInt8;
+        param.defaultValue = 0;
+        param.isOptional = 0;
+        param.isHexString = 1;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Manufacturer code";
+        param.key = "mf";
+        param.description = "As string hex value.";
+        param.dataType = DataTypeUInt16;
+        param.defaultValue = 0;
+        param.isOptional = 1;
+        param.isHexString = 1;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+        
+        param.name = "Javascript file";
+        param.key = "script";
+        param.description = "Relative path of a Javascript .js file.";
+        param.dataType = DataTypeString;
+        param.defaultValue = {};
+        param.isOptional = 1;
+        param.isHexString = 0;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Expression";
+        param.key = "eval";
+        param.description = "Javascript expression to transform the raw value.";
+        param.dataType = DataTypeString;
+        param.defaultValue = 0;
+        param.isOptional = 1;
+        param.isHexString = 0;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        d_ptr2->readFunctions.push_back(fn);
+    }
+    
+    {
+        DDF_FunctionDescriptor fn;
+        fn.name = "zcl:cmd";
+        fn.description = "Generic function to send ZCL commands.";
+
+        DDF_FunctionDescriptor::Parameter param;
+
+        param.name = "Endpoint";
+        param.key = "ep";
+        param.description = "255 means any endpoint, 0 means auto selected from subdevice.";
+        param.dataType = DataTypeUInt8;
+        param.defaultValue = 0;
+        param.isOptional = 1;
+        param.isHexString = 0;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Cluster ID";
+        param.key = "cl";
+        param.description = "As string hex value.";
+        param.dataType = DataTypeUInt16;
+        param.defaultValue = 0;
+        param.isOptional = 0;
+        param.isHexString = 1;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Command ID";
+        param.key = "cmd";
+        param.description = "As string hex value.";
+        param.dataType = DataTypeUInt8;
+        param.defaultValue = 0;
+        param.isOptional = 0;
+        param.isHexString = 1;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Manufacturer code";
+        param.key = "mf";
+        param.description = "As string hex value.";
+        param.dataType = DataTypeUInt16;
+        param.defaultValue = 0;
+        param.isOptional = 1;
+        param.isHexString = 1;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Javascript file";
+        param.key = "script";
+        param.description = "Relative path of a Javascript .js file.";
+        param.dataType = DataTypeString;
+        param.defaultValue = {};
+        param.isOptional = 1;
+        param.isHexString = 0;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Expression";
+        param.key = "eval";
+        param.description = "Javascript expression to transform the raw value.";
+        param.dataType = DataTypeString;
+        param.defaultValue = 0;
+        param.isOptional = 1;
+        param.isHexString = 0;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        d_ptr2->writeFunctions.push_back(fn);
+    }
+    
+    {
+        DDF_FunctionDescriptor fn;
+        fn.name = "tuya";
+        fn.description = "Generic function to parse Tuya data.";
+
+        DDF_FunctionDescriptor::Parameter param;
+
+        param.name = "Datapoint";
+        param.key = "dpid";
+        param.description = "1-255 the datapoint ID.";
+        param.dataType = DataTypeUInt8;
+        param.defaultValue = 0;
+        param.isOptional = 0;
+        param.isHexString = 0;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Javascript file";
+        param.key = "script";
+        param.description = "Relative path of a Javascript .js file.";
+        param.dataType = DataTypeString;
+        param.defaultValue = {};
+        param.isOptional = 1;
+        param.isHexString = 0;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Expression";
+        param.key = "eval";
+        param.description = "Javascript expression to transform the raw value.";
+        param.dataType = DataTypeString;
+        param.defaultValue = QLatin1String("Item.val = Attr.val");
+        param.isOptional = 1;
+        param.isHexString = 0;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        d_ptr2->parseFunctions.push_back(fn);
+    }
+
+    {
+        DDF_FunctionDescriptor fn;
+        fn.name = "tuya";
+        fn.description = "Generic function to read all Tuya datapoints. It has no parameters.";
+        d_ptr2->readFunctions.push_back(fn);
+    }
+
+    {
+        DDF_FunctionDescriptor fn;
+        fn.name = "tuya";
+        fn.description = "Generic function to write Tuya data.";
+
+        DDF_FunctionDescriptor::Parameter param;
+
+        param.name = "Datapoint";
+        param.key = "dpid";
+        param.description = "1-255 the datapoint ID.";
+        param.dataType = DataTypeUInt8;
+        param.defaultValue = 0;
+        param.isOptional = 0;
+        param.isHexString = 0;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+        
+        param.name = "Datatype";
+        param.key = "dt";
+        param.description = "Datatype of the data to be written.";
+        param.dataType = DataTypeUInt8;
+        param.defaultValue = 0;
+        param.isOptional = 0;
+        param.isHexString = 1;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Expression";
+        param.key = "eval";
+        param.description = "Javascript expression to transform the raw value.";
+        param.dataType = DataTypeString;
+        param.defaultValue = QLatin1String("Item.val;");
+        param.isOptional = 1;
+        param.isHexString = 0;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        d_ptr2->writeFunctions.push_back(fn);
+    }
 
     {
         DDF_FunctionDescriptor fn;
@@ -325,123 +702,6 @@ DeviceDescriptions::DeviceDescriptions(QObject *parent) :
         fn.parameters.push_back(param);
 
         d_ptr2->parseFunctions.push_back(fn);
-    }
-
-    {
-        DDF_FunctionDescriptor fn;
-        fn.name = "tuya";
-        fn.description = "Generic function to read all Tuya datapoints. It has no parameters.";
-        d_ptr2->readFunctions.push_back(fn);
-    }
-
-    {
-        DDF_FunctionDescriptor fn;
-        fn.name = "tuya";
-        fn.description = "Generic function to parse Tuya data.";
-
-        DDF_FunctionDescriptor::Parameter param;
-
-        param.name = "Datapoint";
-        param.key = "dpid";
-        param.description = "1-255 the datapoint ID.";
-        param.dataType = DataTypeUInt8;
-        param.defaultValue = 0;
-        param.isOptional = 0;
-        param.isHexString = 0;
-        param.supportsArray = 0;
-        fn.parameters.push_back(param);
-
-        param.name = "Javascript file";
-        param.key = "script";
-        param.description = "Relative path of a Javascript .js file.";
-        param.dataType = DataTypeString;
-        param.defaultValue = {};
-        param.isOptional = 1;
-        param.isHexString = 0;
-        param.supportsArray = 0;
-        fn.parameters.push_back(param);
-
-        param.name = "Expression";
-        param.key = "eval";
-        param.description = "Javascript expression to transform the raw value.";
-        param.dataType = DataTypeString;
-        param.defaultValue = QLatin1String("Item.val = Attr.val");
-        param.isOptional = 1;
-        param.isHexString = 0;
-        param.supportsArray = 0;
-        fn.parameters.push_back(param);
-
-        d_ptr2->parseFunctions.push_back(fn);
-    }
-
-    {  // Write function as shown in the DDF editor.
-        DDF_FunctionDescriptor fn;
-        fn.name = "zcl:attr";
-        fn.description = "Generic function to write ZCL attributes.";
-
-        DDF_FunctionDescriptor::Parameter param;
-
-        param.name = "Endpoint";
-        param.key = "ep";
-        param.description = "255 means any endpoint, 0 means auto selected from subdevice.";
-        param.dataType = DataTypeUInt8;
-        param.defaultValue = 0;
-        param.isOptional = 1;
-        param.isHexString = 0;
-        param.supportsArray = 0;
-        fn.parameters.push_back(param);
-
-        param.name = "Cluster ID";
-        param.key = "cl";
-        param.description = "As string hex value";
-        param.dataType = DataTypeUInt16;
-        param.defaultValue = 0;
-        param.isOptional = 0;
-        param.isHexString = 1;
-        param.supportsArray = 0;
-        fn.parameters.push_back(param);
-
-        param.name = "Attribute ID";
-        param.key = "at";
-        param.description = "As string hex value";
-        param.dataType = DataTypeUInt16;
-        param.defaultValue = 0;
-        param.isOptional = 0;
-        param.isHexString = 1;
-        param.supportsArray = 0;
-        fn.parameters.push_back(param);
-
-        param.name = "Manufacturer code";
-        param.key = "mf";
-        param.description = "As string hex value.";
-        param.dataType = DataTypeUInt16;
-        param.defaultValue = 0;
-        param.isOptional = 1;
-        param.isHexString = 1;
-        param.supportsArray = 0;
-        fn.parameters.push_back(param);
-
-        param.name = "Javascript file";
-        param.key = "script";
-        param.description = "Relative path of a Javascript .js file.";
-        param.dataType = DataTypeString;
-        param.defaultValue = {};
-        param.isOptional = 1;
-        param.isHexString = 0;
-        param.supportsArray = 0;
-        fn.parameters.push_back(param);
-
-        param.name = "Expression";
-        param.key = "eval";
-        param.description = "Javascript expression to transform the raw value.";
-        param.dataType = DataTypeString;
-        param.defaultValue = QLatin1String("Item.val = Attr.val");
-        param.isOptional = 1;
-        param.isHexString = 0;
-        param.supportsArray = 0;
-        fn.parameters.push_back(param);
-
-        d_ptr2->writeFunctions.push_back(fn);
     }
 }
 

--- a/device_descriptions.cpp
+++ b/device_descriptions.cpp
@@ -91,8 +91,8 @@ DeviceDescriptions::DeviceDescriptions(QObject *parent) :
 
     {  // Parse function as shown in the DDF editor.
         DDF_FunctionDescriptor fn;
-        fn.name = "zcl";
-        fn.description = "Generic function to parse ZCL attributes and commands.";
+        fn.name = "zcl:attr";
+        fn.description = "Generic function to parse ZCL attributes.";
 
         DDF_FunctionDescriptor::Parameter param;
 
@@ -161,7 +161,7 @@ DeviceDescriptions::DeviceDescriptions(QObject *parent) :
 
     {  // Read function as shown in the DDF editor.
         DDF_FunctionDescriptor fn;
-        fn.name = "zcl";
+        fn.name = "zcl:attr";
         fn.description = "Generic function to read ZCL attributes.";
 
         DDF_FunctionDescriptor::Parameter param;
@@ -372,6 +372,76 @@ DeviceDescriptions::DeviceDescriptions(QObject *parent) :
         fn.parameters.push_back(param);
 
         d_ptr2->parseFunctions.push_back(fn);
+    }
+
+    {  // Write function as shown in the DDF editor.
+        DDF_FunctionDescriptor fn;
+        fn.name = "zcl:attr";
+        fn.description = "Generic function to write ZCL attributes.";
+
+        DDF_FunctionDescriptor::Parameter param;
+
+        param.name = "Endpoint";
+        param.key = "ep";
+        param.description = "255 means any endpoint, 0 means auto selected from subdevice.";
+        param.dataType = DataTypeUInt8;
+        param.defaultValue = 0;
+        param.isOptional = 1;
+        param.isHexString = 0;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Cluster ID";
+        param.key = "cl";
+        param.description = "As string hex value";
+        param.dataType = DataTypeUInt16;
+        param.defaultValue = 0;
+        param.isOptional = 0;
+        param.isHexString = 1;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Attribute ID";
+        param.key = "at";
+        param.description = "As string hex value";
+        param.dataType = DataTypeUInt16;
+        param.defaultValue = 0;
+        param.isOptional = 0;
+        param.isHexString = 1;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Manufacturer code";
+        param.key = "mf";
+        param.description = "As string hex value.";
+        param.dataType = DataTypeUInt16;
+        param.defaultValue = 0;
+        param.isOptional = 1;
+        param.isHexString = 1;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Javascript file";
+        param.key = "script";
+        param.description = "Relative path of a Javascript .js file.";
+        param.dataType = DataTypeString;
+        param.defaultValue = {};
+        param.isOptional = 1;
+        param.isHexString = 0;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        param.name = "Expression";
+        param.key = "eval";
+        param.description = "Javascript expression to transform the raw value.";
+        param.dataType = DataTypeString;
+        param.defaultValue = QLatin1String("Item.val = Attr.val");
+        param.isOptional = 1;
+        param.isHexString = 0;
+        param.supportsArray = 0;
+        fn.parameters.push_back(param);
+
+        d_ptr2->writeFunctions.push_back(fn);
     }
 }
 
@@ -903,6 +973,11 @@ const std::vector<DDF_FunctionDescriptor> &DeviceDescriptions::getParseFunctions
 const std::vector<DDF_FunctionDescriptor> &DeviceDescriptions::getReadFunctions() const
 {
     return d_ptr2->readFunctions;
+}
+
+const std::vector<DDF_FunctionDescriptor> &DeviceDescriptions::getWriteFunctions() const
+{
+    return d_ptr2->writeFunctions;
 }
 
 const std::vector<DDF_SubDeviceDescriptor> &DeviceDescriptions::getSubDevices() const

--- a/device_descriptions.h
+++ b/device_descriptions.h
@@ -258,6 +258,7 @@ public:
     const DeviceDescription::Item &getGenericItem(const char *suffix) const;
     const std::vector<DDF_FunctionDescriptor> &getParseFunctions() const;
     const std::vector<DDF_FunctionDescriptor> &getReadFunctions() const;
+    const std::vector<DDF_FunctionDescriptor> &getWriteFunctions() const;
     const std::vector<DDF_SubDeviceDescriptor> &getSubDevices() const;
 
     static DeviceDescriptions *instance();

--- a/ui/ddf_itemeditor.h
+++ b/ui/ddf_itemeditor.h
@@ -59,6 +59,7 @@ public:
 public Q_SLOTS:
     void parseParamChanged();
     void readParamChanged();
+    void writeParamChanged();
     void attributeChanged();
     void functionChanged(const QString &text);
     void droppedUrl(const QUrl &url);


### PR DESCRIPTION
This PR finally adds the possibility to view/set write functions in the DDF editor. Set parameters in the DDF are displayed correctly and newly set parameters appear as expected in the preview tab.

Additionally, the split of the previously available `zcl` function into `zcl:attr` and `zcl:cmd` should be completed. Both functions are now available to have better distinction.

![grafik](https://github.com/dresden-elektronik/deconz-rest-plugin/assets/4005212/d760e022-6321-4416-a9b4-eae6ea989fe0)
