### PR TITLE
Fix MHCOZY 4-Channel SyntaxError: unterminated statement (_TZ3000_u3oupgdy)

### DIFF
--- a/devices/mhcozy/ts0004.json
+++ b/devices/mhcozy/ts0004.json
@@ -81,7 +81,7 @@
             "cl": "0xE001",
             "at": "0xD030",
             "dt": "0x30",
-            "eval": "{ toggle: 0, state: 1, momentary: 2 }[Item.val]"
+            "eval": "Item.val === 'toggle' ?  0 : Item.val === 'state' ? 1 : 2"
           }
         },
         {


### PR DESCRIPTION
Bug fix: SyntaxError: unterminated statement

From log:
```
Feb  5 17:41:39 pi6 deCONZ[1500315]: 17:41:37:724 DDF failed to compile JS: /usr/share/deCONZ/devices/mhcozy/ts0004.json
Feb  5 17:41:39 pi6 deCONZ[1500315]: SyntaxError: unterminated statement (line 1)
```

Had to comment out the statement in each `eval`, and un-comment them one by one to identify the offending statement.  NodeJS seems happy with it, but Duktape doesn't like it.