### PR TITLE
Improve rules database handling

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -3251,6 +3251,17 @@ static int sqliteLoadAllRulesCallback(void *user, int ncols, char **colval , cha
             {
                 rule.etag = val;
             }
+            else if (strcmp(colname[i], "lasttriggered") == 0)
+            {
+                if (colval[i][0] >= '0' && colval[i][0] <= '9') // isdigit()
+                {
+                    rule.m_lastTriggered = QDateTime::fromString(val, QLatin1String("yyyy-MM-ddTHH:mm:ssZ"));
+                }
+            }
+            else if (strcmp(colname[i], "timestriggered") == 0)
+            {
+                rule.setTimesTriggered(val.toUInt());
+            }
             else if (strcmp(colname[i], "owner") == 0)
             {
                 rule.setOwner(val);
@@ -5423,11 +5434,18 @@ void DeRestPluginPrivate::saveDb()
     // save/delete rules
     if (saveDatabaseItems & DB_RULES)
     {
-        std::vector<Rule>::const_iterator i = rules.begin();
-        std::vector<Rule>::const_iterator end = rules.end();
+        auto i = rules.begin();
+        const auto end = rules.end();
 
         for (; i != end; ++i)
         {
+            if (!i->needSaveDatabase())
+            {
+                continue;
+            }
+
+            i->clearNeedSaveDatabase();
+
             const QString &rid = i->id();
 
             if (i->state() == Rule::StateDeleted)
@@ -5453,19 +5471,23 @@ void DeRestPluginPrivate::saveDb()
 
             QString actionsJSON = Rule::actionsToString(i->actions());
             QString conditionsJSON = Rule::conditionsToString(i->conditions());
+            QString lastTriggered;
 
-//            QString sql = QString(QLatin1String("REPLACE INTO rules (rid, name, created, etag, lasttriggered, owner, status, timestriggered, actions, conditions) VALUES ('%1', '%2', '%3', '%4', '%5', '%6', '%7', '%8', '%9', '%10')"))
-//                    .arg(rid, i->name(), i->creationtime(),
-//                         i->etag, i->lastTriggered(), i->owner(),
-//                         i->status(), QString::number(i->timesTriggered()), actionsJSON)
-//                    .arg(conditionsJSON);
+            if (i->lastTriggered().isValid())
+            {
+                lastTriggered = i->lastTriggered().toString(QLatin1String("yyyy-MM-ddTHH:mm:ssZ"));
+            }
+            else
+            {
+                lastTriggered = QLatin1String("none");
+            }
 
             QString sql = QLatin1String("REPLACE INTO rules (rid, name, created, etag, lasttriggered, owner, status, timestriggered, actions, conditions, periodic) VALUES ('") +
                     rid + QLatin1String("','") +
                     i->name() + QLatin1String("','") +
                     i->creationtime() + QLatin1String("','") +
                     i->etag + QLatin1String("','") +
-                    QLatin1String("none','") +
+                    lastTriggered + QLatin1String("','") +
                     i->owner() + QLatin1String("','") +
                     i->status() + QLatin1String("','") +
                     QString::number(i->timesTriggered()) + QLatin1String("','") +

--- a/rest_rules.cpp
+++ b/rest_rules.cpp
@@ -530,6 +530,7 @@ int DeRestPluginPrivate::createRule(const ApiRequest &req, ApiResponse &rsp)
 
             DBG_Printf(DBG_INFO, "create rule %s: %s\n", qPrintable(rule.id()), qPrintable(rule.name()));
             rules.push_back(rule);
+            rules.back().setNeedSaveDatabase();
             indexRulesTriggers();
             queSaveDb(DB_RULES, DB_SHORT_SAVE_DELAY);
 
@@ -811,6 +812,7 @@ int DeRestPluginPrivate::updateRule(const ApiRequest &req, ApiResponse &rsp)
     {
         updateEtag(rule->etag);
         updateEtag(gwConfigEtag);
+        rule->setNeedSaveDatabase();
         queSaveDb(DB_RULES, DB_SHORT_SAVE_DELAY);
     }
 
@@ -947,6 +949,7 @@ int DeRestPluginPrivate::deleteRule(const ApiRequest &req, ApiResponse &rsp)
 
     updateEtag(gwConfigEtag);
     updateEtag(rule->etag);
+    rule->setNeedSaveDatabase();
 
     queSaveDb(DB_RULES, DB_SHORT_SAVE_DELAY);
 
@@ -1435,9 +1438,10 @@ void DeRestPluginPrivate::triggerRule(Rule &rule)
     {
         rule.m_lastTriggered = QDateTime::currentDateTimeUtc();
         rule.setTimesTriggered(rule.timesTriggered() + 1);
+        rule.setNeedSaveDatabase();
         updateEtag(rule.etag);
         updateEtag(gwConfigEtag);
-        queSaveDb(DB_RULES, DB_HUGE_SAVE_DELAY);
+        //queSaveDb(DB_RULES, DB_HUGE_SAVE_DELAY);
     }
 }
 

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -3937,6 +3937,7 @@ void DeRestPluginPrivate::handleIndicationSearchSensors(const deCONZ::ApsDataInd
                         {
                             DBG_Printf(DBG_INFO, "ikea remote delete legacy rule %s\n", qPrintable(ri->name()));
                             ri->setState(Rule::StateDeleted);
+                            ri->setNeedSaveDatabase();
                             changed = true;
                         }
                     }

--- a/rule.cpp
+++ b/rule.cpp
@@ -97,17 +97,17 @@ void Rule::setCreationtime(const QString &creationtime)
 
 /*! Returns the count the rule was triggered.
  */
-const quint32 &Rule::timesTriggered() const
+quint32 Rule::timesTriggered() const
 {
-    return this->m_timesTriggered;
+    return m_timesTriggered;
 }
 
 /*! Sets the count the rule was triggered.
     \param timesTriggered the count the rule was triggered
  */
-void Rule::setTimesTriggered(const quint32 &timesTriggered)
+void Rule::setTimesTriggered(quint32 timesTriggered)
 {
-    this->m_timesTriggered = timesTriggered;
+    m_timesTriggered = timesTriggered;
 }
 
 /*! Returns the trigger periodic time value in milliseconds.

--- a/rule.h
+++ b/rule.h
@@ -96,8 +96,8 @@ public:
     const QDateTime &lastTriggered() const;
     const QString &creationtime() const;
     void setCreationtime(const QString &creationtime);
-    const quint32 &timesTriggered() const;
-    void setTimesTriggered(const quint32 &timesTriggered);
+    quint32 timesTriggered() const;
+    void setTimesTriggered(quint32 timesTriggered);
     int triggerPeriodic() const;
     void setTriggerPeriodic(int ms);
     const QString &owner() const;
@@ -110,6 +110,9 @@ public:
     void setActions(const std::vector<RuleAction> &actions);
     bool isEnabled() const;
     int handle() const;
+    bool needSaveDatabase() const { return m_needSave; }
+    void setNeedSaveDatabase() { m_needSave = true; }
+    void clearNeedSaveDatabase() { m_needSave = false; }
 
     static QString actionsToString(const std::vector<RuleAction> &actions);
     static QString conditionsToString(const std::vector<RuleCondition> &conditions);
@@ -122,6 +125,7 @@ public:
     QDateTime m_lastTriggered;
 
 private:
+    bool m_needSave = false;
     State m_state;
     QString m_id;
     int m_handle;


### PR DESCRIPTION
- Only store rules than needed and on application exit.
- Fix store/reload `timestriggered` and `lasttriggered` which was always "none" previously.

