### PR TITLE
Don't load rules lasttriggered and timestriggered from database

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -3251,6 +3251,8 @@ static int sqliteLoadAllRulesCallback(void *user, int ncols, char **colval , cha
             {
                 rule.etag = val;
             }
+#if 0 // don't reload for now, see https://github.com/dresden-elektronik/deconz-rest-plugin/pull/7672
+      // the values are still stored in the database for the last session to provide debugging hints
             else if (strcmp(colname[i], "lasttriggered") == 0)
             {
                 if (colval[i][0] >= '0' && colval[i][0] <= '9') // isdigit()
@@ -3262,6 +3264,7 @@ static int sqliteLoadAllRulesCallback(void *user, int ncols, char **colval , cha
             {
                 rule.setTimesTriggered(val.toUInt());
             }
+#endif
             else if (strcmp(colname[i], "owner") == 0)
             {
                 rule.setOwner(val);


### PR DESCRIPTION
Partly roll back PR: https://github.com/dresden-elektronik/deconz-rest-plugin/pull/7672 (see comments there)

The main reason to have `lasttriggered` and `timestriggered` in the database is to be able to get some insights for if rules are actually used in user setups, when we debug mailed databases.

With the PR the values aren't loaded but are still stored in the database for the last session to aid in debugging.