### PR TITLE
Fix non stop reading of binding table for legacy devices

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -201,7 +201,7 @@ bool DeRestPluginPrivate::readBindingTable(RestNodeBase *node, quint8 startIndex
         bindingTableReaderTimer->start();
     }
 
-    return false;
+    return true;
 }
 
 /*! Handle bind table confirm.


### PR DESCRIPTION
For legacy devices after scheduling the read of binding table, the flag was never cleared proper.
This was quite spammy and in some setups might have lead to slowness.