### PR TITLE
Use bundled OpenSSL on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,7 +273,11 @@ target_compile_definitions(${PROJECT_NAME}
 
 if (OPENSSL_FOUND)
     target_compile_definitions(${PROJECT_NAME} PRIVATE HAS_OPENSSL=1)
-    target_include_directories(${PROJECT_NAME} PRIVATE ${OPENSSL_INCLUDE_DIR})
+    if (APPLE)
+        target_include_directories(${PROJECT_NAME} PRIVATE ${OPENSSL_INCLUDE_DIRS})
+    else()
+        target_include_directories(${PROJECT_NAME} PRIVATE ${OPENSSL_INCLUDE_DIR})
+    endif()
 endif()
 
 if (Qt5Core_VERSION_STRING VERSION_LESS "5.15.0")

--- a/crypto/mmohash.cpp
+++ b/crypto/mmohash.cpp
@@ -100,6 +100,8 @@ bool CRYPTO_GetMmoHashFromInstallCode(const std::string &hexString, std::vector<
 {
 #ifdef Q_OS_WIN
     QLibrary libCrypto(QLatin1String("libcrypto-1_1.dll"));
+#elif defined (__APPLE__)
+    QLibrary libCrypto(QLatin1String("../Frameworks/libcrypto.3.dylib"));
 #else
     QLibrary libCrypto("crypto");
 #endif

--- a/crypto/scrypt.cpp
+++ b/crypto/scrypt.cpp
@@ -66,6 +66,9 @@ static int scryptDerive(const char *input, size_t inputLength, std::array<unsign
 #ifdef Q_OS_WIN
     QLibrary libCrypto(QLatin1String("libcrypto-1_1.dll"));
     QLibrary libSsl(QLatin1String("libssl-1_1.dll"));
+#elif defined (__APPLE__)
+    QLibrary libCrypto(QLatin1String("../Frameworks/libcrypto.3.dylib"));
+    QLibrary libSsl(QLatin1String("../Frameworks/libssl.3.dylib"));
 #else
     QLibrary libCrypto(QLatin1String("crypto"));
     QLibrary libSsl(QLatin1String("ssl"));


### PR DESCRIPTION
On macOS the system `libssl` and `libcrypto` libraries are not allowed to be used anymore and lead to a crash on `dlopen()`. Upcoming versions of deCONZ bundle OpenSSL version 3.x in `deCONZ.app/Contents/Frameworks/`.