### PR TITLE
DDF for Tuya Fingerbot

### DIFF
--- a/devices/tuya/_TZ3210_dse8ogfy_fingerbot.json
+++ b/devices/tuya/_TZ3210_dse8ogfy_fingerbot.json
@@ -1,0 +1,132 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": ["_TZ3210_dse8ogfy", "_TZ3210_j4pdtz9v"],
+  "modelid": ["TS0001", "TS0001"],
+  "vendor": "Tuya",
+  "product": "Fingerbot",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_ON_OFF_OUTPUT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001", "script": "tuya_swversion.js"},
+          "read": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001"}
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/on"
+        },
+        {
+          "name": "config/tuya_unlock"
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+   {
+      "type": "$TYPE_BATTERY_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0001"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001", "script": "tuya_swversion.js"},
+          "read": {"fn": "zcl", "ep": 1, "cl": "0x0000", "at": "0x0001"}
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "config/battery",
+          "parse": {"fn": "tuya", "dpid": 105, "eval": "Item.val = Attr.val;" },
+          "read": {"fn": "none"},
+          "default": 0
+        },
+        {
+          "name":"config/delay",
+          "read":{
+            "fn":"none"
+          },
+          "write":{
+            "dpid":103,
+            "dt":"0x2b",
+            "eval":"Item.val;",
+            "fn":"tuya"
+          },
+          "parse":{
+            "dpid":103,
+            "eval":"Item.val = Attr.val;",
+            "fn":"tuya"
+          },
+          "default":1
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
There is 2 versions for this device. This DDF is for the version that use the on/off cluster (0x0006).

- Model ID : TS0001
- Manufacture Name : _TZ3210_dse8ogfy, _TZ3210_j4pdtz9v


See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7303 
and https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7094



