### PR TITLE
Prevent heavy database writes during APS indications

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -6461,8 +6461,13 @@ static int sqliteSelectDeviceItemCallback(void *user, int ncols, char **colval ,
     return 1;
 }
 
-bool DB_StoreSubDeviceItem(const Resource *sub, const ResourceItem *item)
+bool DB_StoreSubDeviceItem(const Resource *sub, ResourceItem *item)
 {
+    if (!item->needStore())
+    {
+        return true;
+    }
+
     const ResourceItem *uniqueId = sub->item(RAttrUniqueId);
     if (!uniqueId)
     {
@@ -6527,16 +6532,37 @@ bool DB_StoreSubDeviceItem(const Resource *sub, const ResourceItem *item)
                 dt = timestamp - dbResult.timestamp;
             }
 
+            const char *suffix = item->descriptor().suffix;
+
+#ifdef ARCH_ARM
+            uint64_t storeDelay = 1800;
+#else
+            uint64_t storeDelay = 600;
+#endif
+
             if (isEqual)
             {
                 if (item->descriptor().type == DataTypeString)
                 {
+                    item->clearNeedStore();
                     return true; // don't check timestamp for strings
                 }
 
-                if (item->descriptor().suffix[0] == 's' && dt < 600) // state/*
+                if (suffix[0] == 'a' && dt < storeDelay) // attr/*  but not a string
                 {
                     return true; // only update timestamp every 10 minutes
+                }
+                if (suffix[0] == 's' && dt < storeDelay) // state/*
+                {
+                    return true; // only update timestamp every 10 minutes
+                }
+                if (suffix[0] == 'c' && suffix[1] == 'o' && dt < storeDelay) // config/*
+                {
+                    return true; // only update timestamp every 10 minutes
+                }
+                if (suffix[0] == 'c' && suffix[1] == 'a' && suffix[2] == 'p' && dt < 84000) // cap/*
+                {
+                    return true; // hmm could be skipped all together?
                 }
             }
             else
@@ -6544,7 +6570,7 @@ bool DB_StoreSubDeviceItem(const Resource *sub, const ResourceItem *item)
                 // only update 'value' and 'timestamp' every 10 minutes if changed
                 // TODO(mpi): extend the item descriptor to specify storage intervals
                 // we don't need to write the DB for rapid changing values
-                if (item->descriptor().suffix[0] == 's' && dt < 600) // state/*
+                if (item->descriptor().suffix[0] == 's' && dt < storeDelay) // state/*
                 {
                     return true;
                 }
@@ -6562,11 +6588,15 @@ bool DB_StoreSubDeviceItem(const Resource *sub, const ResourceItem *item)
                        value.constData(),
                        timestamp, uniqueId->toCString());
 
-
     DBG_Assert(size_t(ret) < sizeof(sqlBuf));
     if (size_t(ret) < sizeof(sqlBuf))
     {
-        DBG_Printf(DBG_INFO_L2, "%s\n", &sqlBuf[0]);
+//        DBG_Printf(DBG_INFO_L2, "%s\n", &sqlBuf[0]);
+
+        if (DBG_IsEnabled(DBG_MEASURE))
+        {
+            DBG_Printf(DBG_MEASURE, "DB store %s%s/%s ## %s\n", uniqueId->toCString(), sub->prefix(), item->descriptor().suffix, sqlBuf);
+        }
 
         char *errmsg = nullptr;
 
@@ -6579,6 +6609,10 @@ bool DB_StoreSubDeviceItem(const Resource *sub, const ResourceItem *item)
                 DBG_Printf(DBG_ERROR_L2, "SQL exec failed: %s, error: %s (%d)\n", sqlBuf, errmsg, rc);
                 sqlite3_free(errmsg);
             }
+        }
+        else
+        {
+            item->clearNeedStore();
         }
     }
 
@@ -6727,13 +6761,15 @@ std::vector<DB_ResourceItem> DB_LoadSubDeviceItems(QLatin1String uniqueId)
     return result;
 }
 
-bool DB_StoreSubDeviceItems(const Resource *sub)
+bool DB_StoreSubDeviceItems(Resource *sub)
 {
     for (int i = 0; i < sub->itemCount(); i++)
     {
         auto *item = sub->itemForIndex(size_t(i));
-        Q_ASSERT(item);
-        DB_StoreSubDeviceItem(sub, item);
+        if (item && item->needStore())
+        {
+            DB_StoreSubDeviceItem(sub, item);
+        }
     }
 
     return true;

--- a/database.cpp
+++ b/database.cpp
@@ -6468,6 +6468,16 @@ bool DB_StoreSubDeviceItem(const Resource *sub, ResourceItem *item)
         return true;
     }
 
