### PR TITLE
New `modelid` values for Hue smart button and Hue wall switch module

### DIFF
--- a/devices/philips/rdm001_wall_switch_module.json
+++ b/devices/philips/rdm001_wall_switch_module.json
@@ -1,12 +1,16 @@
 {
   "schema": "devcap1.schema.json",
   "manufacturername": [
+    "$MF_SIGNIFY",
+    "$MF_SIGNIFY",
     "$MF_PHILIPS",
-    "$MF_SIGNIFY"
+    "$MF_PHILIPS"
   ],
   "modelid": [
     "RDM001",
-    "RDM001"
+    "RDM004",
+    "RDM001",
+    "RDM004"
   ],
   "product": "Hue wall switch module",
   "status": "Gold",

--- a/devices/philips/rom001_smart_button.json
+++ b/devices/philips/rom001_smart_button.json
@@ -2,11 +2,15 @@
   "schema": "devcap1.schema.json",
   "manufacturername": [
     "$MF_SIGNIFY",
+    "$MF_SIGNIFY",
+    "$MF_PHILIPS",
     "$MF_PHILIPS"
   ],
   "modelid": [
     "ROM001",
-    "ROM001"
+    "RDM003",
+    "ROM001",
+    "RDM003"
   ],
   "product": "Hue smart button",
   "status": "Gold",


### PR DESCRIPTION
No changes to the devices themselves, just new _Model Identifier_ values.

See also https://hueblog.com/2024/01/12/philips-hue-wall-switch-module-new-revision-available/.

See #7490.