### PR TITLE
Expose OTA file version for matchexpr

### DIFF
--- a/database.h
+++ b/database.h
@@ -21,6 +21,10 @@
 
 #define DB_MAX_UNIQUEID_SIZE 31
 
+namespace deCONZ {
+    class Address;
+}
+
 struct DB_Secret
 {
     std::string uniqueId;
@@ -82,7 +86,23 @@ struct DB_LegacyItem
     BufString<128> value;
 };
 
+struct DB_ZclValue
+{
+    int64_t data;
+    int deviceId;
+    uint16_t clusterId;
+    uint16_t attrId;
+    uint8_t endpoint;
+
+    // internal
+    uint8_t loaded;
+};
+
+int DB_StoreDevice(const deCONZ::Address &addr);
+
 int DB_GetSubDeviceItemCount(QLatin1String uniqueId);
+bool DB_LoadZclValue(DB_ZclValue *val);
+bool DB_StoreZclValue(const DB_ZclValue *val);
 bool DB_StoreSubDevice(const QString &parentUniqueId, const QString &uniqueId);
 bool DB_StoreSubDeviceItem(const Resource *sub, ResourceItem *item);
 bool DB_StoreSubDeviceItems(Resource *sub);

--- a/de_otau.cpp
+++ b/de_otau.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2016-2024 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -9,6 +9,9 @@
  */
 
 #include "de_web_plugin_private.h"
+#include "device_descriptions.h"
+#include "database.h"
+
 
 // de otau specific
 #define OTAU_IMAGE_NOTIFY_CLID                 0x0201
@@ -57,34 +60,108 @@ void DeRestPluginPrivate::initOtau()
 
 /*! Handler for incoming otau packets.
  */
