### PR TITLE
Removing erroneous temperature exposure for Aqara SSM-U01 switch

### DIFF
--- a/devices/xiaomi/xiaomi_ssm-u01_t1_switch.json
+++ b/devices/xiaomi/xiaomi_ssm-u01_t1_switch.json
@@ -125,16 +125,6 @@
           "name": "config/reachable"
         },
         {
-          "name": "config/temperature",
-          "parse": {
-            "at": "0x0000",
-            "cl": "0x0002",
-            "ep": 1,
-            "eval": "Item.val = Attr.val * 100;",
-            "fn": "zcl:attr"
-          }
-        },
-        {
           "name": "state/current",
           "parse": {
             "at": "0x00F7",
@@ -238,16 +228,6 @@
         },
         {
           "name": "config/reachable"
-        },
-        {
-          "name": "config/temperature",
-          "parse": {
-            "at": "0x0000",
-            "cl": "0x0002",
-            "ep": 1,
-            "eval": "Item.val = Attr.val * 100;",
-            "fn": "zcl:attr"
-          }
         },
         {
           "name": "state/consumption",


### PR DESCRIPTION
When the DDF was created, the resource item `config/temperature` apparently sneaked in, but without any function. Functionality was applied with PR #7650, however, this should not have happened. First of all, `temperature` is a `state` and not `config` item and secondly, it misleadingly exposes a device temperature.

This PR basically reverts back to the initial state while removing the item completely.