### PR TITLE
DDF support disable binding table requests

### DIFF
--- a/device.cpp
+++ b/device.cpp
@@ -2120,6 +2120,18 @@ void Device::setManaged(bool managed)
     d->managed = managed;
 }
 
+void Device::setSupportsMgmtBind(bool supported)
+{
+    if (supported)
+    {
+        d->binding.mgmtBindSupported = MGMT_BIND_SUPPORTED;
+    }
+    else
+    {
+        d->binding.mgmtBindSupported = MGMT_BIND_NOT_SUPPORTED;
+    }
+}
+
 void Device::handleEvent(const Event &event, DEV_StateLevel level)
 {
     if (event.what() == REventStateEnter || event.what() == REventStateLeave)

--- a/device.h
+++ b/device.h
@@ -104,6 +104,7 @@ public:
     const deCONZ::Node *node() const;
     bool managed() const;
     void setManaged(bool managed);
+    void setSupportsMgmtBind(bool supported);
     void handleEvent(const Event &event, DEV_StateLevel level = StateLevel0);
     void timerEvent(QTimerEvent *event) override;
     qint64 lastAwakeMs() const;

--- a/device_descriptions.cpp
+++ b/device_descriptions.cpp
@@ -2133,6 +2133,11 @@ static DeviceDescription DDF_ParseDeviceObject(const QJsonObject &obj, const QSt
         result.sleeper = obj.value(QLatin1String("sleeper")).toBool() ? 1 : 0;
     }
 
+    if (obj.contains(QLatin1String("supportsMgmtBind")))
+    {
+        result.supportsMgmtBind = obj.value(QLatin1String("supportsMgmtBind")).toBool() ? 1 : 0;
+    }
+
     if (obj.contains(QLatin1String("matchexpr")))
     {
         result.matchExpr = obj.value(QLatin1String("matchexpr")).toString();

--- a/device_descriptions.h
+++ b/device_descriptions.h
@@ -103,6 +103,7 @@ public:
 
     int handle = -1; // index in container
     int sleeper = -1;
+    int supportsMgmtBind = -1;
 
     class Item
     {


### PR DESCRIPTION
There are some devices which support it but reading the binding table results in errors or crashes. If `supportsMgmtBind` is set to `false` no attempts are made to query the binding table.

If nothing is specified the usual auto detection mechanism is used.

Related: https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7546#issuecomment-1944671941