### PR TITLE
Replace use of deCONZ::jsonStringFromMap() by Json::serialize()

### DIFF
--- a/gateway.cpp
+++ b/gateway.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2013-2024 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ */
+
 #include <QBuffer>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
@@ -546,7 +556,7 @@ void GatewayPrivate::handleEventStateNotAuthorized(GW_Event event)
         map[QLatin1String("devicetype")] = QLatin1String("x-gw");
         //map[QLatin1String("username")] = apikey;
 
-        QString json = deCONZ::jsonStringFromMap(map);
+        QString json = Json::serialize(map);
 
         reqBuffer->close();
         reqBuffer->setData(json.toUtf8());
@@ -757,7 +767,7 @@ void GatewayPrivate::handleEventStateConnected(GW_Event event)
                 {
                     map[QLatin1String("transitiontime")] = (double) cmd.transitionTime;
                 }
-                json = deCONZ::jsonStringFromMap(map);
+                json = Json::serialize(map);
                 DBG_Printf(DBG_INFO_L2, "GW body %s\n", qPrintable(json));
             }
             else

--- a/rest_schedules.cpp
+++ b/rest_schedules.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2016-2024 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -365,7 +365,7 @@ int DeRestPluginPrivate::setScheduleAttributes(const ApiRequest &req, ApiRespons
 
             if (!cmd.isEmpty() && cmd.contains("address") && cmd.contains("method") && cmd.contains("body"))
             {
-                i->command = deCONZ::jsonStringFromMap(cmd);
+                i->command = Json::serialize(cmd);
                 i->jsonMap["command"] = map["command"];
 
                 QVariantMap rspItem;
@@ -802,7 +802,7 @@ bool DeRestPluginPrivate::jsonToSchedule(const QString &jsonString, Schedule &sc
             return false;
         }
 
-        schedule.command = deCONZ::jsonStringFromMap(cmd);
+        schedule.command = Json::serialize(cmd);
     }
     else
     {
@@ -1146,7 +1146,7 @@ void DeRestPluginPrivate::scheduleTimerFired()
         {
             if (i->endtime.isValid() && i->endtime > now)
             {
-                DBG_Printf(DBG_INFO, "schedule %s timeout in %d s\n", qPrintable(i->id), now.secsTo(i->endtime));
+                DBG_Printf(DBG_INFO, "schedule %s timeout in %d s\n", qPrintable(i->id), (int)now.secsTo(i->endtime));
                 continue;
             }
             else if (i->endtime.isValid())
@@ -1226,7 +1226,7 @@ void DeRestPluginPrivate::scheduleTimerFired()
         {
             i->status = QLatin1String("disabled");
             i->jsonMap["status"] = i->status;
-            i->jsonString = deCONZ::jsonStringFromMap(i->jsonMap);
+            i->jsonString = Json::serialize(i->jsonMap);
             if (i->autodelete)
             {
                 DBG_Printf(DBG_INFO, "schedule %s: %s deleted (too old)\n", qPrintable(i->id), qPrintable(i->name));
@@ -1260,7 +1260,7 @@ void DeRestPluginPrivate::scheduleTimerFired()
                 {
                     i->status = QLatin1String("disabled");
                     i->jsonMap["status"] = i->status;
-                    i->jsonString = deCONZ::jsonStringFromMap(i->jsonMap);
+                    i->jsonString = Json::serialize(i->jsonMap);
                 }
                 queSaveDb(DB_SCHEDULES, DB_SHORT_SAVE_DELAY);
             }
@@ -1355,7 +1355,7 @@ void DeRestPluginPrivate::scheduleTimerFired()
             }
             QString method = cmd["method"].toString();
             QString address = cmd["address"].toString();
-            QString content = deCONZ::jsonStringFromMap(cmd["body"].toMap());
+            QString content = Json::serialize(cmd["body"].toMap());
 
             // check if fields contain data
             if (method.isEmpty() || address.isEmpty() || content.isEmpty())

--- a/sensor.cpp
+++ b/sensor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2021 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2013-2024 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -46,7 +46,7 @@ QString SensorFingerprint::toString() const
         map["out"] = ls;
     }
 
-    return deCONZ::jsonStringFromMap(map);
+    return Json::serialize(map);
 }
 
 /*! Parses a fingerprint from JSON string.


### PR DESCRIPTION
`deCONZ::jsonStringFromMap()` is a old function in deCONZ library and about to be removed.
`Json::serialize()` is part of the plugin code, it also sucks but is only one entry point to be refactored later on.