### PR TITLE
Remove duplicate device identifier for _TZ3000_TS011F_PowerStrip.json

### DIFF
--- a/devices/tuya/_TZ3000_TS011F_PowerStrip.json
+++ b/devices/tuya/_TZ3000_TS011F_PowerStrip.json
@@ -1,7 +1,19 @@
 {
    "schema":"devcap1.schema.json",
-   "manufacturername":["_TZ3000_cfnprab5","_TZ3000_o005nuxx","TZ3000_air9m6af","_TZ3000_9djocypn","_TZ3000_bppxj3sf","_TZ3000_bppxj3sf"],
-   "modelid":["TS011F","TS011F","TS011F","TS011F","TS011F","TS011F"],
+   "manufacturername": [
+      "_TZ3000_cfnprab5",
+      "_TZ3000_o005nuxx",
+      "TZ3000_air9m6af",
+      "_TZ3000_9djocypn",
+      "_TZ3000_bppxj3sf"
+   ],
+   "modelid": [
+      "TS011F",
+      "TS011F",
+      "TS011F",
+      "TS011F",
+      "TS011F"
+   ],
    "product":"Tuya Powerstrip w/USB",
    "sleeper":false,
    "status":"Gold",


### PR DESCRIPTION
Removed _TZ3000_bppxj3sf
About `TZ3000_air9m6af` maybe it's `_TZ3000_air9m6af` ?
PS : Who indent with 3 spaces ^^'