### PR TITLE
DDF clone for Tuya door sensor (_TZ3000_1bwpjvlz)

### DIFF
--- a/devices/tuya/_TZ3000_TS0203_door_sensor.json
+++ b/devices/tuya/_TZ3000_TS0203_door_sensor.json
@@ -1,6 +1,6 @@
 {
   "schema": "devcap1.schema.json",
-  "manufacturername": ["_TZ3000_n2egfsli", "_TZ3000_oxslv1c9", "_TZ3000_7tbsruql", "_TZ3000_7d8yme6f", "_TZ3000_rgchmad8", "_TZ3000_bzxlofth","_TZ3000_au1rjicn", "_TZ3000_4ugnzsli", "_TZ3000_decxrtwa", "_TZ3000_2mbfxlzr", "_TZ3000_6zvw8ham", "_TZ3000_v7chgqso", "_TZ3000_yxqnffam", "_TZ3000_zgrffiwg"],
+  "manufacturername": ["_TZ3000_n2egfsli", "_TZ3000_oxslv1c9", "_TZ3000_7tbsruql", "_TZ3000_7d8yme6f", "_TZ3000_rgchmad8", "_TZ3000_bzxlofth","_TZ3000_au1rjicn", "_TZ3000_4ugnzsli", "_TZ3000_decxrtwa", "_TZ3000_2mbfxlzr", "_TZ3000_6zvw8ham", "_TZ3000_v7chgqso", "_TZ3000_yxqnffam", "_TZ3000_zgrffiwg","_TZ3000_1bwpjvlz"],
   "modelid": ["TS0203", "TS0203", "TS0203", "TS0203", "TS0203", "TS0203","TS0203","TS0203","TS0203", "TS0203", "TS0203", "TS0203", "TS0203", "TS0203"],
   "vendor": "Tuya",
   "product": "Smart Zigbee Door Window Contact",

--- a/devices/tuya/_TZ3000_TS0203_door_sensor.json
+++ b/devices/tuya/_TZ3000_TS0203_door_sensor.json
@@ -1,7 +1,7 @@
 {
   "schema": "devcap1.schema.json",
   "manufacturername": ["_TZ3000_n2egfsli", "_TZ3000_oxslv1c9", "_TZ3000_7tbsruql", "_TZ3000_7d8yme6f", "_TZ3000_rgchmad8", "_TZ3000_bzxlofth","_TZ3000_au1rjicn", "_TZ3000_4ugnzsli", "_TZ3000_decxrtwa", "_TZ3000_2mbfxlzr", "_TZ3000_6zvw8ham", "_TZ3000_v7chgqso", "_TZ3000_yxqnffam", "_TZ3000_zgrffiwg","_TZ3000_1bwpjvlz"],
-  "modelid": ["TS0203", "TS0203", "TS0203", "TS0203", "TS0203", "TS0203","TS0203","TS0203","TS0203", "TS0203", "TS0203", "TS0203", "TS0203", "TS0203"],
+  "modelid": ["TS0203", "TS0203", "TS0203", "TS0203", "TS0203", "TS0203","TS0203","TS0203","TS0203", "TS0203", "TS0203", "TS0203", "TS0203", "TS0203", "TS0203"],
   "vendor": "Tuya",
   "product": "Smart Zigbee Door Window Contact",
   "sleeper": true,


### PR DESCRIPTION
Added new version ZD08Y-ZTU-V1.1 2023-12-08
Manufacturername: "_TZ3000_1bwpjvlz"

![Screenshot 2024-04-07 213930](https://github.com/dresden-elektronik/deconz-rest-plugin/assets/11261849/fb77e10d-7f50-4c44-aba9-a97456a44485)

Seller: https://de.aliexpress.com/item/1005006629101795.html