### PR TITLE
Forward device has DDF info to core for UI

### DIFF
--- a/device.cpp
+++ b/device.cpp
@@ -794,6 +794,8 @@ void DEV_GetDeviceDescriptionHandler(Device *device, const Event &event)
             d->managed = true;
             d->flags.hasDdf = 1;
             d->setState(DEV_IdleStateHandler);
+            // TODO(mpi): temporary forward this info here, gets replaced by device actor later
+            DEV_ForwardNodeChange(device, QLatin1String("hasddf"), QLatin1String("1"));
         }
         else
         {


### PR DESCRIPTION
The core shows a DDF label on a UI node when a device is running via DDF.
This allows to quickly see which devices aren't handled yet via DDF.