### PR TITLE
C++ Add support for set Level for Legrand covering

### DIFF
--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -2552,9 +2552,14 @@ int DeRestPluginPrivate::setWindowCoveringState(const ApiRequest &req, ApiRespon
             {
                 targetLiftZigBee = targetLift == 0 ? 100 : 0;
             }
-            else
+            else if (bStatus && nHex < 44)
             {
                 targetLiftZigBee = targetLift == 100 ? 100 : 0;
+            }
+            else
+            {
+                // New devices no need thoses previous hack
+                targetLiftZigBee = targetLift;
             }
         }
         else


### PR DESCRIPTION
Ok, it's a long story, first Legrand firmware don't support set level request, and it need to be blocked.
Medium version don't support it too and are reversed.
New firmware now support it, so the hack can be removed, but somes users still using old firmware.

And as it's covering, not possible to do with DDF

Old firmware have as SwBuild 0xXX and new one 0xXXXXXXXX so the fonction .toUInt() just fail on the check.

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7390

Here the full code

```
        else if (taskRef.lightNode->modelId() == QLatin1String("Shutter switch with neutral") ||
                 taskRef.lightNode->modelId() == QLatin1String("Shutter SW with level control"))
        {
            // Legrand invert bri and don't support other value than 0
            bool bStatus = false;
            uint nHex = taskRef.lightNode->swBuildId().toUInt(&bStatus, 16);
            if (bStatus && nHex < 28)
            {
                targetLiftZigBee = targetLift == 0 ? 100 : 0;
            }
            else if (bStatus && nHex < 44)
            {
                targetLiftZigBee = targetLift == 100 ? 100 : 0;
            }
            else
            {
                // New devices no need thoses previous hack
                targetLiftZigBee = targetLift;
            }
        }
```