### PR TITLE
Don't poll unsupported ZCL attributes more than once

### DIFF
--- a/resource.cpp
+++ b/resource.cpp
@@ -904,6 +904,15 @@ void ResourceItem::setImplicit(bool implicit)
     }
 }
 
+void ResourceItem::setZclUnsupportedAttribute()
+{
+    m_flags |= static_cast<uint16_t>(FlagZclUnsupportedAttr);
+}
+
+bool ResourceItem::zclUnsupportedAttribute() const
+{
+    return (m_flags & FlagZclUnsupportedAttr) > 0;
+}
 
 /*! Copy assignment. */
 ResourceItem &ResourceItem::operator=(const ResourceItem &other)

--- a/resource.h
+++ b/resource.h
@@ -442,7 +442,8 @@ public:
         FlagAwakeOnSet      = 0x10, // REventAwake will be generated when item is set after parse
         FlagImplicit        = 0x20, // the item is always present for a specific resource type
         FlagDynamicDescriptor = 0x40, // ResourceItemDescriptor is dynamic (not specified in code)
-        FlagNeedStore      = 0x80   // set when item needs to be stored to database
+        FlagNeedStore      = 0x80,   // set when item needs to be stored to database
+        FlagZclUnsupportedAttr = 0x100  // set when the "read" function failed with ZCL unsupported attribute status
     };
 
     enum ValueSource
@@ -472,6 +473,8 @@ public:
     void setAwake(bool awake);
     bool implicit() const;
     void setImplicit(bool implicit);
+    void setZclUnsupportedAttribute();
+    bool zclUnsupportedAttribute() const;
     const QString &toString() const;
     QLatin1String toLatin1String() const;
     const char *toCString() const;
@@ -522,7 +525,7 @@ private:
 
     ValueSource m_valueSource = SourceUnknown;
     bool m_isPublic = true;
-    quint16 m_flags = 0; // bitmap of ResourceItem::ItemFlags
+    uint16_t m_flags = 0; // bitmap of ResourceItem::ItemFlags
     union
     {
         struct {


### PR DESCRIPTION
Some DDFs poll ZCL attributes which aren't present on the device. For example when the DDF was made for a newer firmware version.

The PR marks such items with unsupported attribute flag based on the first ZCL read attribute response and skips polling them from there on.