### PR TITLE
DDF clone for Tuya 2 channel module (_TZ3000_nuenzetq)

### DIFF
--- a/devices/tuya/_TZ3000_2channel_module.json
+++ b/devices/tuya/_TZ3000_2channel_module.json
@@ -2,9 +2,11 @@
   "schema": "devcap1.schema.json",
   "manufacturername": [
     "_TZ3000_zmy4lslw",
-    "_TZ3000_lmlsduws"
+    "_TZ3000_lmlsduws",
+    "_TZ3000_nuenzetq"
   ],
   "modelid": [
+   "TS0002",
    "TS0002",
    "TS0002"
   ],


### PR DESCRIPTION
- Manufacturer: _TZ3000_nuenzetq 
- Model identifier: TS0002
- Device type : 2 gang/ch Switch

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/6446