### PR TITLE
Improve DDF for dresden elektronik's kobolt

### DIFF
--- a/devices/dresden_elektronik/kobold.json
+++ b/devices/dresden_elektronik/kobold.json
@@ -43,42 +43,51 @@
           "name": "attr/uniqueid"
         },
         {
+          "name": "cap/bri/move_with_onoff"
+        },
+        {
+          "name": "cap/on/off_with_effect"
+        },
+        {
+          "name": "config/bri/execute_if_off",
+          "read": {
+            "fn": "zcl:attr",
+            "ep": "0x01",
+            "cl": "0x0008",
+            "at": [
+              "0x000f",
+              "0x0011",
+              "0x4000"
+            ]
+          },
+          "refresh.interval": 3600
+        },
+        {
+          "name": "config/bri/on_level",
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "config/bri/startup",
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "config/on/startup"
+        },
+        {
           "name": "state/alert",
           "default": "none"
         },
         {
-          "name": "state/bri",
-          "refresh.interval": 5,
-          "read": {
-            "at": "0x0000",
-            "cl": "0x0008",
-            "ep": 1,
-            "fn": "zcl:attr"
-          },
-          "parse": {
-            "at": "0x0000",
-            "cl": "0x0008",
-            "ep": 1,
-            "eval": "Item.val = Attr.val",
-            "fn": "zcl:attr"
-          }
+          "name": "state/on",
+          "refresh.interval": 360
         },
         {
-          "name": "state/on",
-          "refresh.interval": 5,
-          "read": {
-            "at": "0x0000",
-            "cl": "0x0006",
-            "ep": 1,
-            "fn": "zcl:attr"
-          },
-          "parse": {
-            "at": "0x0000",
-            "cl": "0x0006",
-            "ep": 1,
-            "eval": "Item.val = Attr.val",
-            "fn": "zcl:attr"
-          }
+          "name": "state/bri",
+          "refresh.interval": 360
         },
         {
           "name": "state/reachable"
@@ -87,7 +96,15 @@
     },
     {
       "type": "$TYPE_SWITCH",
-      "fingerprint": { "profile": "0x0104", "device": "0x0104", "endpoint": "0x02", "out": ["0x0006", "0x0008"] },
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0104",
+        "endpoint": "0x02",
+        "out": [
+          "0x0006",
+          "0x0008"
+        ]
+      },
       "restapi": "/sensors",
       "uuid": [
         "$address.ext",
@@ -95,12 +112,23 @@
         "0x0006"
       ],
       "buttons": {
-        "1": {"name": "Push"}
+        "1": {
+          "name": "Push"
+        }
       },
       "buttonevents": {
-        "1001": {"action": "HOLD", "button": 1},
-        "1002": {"action": "SHORT_RELEASE", "button": 1},
-        "1003": {"action": "LONG_RELEASE", "button": 1}
+        "1001": {
+          "action": "HOLD",
+          "button": 1
+        },
+        "1002": {
+          "action": "SHORT_RELEASE",
+          "button": 1
+        },
+        "1003": {
+          "action": "LONG_RELEASE",
+          "button": 1
+        }
       },
       "items": [
         {
@@ -156,7 +184,12 @@
       "src.ep": 1,
       "cl": "0x0006",
       "report": [
-          {"at": "0x0000", "dt": "0x10", "min": 65535, "max": 65535 }
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 300
+        }
       ]
     },
     {
@@ -164,7 +197,13 @@
       "src.ep": 1,
       "cl": "0x0008",
       "report": [
-          {"at": "0x0000", "dt": "0x20", "min": 65535, "max": 65535, "change": "0x01" }
+        {
+          "at": "0x0000",
+          "dt": "0x20",
+          "min": 1,
+          "max": 300,
+          "change": "0x01"
+        }
       ]
     },
     {


### PR DESCRIPTION
- Add missing `capabilities` and `config` items;
- Use attribute reporting for `state/on` and `state/bri` - any reason why this was disabled in favour of polling?