### PR TITLE
Fix button handlers for dresden elektronik Scene Switch

### DIFF
--- a/devices/dresden_elektronik/scene_switch.json
+++ b/devices/dresden_elektronik/scene_switch.json
@@ -135,6 +135,48 @@
         },
         {
           "name": "state/lastupdated"
+        },
+        {
+          "name": "state/on",
+          "public": false,
+          "parse": {
+            "fn": "zcl:cmd",
+            "ep": 1,
+            "cl": "0x0006",
+            "cmd": "any",
+            "script": "scene_switch_on.js"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "state/bri",
+          "public": false,
+          "parse": {
+            "fn": "zcl:cmd",
+            "ep": 1,
+            "cl": "0x0008",
+            "cmd": "any",
+            "script": "scene_switch_bri.js"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "state/sat",
+          "public": false,
+          "parse": {
+            "fn": "zcl:cmd",
+            "ep": 1,
+            "cl": "0x0005",
+            "cmd": "any",
+            "script": "scene_switch_scenes.js"
+          },
+          "read": {
+            "fn": "none"
+          }
         }
       ]
     }

--- a/devices/dresden_elektronik/scene_switch_bri.js
+++ b/devices/dresden_elektronik/scene_switch_bri.js
@@ -1,0 +1,10 @@
+var i = R.item("state/buttonevent");
+if (ZclFrame.cmd == 1) {
+	if (ZclFrame.at(0) == 0)
+		i.val = 1001;
+	else
+		i.val = 2001;
+} else if (ZclFrame.cmd == 3) {
+	var v = i.val >> 2;
+	i.val = ((v << 2) / 1000) * 1000 + 3;
+}

--- a/devices/dresden_elektronik/scene_switch_on.js
+++ b/devices/dresden_elektronik/scene_switch_on.js
@@ -1,0 +1,6 @@
+var i = R.item("state/buttonevent");
+if (ZclFrame.cmd == 1) {
+	i.val = 1002;
+} else if (ZclFrame.cmd == 0) {
+	i.val = 2002;
+}

--- a/devices/dresden_elektronik/scene_switch_scenes.js
+++ b/devices/dresden_elektronik/scene_switch_scenes.js
@@ -1,0 +1,7 @@
+var i = R.item("state/buttonevent");
+var scene = ZclFrame.at(2);
+if (ZclFrame.cmd == 5) {
+	i.val = ((scene + 2) * 1000) + 2;
+} else if (ZclFrame.cmd == 4) {
+	i.val = ((scene + 2) * 1000) + 3;
+}


### PR DESCRIPTION
Regression from v2.25.0-beta which removed the button_maps.json entries for the switch.