### PR TITLE
Correct battery percentage of Danalock V3

### DIFF
--- a/devices/danalock/danalock_v3.json
+++ b/devices/danalock/danalock_v3.json
@@ -130,7 +130,7 @@
           "parse": {
             "cl": "0x0001",
             "at": "0x0021",
-            "eval": "Item.val = Attr.val"
+            "eval": "Item.val = Attr.val / 2"
           },
           "read": {
             "cl": "0x0001",


### PR DESCRIPTION
danalock battery percentage needs to be divided by 2 otherwise I didn't get any values via rest and values like 182 in deCONZ(VNC).