### PR TITLE
Fix path of xiaomi_firmware.js for xiaomi_sp-euc01_smart_plug.json

### DIFF
--- a/devices/xiaomi/xiaomi_sp-euc01_smart_plug.json
+++ b/devices/xiaomi/xiaomi_sp-euc01_smart_plug.json
@@ -43,7 +43,7 @@
             "ep": 1,
             "fn": "xiaomi:special",
             "idx": "0x08",
-            "script": "xiaomi_firmware.js"
+            "script": "xiaomi_swversion.js"
           },
           "read": {
             "fn": "none"
@@ -106,7 +106,7 @@
             "ep": 1,
             "fn": "xiaomi:special",
             "idx": "0x08",
-            "script": "xiaomi_firmware.js"
+            "script": "xiaomi_swversion.js"
           },
           "read": {
             "fn": "none"
@@ -214,7 +214,7 @@
             "ep": 1,
             "fn": "xiaomi:special",
             "idx": "0x08",
-            "script": "xiaomi_firmware.js"
+            "script": "xiaomi_swversion.js"
           },
           "read": {
             "fn": "none"


### PR DESCRIPTION
There is no such file named `xiaomi_firmware.js`. I suppose it's `xiaomi_swversion.js` used by other DDF.