### PR TITLE
Fix LIDL smart plug consumption reporting 0

### DIFF
--- a/devices/lidl/hg08673.json
+++ b/devices/lidl/hg08673.json
@@ -180,7 +180,7 @@
             "at": "0x0000",
             "cl": "0x0702",
             "ep": 1,
-            "eval": "item.val = 10 * Attr.val"
+            "eval": "item.val = 10 * Attr.val;"
           }
         },
         {


### PR DESCRIPTION
fix consumption reporting 0 because of missing semicolon