### PR TITLE
DDF for Ikea on/off switch version < 0x23079631

### DIFF
--- a/devices/ikea/tradfri_on_off_switch_old_fw.json
+++ b/devices/ikea/tradfri_on_off_switch_old_fw.json
@@ -5,7 +5,7 @@
   "product": "TRADFRI on/off switch - E1743",
   "sleeper": true,
   "status": "Gold",
-  "matchexpr": "var v = R.item('attr/otaversion').val; (v == 0 || v >= 0x23079631);",
+  "matchexpr": "var v = R.item('attr/otaversion').val; (v != 0 && v < 0x23079631);",
   "subdevices": [
     {
       "type": "$TYPE_SWITCH",
@@ -114,6 +114,10 @@
           "refresh.interval": 86400
         },
         {
+          "name": "config/group",
+          "default": "auto"
+        },
+        {
           "name": "config/on"
         },
         {
@@ -130,14 +134,16 @@
   ],
   "bindings": [
     {
-      "bind": "unicast",
+      "bind": "groupcast",
       "src.ep": 1,
-      "cl": "0x0006"
+      "cl": "0x0006",
+      "config.group": 0
     },
     {
-      "bind": "unicast",
+      "bind": "groupcast",
       "src.ep": 1,
-      "cl": "0x0008"
+      "cl": "0x0008",
+      "config.group": 0
     },
     {
       "bind": "unicast",


### PR DESCRIPTION
The older firmware versions for the on/off switch require a group binding to stop spamming Zigbee group 0 with requests and by that controlling all devices.

Newer firmware versions don't support group bindings well or at all. Therefore two DDFs are needed.
They are selected based on the OTA file version in OTA cluster attribute 0x0002.


More details how it works: https://github.com/dresden-elektronik/deconz-rest-plugin/pull/7642