### PR TITLE
DDF Add support for Doorlock clone from Onesti Products AS

### DIFF
--- a/devices/easyaccess/easyfingertouch_doorlock.json
+++ b/devices/easyaccess/easyfingertouch_doorlock.json
@@ -1,9 +1,9 @@
 {
   "schema": "devcap1.schema.json",
-  "manufacturername": "Onesti Products AS",
-  "modelid": "EasyFingerTouch",
-  "vendor": "EasyAccess",
-  "product": "EasyFingerTouch",
+  "manufacturername": ["Onesti Products AS", "Onesti Products AS", "Onesti Products AS", "Onesti Products AS", "Onesti Products AS", "Onesti Products AS"],
+  "modelid": ["EasyFingerTouch", "EasyCodeTouch", "NimlyPRO", "NimlyCode", "NimlyTouch", "NimlyIn"],
+  "vendor": "Onesti Products AS",
+  "product": "Keypad Doorlock",
   "sleeper": false,
   "status": "Gold",
   "subdevices": [


### PR DESCRIPTION
- Product : Doorlock with keypad.
- Manufacturer : EasyAccess / Nimly
- Model identifier : EasyCodeTouch


`zigbeeModel: ['easyCodeTouch_v1', 'EasyCodeTouch', 'EasyFingerTouch', 'NimlyPRO', 'NimlyCode', 'NimlyTouch', 'NimlyIn'],`

All of thoses devices are able to work with the same DDF, haven't added the "easyCodeTouch_v1" because this one is managed by the legacy code, adn I don't want to break something (can't test the impact)

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7525