### PR TITLE
DDF for ubisys H1 thermostat

### DIFF
--- a/devices/ubisys/h1.json
+++ b/devices/ubisys/h1.json
@@ -1,0 +1,216 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "ubisys",
+  "modelid": "H1",
+  "vendor": "ubisys",
+  "product": "H1",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_THERMOSTAT",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0201"
+      ],
+      "meta": {
+        "values": {
+          "config/mode": {"off": 0, "auto": 1, "heat": 4}
+        }
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "parse": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "eval": "Item.val = Attr.val / 2;",
+            "fn": "zcl:attr"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "config/heatsetpoint",
+          "refresh.interval": 3660
+        },
+        {
+          "name": "config/mode",
+          "refresh.interval": 3660,
+          "read": {
+            "at": "0x001C",
+            "cl": "0x0201",
+            "ep": 1,
+            "fn": "zcl:attr"
+          },
+          "parse": {
+            "at": "0x001C",
+            "cl": "0x0201",
+            "ep": 1,
+            "eval": "if (Attr.val == 0) { Item.val = 'off' } else if (Attr.val == 1) { Item.val = 'auto' } else if (Attr.val == 4) { Item.val = 'heat' };",
+            "fn": "zcl:attr"
+          },
+          "write": {
+            "at": "0x001C",
+            "cl": "0x0201",
+            "dt": "0x10",
+            "ep": 1,
+            "eval": "if (Item.val == 'off') { 0 } else if (Item.val == 'auto') { 1 } else if (Item.val == 'heat') { 4 };",
+            "fn": "zcl:attr"
+          },
+          "default": "heat"
+        },
+        {
+          "name": "config/offset",
+          "refresh.interval": 3660,
+          "read": {
+            "at": "0x0003",
+            "cl": "0x0201",
+            "ep": 1,
+            "fn": "zcl:attr",
+            "mf": "0x10f2"
+          },
+          "parse": {
+            "at": "0x0003",
+            "cl": "0x0201",
+            "ep": 1,
+            "eval": "Item.val = Attr.val * 100;",
+            "fn": "zcl:attr",
+            "mf": "0x10f2"
+          },
+          "write": {
+            "at": "0x0003",
+            "cl": "0x0201",
+            "dt": "0x30",
+            "ep": 1,
+            "eval": "Item.val / 100;",
+            "fn": "zcl:attr",
+            "mf": "0x10f2"
+          },
+          "range": [-1000, 1000]
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "config/schedule"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/on",
+          "parse": {
+            "at": "0x0008",
+            "cl": "0x0201",
+            "ep": 1,
+            "eval": "Item.val = Attr.val > 3;",
+            "fn": "zcl:attr"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "state/temperature",
+          "refresh.interval": 3660,
+          "parse": {
+            "at": "0x0000",
+            "cl": "0x0201",
+            "ep": 1,
+            "eval": "Item.val = Attr.val;",
+            "fn": "zcl:attr"
+          }
+        },
+        {
+          "name": "state/valve",
+          "refresh.interval": 3660
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 3600,
+          "max": 43200,
+          "change": "0x00000002"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0201",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x29",
+          "min": 60,
+          "max": 300,
+          "change": "0x00000064"
+        },
+        {
+          "at": "0x0008",
+          "dt": "0x20",
+          "min": 60,
+          "max": 3600,
+          "change": "0x00000001"
+        },
+        {
+          "at": "0x0012",
+          "dt": "0x29",
+          "min": 1,
+          "max": 3600,
+          "change": "0x00000064"
+        },
+        {
+          "at": "0x001C",
+          "dt": "0x30",
+          "min": 1,
+          "max": 3600
+        }
+      ]
+    }
+  ]
+}

