### PR TITLE
Stop unnecessary attribute read requests for many Philips/Signify devices

### DIFF
--- a/devices/philips/light_zb3_C.json
+++ b/devices/philips/light_zb3_C.json
@@ -152,7 +152,8 @@
             "ep": "0x0b",
             "cl": "0x0000",
             "at": "0x0005"
-          }
+          },
+          "refresh.interval": 86400
         },
         {
           "name": "attr/name"

--- a/devices/philips/light_zb3_C_gradient.json
+++ b/devices/philips/light_zb3_C_gradient.json
@@ -132,7 +132,8 @@
             "ep": "0x0b",
             "cl": "0x0000",
             "at": "0x0005"
-          }
+          },
+          "refresh.interval": 86400
         },
         {
           "name": "attr/name"

--- a/devices/philips/light_zb3_white.json
+++ b/devices/philips/light_zb3_white.json
@@ -64,7 +64,8 @@
             "ep": "0x0b",
             "cl": "0x0000",
             "at": "0x0005"
-          }
+          },
+          "refresh.interval": 86400
         },
         {
           "name": "attr/name"

--- a/devices/philips/light_zb3_white_ambiance.json
+++ b/devices/philips/light_zb3_white_ambiance.json
@@ -76,7 +76,8 @@
             "ep": "0x0b",
             "cl": "0x0000",
             "at": "0x0005"
-          }
+          },
+          "refresh.interval": 86400
         },
         {
           "name": "attr/name"

--- a/devices/philips/light_zll_A.json
+++ b/devices/philips/light_zll_A.json
@@ -92,7 +92,8 @@
             "ep": "0x0b",
             "cl": "0x0000",
             "at": "0x0005"
-          }
+          },
+          "refresh.interval": 86400
         },
         {
           "name": "attr/name"

--- a/devices/philips/light_zll_B.json
+++ b/devices/philips/light_zll_B.json
@@ -76,7 +76,8 @@
             "ep": "0x0b",
             "cl": "0x0000",
             "at": "0x0005"
-          }
+          },
+          "refresh.interval": 86400
         },
         {
           "name": "attr/name"

--- a/devices/philips/light_zll_C.json
+++ b/devices/philips/light_zll_C.json
@@ -88,7 +88,8 @@
             "ep": "0x0b",
             "cl": "0x0000",
             "at": "0x0005"
-          }
+          },
+          "refresh.interval": 86400
         },
         {
           "name": "attr/name"

--- a/devices/philips/lom007_smart_plug.json
+++ b/devices/philips/lom007_smart_plug.json
@@ -60,7 +60,8 @@
             "ep": "0x0b",
             "cl": "0x0000",
             "at": "0x0005"
-          }
+          },
+          "refresh.interval": 86400
         },
         {
           "name": "attr/name"

--- a/devices/philips/sml001_motion_sensor.json
+++ b/devices/philips/sml001_motion_sensor.json
@@ -34,37 +34,10 @@
           "name": "attr/lastseen"
         },
         {
-          "name": "attr/manufacturername",
-          "parse": {
-            "fn": "zcl:attr",
-            "ep": 2,
-            "cl": "0x0000",
-            "at": "0x0004",
-            "eval": "Item.val = Attr.val"
-          },
-          "read": {
-            "fn": "zcl:attr",
-            "ep": 2,
-            "cl": "0x0000",
-            "at": "0x0004"
-          },
-          "refresh.interval": 86400
+          "name": "attr/manufacturername"
         },
         {
-          "name": "attr/modelid",
-          "parse": {
-            "fn": "zcl:attr",
-            "ep": 2,
-            "cl": "0x0000",
-            "at": "0x0005",
-            "eval": "Item.val = Attr.val"
-          },
-          "read": {
-            "fn": "zcl:attr",
-            "ep": 2,
-            "cl": "0x0000",
-            "at": "0x0005"
-          }
+          "name": "attr/modelid"
         },
         {
           "name": "attr/name"

--- a/devices/philips/sml002_motion_sensor.json
+++ b/devices/philips/sml002_motion_sensor.json
@@ -34,37 +34,10 @@
           "name": "attr/lastseen"
         },
         {
-          "name": "attr/manufacturername",
-          "parse": {
-            "fn": "zcl:attr",
-            "ep": 2,
-            "cl": "0x0000",
-            "at": "0x0004",
-            "eval": "Item.val = Attr.val"
-          },
-          "read": {
-            "fn": "zcl:attr",
-            "ep": 2,
-            "cl": "0x0000",
-            "at": "0x0004"
-          },
-          "refresh.interval": 86400
+          "name": "attr/manufacturername"
         },
         {
-          "name": "attr/modelid",
-          "parse": {
-            "fn": "zcl:attr",
-            "ep": 2,
-            "cl": "0x0000",
-            "at": "0x0005",
-            "eval": "Item.val = Attr.val"
-          },
-          "read": {
-            "fn": "zcl:attr",
-            "ep": 2,
-            "cl": "0x0000",
-            "at": "0x0005"
-          }
+          "name": "attr/modelid"
         },
         {
           "name": "attr/name"

--- a/devices/philips/sml003_motion_sensor.json
+++ b/devices/philips/sml003_motion_sensor.json
@@ -40,37 +40,10 @@
           "name": "attr/lastseen"
         },
         {
-          "name": "attr/manufacturername",
-          "parse": {
-            "fn": "zcl:attr",
-            "ep": 2,
-            "cl": "0x0000",
-            "at": "0x0004",
-            "eval": "Item.val = Attr.val"
-          },
-          "read": {
-            "fn": "zcl:attr",
-            "ep": 2,
-            "cl": "0x0000",
-            "at": "0x0004"
-          },
-          "refresh.interval": 86400
+          "name": "attr/manufacturername"
         },
         {
-          "name": "attr/modelid",
-          "parse": {
-            "fn": "zcl:attr",
-            "ep": 2,
-            "cl": "0x0000",
-            "at": "0x0005",
-            "eval": "Item.val = Attr.val"
-          },
-          "read": {
-            "fn": "zcl:attr",
-            "ep": 2,
-            "cl": "0x0000",
-            "at": "0x0005"
-          }
+          "name": "attr/modelid"
         },
         {
           "name": "attr/name"

--- a/devices/philips/sml004_motion_sensor.json
+++ b/devices/philips/sml004_motion_sensor.json
@@ -40,37 +40,10 @@
           "name": "attr/lastseen"
         },
         {
-          "name": "attr/manufacturername",
-          "parse": {
-            "fn": "zcl:attr",
-            "ep": 2,
-            "cl": "0x0000",
-            "at": "0x0004",
-            "eval": "Item.val = Attr.val"
-          },
-          "read": {
-            "fn": "zcl:attr",
-            "ep": 2,
-            "cl": "0x0000",
-            "at": "0x0004"
-          },
-          "refresh.interval": 86400
+          "name": "attr/manufacturername"
         },
         {
-          "name": "attr/modelid",
-          "parse": {
-            "fn": "zcl:attr",
-            "ep": 2,
-            "cl": "0x0000",
-            "at": "0x0005",
-            "eval": "Item.val = Attr.val"
-          },
-          "read": {
-            "fn": "zcl:attr",
-            "ep": 2,
-            "cl": "0x0000",
-            "at": "0x0005"
-          }
+          "name": "attr/modelid"
         },
         {
           "name": "attr/name"


### PR DESCRIPTION
Stumbled upon that accidentally while the sniffer was running. Due to an unfortunate DDF amendment, many devices were queried for their modelID as fast as possible. Especially for battery powered devices, this could lead to a more rapid battery drain and eventually have some impact on network resposiveness.

The PR adds either throttling (one query per day) or removes the attribute read requests completely, where appropriate.