### PR TITLE
DDF add Tuya water sensor clone (_TZ3000_kstbkt6a)

### DIFF
--- a/devices/tuya/_TZ3000_TS0207_water_leak_sensor.json
+++ b/devices/tuya/_TZ3000_TS0207_water_leak_sensor.json
@@ -15,9 +15,11 @@
     "_TZ3000_it1hm1cr",
     "_TZ3000_upgcbody",
     "_TZ3000_k4ej3ww2",
-    "_TZ3000_awvmkayh"
+    "_TZ3000_awvmkayh",
+    "_TZ3000_kstbkt6a"
   ],
   "modelid": [
+    "TS0207",
     "TS0207",
     "TS0207",
     "TS0207",


### PR DESCRIPTION
-    Product name: Tuya Zigbee Water Sensor
-    Manufacturer: _TZ3000_kstbkt6a
-    Model identifier: TS0207
-    Device type : Sensor

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7259#issuecomment-1910332767