### PR TITLE
DDF for newer version of Popp smart thermostat eT093WRG

### DIFF
--- a/devices/danfoss/etrv0100_thermostat.json
+++ b/devices/danfoss/etrv0100_thermostat.json
@@ -1,7 +1,7 @@
 {
   "schema": "devcap1.schema.json",
-  "manufacturername": ["Danfoss", "Danfoss", "DSX84YU", "Danfoss"],
-  "modelid": ["eTRV0100", "eTRV0103", "eT093WRO", "TRV001"],
+  "manufacturername": ["Danfoss", "Danfoss", "D5X84YU", "D5X84YU", "Danfoss"],
+  "modelid": ["eTRV0100", "eTRV0103", "eT093WRO", "eT093WRG", "TRV001"],
   "vendor": "Danfoss",
   "product": "Ally thermostat",
   "sleeper": false,


### PR DESCRIPTION
Adds the newer version of the thermostat to the DDF. As mentioned in #7472, there was a typo in the manufacturer name (coming from the initial Popp device request), which is now corrected.