### PR TITLE
DDF clone for Tuya contact sensor (_TZ3000_zgrffiwg)

### DIFF
--- a/devices/tuya/_TZ3000_2channel_module.json
+++ b/devices/tuya/_TZ3000_2channel_module.json
@@ -2,9 +2,11 @@
   "schema": "devcap1.schema.json",
   "manufacturername": [
     "_TZ3000_zmy4lslw",
-    "_TZ3000_lmlsduws"
+    "_TZ3000_lmlsduws",
+    "_TZ3000_nuenzetq"
   ],
   "modelid": [
+   "TS0002",
    "TS0002",
    "TS0002"
   ],

--- a/devices/tuya/_TZ3000_TS0203_door_sensor.json
+++ b/devices/tuya/_TZ3000_TS0203_door_sensor.json
@@ -1,7 +1,7 @@
 {
   "schema": "devcap1.schema.json",
-  "manufacturername": ["_TZ3000_n2egfsli", "_TZ3000_oxslv1c9", "_TZ3000_7tbsruql", "_TZ3000_7d8yme6f", "_TZ3000_rgchmad8", "_TZ3000_bzxlofth","_TZ3000_au1rjicn", "_TZ3000_4ugnzsli", "_TZ3000_decxrtwa", "_TZ3000_2mbfxlzr", "_TZ3000_6zvw8ham", "_TZ3000_v7chgqso", "_TZ3000_yxqnffam"],
-  "modelid": ["TS0203", "TS0203", "TS0203", "TS0203", "TS0203", "TS0203","TS0203","TS0203","TS0203", "TS0203", "TS0203", "TS0203", "TS0203"],
+  "manufacturername": ["_TZ3000_n2egfsli", "_TZ3000_oxslv1c9", "_TZ3000_7tbsruql", "_TZ3000_7d8yme6f", "_TZ3000_rgchmad8", "_TZ3000_bzxlofth","_TZ3000_au1rjicn", "_TZ3000_4ugnzsli", "_TZ3000_decxrtwa", "_TZ3000_2mbfxlzr", "_TZ3000_6zvw8ham", "_TZ3000_v7chgqso", "_TZ3000_yxqnffam", "_TZ3000_zgrffiwg"],
+  "modelid": ["TS0203", "TS0203", "TS0203", "TS0203", "TS0203", "TS0203","TS0203","TS0203","TS0203", "TS0203", "TS0203", "TS0203", "TS0203", "TS0203"],
   "vendor": "Tuya",
   "product": "Smart Zigbee Door Window Contact",
   "sleeper": true,


### PR DESCRIPTION
Product name : Tuya Door/Window Sensor
Manufacturer : _TZ3000_zgrffiwg
Model identifier : TS0203
Device type to add : Sensor

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7552

Nothing special, just one more clone.