### PR TITLE
DDF clone for Tuya 2-gang switch (_TZ3000_mtnpt6ws)

### DIFF
--- a/devices/tuya/_TZ3000_2channel_module.json
+++ b/devices/tuya/_TZ3000_2channel_module.json
@@ -3,9 +3,11 @@
   "manufacturername": [
     "_TZ3000_zmy4lslw",
     "_TZ3000_lmlsduws",
+    "_TZ3000_mtnpt6ws",
     "_TZ3000_nuenzetq"
   ],
   "modelid": [
+   "TS0002",
    "TS0002",
    "TS0002",
    "TS0002"


### PR DESCRIPTION
Product name : AVATTO ZWSM16-2-Zigbee
Manufacturer : _TZ3000_mtnpt6ws
Model identifier : TS0002
Device type to add : Light

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7646