### PR TITLE
DDF Tuya multi sensor clone (_TZE200_zl1kmjqx)

### DIFF
--- a/devices/tuya/_TZE200_bjawzodf_humidity_temp.json
+++ b/devices/tuya/_TZE200_bjawzodf_humidity_temp.json
@@ -1,7 +1,7 @@
 {
   "schema": "devcap1.schema.json",
-  "manufacturername": "_TZE200_bjawzodf",
-  "modelid": "TS0601",
+  "manufacturername": ["_TZE200_bjawzodf", "_TZE200_zl1kmjqx"],
+  "modelid": ["TS0601", "TS0601"],
   "product": "Tuya multi sensor",
   "sleeper": true,
   "status": "Gold",


### PR DESCRIPTION
Product name : Tuya Smart Zigbee Thermometer
Manufacturer : _TZE200_zl1kmjqx
Model identifier : TS0601

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7542