### PR TITLE
JS add R.hasCluster(ep,clusterId [,side])

### DIFF
--- a/device_js/device_js.h
+++ b/device_js/device_js.h
@@ -57,6 +57,12 @@ namespace deCONZ
     Attr.index     -> attribute index (read only), 0 based, tells which attribute in a frame is  currently processed
 
     ### under consideration (not implemented)
+    R.hasCluster(ep,clusterId [,side]) -> bool
+                    ep = Number, clusterId = Number, side: Number (optional)
+                    side: 0 server (default), 1 client
+                    e.g. R.hasCluster(0x01, 0xFC77)
+                         R.hasCluster(0x01, 0xFC77, 0)
+
     R.parent --> get the parent resource object (Device)
     R.subDevice(uniqueId) --> get another sub-device resource object
     Item.lastSet --> timestamp when item was last set


### PR DESCRIPTION
`R.hasCluster(endpoint, clusterId [, side]) -> bool`

- endpoint : Number
- clusterId: Number
- side: Number  (optional;  0: server and 1: client cluster side; default: 0)

The numbers can be written as decimal or hexadecimal (but not strings).

In a `matchexpr` this function can be used to select a DDF if the device Simple Descriptors have (or have not) a specific cluster. This is useful since some devices add new clusters via OTA firmware updates, for which new DDFs might be required.

**Important:** This must only be used in DDF `matchexpr` it's not meant for "write" or "parse" functions!


Example: `{ matchexpr: "R.hasCluster(0x0b, 0xFC03)" }`