-void DeRestPluginPrivate::otauDataIndication(const deCONZ::ApsDataIndication &ind, const deCONZ::ZclFrame &zclFrame)
+void DeRestPluginPrivate::otauDataIndication(const deCONZ::ApsDataIndication &ind, const deCONZ::ZclFrame &zclFrame, Device *device)
 {
-    if ((ind.clusterId() == OTAU_CLUSTER_ID) && (zclFrame.commandId() == OTAU_QUERY_NEXT_IMAGE_REQUEST_CMD_ID))
+    if (!device || ind.clusterId() != OTAU_CLUSTER_ID)
     {
-        LightNode *lightNode = getLightNodeForAddress(ind.srcAddress(), ind.srcEndpoint());
+        return;
+    }
 
+    quint8 fieldControl;
+    quint16 manufacturerId;
+    quint16 imageType;
+    quint32 swVersion = 0;
+    quint16 hwVersion;
+    bool updateOtaTicks = false;
+
+    if (zclFrame.isProfileWideCommand() && zclFrame.commandId() == deCONZ::ZclReadAttributesResponseId)
+    {
+        // TODO(mpi): parsing the attribute response can likely be removed here
+        // since this is already done by the read function.
+        // Below the item->needPushChange() check is used to capture the change in any case.
+        QDataStream stream(zclFrame.payload());
+        stream.setByteOrder(QDataStream::LittleEndian);
+
+        quint16 attrId;
+        quint8 status;
+        quint8 dataType;
+
+        stream >> attrId;
+        stream >> status;
+        stream >> dataType;
+
+        if (status == deCONZ::ZclSuccessStatus && attrId == 0x0002 && dataType == deCONZ::Zcl32BitUint && stream.status() == QDataStream::Ok)
+        {
+            deCONZ::ZclAttribute attr(attrId, dataType, QLatin1String(""), deCONZ::ZclReadWrite, true);
+
+            if (attr.readFromStream(stream))
+            {
+                swVersion = attr.numericValue().u32;
+            }
+        }
+    }
+    else if (zclFrame.isClusterCommand() && zclFrame.commandId() == OTAU_QUERY_NEXT_IMAGE_REQUEST_CMD_ID)
+    {
+        QDataStream stream(zclFrame.payload());
+        stream.setByteOrder(QDataStream::LittleEndian);
+
+        stream >> fieldControl;
+        stream >> manufacturerId;
+        stream >> imageType;
+        stream >> swVersion;
+
+        if (fieldControl & 0x01)
+        {
+            stream >> hwVersion;
+        }
+
+        if (swVersion == 0 || stream.status() != QDataStream::Ok)
+        {
+            return;
+        }
+    }
+
+    if (swVersion != 0)
+    {
+        // the OTA cluster 0x0002 attribute isn't always present, but it can be extracted from the Query Next Image Request
+        // store the OTA versions for DDF and non DDF devices, so it can be used in DDF matchexpr
+
+        DB_ZclValue zclVal;
+        zclVal.deviceId = device->deviceId();
+        zclVal.endpoint = ind.srcEndpoint();
+        zclVal.clusterId = ind.clusterId();
+        zclVal.attrId = 0x0002; // OTA current file version
+        zclVal.data = swVersion;
+
+        DB_StoreZclValue(&zclVal); // does only write if the value is already there
+
+        ResourceItem *item = device->item(RAttrOtaVersion);
+        if (item && item->toNumber() != swVersion)
+        {
+            item->setValue(swVersion, ResourceItem::SourceDevice);
+        }
+
+        if (device->managed() && item->needPushChange())
+        {
+            // the known OTA version has changed (or initially set)
+            // there might be a different DDF to match, trigger reload
+            const auto &ddf = DeviceDescriptions::instance()->get(device, DDF_EvalMatchExpr);
+            if (ddf.isValid() && !ddf.matchExpr.isEmpty())
+            {
+                Event e(device->prefix(), REventDDFReload, 1, device->key());
+                enqueueEvent(e);
+            }
+        }
+
+        if (device->managed())
+        {
+            return;
+        }
+
+        LightNode *lightNode = getLightNodeForAddress(ind.srcAddress(), ind.srcEndpoint());
         // extract software version from request
         if (lightNode)
         {
-            QDataStream stream(zclFrame.payload());
-            stream.setByteOrder(QDataStream::LittleEndian);
-
-            quint8 fieldControl;
-            quint16 manufacturerId;
-            quint16 imageType;
-            quint32 swVersion;
-            quint16 hwVersion;
-
-            stream >> fieldControl;
-            stream >> manufacturerId;
-            stream >> imageType;
-            stream >> swVersion;
-
-            if (fieldControl & 0x01)
-            {
-                stream >> hwVersion;
-            }
-
             deCONZ::NumericUnion val = {0};
             val.u32 = swVersion;
 
@@ -106,7 +183,11 @@ void DeRestPluginPrivate::otauDataIndication(const deCONZ::ApsDataIndication &in
             }
         }
     }
-    else if ((ind.clusterId() == OTAU_CLUSTER_ID) && (zclFrame.commandId() == OTAU_UPGRADE_END_REQUEST_CMD_ID))
+    else if (zclFrame.isProfileWideCommand())
+    {
+        return; // all done here
+    }
+    else if (zclFrame.commandId() == OTAU_UPGRADE_END_REQUEST_CMD_ID)
     {
         LightNode *lightNode = getLightNodeForAddress(ind.srcAddress(), ind.srcEndpoint());
 
@@ -118,10 +199,19 @@ void DeRestPluginPrivate::otauDataIndication(const deCONZ::ApsDataIndication &in
             storeRecoverOnOffBri(lightNode);
         }
     }
-    else if (ind.clusterId() == OTAU_CLUSTER_ID && zclFrame.commandId() == OTAU_IMAGE_BLOCK_REQUEST_CMD_ID)
+    else if (zclFrame.commandId() == OTAU_IMAGE_BLOCK_REQUEST_CMD_ID)
     {
         // remember last activity time
         otauIdleTotalCounter = idleTotalCounter;
+        updateOtaTicks = true;
+    }
+    else if (zclFrame.commandId() == OTAU_IMAGE_PAGE_REQUEST_CMD_ID)
+    {
+        updateOtaTicks = true;
+    }
+    else
+    {
+        return;
     }
 
     if (!isOtauActive())
@@ -129,9 +219,7 @@ void DeRestPluginPrivate::otauDataIndication(const deCONZ::ApsDataIndication &in
         return;
     }
 
-    if (((ind.profileId() == DE_PROFILE_ID) && (ind.clusterId() == OTAU_IMAGE_BLOCK_REQUEST_CLID)) ||
-        ((ind.clusterId() == OTAU_CLUSTER_ID) && (zclFrame.commandId() == OTAU_IMAGE_BLOCK_REQUEST_CMD_ID)) ||
-        ((ind.clusterId() == OTAU_CLUSTER_ID) && (zclFrame.commandId() == OTAU_IMAGE_PAGE_REQUEST_CMD_ID)))
+    if (updateOtaTicks)
     {
         if (otauIdleTicks > 0)
         {

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1263,7 +1263,7 @@ public:
 
     // Otau
     void initOtau();
-    void otauDataIndication(const deCONZ::ApsDataIndication &ind, const deCONZ::ZclFrame &zclFrame);
+    void otauDataIndication(const deCONZ::ApsDataIndication &ind, const deCONZ::ZclFrame &zclFrame, Device *device);
     bool isOtauBusy();
     bool isOtauActive();
     int otauLastBusyTimeDelta() const;
@@ -1645,7 +1645,6 @@ public:
     bool upgradeDbToUserVersion7();
     bool upgradeDbToUserVersion8();
     bool upgradeDbToUserVersion9();
-    void refreshDeviceDb(const deCONZ::Address &addr);
     void pushZdpDescriptorDb(quint64 extAddress, quint8 endpoint, quint16 type, const QByteArray &data);
     void pushZclValueDb(quint64 extAddress, quint8 endpoint, quint16 clusterId, quint16 attributeId, qint64 data);
     bool dbIsOpen() const;

--- a/device.h
+++ b/device.h
@@ -99,6 +99,8 @@ public:
     Device(const Device &) = delete;
     explicit Device(DeviceKey key, deCONZ::ApsController*apsCtrl, QObject *parent = nullptr);
     ~Device();
+    void setDeviceId(int id);
+    int deviceId() const;
     void addSubDevice(Resource *sub);
     DeviceKey key() const;
     const deCONZ::Node *node() const;

--- a/device_access_fn.cpp
+++ b/device_access_fn.cpp
@@ -1733,7 +1733,14 @@ static DA_ReadResult readZclAttribute(const Resource *r, const ResourceItem *ite
 
     if (param.endpoint == AutoEndpoint)
     {
-        param.endpoint = resolveAutoEndpoint(r);
+        if (r->prefix() == RDevices)
+        {
+            param.endpoint = item->readEndpoint();
+        }
+        else
+        {
+            param.endpoint = resolveAutoEndpoint(r);
+        }
 
         if (param.endpoint == AutoEndpoint)
         {

--- a/device_descriptions.cpp
+++ b/device_descriptions.cpp
@@ -871,7 +871,10 @@ void DeviceDescriptions::handleEvent(const Event &event)
     }
     else if (event.what() == REventDDFReload)
     {
-        readAll(); // todo read only device specific files?
+        if (event.num() == 0)
+        {
+            readAll(); // todo read only device specific files?
+        }
     }
 }
 
@@ -931,6 +934,22 @@ const DeviceDescription &DeviceDescriptions::get(const Resource *resource, DDF_M
         else
         {
             return *i;
+        }
+    }
+
+    return d->invalidDescription;
+}
+
+const DeviceDescription &DeviceDescriptions::getFromHandle(DeviceDescription::Item::Handle hnd) const
+{
+    Q_D(const DeviceDescriptions);
+    ItemHandlePack h;
+    h.handle = hnd;
+    if (h.handle != DeviceDescription::Item::InvalidItemHandle)
+    {
+        if (h.description < d->descriptions.size())
+        {
+            return d->descriptions[h.description];
         }
     }
 
@@ -1456,7 +1475,7 @@ void DeviceDescriptions::handleDDFInitRequest(const Event &event)
 
     if (resource)
     {
-        const auto ddf = get(resource);
+        const auto ddf = get(resource, DDF_EvalMatchExpr);
 
         if (ddf.isValid())
         {

--- a/device_descriptions.h
+++ b/device_descriptions.h
@@ -245,6 +245,7 @@ public:
     void setEnabledStatusFilter(const QStringList &filter);
     const QStringList &enabledStatusFilter() const;
     const DeviceDescription &get(const Resource *resource, DDF_MatchControl match = DDF_EvalMatchExpr) const;
+    const DeviceDescription &getFromHandle(DeviceDescription::Item::Handle hnd) const;
     void put(const DeviceDescription &ddf);
     const DeviceDescription &load(const QString &path);
 

--- a/devices/generic/items/attr_appversion_item.json
+++ b/devices/generic/items/attr_appversion_item.json
@@ -1,0 +1,23 @@
+{
+  "schema": "resourceitem1.schema.json",
+  "id": "attr/appversion",
+  "datatype": "UInt32",
+  "access": "R",
+  "public": true,
+  "implicit": false,
+  "description": "ZCL Basic cluster application version.",
+  "parse": {
+    "fn": "zcl:attr",
+    "ep": 255,
+    "cl": "0x0000",
+    "at": "0x0001",
+    "eval": "Item.val = Attr.val"
+  },
+  "read": {
+    "fn": "zcl:attr",
+    "ep": 0,
+    "cl": "0x0000",
+    "at": "0x0001"
+  },
+  "refresh.interval": 86400
+}

--- a/devices/generic/items/attr_otaversion_item.json
+++ b/devices/generic/items/attr_otaversion_item.json
@@ -1,0 +1,23 @@
+{
+  "schema": "resourceitem1.schema.json",
+  "id": "attr/otaversion",
+  "datatype": "UInt32",
+  "access": "R",
+  "public": true,
+  "implicit": false,
+  "description": "OTA cluster file version.",
+  "parse": {
+    "fn": "zcl:attr",
+    "ep": 255,
+    "cl": "0x0019",
+    "at": "0x0002",
+    "eval": "Item.val = Attr.val"
+  },
+  "read": {
+    "fn": "zcl:attr",
+    "ep": 0,
+    "cl": "0x0019",
+    "at": "0x0002"
+  },
+  "refresh.interval": 86400
+}

--- a/resource.cpp
+++ b/resource.cpp
@@ -56,6 +56,7 @@ const char *REventZdpResponse = "event/zdp.response";
 
 const char *RInvalidSuffix = "invalid/suffix";
 
+const char *RAttrAppVersion = "attr/appversion";
 const char *RAttrClass = "attr/class";
 const char *RAttrConfigId = "attr/configid";
 const char *RAttrExtAddress = "attr/extaddress";
@@ -69,6 +70,7 @@ const char *RAttrMode = "attr/mode";
 const char *RAttrModelId = "attr/modelid";
 const char *RAttrName = "attr/name";
 const char *RAttrNwkAddress = "attr/nwkaddress";
+const char *RAttrOtaVersion = "attr/otaversion";
 const char *RAttrPowerOnCt = "attr/poweronct";
 const char *RAttrPowerOnLevel = "attr/poweronlevel";
 const char *RAttrPowerup = "attr/powerup";
@@ -372,6 +374,7 @@ void initResourceDescriptors()
     rItemDescriptors.clear();
 
     // init resource lookup
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt32, QVariant::Double, RAttrAppVersion));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, QVariant::String, RAttrClass));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt32, QVariant::Double, RAttrConfigId));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt64, QVariant::Double, RAttrExtAddress));
@@ -385,6 +388,7 @@ void initResourceDescriptors()
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, QVariant::String, RAttrModelId));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeString, QVariant::String, RAttrName));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, QVariant::Double, RAttrNwkAddress));
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt32, QVariant::Double, RAttrOtaVersion));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt16, QVariant::Double, RAttrPowerOnCt));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt8, QVariant::Double, RAttrPowerOnLevel));
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt32, QVariant::Double, RAttrPowerup));
@@ -930,6 +934,7 @@ ResourceItem &ResourceItem::operator=(const ResourceItem &other)
     m_parseFunction = other.m_parseFunction;
     m_refreshInterval = other.m_refreshInterval;
     m_zclParam = other.m_zclParam;
