### PR TITLE
Remove legacy FLS-PP (version 1)  color XY quirk

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -160,9 +160,6 @@ bool DeRestPluginPrivate::readBindingTable(RestNodeBase *node, quint8 startIndex
     else if (existDevicesWithVendorCodeForMacPrefix(node->address(), VENDOR_DEVELCO))
     {
     }
-    else if (r && r->item(RAttrModelId)->toString().startsWith(QLatin1String("FLS-")))
-    {
-    }
     else
     {
         node->clearRead(READ_BINDING_TABLE);
@@ -2146,16 +2143,6 @@ void DeRestPluginPrivate::checkLightBindingsForAttributeReporting(LightNode *lig
     if (!apsCtrl || !lightNode || !lightNode->address().hasExt())
     {
         return;
-    }
-
-    // prevent binding action if otau was busy recently
-    if (otauLastBusyTimeDelta() < OTA_LOW_PRIORITY_TIME)
-    {
-        if (lightNode->modelId().startsWith(QLatin1String("FLS-")))
-        {
-            DBG_Printf(DBG_INFO, "don't check binding for attribute reporting of %s (otau busy)\n", qPrintable(lightNode->name()));
-            return;
-        }
     }
 
     Device *device = DEV_GetDevice(m_devices, lightNode->address().ext());

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -690,7 +690,6 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
     udpSock = 0;
     haEndpoint = 0;
     gwGroupSendDelay = deCONZ::appArgumentNumeric("--group-delay", GROUP_SEND_DELAY);
-    supportColorModeXyForGroups = true;
     gwLinkButton = false;
     gwWebSocketNotifyAll = true;
     gwdisablePermitJoinAutoOff = false;
@@ -15634,38 +15633,6 @@ void DeRestPlugin::idleTimerFired()
                     DBG_Printf(DBG_INFO_L2, "Force binding of attribute reporting for node %s\n", qPrintable(sensorNode->name()));
                     processSensors = true;
                 }
-            }
-        }
-
-        if (!DEV_TestManaged())
-        {
-            std::vector<LightNode>::iterator i = d->nodes.begin();
-            std::vector<LightNode>::iterator end = d->nodes.end();
-
-            int countNoColorXySupport = 0;
-
-            for (; i != end; ++i)
-            {
-                // older FLS which do not have correct support for color mode xy has atmel vendor id
-                if (i->isAvailable() && i->manufacturerCode() == VENDOR_ATMEL && i->modelId().startsWith("FLS")) // old FLS devices
-                {
-                    countNoColorXySupport++;
-                }
-            }
-
-            if ((countNoColorXySupport > 0) && d->supportColorModeXyForGroups)
-            {
-                DBG_Printf(DBG_INFO_L2, "disable support for CIE 1931 XY color mode for groups\n");
-                d->supportColorModeXyForGroups = false;
-            }
-            else if ((countNoColorXySupport == 0) && !d->supportColorModeXyForGroups)
-            {
-                DBG_Printf(DBG_INFO_L2, "enable support for CIE 1931 XY color mode for groups\n");
-                d->supportColorModeXyForGroups = true;
-            }
-            else
-            {
-    //            DBG_Printf(DBG_INFO_L2, "support for CIE 1931 XY color mode for groups %u\n", d->supportColorModeXyForGroups);
             }
         }
 

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -2091,7 +2091,6 @@ public:
     int idleLimit;
     int idleUpdateZigBeeConf; //
     int idleLastActivity; // delta in seconds
-    bool supportColorModeXyForGroups;
     size_t lightIter;
     size_t sensorIter;
     size_t lightAttrIter;

--- a/rest_groups.cpp
+++ b/rest_groups.cpp
@@ -1160,7 +1160,7 @@ int DeRestPluginPrivate::setGroupState(const ApiRequest &req, ApiResponse &rsp)
     }
 
     // hue and saturation
-    if (hasHue && hasSat && (!supportColorModeXyForGroups || (!hasXy && !hasCt)))
+    if (hasHue && hasSat && (!hasXy && !hasCt))
     {
         if (!hasEffectColorLoop && (hue != UINT_MAX) && (sat != UINT_MAX))
         {
@@ -1191,7 +1191,7 @@ int DeRestPluginPrivate::setGroupState(const ApiRequest &req, ApiResponse &rsp)
     }
 
     // xy
-    if (hasXy && supportColorModeXyForGroups)
+    if (hasXy)
     {
         hasXy = false;
         QVariantList ls = map["xy"].toList();


### PR DESCRIPTION
The device is the old black one, not the white FLS-PP lp. Since the firmware didn't support XY color mode there was a loop in the idleTimer handler iterating over all lights to find out if this device is present. Since the device is likely not in use anymore we can get rid of this CPU cycle eater. If needed introduce a DDF later on.