### PR TITLE
FIX, prevent a tuya TRV to freeze zigbee network.

### DIFF
--- a/devices/tuya/_TZE200_ztvwu4nk_thermostat.json
+++ b/devices/tuya/_TZE200_ztvwu4nk_thermostat.json
@@ -92,11 +92,6 @@
           "name": "state/temperature",
           "parse": {"fn": "tuya", "dpid": 24, "eval": "Item.val = Attr.val * 10;"},
           "read": {"fn": "none"}
-        },
-        {
-          "name": "state/valve",
-          "parse": {"fn": "tuya", "dpid": 36, "eval": "Item.val = Attr.val > 5;"},
-          "read": {"fn": "none"}
         }
       ]
     }


### PR DESCRIPTION
Concern  devices "_TZE200_ztvwu4nk", "_TZE204_5toc8efa", "_TZE200_5toc8efa", "_TZE200_ye5jkfsb", "_TZE204_aoclfnxz", "_TZE200_u9bfwha0".

This device is powered, so relay talkative and it can send the valve position realy fastly, even the state doesn't change.

```
16:28:28:757 TY_DATA_REPORT: seq 465, dpid: 0x24, type: 0x04, length: 1, val: 1
16:28:28:759 TY_DATA_REPORT: seq 465, dpid: 0x24, type: 0x04, length: 1, val: 1
16:28:28:761 Websocket 10.0.0.1:45396 send message: {"e":"changed","id":"159","r":"sensors","state":{"lastupdated":"2024-02-18T15:28:28.759","temperature":2100,"valve":0},"t":"event","uniqueid":"a4:c1:38:53:57:a4:3e:2f-01-ef00"} (ret = 1696907060)
16:28:28:924 TY_DATA_REPORT: seq 465, dpid: 0x24, type: 0x04, length: 1, val: 1
16:28:28:926 TY_DATA_REPORT: seq 465, dpid: 0x24, type: 0x04, length: 1, val: 1
16:28:28:928 TY_DATA_REPORT: seq 465, dpid: 0x24, type: 0x04, length: 1, val: 1
16:28:28:929 TY_DATA_REPORT: seq 465, dpid: 0x24, type: 0x04, length: 1, val: 1
16:28:28:931 TY_DATA_REPORT: seq 465, dpid: 0x24, type: 0x04, length: 1, val: 1
16:28:28:933 Websocket 10.0.0.1:45396 send message: {"e":"changed","id":"159","r":"sensors","state":{"lastupdated":"2024-02-18T15:28:28.931","temperature":2100,"valve":0},"t":"event","uniqueid":"a4:c1:38:53:57:a4:3e:2f-01-ef00"} (ret = 1696907060)
```

And deconz make a new websocket notification every time, even the state not change, and third app probably do same after.

We have tried 

```
        {
          "name": "state/valve",
          "parse": {"fn": "tuya", "dpid": 36, "eval": "if R.item('state/valve').val != Attr.val {Item.val = Attr.val;}"},
          "read": {"fn": "none"}
        }
```

To prevent spam, it's better, but not a sucess.

And ofc not way to set a report delay on tuya cluster.