+    m_readEndpoint = other.m_readEndpoint;
     m_num = other.m_num;
     m_numPrev = other.m_numPrev;
     m_lastZclReport = other.m_lastZclReport;
@@ -981,6 +986,7 @@ ResourceItem &ResourceItem::operator=(ResourceItem &&other) noexcept
     m_lastChanged = std::move(other.m_lastChanged);
     m_rulesInvolved = std::move(other.m_rulesInvolved);
     m_zclParam = other.m_zclParam;
+    m_readEndpoint = other.m_readEndpoint;
     m_parseFunction = other.m_parseFunction;
     m_refreshInterval = other.m_refreshInterval;
     m_ddfItemHandle = other.m_ddfItemHandle;

--- a/resource.h
+++ b/resource.h
@@ -85,6 +85,7 @@ extern const char *REventZdpResponse;
 // resouce suffixes: state/buttonevent, config/on, ...
 extern const char *RInvalidSuffix;
 
+extern const char *RAttrAppVersion;
 extern const char *RAttrClass;
 extern const char *RAttrConfigId;
 extern const char *RAttrExtAddress;
@@ -98,6 +99,7 @@ extern const char *RAttrMode;
 extern const char *RAttrModelId;
 extern const char *RAttrName;
 extern const char *RAttrNwkAddress;
