### PR TITLE
Fix unnecessary read requests for some Xiaomi devices

### DIFF
--- a/devices/xiaomi/xiaomi_mfkzq12lm_t1_pro_cube.json
+++ b/devices/xiaomi/xiaomi_mfkzq12lm_t1_pro_cube.json
@@ -78,6 +78,7 @@
                 {
           "name": "config/devicemode",
           "awake": true,
+          "refresh.interval": 86400,
           "parse": {
             "at": "0x0148",
             "cl": "0xfcc0",

--- a/devices/xiaomi/xiaomi_wrs-r02_h1_switch.json
+++ b/devices/xiaomi/xiaomi_wrs-r02_h1_switch.json
@@ -87,6 +87,7 @@
         {
           "name": "config/clickmode",
           "awake": true,
+          "refresh.interval": 86400,
           "parse": {
             "at": "0x0125",
             "cl": "0xfcc0",
@@ -122,6 +123,7 @@
         {
           "name": "config/devicemode",
           "awake": true,
+          "refresh.interval": 86400,
           "parse": {
             "at": "0x0009",
             "cl": "0xfcc0",


### PR DESCRIPTION
Some read functions were without `refresh.interval`, potentially resulting in excessive unwanted read requests.