### PR TITLE
Fix a problem for the Legrand Wireless Scenes command

### DIFF
--- a/devices/legrand/wireless_scenes_command.json
+++ b/devices/legrand/wireless_scenes_command.json
@@ -64,7 +64,7 @@
           "parse": {
             "cl": "0x0005",
             "cmd": "0x05",
-            "eval": "Item.val = (ZclFrame.at(0) + 18) * -1000 + 2"
+            "eval": "Item.val = ((ZclFrame.at(0) << 24 >> 24) + 18) * -1000 + 2"
           }
         },
         {


### PR DESCRIPTION
IDK what happen, but on last version the DDF work with unsigned value and previsouly with signed.
The code is now compatible with both.

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7463