+extern const char *RAttrOtaVersion;
 extern const char *RAttrPowerOnCt;
 extern const char *RAttrPowerOnLevel;
 extern const char *RAttrPowerup;
@@ -488,6 +490,8 @@ public:
     deCONZ::TimeSeconds refreshInterval() const { return m_refreshInterval; }
     void setRefreshInterval(deCONZ::TimeSeconds interval) { m_refreshInterval = interval; }
     void setZclProperties(const ZCL_Param &param) { m_zclParam = param; }
+    void setReadEndpoint(uint8_t ep) { m_readEndpoint = ep; }
+    uint8_t readEndpoint() const { return m_readEndpoint; }
     bool setValue(const QString &val, ValueSource source = SourceUnknown);
     bool setValue(qint64 val, ValueSource source = SourceUnknown);
     bool setValue(const QVariant &val, ValueSource source = SourceUnknown);
@@ -548,9 +552,10 @@ private:
     QDateTime m_lastSet;
     QDateTime m_lastChanged;
     std::vector<int> m_rulesInvolved; // the rules a resource item is trigger
-    ZCL_Param m_zclParam{};
+    ZCL_Param m_zclParam{}; // for parse function
     ParseFunction_t m_parseFunction = nullptr;
     quint32 m_ddfItemHandle = 0; // invalid item handle
