### PR TITLE
Fix negative value for sensitivity for Aqara/Xiaomi vibration sensor

### DIFF
--- a/devices/xiaomi/lumi_vibration_aq1.json
+++ b/devices/xiaomi/lumi_vibration_aq1.json
@@ -92,7 +92,7 @@
             "cl": "0x0000",
             "mf": "0x115F",
             "at": "0xFF0D",
-            "eval": "Attr.val < 3 ? 3 - Attr.val : 2"
+            "eval": "Item.val = Attr.val < 3 ? 3 - Attr.val : 2"
           },
           "read": {
             "fn": "zcl:attr",

--- a/devices/xiaomi/lumi_vibration_aq1.json
+++ b/devices/xiaomi/lumi_vibration_aq1.json
@@ -92,7 +92,7 @@
             "cl": "0x0000",
             "mf": "0x115F",
             "at": "0xFF0D",
-            "eval": "Item.val = 3 - Attr.val"
+            "eval": "Attr.val < 3 ? 3 - Attr.val : 2"
           },
           "read": {
             "fn": "zcl:attr",


### PR DESCRIPTION
Untested, I haven't the device, but I don't thing It can cause issues.

```
{
  "config": {
    "battery": 100,
    "duration": 65,
    "on": true,
    "reachable": true,
    "sensitivity": -8,
    "sensitivitymax": 2,
    "temperature": 2600
  },
  "ep": 1,
  "etag": "241c373ed0ac1b2e46c84b5985520189",
  "lastannounced": null,
  "lastseen": "2024-02-17T16:26Z",
  "manufacturername": "LUMI",
  "modelid": "lumi.vibration.aq1",
  "name": "Vibration Chambre Devant",
  "state": {
    "lastupdated": "2024-02-17T16:26:25.934",
    "orientation": [
      -1,
      79,
      11
    ],
    "tiltangle": 6,
    "vibration": false,
    "vibrationstrength": 4
  },
  "swversion": "0.0.0_0008",
  "type": "ZHAVibration",
}
```

If user have set a value > 2 for sensitivity on the device before the DDF was used (autorised value could go up to 21), this one was stored on the device. And even it don't have impact, it can make a negative value as return.