### PR TITLE
Skip more legacy code for DDF devices

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -151,6 +151,11 @@ bool DeRestPluginPrivate::readBindingTable(RestNodeBase *node, quint8 startIndex
     if (node->mgmtBindSupported())
     {
     }
+    else if (!node->mgmtBindSupported())
+    {
+        node->clearRead(READ_BINDING_TABLE);
+        return false;
+    }
     else if (existDevicesWithVendorCodeForMacPrefix(node->address(), VENDOR_DDEL))
     {
     }


### PR DESCRIPTION
The old code loops over all sensors and lights until one is found which needs to be queried. With more DDFs this code uses more CPU since almost nothing is to be done here. The PR skips some parts for DDF devices and also breaks up the loops to only process max. 5 sensors and 5 lights at a time, so it scales independent of network size.