### PR TITLE
DDF support "cmd": "any" wildcard

### DIFF
--- a/device_access_fn.cpp
+++ b/device_access_fn.cpp
@@ -16,6 +16,8 @@
 #include "resource.h"
 #include "zcl/zcl.h"
 
+
+#define CMD_ID_ANY 0x100
 #define TIME_CLUSTER_ID     0x000A
 
 #define TIME_ATTRID_TIME                    0x0000
@@ -199,8 +201,16 @@ static ZCL_Param getZclParam(const QVariantMap &param)
 
     if (param.contains(QLatin1String("cmd"))) // optional
     {
-        result.commandId = variantToUint(param["cmd"], UINT8_MAX, &ok);
-        result.hasCommandId = ok ? 1 : 0;
+        if (param["cmd"].toString() == QLatin1String("any"))
+        {
+            result.commandId = CMD_ID_ANY;
+            result.hasCommandId = 1;
+        }
+        else
+        {
+            result.commandId = variantToUint(param["cmd"], UINT32_MAX, &ok);
+            result.hasCommandId = ok ? 1 : 0;
+        }
     }
     else
     {
@@ -525,9 +535,16 @@ bool parseZclAttribute(Resource *r, ResourceItem *item, const deCONZ::ApsDataInd
             return result;
         }
 
-        if (param.hasCommandId && param.commandId != zclFrame.commandId())
+        if (param.hasCommandId)
         {
-            return result;
+            if (param.commandId == CMD_ID_ANY)
+            {
+
+            }
+            else if (param.commandId != zclFrame.commandId())
+            {
+                return result;
+            }
         }
         else if (!param.hasCommandId && param.attributeCount == 0)
         {
@@ -564,7 +581,10 @@ bool parseZclAttribute(Resource *r, ResourceItem *item, const deCONZ::ApsDataInd
         return result;
     }
     
-    if (!zclParam.hasCommandId && zclFrame.commandId() != deCONZ::ZclReadAttributesResponseId && zclFrame.commandId() != deCONZ::ZclReportAttributesId)
+    if (!zclParam.hasCommandId &&
+         zclFrame.isProfileWideCommand() &&
+         zclFrame.commandId() != deCONZ::ZclReadAttributesResponseId &&
+         zclFrame.commandId() != deCONZ::ZclReportAttributesId)
     {
         return result;
     }
@@ -581,9 +601,16 @@ bool parseZclAttribute(Resource *r, ResourceItem *item, const deCONZ::ApsDataInd
 
     if (zclParam.attributeCount == 0) // attributes are optional
     {
-        if (zclParam.hasCommandId && zclParam.commandId != zclFrame.commandId())
+        if (zclParam.hasCommandId)
         {
-            return result;
+            if (zclParam.commandId == CMD_ID_ANY)
+            {
+
+            }
+            else if (zclParam.commandId != zclFrame.commandId())
+            {
+                return result;
+            }
         }
         
         if (evalZclFrame(r, item, ind, zclFrame, parseParameters))

--- a/zcl/zcl.h
+++ b/zcl/zcl.h
@@ -27,8 +27,8 @@ struct ZCL_Param
     std::array<uint16_t, MaxAttributes> attributes;
     uint16_t clusterId = 0;
     uint16_t manufacturerCode = 0;
+    uint16_t commandId = 0;
     uint8_t endpoint = 0;
-    uint8_t commandId = 0;
     struct {
         uint8_t valid : 1;
         uint8_t hasCommandId : 1;


### PR DESCRIPTION
The `"any"` wildcard allows forwarding any ZCL command ID on a cluster to the same Javascript handler in `"zcl:cmd"`. Note the command is still filtered for ClusterID. This can be useful for switch button handlers until a more lightweight solution without Javascript will be available.

Warning: This should **not** be used as a default  way to parse different commands leading to large Javascript blobs.