### PR TITLE
Corrected critical typo in _TZ3000_TS0041_1gang_bat.json

### DIFF
--- a/devices/tuya/_TZ3000_TS0041_1gang_bat.json
+++ b/devices/tuya/_TZ3000_TS0041_1gang_bat.json
@@ -1,6 +1,6 @@
 {
   "schema": "devcap1.schema.json",
-  "manufacturername": [" _TZ3000_itb0omhv", "_TZ3000_4upl1fcj","_TZ3000_wqcbzbae", "_TZ3000_tk3s5tyg", "_TZ3000_mrpevh8p", "TZ3000_qgwcxxws"],
+  "manufacturername": [" _TZ3000_itb0omhv", "_TZ3000_4upl1fcj","_TZ3000_wqcbzbae", "_TZ3000_tk3s5tyg", "_TZ3000_mrpevh8p", "_TZ3000_qgwcxxws"],
   "modelid": ["TS0041", "TS0041", "TS0041", "TS0041", "TS0041", "TS0041"],
   "product": "Tuya 1 gangs switch battery",
   "sleeper": false,


### PR DESCRIPTION
Corrected critical typo in _TZ3000_TS0041_1gang_bat.json preventing device detection

Solves the problem introduced in #7520 and referenced in #7364.