### PR TITLE
Fix StateChange write with invalid values on boot

### DIFF
--- a/device_ddf_init.cpp
+++ b/device_ddf_init.cpp
@@ -279,8 +279,14 @@ bool DEV_InitDeviceFromDescription(Device *device, const DeviceDescription &ddf)
                 {
                     bool ok;
 
+                    QVariant value = item->toVariant();
+                    if (!value.isValid())
+                    {
+                        value = ddfItem.defaultValue;
+                    }
+
                     StateChange stateChange(StateChange::StateWaitSync, SC_WriteZclAttribute, sub.uniqueId.at(1).toUInt());
-                    stateChange.addTargetValue(item->descriptor().suffix, item->toVariant());
+                    stateChange.addTargetValue(item->descriptor().suffix, value);
                     stateChange.setChangeTimeoutMs(1000 * 60 * 60);
 
                     if (writeParam.contains(QLatin1String("state.timeout")))

--- a/state_change.cpp
+++ b/state_change.cpp
@@ -188,7 +188,14 @@ void StateChange::verifyItemChange(const ResourceItem *item)
 /*! Adds a target value. */
 void StateChange::addTargetValue(const char *suffix, const QVariant &value)
 {
-    m_items.push_back({suffix, value});
+    if (value.isValid())
+    {
+        m_items.push_back({suffix, value});
+    }
+    else
+    {
+        DBG_Printf(DBG_ERROR, "SC add invalid traget value for: %s\n", suffix);
+    }
 }
 
 /*! Adds a parameter. If the parameter already exsits it will be replaced. */


### PR DESCRIPTION
This happens rarely, but still. If no actual value is present but the DDF has a default value, use that instead.