### PR TITLE
DDF for OSRAM PAR16 50 TW (GU10)

### DIFF
--- a/devices/osram/par16_50_tw.json
+++ b/devices/osram/par16_50_tw.json
@@ -1,0 +1,93 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "OSRAM",
+  "modelid": "PAR16 50 TW",
+  "product": "PAR16 50 TW",
+  "sleeper": false,
+  "supportsMgmtBind": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_COLOR_TEMPERATURE_LIGHT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x03"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "cap/bri/move_with_onoff",
+          "static": true
+        },
+        {
+          "name": "cap/color/capabilities",
+          "refresh.interval": 86400
+        },
+        {
+          "name": "cap/color/ct/max",
+          "refresh.interval": 86400,
+          "default": 370
+        },
+        {
+          "name": "cap/color/ct/min",
+          "refresh.interval": 86400,
+          "default": 153
+        },
+        {
+          "name": "cap/on/off_with_effect",
+          "static": true
+        },
+        {
+          "name": "state/alert",
+          "default": "none"
+        },
+        {
+          "name": "state/bri",
+          "refresh.interval": 20
+        },
+        {
+          "name": "state/colormode",
+          "refresh.interval": 20
+        },
+        {
+          "name": "state/ct",
+          "refresh.interval": 20
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 20
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Similar to OSRAM Classic A60 RGBW this DDF doesn't use ZCL attribute reporting or binding table requests, to prevent the firmware crashing.

Related https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7546