### PR TITLE
Add resource item for external temp measurement for Bosch Thermostat II

### DIFF
--- a/devices/bosch/thermostat2.json
+++ b/devices/bosch/thermostat2.json
@@ -111,6 +111,35 @@
           "default": false
         },
         {
+          "name": "config/externalsensortemp",
+          "refresh.interval": 360,
+          "read": {
+            "at": "0x4040",
+            "cl": "0x0201",
+            "ep": 1,
+            "fn": "zcl:attr",
+            "mf": "0x1209"
+          },
+          "parse": {
+            "at": "0x4040",
+            "cl": "0x0201",
+            "ep": 1,
+            "eval": "Item.val = Attr.val;",
+            "fn": "zcl:attr",
+            "mf": "0x1209"
+          },
+          "write": {
+            "at": "0x4040",
+            "cl": "0x0201",
+            "dt": "0x29",
+            "ep": 1,
+            "eval": "Item.val = Attr.val;",
+            "fn": "zcl:attr",
+            "mf": "0x1209"
+          },
+          "default": 0
+        },
+        {
           "name": "config/externalwindowopen",
           "refresh.interval": 3660,
           "read": {

--- a/devices/bosch/thermostat2.json
+++ b/devices/bosch/thermostat2.json
@@ -238,7 +238,15 @@
           "name": "config/reachable"
         },
         {
-          "name": "config/schedule"
+          "name": "config/schedule",
+          "refresh.interval": 3660,
+          "read": {
+            "fn": "zcl:cmd",
+            "ep": "0x01",
+            "cl": "0x0201",
+            "cmd": "0x02",
+            "eval": "'7F01'"
+          }
         },
         {
           "name": "config/schedule_on",

--- a/general.xml
+++ b/general.xml
@@ -2568,7 +2568,7 @@ Note: It does not clear or delete previous weekly schedule programming configura
             <value name="3" value="0x03"></value>
             <value name="4" value="0x04"></value>
           </attribute>
-          <attribute id="0x4040" name="Unknown" type="s16" access="rw" required="o" mfcode="0x1209"></attribute>
+          <attribute id="0x4040" name="External Measured Room Sensor" type="s16" access="rw" required="o" mfcode="0x1209"></attribute>
           <attribute id="0x4041" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209">
             <value name="0" value="0x00"></value>
             <value name="1" value="0x01"></value>


### PR DESCRIPTION
Apparently, this is attribute 0x4040 🙂 