+    uint8_t m_readEndpoint = 0;
 };
 
 class Resource


### PR DESCRIPTION
The PR introduces a new `ResourceItem` `attr/otaversion` which can be used to select DDFs. First example for it is the Ikea on/off switch which needs a DDF for newer and older firmware versions (will be added as separate PR).

## How it works for Ikea on/off switch

**DDF 1)** The old firmware version DDF has following expression:

```json
{
  "matchexpr": "var v = R.item('attr/otaversion').val; (v != 0 && v < 0x23079631);"
}
```

**DDF 2)** And the new one:

```json
{
  "matchexpr": "var v = R.item('attr/otaversion').val; (v == 0 || v >= 0x23079631);"
}
```

- On first join and after deCONZ update from v2.26.0 to v2.26.1 the firmware version is **not** known yet, and is `0`.
- Therefore the new firmware version **DDF 2** is selected due the `(v == 0 || v >= 0x23079631)` condition!
- When the firmware version is queried via Read Attribute Request or extracted from OTA Query Next Image request, and if it is different than the previous known version, then the DDF matching starts again for the device, perhaps selecting the older **DDF 1** if the version check `(v != 0 && v < 0x23079631)` applies.

------------------

Under the hood the PR does the following:

- Every Device Resource has the `attr/otaversion` item by default and it is filled by either ZCL Read Attributes Request from OTA cluster attribute 0x0002 or when OTA Query Next Image request is received.
- The device firmware version value is stored in the database `zcl_values` table if it doesn't exist or is changed.
- This happens for DDF **and** non DDF legacy devices, so that we have it ready when a DDF is created later on!
- A important part is that once a new version is detected, e.g. initially or after an OTA update, the DDF matching process is started again automatically if the DDF has a `matchexpr`, no restart of deCONZ is required.
