### PR TITLE
Add scratch memory allocator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ set(PLUGIN_INCLUDE_FILES
     utils/ArduinoJson.h
     utils/ArduinoJson-v6.19.4.h
     utils/bufstring.h
+    utils/scratchmem.h
     utils/stringcache.h
     utils/utils.h
     websocket_server.h
@@ -222,6 +223,7 @@ add_library(${PROJECT_NAME} SHARED
     ui/text_lineedit.cpp
     upnp.cpp
     utils/bufstring.cpp
+    utils/scratchmem.cpp
     utils/stringcache.cpp
     utils/utils.cpp
     websocket_server.cpp

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -53,6 +53,7 @@
 #include "read_files.h"
 #include "tuya.h"
 #include "utils/utils.h"
+#include "utils/scratchmem.h"
 #include "xiaomi.h"
 #include "zcl/zcl.h"
 #include "zdp/zdp.h"
@@ -594,6 +595,7 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
     apsCtrlWrapper(deCONZ::ApsController::instance())
 {
     plugin = this;
+    ScratchMemInit();
 
     DEV_SetTestManaged(deCONZ::appArgumentNumeric("--dev-test-managed", 0));
 
@@ -944,6 +946,7 @@ DeRestPluginPrivate::~DeRestPluginPrivate()
     delete deviceJs;
     deviceJs = nullptr;
     eventEmitter = nullptr;
+    ScratchMemDestroy();
 }
 
 DeRestPluginPrivate *DeRestPluginPrivate::instance()
@@ -15887,6 +15890,9 @@ int DeRestPlugin::handleHttpRequest(const QHttpRequestHeader &hdr, QTcpSocket *s
 {
     QString content;
     QTextStream stream(sock);
+
+    ScratchMemRewind(0);
+    ScratchMemWaypoint swp;
 
     stream.setCodec(QTextCodec::codecForName("UTF-8"));
     d->pushClientForClose(sock, 60);

--- a/utils/scratchmem.cpp
+++ b/utils/scratchmem.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ */
+
+#include "deconz/u_assert.h"
+#include "deconz/u_arena.h"
+#include "scratchmem.h"
+
+#define INITIAL_SCRATCH_SIZE (1 << 22)  // 4 MB
+
+static U_Arena scratch_arena;
+
+void ScratchMemInit(void)
+{
+    U_InitArena(&scratch_arena, INITIAL_SCRATCH_SIZE);
+}
+
+void ScratchMemDestroy(void)
+{
+    U_FreeArena(&scratch_arena);
+}
+
+unsigned long ScratchMemPos(void)
+{
+    return scratch_arena.size;
+}
+
+void *ScratchMemAlloc(unsigned long size)
+{
+    U_ASSERT((scratch_arena.size + size + 16) < scratch_arena._total_size);
+    if (scratch_arena._total_size < (scratch_arena.size + size + 16))
+    {
+        // TODO we can't grow since that invalidates pointers
+        // if needed old arenas could be preserved until rewind(0) is called
+        // but that's rather meh
+        return nullptr;
+    }
+
+    void *p;
+    p = U_AllocArena(&scratch_arena, size, U_ARENA_ALIGN_8);
+    return p;
+}
+
+void ScratchMemRewind(unsigned long pos)
+{
+    if (pos < scratch_arena._total_size)
+    {
+        scratch_arena.size = pos;
+    }
+}

--- a/utils/scratchmem.h
+++ b/utils/scratchmem.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ */
+
+#ifndef SCRATCHMEM_H
+#define SCRATCHMEM_H
+
+void ScratchMemInit(void);
+void ScratchMemDestroy(void);
+unsigned long ScratchMemPos(void);
+void *ScratchMemAlloc(unsigned long);
+void ScratchMemRewind(unsigned long);
+
+
+#define SCRATCH_ALLOC(type, size) (static_cast<type>(ScratchMemAlloc(size)))
+
+/* helper to restore scratch position on stack unwind */
+class ScratchMemWaypoint
+{
+public:
+    ScratchMemWaypoint() { m_pos = ScratchMemPos(); }
+    ~ScratchMemWaypoint() { ScratchMemRewind(m_pos); }
+
+private:
+    unsigned long m_pos;
+};
+
+
+#endif // SCRATCHMEM_H


### PR DESCRIPTION
The scratch memory arena allocator allows fast and deterministic allocations of short life memory. E.g. when creating API responses or other short lived allocations that are only needed for the duration of a call stack.

This PR is in preparation of the DDF bundle integration.