### PR TITLE
Relax polling of DDF devices without refresh.interval

### DIFF
--- a/device_ddf_init.cpp
+++ b/device_ddf_init.cpp
@@ -182,6 +182,18 @@ static ResourceItem *DEV_InitDeviceDescriptionItem(const DeviceDescription::Item
         item->setRefreshInterval(deCONZ::TimeSeconds{ddfItem.refreshInterval});
     }
 
+    if (item->refreshInterval().val == 0 && !ddfItem.readParameters.isNull())
+    {
+        // If a DDF doesn't specify a refresh.interval and also not the generic item
+        // default to 30 seconds to relax polling a bit.
+        // Note: ideally this should be specified in a DDF/generic item.
+        const auto m = ddfItem.readParameters.toMap();
+        if (m.value(QLatin1String("fn")) != QLatin1String("none"))
+        {
+            item->setRefreshInterval(deCONZ::TimeSeconds{30});
+        }
+    }
+
     item->setParseFunction(nullptr);
 
     return item;


### PR DESCRIPTION
For items which don't specify a `refresh.interval` in the DDF or at least the generic item, relax to poll every 30 seconds instead of "always and as fast as possible".

This is not ideal and we should have a closer look at the items, also if they use a reasonable poll interval in combination with ZCL attribute reporting.