+    const char *suffix = item->descriptor().suffix;
+
+    if ((suffix == RAttrMode && item->toNumber() == Sensor::ModeScenes) || suffix == RStatePresence)
+    {
+        // don't waste time on these
+        // TODO(mpi): this needs to be controlled via DDF
+        item->clearNeedStore();
+        return true;
+    }
+
     const ResourceItem *uniqueId = sub->item(RAttrUniqueId);
     if (!uniqueId)
     {
@@ -6531,8 +6541,6 @@ bool DB_StoreSubDeviceItem(const Resource *sub, ResourceItem *item)
             {
                 dt = timestamp - dbResult.timestamp;
             }
-
-            const char *suffix = item->descriptor().suffix;
 
 #ifdef ARCH_ARM
             uint64_t storeDelay = 1800;

--- a/database.h
+++ b/database.h
@@ -84,8 +84,8 @@ struct DB_LegacyItem
 
 int DB_GetSubDeviceItemCount(QLatin1String uniqueId);
 bool DB_StoreSubDevice(const QString &parentUniqueId, const QString &uniqueId);
-bool DB_StoreSubDeviceItem(const Resource *sub, const ResourceItem *item);
-bool DB_StoreSubDeviceItems(const Resource *sub);
+bool DB_StoreSubDeviceItem(const Resource *sub, ResourceItem *item);
+bool DB_StoreSubDeviceItems(Resource *sub);
 std::vector<DB_ResourceItem> DB_LoadSubDeviceItemsOfDevice(QLatin1String deviceUniqueId);
 std::vector<DB_ResourceItem> DB_LoadSubDeviceItems(QLatin1String uniqueId);
 bool DB_LoadLegacySensorValue(DB_LegacyItem *litem);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2365,11 +2365,6 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
     auto *device = DEV_GetOrCreateDevice(this, deCONZ::ApsController::instance(), eventEmitter, m_devices, node->address().ext());
     Q_ASSERT(device);
 
-    if (device && device->managed())
-    {
-        return;
-    }
-
     if (permitJoinFlag)
     {
         // during pairing only proceed when device code has finished query Basic Cluster
@@ -15777,8 +15772,6 @@ void DeRestPlugin::appAboutToQuit()
             }
         }
 #endif
-
-        DBG_Flush();
 
         d->ttlDataBaseConnection = 0;
         d->closeDb();

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1159,7 +1159,9 @@ void DeRestPluginPrivate::apsdeDataIndicationDevice(const deCONZ::ApsDataIndicat
                 enqueueEvent(Event(r->prefix(), i->descriptor().suffix, idItem->toString(), i, device->key()));
                 if (push && i->lastChanged() == i->lastSet())
                 {
+                    DBG_MEASURE_START(DB_StoreSubDeviceItem);
                     DB_StoreSubDeviceItem(r, i);
+                    DBG_MEASURE_END(DB_StoreSubDeviceItem);
                 }
 
                 if (!eventLastUpdatedEmitted && i->descriptor().suffix[0] == 's') // state/*

--- a/device_ddf_init.cpp
+++ b/device_ddf_init.cpp
@@ -135,6 +135,7 @@ static ResourceItem *DEV_InitDeviceDescriptionItem(const DeviceDescription::Item
             item->setValue(dbItem->value);
             item->setTimeStamps(QDateTime::fromMSecsSinceEpoch(dbItem->timestampMs));
         }
+        item->clearNeedStore(); // already in DB
     }
     else if (!ddfItem.isStatic && dbItem == dbItems.cend() && !item->lastSet().isValid())
     {
@@ -165,6 +166,7 @@ static ResourceItem *DEV_InitDeviceDescriptionItem(const DeviceDescription::Item
         if (ddfItem.isStatic || !item->lastSet().isValid())
         {
             item->setValue(ddfItem.defaultValue);
+            item->clearNeedStore(); // already in DB
         }
     }
 
@@ -248,6 +250,7 @@ bool DEV_InitDeviceFromDescription(Device *device, const DeviceDescription &ddf)
             {
                 DBG_Printf(DBG_DDF, "sub-device: %s, presence state is true, reverting to false\n", qPrintable(uniqueId));
                 item->setValue(false);
+                item->clearNeedStore();
             }
 
             if (!ddfItem.defaultValue.isNull() && !ddfItem.writeParameters.isNull())
@@ -311,6 +314,14 @@ bool DEV_InitDeviceFromDescription(Device *device, const DeviceDescription &ddf)
                     {
                         itemPending->setValue(itemPending->toNumber() | R_PENDING_SET_LONG_POLL_INTERVAL);
                     }
+                }
+            }
+
+            if (item->descriptor().suffix == RAttrId)
+            {
+                if (item->needStore())
+                {
+                    DBG_Printf(DBG_INFO, "needs store %s\n", item->descriptor().suffix);
                 }
             }
         }

