### PR TITLE
Philips Hue ZLL/ZB3 match DDF only for newer firmware

### DIFF
--- a/devices/philips/light_zb3_C.json
+++ b/devices/philips/light_zb3_C.json
@@ -111,6 +111,7 @@
   "product": "Hue white and color ambiance light",
   "sleeper": false,
   "status": "Gold",
+  "matchexpr": "R.hasCluster(0x0b,0xfc03)",
   "subdevices": [
     {
       "type": "$TYPE_EXTENDED_COLOR_LIGHT",

--- a/devices/philips/light_zb3_C_festavia.json
+++ b/devices/philips/light_zb3_C_festavia.json
@@ -11,6 +11,7 @@
   "product": "Hue Festavia",
   "sleeper": false,
   "status": "Gold",
+  "matchexpr": "R.hasCluster(0x0b,0xfc03)",
   "subdevices": [
     {
       "type": "$TYPE_EXTENDED_COLOR_LIGHT",

--- a/devices/philips/light_zb3_C_gradient.json
+++ b/devices/philips/light_zb3_C_gradient.json
@@ -83,6 +83,7 @@
   "product": "Hue white and color ambiance gradient light",
   "sleeper": false,
   "status": "Gold",
+  "matchexpr": "R.hasCluster(0x0b,0xfc03)",
   "subdevices": [
     {
       "type": "$TYPE_EXTENDED_COLOR_LIGHT",

--- a/devices/philips/light_zb3_white.json
+++ b/devices/philips/light_zb3_white.json
@@ -15,6 +15,7 @@
   "product": "Hue white light",
   "sleeper": false,
   "status": "Gold",
+  "matchexpr": "R.hasCluster(0x0b,0xfc03)",
   "subdevices": [
     {
       "type": "$TYPE_DIMMABLE_LIGHT",

--- a/devices/philips/light_zb3_white_ambiance.json
+++ b/devices/philips/light_zb3_white_ambiance.json
@@ -31,6 +31,7 @@
   "product": "Hue white ambiance light",
   "sleeper": false,
   "status": "Gold",
+  "matchexpr": "R.hasCluster(0x0b,0xfc03)",
   "subdevices": [
     {
       "type": "$TYPE_COLOR_TEMPERATURE_LIGHT",

--- a/devices/philips/light_zll_A.json
+++ b/devices/philips/light_zll_A.json
@@ -43,6 +43,7 @@
   "product": "Hue color ambiance light",
   "sleeper": false,
   "status": "Gold",
+  "matchexpr": "R.hasCluster(0x0b,0xfc03)",
   "subdevices": [
     {
       "type": "$TYPE_COLOR_LIGHT",

--- a/devices/philips/light_zll_B.json
+++ b/devices/philips/light_zll_B.json
@@ -27,6 +27,7 @@
   "product": "Hue white and color ambiance light",
   "sleeper": false,
   "status": "Gold",
+  "matchexpr": "R.hasCluster(0x0b,0xfc03)",
   "subdevices": [
     {
       "type": "$TYPE_EXTENDED_COLOR_LIGHT",

--- a/devices/philips/light_zll_C.json
+++ b/devices/philips/light_zll_C.json
@@ -39,6 +39,7 @@
   "product": "Hue white and color ambiance light",
   "sleeper": false,
   "status": "Gold",
+  "matchexpr": "R.hasCluster(0x0b,0xfc03)",
   "subdevices": [
     {
       "type": "$TYPE_EXTENDED_COLOR_LIGHT",

--- a/devices/philips/light_zll_white_ambiance.json
+++ b/devices/philips/light_zll_white_ambiance.json
@@ -19,6 +19,7 @@
   "product": "Hue white ambiance light",
   "sleeper": false,
   "status": "Gold",
+  "matchexpr": "R.hasCluster(0x0b,0xfc03)",
   "subdevices": [
     {
       "type": "$TYPE_COLOR_TEMPERATURE_LIGHT",


### PR DESCRIPTION
The existing DDFs require that the lights have a recent firmware which provides the 0xFC03 cluster and otherwise won't function fully for polling and updating the light state.

The PR no longer matches DDFs for older firmware lights, and falls back to the legacy code for them.

Later on we can introduce DDFs which also handle the old firmware with standard clusters instead of 0xFC03 cluster.
~~Note this PR only affects the ZLL lights, I'm not sure if also ZB30 lights need this for older firmware?~~