### PR TITLE
Bug fix: wrong sign applying `config/offset` to `state/measured_value`

### DIFF
--- a/devices/ikea/vindstyrka_air_quality_sensor.json
+++ b/devices/ikea/vindstyrka_air_quality_sensor.json
@@ -135,7 +135,7 @@
             "ep": 1,
             "cl": "0x0402",
             "at": "0x0000",
-            "eval": "Item.val = (Attr.val - R.item('config/offset').val) / 100"
+            "eval": "Item.val = (Attr.val + R.item('config/offset').val) / 100"
           },
           "read": {
             "fn": "zcl:attr",
@@ -280,7 +280,7 @@
             "ep": 1,
             "cl": "0x0405",
             "at": "0x0000",
-            "eval": "Item.val = (Attr.val - R.item('config/offset').val) / 100"
+            "eval": "Item.val = (Attr.val + R.item('config/offset').val) / 100"
           },
           "read": {
             "fn": "zcl:attr",

--- a/devices/philips/sml001_motion_sensor.json
+++ b/devices/philips/sml001_motion_sensor.json
@@ -482,7 +482,7 @@
             "ep": 2,
             "cl": "0x0402",
             "at": "0x0000",
-            "eval": "Item.val = (Attr.val - R.item('config/offset').val) / 100"
+            "eval": "Item.val = (Attr.val + R.item('config/offset').val) / 100"
           },
           "read": {
             "fn": "zcl:attr",

--- a/devices/philips/sml002_motion_sensor.json
+++ b/devices/philips/sml002_motion_sensor.json
@@ -490,7 +490,7 @@
             "ep": 2,
             "cl": "0x0402",
             "at": "0x0000",
-            "eval": "Item.val = (Attr.val - R.item('config/offset').val) / 100"
+            "eval": "Item.val = (Attr.val + R.item('config/offset').val) / 100"
           },
           "read": {
             "fn": "zcl:attr",

--- a/devices/philips/sml003_motion_sensor.json
+++ b/devices/philips/sml003_motion_sensor.json
@@ -496,7 +496,7 @@
             "ep": 2,
             "cl": "0x0402",
             "at": "0x0000",
-            "eval": "Item.val = (Attr.val - R.item('config/offset').val) / 100"
+            "eval": "Item.val = (Attr.val + R.item('config/offset').val) / 100"
           },
           "read": {
             "fn": "zcl:attr",

--- a/devices/philips/sml004_motion_sensor.json
+++ b/devices/philips/sml004_motion_sensor.json
@@ -496,7 +496,7 @@
             "ep": 2,
             "cl": "0x0402",
             "at": "0x0000",
-            "eval": "Item.val = (Attr.val - R.item('config/offset').val) / 100"
+            "eval": "Item.val = (Attr.val + R.item('config/offset').val) / 100"
           },
           "read": {
             "fn": "zcl:attr",


### PR DESCRIPTION
As the title says, `config/offset` should be added to the temperature or humidity (`measured value`), not subtracted.