### PR TITLE
DDF for Avatto TRV16 and TRV06 TRVs + add support for offset (_TZE200_TS0601)

### DIFF
--- a/devices/tuya/_TZE200_TS0601_trv.json
+++ b/devices/tuya/_TZE200_TS0601_trv.json
@@ -60,6 +60,12 @@
           "read": {"fn": "tuya"}
         },
         {
+          "name": "config/offset",
+          "parse": {"fn": "tuya", "dpid": 47, "eval": "Item.val = Attr.val * 100;"},
+          "write": {"fn": "tuya", "dpid": 47, "dt": "0x2b", "eval": "Item.val / 100;"},
+          "read": {"fn": "none"}
+        },
+        {
           "name": "config/locked",
           "parse": {"fn": "tuya", "dpid": 7, "eval": "Item.val = Attr.val;"},
           "write": {"fn": "tuya", "dpid": 7, "dt": "0x10", "eval": "Item.val;"},

--- a/devices/tuya/_TZE200_TS0601_trv.json
+++ b/devices/tuya/_TZE200_TS0601_trv.json
@@ -1,7 +1,7 @@
 {
   "schema": "devcap1.schema.json",
-  "manufacturername": ["_TZE200_bvu2wnxz", "_TZE200_6rdj8dzm", "_TZE200_gd4rvykv"],
-  "modelid": ["TS0601", "TS0601", "TS0601"],
+  "manufacturername": ["_TZE200_bvu2wnxz", "_TZE200_6rdj8dzm", "_TZE200_gd4rvykv", "_TZE200_rxntag7i", "_TZE200_p3dbf6qs"],
+  "modelid": ["TS0601", "TS0601", "TS0601", "TS0601", "TS0601"],
   "vendor": "Tuya",
   "product": "Tuya TRV",
   "sleeper": false,


### PR DESCRIPTION
Fixes #7333

Adds support for the following TRVs:
* Avatto TRV16 (`_TZE200_rxntag7i`): https://aliexpress.com/item/1005005850177778.html
* Avatto TRV06 (`_TZE200_p3dbf6qs`): https://aliexpress.com/item/1005006191834430.html

In addition, support for the `config/offset` property of the `_TZE200_TS0601` TRVs is added.