--- a/devices/ubisys/h1.json
+++ b/devices/ubisys/h1.json
@@ -135,7 +135,15 @@
           "name": "config/reachable"
         },
         {
-          "name": "config/schedule"
+          "name": "config/schedule",
+          "refresh.interval": 3660,
+          "read": {
+            "fn": "zcl:cmd",
+            "ep": "0x01",
+            "cl": "0x0201",
+            "cmd": "0x02",
+            "eval": "'7F01'"
+          }
         },
         {
           "name": "config/schedule_on",

--- a/devices/ubisys/h1.json
+++ b/devices/ubisys/h1.json
@@ -183,7 +183,6 @@
         },
         {
           "name": "state/utc",
-          "change.timeout": 30,
           "refresh.interval": 3660
         },
         {

--- a/devices/ubisys/h1.json
+++ b/devices/ubisys/h1.json
@@ -63,6 +63,9 @@
           }
         },
         {
+          "name": "config/checkin"
+        },
+        {
           "name": "config/group",
           "default": "auto"
         },
@@ -139,6 +142,11 @@
           "static": true
         },
         {
+          "name": "config/unoccupiedheatsetpoint",
+          "refresh.interval": 3660,
+          "default": 1600
+        },
+        {
           "name": "state/lastupdated"
         },
         {
@@ -167,6 +175,7 @@
         },
         {
           "name": "state/utc",
+          "change.timeout": 30,
           "refresh.interval": 3660
         },
         {
@@ -212,6 +221,13 @@
         },
         {
           "at": "0x0012",
+          "dt": "0x29",
+          "min": 1,
+          "max": 3600,
+          "change": "0x00000064"
+        },
+        {
+          "at": "0x0014",
           "dt": "0x29",
           "min": 1,
           "max": 3600,

--- a/devices/ubisys/h1.json
+++ b/devices/ubisys/h1.json
@@ -18,7 +18,8 @@
       "meta": {
         "values": {
           "config/mode": {"off": 0, "auto": 1, "heat": 4}
-        }
+        },
+        "group.endpoints": [1]
       },
       "items": [
         {
@@ -60,6 +61,10 @@
           "read": {
             "fn": "none"
           }
+        },
+        {
+          "name": "config/group",
+          "default": "auto"
         },
         {
           "name": "config/heatsetpoint",
@@ -114,7 +119,7 @@
             "cl": "0x0201",
             "dt": "0x30",
             "ep": 1,
-            "eval": "Item.val / 100;",
+            "eval": "parseInt(Item.val / 100);",
             "fn": "zcl:attr",
             "mf": "0x10f2"
           },
@@ -128,6 +133,10 @@
         },
         {
           "name": "config/schedule"
+        },
+        {
+          "name": "config/schedule_on",
+          "static": true
         },
         {
           "name": "state/lastupdated"
@@ -155,6 +164,10 @@
             "eval": "Item.val = Attr.val;",
             "fn": "zcl:attr"
           }
+        },
+        {
+          "name": "state/utc",
+          "refresh.interval": 3660
         },
         {
           "name": "state/valve",
@@ -211,6 +224,12 @@
           "max": 3600
         }
       ]
+    },
+    {
+      "bind": "groupcast",
+      "config.group": 0,
+      "src.ep": 1,
+      "cl": "0x0201"
     }
   ]
 }

--- a/general.xml
+++ b/general.xml
@@ -2317,7 +2317,29 @@ Note: It does not clear or delete previous weekly schedule programming configura
           <attribute id="0x0081" name="Unknown" type="s16" access="r" required="o"/>
           <attribute id="0x0082" name="Unknown (Heat Setpoint?)" type="s16" access="r" required="o"/>
         </attribute-set>
