### PR TITLE
DDF for LEDVANCE A60 FIL DIM T

### DIFF
--- a/devices/osram/classic_a60_fil_dim_t.json
+++ b/devices/osram/classic_a60_fil_dim_t.json
@@ -1,0 +1,99 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "LEDVANCE",
+  "modelid": "A60 FIL DIM T",
+  "product": "Filament Classic A 52",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_DIMMABLE_LIGHT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "cap/bri/move_with_onoff",
+          "static": true
+        },
+        {
+          "name": "cap/on/off_with_effect",
+          "static": true
+        },
+        {
+          "name": "state/alert",
+          "default": "none"
+        },
+        {
+          "name": "state/bri",
+          "refresh.interval": 365
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 365
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0006",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 300
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0008",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x20",
+          "min": 1,
+          "max": 300,
+          "change": "0x00000001"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Labeled as Filament Clssic A 52 (E27).
The light is likely using a newer chip / Zigbee stack, and seems to support ZCL attribute reporting and binding table requests just fine.