### PR TITLE
Fix non-functioning Aqara T1 open/close sensor

### DIFF
--- a/devices/xiaomi/xiaomi_dw-s03d_t1_openclose_sensor.json
+++ b/devices/xiaomi/xiaomi_dw-s03d_t1_openclose_sensor.json
@@ -3,7 +3,7 @@
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.magnet.agl02",
   "vendor": "Xiaomi",
-  "product": "Aqara T1 open/close sensor MCCGQ12LM",
+  "product": "Aqara T1 open/close sensor DW-S03D",
   "sleeper": true,
   "status": "Gold",
   "subdevices": [
@@ -81,14 +81,7 @@
           }
         },
         {
-          "name": "config/enrolled",
-          "default": 1
-        },
-        {
           "name": "config/on"
-        },
-        {
-          "name": "config/pending"
         },
         {
           "name": "config/reachable"
@@ -97,7 +90,14 @@
           "name": "state/lastupdated"
         },
         {
-          "name": "state/open"
+          "name": "state/open",
+          "parse": {
+            "at": "0x0000",
+            "cl": "0x0006",
+            "ep": 1,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl:attr"
+          }
         }
       ]
     }


### PR DESCRIPTION
Apparently, the sensor was in the wrong operational mode during the initial DDF implementation (worked based on the IAS Zone cluster). The expected way is, however, using the on/off cluster here. The PR fixes the used cluster and removes any unnecessary resource items.