### PR TITLE
Restore `parse` functions for `maufacturername` and `modelid`

### DIFF
--- a/devices/generic/items/attr_manufacturername_item.json
+++ b/devices/generic/items/attr_manufacturername_item.json
@@ -8,7 +8,7 @@
   "description": "Manufacturer name of the device.",
   "parse": {
     "fn": "zcl:attr",
-    "ep": 0,
+    "ep": 255,
     "cl": "0x0000",
     "at": "0x0004",
     "eval": "Item.val = Attr.val"

--- a/devices/generic/items/attr_manufacturername_item.json
+++ b/devices/generic/items/attr_manufacturername_item.json
@@ -5,5 +5,12 @@
   "access": "R",
   "public": true,
   "implicit": true,
-  "description": "Manufacturer name of the device."
+  "description": "Manufacturer name of the device.",
+  "parse": {
+    "fn": "zcl:attr",
+    "ep": 0,
+    "cl": "0x0000",
+    "at": "0x0004",
+    "eval": "Item.val = Attr.val"
+  }
 }

--- a/devices/generic/items/attr_modelid_item.json
+++ b/devices/generic/items/attr_modelid_item.json
@@ -8,7 +8,7 @@
   "description": "Model identifier of the device.",
   "parse": {
     "fn": "zcl:attr",
-    "ep": 0,
+    "ep": 255,
     "cl": "0x0000",
     "at": "0x0005",
     "eval": "Item.val = Attr.val"

--- a/devices/generic/items/attr_modelid_item.json
+++ b/devices/generic/items/attr_modelid_item.json
@@ -5,5 +5,12 @@
   "access": "R",
   "public": true,
   "implicit": true,
-  "description": "Model identifier of the device."
+  "description": "Model identifier of the device.",
+  "parse": {
+    "fn": "zcl:attr",
+    "ep": 0,
+    "cl": "0x0000",
+    "at": "0x0005",
+    "eval": "Item.val = Attr.val"
+  }
 }


### PR DESCRIPTION
As discussed in Discord (**general** channel).  `parse` functions were removed in #6878.  This causes issues paring devices, as DDFs are matched an `manufacturername` and `modelid`.  The corresponding Zigbee attribites are read from C++ code alright, so a `read` function isn't needed.  But the resource items were no longer populated, due to the `parse` function missing.