### PR TITLE
DDF for Aqara T1 wireless mini switch WB-R02D

### DIFF
--- a/button_maps.json
+++ b/button_maps.json
@@ -734,11 +734,12 @@
         },
         "xiaomiSwitchB1acn01Map": {
             "vendor": "Xiaomi",
-            "doc": "WXKG11LM 2018 remote",
-            "modelids": ["lumi.remote.b1acn01"],
+            "doc": "WXKG11LM 2018 remote and WB-R02D switch",
+            "modelids": ["lumi.remote.b1acn01", "lumi.remote.b1acn02"],
             "map": [
                 [1, "0x01", "MULTISTATE_INPUT", "ATTRIBUTE_REPORT", "1", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "Normal press"],
                 [1, "0x01", "MULTISTATE_INPUT", "ATTRIBUTE_REPORT", "2", "S_BUTTON_1", "S_BUTTON_ACTION_DOUBLE_PRESS", "Double press"],
+                [1, "0x01", "MULTISTATE_INPUT", "ATTRIBUTE_REPORT", "3", "S_BUTTON_1", "S_BUTTON_ACTION_TREBLE_PRESS", "Tripple press"],
                 [1, "0x01", "MULTISTATE_INPUT", "ATTRIBUTE_REPORT", "0", "S_BUTTON_1", "S_BUTTON_ACTION_HOLD", "Hold"],
                 [1, "0x01", "MULTISTATE_INPUT", "ATTRIBUTE_REPORT", "255", "S_BUTTON_1", "S_BUTTON_ACTION_LONG_RELEASED", "Long released"]
             ]

--- a/devices/xiaomi/xiaomi_wb-r02d_t1_wireless_mini_switch.json
+++ b/devices/xiaomi/xiaomi_wb-r02d_t1_wireless_mini_switch.json
@@ -1,0 +1,101 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "$MF_LUMI",
+  "modelid": "lumi.remote.b1acn02",
+  "vendor": "Xiaomi",
+  "product": "Aqara T1 wireless mini switch WB-R02D",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_SWITCH",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0012"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0103",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x0012",
+          "0xFCC0"
+        ],
+        "out": [
+          "0x0006"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername",
+          "awake": true
+        },
+        {
+          "name": "attr/modelid",
+          "awake": true
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "awake": true,
+          "parse": {
+            "at": "0x00F7",
+            "ep": 1,
+            "eval": "Item.val = '0.0.0_' + ('0000' + (Attr.val & 0xFF).toString()).slice(-4)",
+            "fn": "xiaomi:special",
+            "idx": "0x08",
+            "mf": "0x115F"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "awake": true,
+          "parse": {
+            "at": "0x00F7",
+            "ep": 1,
+            "fn": "xiaomi:special",
+            "idx": "0x01",
+            "mf": "0x115F",
+            "script": "xiaomi_battery.js"
+          }
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/buttonevent"
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
SW version and battery are assumed to be served via attribute 0x00F7 and would require confirmation. Functionality should be given regardless.