--- a/device_ddf_init.cpp
+++ b/device_ddf_init.cpp
@@ -316,14 +316,6 @@ bool DEV_InitDeviceFromDescription(Device *device, const DeviceDescription &ddf)
                     }
                 }
             }
-
-            if (item->descriptor().suffix == RAttrId)
-            {
-                if (item->needStore())
-                {
-                    DBG_Printf(DBG_INFO, "needs store %s\n", item->descriptor().suffix);
-                }
-            }
         }
     }
 

--- a/resource.cpp
+++ b/resource.cpp
@@ -817,6 +817,25 @@ void ResourceItem::clearNeedPush()
     m_flags &= ~static_cast<quint16>(FlagNeedPushSet | FlagNeedPushChange);
 }
 
+/*! Returns true when a value needs to be stored to database.
+ */
+bool ResourceItem::needStore() const
+{
+    return (m_flags & FlagNeedStore) > 0;
+}
+
+/*! Sets need store flag. */
+void ResourceItem::setNeedStore()
+{
+    m_flags |= static_cast<quint16>(FlagNeedStore);
+}
+
+/*! Clears need store flag. */
+void ResourceItem::clearNeedStore()
+{
+    m_flags &= ~static_cast<quint16>(FlagNeedStore);
+}
+
 bool ResourceItem::pushOnSet() const
 {
     return (m_flags & FlagPushOnSet) > 0;
@@ -1104,6 +1123,7 @@ bool ResourceItem::setValue(qint64 val, ValueSource source)
     m_numPrev = m_num;
     m_valueSource = source;
     m_flags |= FlagNeedPushSet;
+    m_flags |= FlagNeedStore;
 
     if (m_num != val)
     {
@@ -1144,6 +1164,7 @@ bool ResourceItem::setValue(const QVariant &val, ValueSource source)
                 *m_str = str;
                 m_lastChanged = m_lastSet;
                 m_flags |= FlagNeedPushChange;
+                m_flags |= FlagNeedStore;
             }
             return true;
         }
@@ -1153,6 +1174,7 @@ bool ResourceItem::setValue(const QVariant &val, ValueSource source)
         m_lastSet = now;
         m_numPrev = m_num;
         m_flags |= FlagNeedPushSet;
+        m_flags |= FlagNeedStore;
 
         if (m_num != val.toBool())
         {
@@ -1183,6 +1205,7 @@ bool ResourceItem::setValue(const QVariant &val, ValueSource source)
                     m_num = dt.toMSecsSinceEpoch();
                     m_lastChanged = m_lastSet;
                     m_flags |= FlagNeedPushChange;
+                    m_flags |= FlagNeedStore;
                 }
                 return true;
             }
@@ -1198,6 +1221,7 @@ bool ResourceItem::setValue(const QVariant &val, ValueSource source)
                 m_num = val.toDateTime().toMSecsSinceEpoch();
                 m_lastChanged = m_lastSet;
                 m_flags |= FlagNeedPushChange;
+                m_flags |= FlagNeedStore;
             }
             return true;
         }
@@ -1218,6 +1242,7 @@ bool ResourceItem::setValue(const QVariant &val, ValueSource source)
                 m_double = d;
                 m_lastChanged = m_lastSet;
                 m_flags |= FlagNeedPushChange;
+                m_flags |= FlagNeedStore;
             }
             return true;
         }
@@ -1241,6 +1266,7 @@ bool ResourceItem::setValue(const QVariant &val, ValueSource source)
             m_lastSet = now;
             m_numPrev = m_num;
             m_flags |= FlagNeedPushSet;
+            m_flags |= FlagNeedStore;
 
             if (m_num != n)
             {

--- a/resource.h
+++ b/resource.h
@@ -442,6 +442,7 @@ public:
         FlagAwakeOnSet      = 0x10, // REventAwake will be generated when item is set after parse
         FlagImplicit        = 0x20, // the item is always present for a specific resource type
         FlagDynamicDescriptor = 0x40, // ResourceItemDescriptor is dynamic (not specified in code)
+        FlagNeedStore      = 0x80   // set when item needs to be stored to database
     };
 
     enum ValueSource
@@ -460,6 +461,9 @@ public:
     bool needPushSet() const;
     bool needPushChange() const;
     void clearNeedPush();
+    bool needStore() const;
+    void setNeedStore();
+    void clearNeedStore();
     bool pushOnSet() const;
     void setPushOnSet(bool enable);
     bool pushOnChange() const;


### PR DESCRIPTION
On weak systems like the Raspberry Pi 1 this could block for ~1 second, which is quite bad considering each command.
The PR marks changed ResourceItems to be stored later on if possible and restricts immediate stores more than before.

It's still far from perfect but before the remaining code base is cleaned up there isn't much that can be optimized further.

