### PR TITLE
Optimize idle timer and legacy device polling

### DIFF
--- a/device.cpp
+++ b/device.cpp
@@ -2005,7 +2005,21 @@ void DEV_DeadStateHandler(Device *device, const Event &event)
         {
             d->setState(DEV_InitStateHandler);
         }
-        return;
+        else
+        {
+
+            if (event.what() == REventPoll || event.what() == REventAwake)
+            {
+                extern void DEV_PollLegacy(Device *device); // defined in de_web_plugin.cpp
+
+                if (d->node && d->node->isCoordinator())
+                {
+                    return;
+                }
+
+                DEV_PollLegacy(device);
+            }
+        }
     }
 }
 

--- a/poll_manager.cpp
+++ b/poll_manager.cpp
@@ -225,13 +225,13 @@ void PollManager::pollTimerFired()
     const LightNode *lightNode = nullptr;
     if (r && r->prefix() == RLights)
     {
-        restNode = plugin->getLightNodeForId(pitem.id);
+        restNode = dynamic_cast<RestNodeBase*>(r);
         lightNode = dynamic_cast<LightNode*>(restNode);
         item = r->item(RStateReachable);
     }
     else if (r && r->prefix() == RSensors)
     {
-        restNode = plugin->getSensorNodeForId(pitem.id);
+        restNode = dynamic_cast<RestNodeBase*>(r);
         item = r->item(RConfigReachable);
     }
 


### PR DESCRIPTION
This part of the code is a mess and grown over time.

The PR tries to:

- Break up looping over all sensors and lights by only processing up to 5 from each per idle timer call.
- Fetch modelid/manufacturer name from parent Device instead of looping over sibling lights and sensors.
- Control pacing of legacy poll manager via DDF device tick to not schedule things in parallel.

Over time the legacy idle timer and poll manager code needs to go, it will take some iterations to do this and even break legacy devices in the process, which needs to be converted to DDF.