### PR TITLE
Fix consumption reporting for Lidl SilverCrest (_TZ3000_j1v25l17)

### DIFF
--- a/devices/lidl/hg08673.json
+++ b/devices/lidl/hg08673.json
@@ -175,7 +175,7 @@
         },
         {
           "name": "state/consumption",
-          "refresh.interval": 300,
+          "refresh.interval": 420,
           "parse": {
             "at": "0x0000",
             "cl": "0x0702",

--- a/devices/lidl/hg08673.json
+++ b/devices/lidl/hg08673.json
@@ -180,7 +180,7 @@
             "at": "0x0000",
             "cl": "0x0702",
             "ep": 1,
-            "eval": "item.val = 10 * Attr.val"
+            "eval": "Item.val = Attr.val * 10;"
           }
         },
         {


### PR DESCRIPTION
I've create a PR for this issue, @FlatTV provided the fix in #7603.

I've used a little bit different approach, because the missing ";" seemed as an issue compare to a different DDF of a Tuya Device.
Seems like the ";" was missing and also the "Item" was written Lowercase.

resolves #7603 

old:
```
"eval": "item.val = 10 * Attr.val"
```
new: 
```
"eval": "Item.val = Attr.val * 10;"
```