-     	<!-- Sinope manufacturer specific -->
+        <!-- ubisys manufacturer specific -->
+        <attribute-set id="0x0000" description="Ubisys specific" mfcode="0x10f2">
+          <attribute id="0x0000" name="Unknown" type="u16" access="rw" required="m" mfcode="0x10f2"></attribute>
+          <attribute id="0x0001" name="Unknown" type="u16" access="rw" required="o" mfcode="0x10f2"></attribute>
+          <attribute id="0x0002" name="Unknown" type="s16" access="r" required="o" mfcode="0x10f2"></attribute>
+          <attribute id="0x0003" name="Offset" type="s8" access="rw" required="o" mfcode="0x10f2"></attribute>
+          <attribute id="0x0004" name="Unknown" type="s16" access="rw" required="o" mfcode="0x10f2"></attribute>
+          <attribute id="0x0005" name="Vacation" type="bool" access="rw" required="o" mfcode="0x10f2"></attribute>
+          <attribute id="0x0009" name="Unknown" type="u16" access="r" required="o" mfcode="0x10f2"></attribute>
+          <attribute id="0x000a" name="Unknown" type="s16" access="r" required="o" mfcode="0x10f2"></attribute>
+          <attribute id="0x000b" name="Unknown" type="s8" access="r" required="m" mfcode="0x10f2"></attribute>
+          <attribute id="0x000c" name="Unknown" type="s8" access="r" required="m" mfcode="0x10f2"></attribute>
+          <attribute id="0x000d" name="Unknown" type="u8" access="r" required="o" mfcode="0x10f2"></attribute>
+          <attribute id="0x000e" name="Unknown" type="u8" access="r" required="o" mfcode="0x10f2"></attribute>
+          <attribute id="0x000f" name="Unknown" type="u8" access="r" required="o" mfcode="0x10f2"></attribute>
+          <attribute id="0x0010" name="Unknown" type="u8" access="r" required="o" mfcode="0x10f2"></attribute>
+          <attribute id="0x0011" name="Unknown" type="u8" access="r" required="o" mfcode="0x10f2"></attribute>
+          <attribute id="0x0012" name="Unknown" type="u8" access="r" required="o" mfcode="0x10f2"></attribute>
+          <attribute id="0x0013" name="Unknown" type="s16" access="rw" required="o" mfcode="0x10f2"></attribute>
+          <attribute id="0x0014" name="Unknown" type="s8" access="rw" required="o" mfcode="0x10f2"></attribute>
+          <attribute id="0x0015" name="Unknown" type="s16" access="rw" required="o" mfcode="0x10f2"></attribute>
+        </attribute-set>
+        <!-- Sinope manufacturer specific -->
         <attribute-set id="0x0400" description="Sinope specific" mfcode="0x119c">
           <attribute id="0x0400" name="Occupancy" type="enum8" access="rw" required="m" mfcode="0x119c">
               <value name="Unoccupied" value="0x00"></value>


### PR DESCRIPTION
Device support is provided based on firmware 1.4.0. A few observations made during testing:

- **Time seems to be asynchronous wherever it can be set or checked.**
On zigbee level, it seems the thermostat queries the coordinator for its time. The respective coordinator response does neither update the time on the thermostat display nor attribute 0x0000 (utc) of the time server cluster.
Similarly, setting the time via the device display, does not have any impact on the attribute 0x0000 (utc) of the time server cluster.
Also, writing the coordinators utc time to the attribute 0x0000 (utc) of the time server cluster does not touch the time on the device display. Overall, this might need some more polishing by ubisys.
- **Sending a direct attribute report from a temperature sensor to the thermostat is not persistent**
As the device has a temperature client cluster, it should be able to handle temperature reports from other devices. That currently works only for a short moment. When the report arrives, the temperature on the device display and on attribute 0x0000 (local temperature) of the thermostat cluster changes. However, it is reset/overwritten by the internal temperature measurement after a short time, latest with the report coming after 5 mins (currently set reporting interval).
- **Offset range is +-10°C, full degrees only**
In contrast to other devices, the offset is set in full degrees, so 2,5° is not possible.
- **Thermostat modes**
During testing, it felt like setting the mode to `heat` is an equivalent to a boost mode. The valve was still kept open although the target temp was already reached. This might be subject to further verification/confirmation.
- **Vacation mode**
The vacation mode can also be set via the manufacturer specific cluster attribute 0x0005 (boolean value). Actually a nice feature, but currently not exposed via API, as an item currently doesn't exist for that very purpose.
- **Attribute support**
Generally, ubisys does only seem to support mandatory attributes. E.g. for the time cluster, only attribute `utc` is available, which collides a bit with the current state code (although harmless). Within the thermostat cluster, attribute 0x0025 (ThermostatProgrammingOperationMode) is also not supported, which is usually used to distinguish if the thermostat temperature is set manually or via programmed schedules.
- **Group support**
The thermostat, although typically treated as sensor, does support groups. `config/groups` as been added, a group was assigned and the thermostat cluster bound to that group.

