### PR TITLE
Make sensors attr/mode a ResourceItem

### DIFF
--- a/devices/generic/items/attr_mode_item.json
+++ b/devices/generic/items/attr_mode_item.json
@@ -4,5 +4,28 @@
   "datatype": "UInt32",
   "access": "RW",
   "public": true,
-  "description": "Operational mode."
+  "description": "Operational mode.",
+  "default": 1,
+  "values": [
+    [
+      0,
+      "none"
+    ],
+    [
+      1,
+      "scenes"
+    ],
+    [
+      2,
+      "two_groups"
+    ],
+    [
+      3,
+      "color_temperature"
+    ],
+    [
+      4,
+      "dimmer"
+    ]
+  ]
 }

--- a/resource.cpp
+++ b/resource.cpp
@@ -64,6 +64,7 @@ const char *RAttrLastAnnounced = "attr/lastannounced";
 const char *RAttrLastSeen = "attr/lastseen";
 const char *RAttrLevelMin = "attr/levelmin";
 const char *RAttrManufacturerName = "attr/manufacturername";
+const char *RAttrMode = "attr/mode";
 const char *RAttrModelId = "attr/modelid";
 const char *RAttrName = "attr/name";
 const char *RAttrNwkAddress = "attr/nwkaddress";
@@ -379,6 +380,7 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeTime, QVariant::String, RAttrLastSeen));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, QVariant::Double, RAttrLevelMin));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, QVariant::String, RAttrManufacturerName));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt32, QVariant::Double, RAttrMode));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, QVariant::String, RAttrModelId));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, QVariant::String, RAttrName));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, QVariant::Double, RAttrNwkAddress));

--- a/resource.h
+++ b/resource.h
@@ -93,6 +93,7 @@ extern const char *RAttrLastAnnounced;
 extern const char *RAttrLastSeen;
 extern const char *RAttrLevelMin;
 extern const char *RAttrManufacturerName;
+extern const char *RAttrMode;
 extern const char *RAttrModelId;
 extern const char *RAttrName;
 extern const char *RAttrNwkAddress;

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -2748,6 +2748,11 @@ bool DeRestPluginPrivate::sensorToMap(const Sensor *sensor, QVariantMap &map, co
             continue; // don't provide reachable for green power devices
         }
 
+        if (rid.suffix == RAttrMode)
+        {
+            continue; // handled later on
+        }
+
         if (strncmp(rid.suffix, "config/", 7) == 0)
         {
             const char *key = item->descriptor().suffix + 7;

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -151,7 +151,6 @@ bool SensorFingerprint::hasOutCluster(quint16 clusterId) const
 Sensor::Sensor() :
     Resource(RSensors),
     m_deletedstate(Sensor::StateNormal),
-    m_mode(ModeScenes),
     m_resetRetryCount(0)
 {
     durationDue = QDateTime();
@@ -159,6 +158,7 @@ Sensor::Sensor() :
     // common sensor items
     addItem(DataTypeString, RAttrName);
     addItem(DataTypeString, RAttrManufacturerName);
+    addItem(DataTypeUInt32, RAttrMode)->setValue(ModeScenes);
     addItem(DataTypeString, RAttrModelId);
     addItem(DataTypeString, RAttrType);
     addItem(DataTypeString, RAttrSwVersion);
@@ -173,7 +173,7 @@ Sensor::Sensor() :
     previousDirection = 0xFF;
     previousCt = 0xFFFF;
     previousSequenceNumber = 0xFF;
-    previousCommandId = 0xFF;
+    previousCommandId = 0xFF;    
 }
 
 /*! Returns the sensor deleted state.
@@ -222,18 +222,15 @@ void Sensor::setName(const QString &name)
  */
 Sensor::SensorMode Sensor::mode() const
 {
-   return m_mode;
+   return static_cast<Sensor::SensorMode>(item(RAttrMode)->toNumber());
 }
 
-/*! Sets the sensor mode (Lighting Switch).
- * 1 = Secenes
- * 2 = Groups
- * 3 = Color Temperature
+/*! Sets the sensor mode
     \param mode the sensor mode
  */
 void Sensor::setMode(SensorMode mode)
 {
-    m_mode = mode;
+    item(RAttrMode)->setValue(static_cast<qint64>(mode));
 }
 
 /*! Returns the sensor type.

--- a/sensor.h
+++ b/sensor.h
@@ -155,7 +155,6 @@ public:
 private:
     DeletedState m_deletedstate;
     SensorFingerprint m_fingerPrint;
-    SensorMode m_mode;
     uint8_t m_resetRetryCount;
     uint8_t m_zdpResetSeq;
     ButtonMapRef m_buttonMapRef{};


### PR DESCRIPTION
It's a legacy thing for switches which was hard wired to Sensor class. Having it as ResourceItem exposes it to DDF to convert legacy switches without breaking changes.