### PR TITLE
DEV refresh non sleeper endpoints and simple descriptors once per session

### DIFF
--- a/resource.cpp
+++ b/resource.cpp
@@ -50,6 +50,7 @@ const char *REventTimerFired = "event/timerfired";
 const char *REventValidGroup = "event/validgroup";
 const char *REventZclReadReportConfigResponse = "event/zcl.read.report.config.response";
 const char *REventZclResponse = "event/zcl.response";
+const char *REventZdpReload = "event/zdp.reload";
 const char *REventZdpMgmtBindResponse = "event/zdp.mgmt.bind.response";
 const char *REventZdpResponse = "event/zdp.response";
 

--- a/resource.h
+++ b/resource.h
@@ -78,6 +78,7 @@ extern const char *REventTick;
 extern const char *REventTimerFired;
 extern const char *REventZclResponse;
 extern const char *REventZclReadReportConfigResponse;
+extern const char *REventZdpReload;
 extern const char *REventZdpMgmtBindResponse;
 extern const char *REventZdpResponse;
 


### PR DESCRIPTION
Due to some issues in core in past versions the Simple Descriptors may have some clusters which aren't actually there.
For example when reading an attribute for a non existing cluster or attribute, due to the response the cluster would be appended. This is fixed in deCONZ versions > v2.26.1 but the Simple Descriptors need to be refreshed.

In older versions this can be done manually by selecting a node and pressing `7` and `8` or via node context menu.

This PR does it automatically once per session for non sleeping devices.
Proper Simple Descriptors and clusters are needed to match DDFs via `matchexpr: R:hasCluster(...)`.

The Simple Descriptors can also change after OTA updates, in future the refresh should be  done automatically after an update, for now the once per session is a ok'ish tradeoff.