### PR TITLE
Fix path for xiaomi_firmware.js for xiaomi_zncz12lm_smart_plug.json

### DIFF
--- a/devices/xiaomi/xiaomi_zncz12lm_smart_plug.json
+++ b/devices/xiaomi/xiaomi_zncz12lm_smart_plug.json
@@ -40,7 +40,7 @@
             "ep": 1,
             "fn": "xiaomi:special",
             "idx": "0x08",
-            "script": "xiaomi_firmware.js"
+            "script": "xiaomi_swversion.js"
           },
           "read": {
             "fn": "none"
@@ -103,7 +103,7 @@
             "ep": 1,
             "fn": "xiaomi:special",
             "idx": "0x08",
-            "script": "xiaomi_firmware.js"
+            "script": "xiaomi_swversion.js"
           },
           "read": {
             "fn": "none"
@@ -211,7 +211,7 @@
             "ep": 1,
             "fn": "xiaomi:special",
             "idx": "0x08",
-            "script": "xiaomi_firmware.js"
+            "script": "xiaomi_swversion.js"
           },
           "read": {
             "fn": "none"


### PR DESCRIPTION
There is no such file named `xiaomi_firmware.js`. I suppose it's `xiaomi_swversion.js` used by other DDF.

See #7437 too