The device is exposed via API as follows:

```
"209": {
    "config": {
      "battery": 100,
      "group": "20003",
      "heatsetpoint": 2050,
      "mode": "heat",
      "offset": 0,
      "on": true,
      "reachable": true,
      "schedule": {
        "W127": [
          {
            "heatsetpoint": 2400,
            "localtime": "T21:25"
          },
          {
            "heatsetpoint": 2000,
            "localtime": "T23:00"
          }
        ]
      },
      "schedule_on": true,
      "unoccupiedheatsetpoint": 1600
    },
    "etag": "4375887cec7d66917a77a764c4e9b736",
    "lastannounced": null,
    "lastseen": "2023-12-10T22:07Z",
    "manufacturername": "ubisys",
    "modelid": "H1",
    "name": "Thermostat 209",
    "state": {
      "lastupdated": "2023-12-10T22:08:18.518",
      "on": true,
      "temperature": 2100,
      "utc": "2023-12-10T22:08:01Z",
      "valve": 7
    },
    "swversion": "1.4.0",
    "type": "ZHAThermostat",
    "uniqueid": "00:1f:ee:00:00:00:00:00-01-0201"
  }
```

The exposed cluster 0xFC57 does currently not seem to have any content and meaning. However, this cannot be verified as no technical reference has been published (yet).

A set of additional manufacturer specific attribtues has been identified on the thermostat cluster. The purpose for all except two of them remains unknown.
```

<attribute id="0x0000" name="Unknown" type="u16" access="rw" required="m" mfcode="0x10f2"></attribute>
<attribute id="0x0001" name="Unknown" type="u16" access="rw" required="o" mfcode="0x10f2"></attribute>
<attribute id="0x0002" name="Unknown" type="s16" access="r" required="o" mfcode="0x10f2"></attribute>
<attribute id="0x0003" name="Offset" type="s8" access="rw" required="o" mfcode="0x10f2"></attribute>
<attribute id="0x0004" name="Unknown" type="s16" access="rw" required="o" mfcode="0x10f2"></attribute>
<attribute id="0x0005" name="Vacation" type="bool" access="rw" required="o" mfcode="0x10f2"></attribute>
<attribute id="0x0009" name="Unknown" type="u16" access="r" required="o" mfcode="0x10f2"></attribute>
<attribute id="0x000a" name="Unknown" type="s16" access="r" required="o" mfcode="0x10f2"></attribute>
<attribute id="0x000b" name="Unknown" type="s8" access="r" required="m" mfcode="0x10f2"></attribute>
<attribute id="0x000c" name="Unknown" type="s8" access="r" required="m" mfcode="0x10f2"></attribute>
<attribute id="0x000d" name="Unknown" type="u8" access="r" required="o" mfcode="0x10f2"></attribute>
<attribute id="0x000e" name="Unknown" type="u8" access="r" required="o" mfcode="0x10f2"></attribute>
<attribute id="0x000f" name="Unknown" type="u8" access="r" required="o" mfcode="0x10f2"></attribute>
<attribute id="0x0010" name="Unknown" type="u8" access="r" required="o" mfcode="0x10f2"></attribute>
<attribute id="0x0011" name="Unknown" type="u8" access="r" required="o" mfcode="0x10f2"></attribute>
<attribute id="0x0012" name="Unknown" type="u8" access="r" required="o" mfcode="0x10f2"></attribute>
<attribute id="0x0013" name="Unknown" type="s16" access="rw" required="o" mfcode="0x10f2"></attribute>
<attribute id="0x0014" name="Unknown" type="s8" access="rw" required="o" mfcode="0x10f2"></attribute>
<attribute id="0x0015" name="Unknown" type="s16" access="rw" required="o" mfcode="0x10f2"></attribute>
```