### PR TITLE
Add CJ JSON parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ add_library(${PROJECT_NAME} SHARED
     crypto/password.cpp
     crypto/random.cpp
     crypto/scrypt.cpp
+    cj/cj_all.c
     database.cpp
     daylight.cpp
     de_otau.cpp
@@ -274,6 +275,8 @@ target_compile_definitions(${PROJECT_NAME}
     GW_MIN_DERFUSB23E0X_FW_VERSION=0x22030300
     GW_DEFAULT_NAME="\"\"Phoscon-GW\"\""
 )
+
+target_include_directories(${PROJECT_NAME} PRIVATE cj)
 
 if (OPENSSL_FOUND)
     target_compile_definitions(${PROJECT_NAME} PRIVATE HAS_OPENSSL=1)

--- a/cj/cj.c
+++ b/cj/cj.c
@@ -1,0 +1,763 @@
+/*
+ * Copyright (c) 2023 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ */
+
+#include "cj.h"
+
+#ifdef NDEBUG
+  #define CJ_ASSERT(c) ((void)0)
+#else
+  #if _MSC_VER
+    #define CJ_ASSERT(c) if (!(c)) __debugbreak()
+  #elif __GNUC__
+    #define CJ_ASSERT(c) if (!(c)) __builtin_trap()
+  #else
+    #define CJ_ASSERT(c) ((void)0)
+  #endif
+#endif /* NDEBUG */
+
+/* Convert utf-8 to unicode code point.
+
+   Returns >0 as number of bytes in utf8 character, and 'codepoint' set
+   or 0 for invalid utf8, codepoint set to 0.
+
+ */
+static int cj_utf8_to_codepoint(const unsigned char *str, unsigned long len, unsigned long *codepoint)
+{
+    int result;
+    unsigned long cp;
+    unsigned bytes;
+
+    if (str && len != 0)
+        cp = (unsigned)*str & 0xFF;
+    else
+        goto invalid;
+
+    for (bytes = 0; cp & 0x80; bytes++)
+        cp = (cp & 0x7F) << 1;
+
+    if (bytes == 0) /* ASCII */
+    {
+        *codepoint = cp;
+        return 1;
+    }
+
+    if (bytes > 4 || bytes > len)
+        goto invalid;
+
+    result = (int)bytes;
+
+    /* 110xxxxx 10xxxxxx */
+    /* 1110xxxx 10xxxxxx 10xxxxxx */
+    /* 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx */
+    cp >>= bytes;
+    bytes--;
+    str++;
+
+    for (;bytes; bytes--, str++)
+    {
+        if (((unsigned)*str & 0xC0) != 0x80) /* must start with 10xxxxxx */
+            goto invalid;
+
+        cp <<= 6;
+        cp |= (unsigned)*str & 0x3F;
+    }
+
+    if      (result == 2 &&  cp < 0x80)  goto invalid;
+    else if (result == 3 &&  cp < 0x800) goto invalid;
+    else if (result == 4 && (cp < 0x10000 || cp > 0x10FFFF)) goto invalid;
+
+    *codepoint = cp;
+    return result;
+
+invalid:
+    *codepoint = 0;
+    return 0;
+}
+
+static cj_status cj_is_valid_utf8(const unsigned char *str, unsigned long len)
+{
+    int ch_count;
+    unsigned long codepoint;
+
+    do /* test valid utf8 codepoints */
+    {
+        ch_count = cj_utf8_to_codepoint(str, len, &codepoint);
+        if (ch_count > 0)
+        {
+            str += ch_count;
+            len -= (unsigned)ch_count;
+        }
+        else
+        {
+            return CJ_INVALID_UTF8;
+        }
+    } while (ch_count > 0 && len > 0);
+
+    return CJ_OK;
+}
+
+static unsigned long cj_eat_white_space(const unsigned char *str, unsigned long len)
+{
+    unsigned long result;
+
+    result = 0;
+
+    for (; str[result] && result < len; )
+    {
+        switch(str[result])
+        {
+        case ' ':
+        case '\t':
+        case '\r':
+        case '\n':
+            result++;
+            break;
+        case '\0':
+        default:
+            goto out;
+        }
+    }
+
+out:
+    return result;
+}
+
+static int cj_is_primitive_char(unsigned char c)
+{
+    return ((c >= '0' && c <= '9') ||
+            (c >= 'a' && c <= 'z') ||
+            (c >= 'A' && c <= 'Z') ||
+            c == '+' || c == '.' || c == '-') ? 1 : 0;
+}
+
+static cj_token_ref cj_alloc_token(cj_ctx *ctx, cj_token **tok)
+{
+    cj_token_ref result;
+
+    result = CJ_INVALID_TOKEN_INDEX;
+
+    if (ctx->tokens_pos < ctx->tokens_size)
+    {
+        CJ_ASSERT((cj_token_ref)ctx->tokens_pos >= 0);
+        result = (cj_token_ref)ctx->tokens_pos;
+        ctx->tokens_pos++;
+
+        *tok = &ctx->tokens[result];
+        (*tok)->type = CJ_TOKEN_INVALID;
+        (*tok)->parent = CJ_INVALID_TOKEN_INDEX;
+    }
+    else
+    {
+        *tok = 0;
+    }
+
+    return result;
+}
+
+enum cj_primitive_state
+{
+    CJ_PRIM_STATE_INIT,
+    CJ_PRIM_STATE_NULL_N,
+    CJ_PRIM_STATE_NULL_U,
+    CJ_PRIM_STATE_NULL_L1,
+    CJ_PRIM_STATE_TRUE_T,
+    CJ_PRIM_STATE_TRUE_R,
+    CJ_PRIM_STATE_TRUE_U,
+    CJ_PRIM_STATE_FALSE_F,
+    CJ_PRIM_STATE_FALSE_A,
+    CJ_PRIM_STATE_FALSE_L,
+    CJ_PRIM_STATE_FALSE_S,
+    CJ_PRIM_STATE_FALSE_E,
+    CJ_PRIM_STATE_NUMBER_SIGN,
+    CJ_PRIM_STATE_NUMBER_INITIAL_ZERO,
+    CJ_PRIM_STATE_NUMBER_DIGIT,
+    CJ_PRIM_STATE_NUMBER_DOT,
+    CJ_PRIM_STATE_NUMBER_FRACT_DIGIT,
+    CJ_PRIM_STATE_NUMBER_EXP_E,
+    CJ_PRIM_STATE_NUMBER_EXP_SIGN,
+    CJ_PRIM_STATE_NUMBER_EXP_DIGIT,
+    CJ_PRIM_STATE_FINISH
+};
+
+static cj_size cj_next_token(const unsigned char *str, cj_size len, cj_size pos, cj_token *tok)
+{
+    int esc;
+    unsigned char ch;
+    enum cj_primitive_state prim_state;
+    enum cj_primitive_state prim_state_next;
+
+    CJ_ASSERT(pos <= len);
+    pos += cj_eat_white_space(&str[pos], len - pos);
+
+    tok->type = CJ_TOKEN_INVALID;
+    tok->pos = pos;
+    tok->len = 0;
+    esc = 0;
+
+    for (;pos < len; pos++)
+    {
+        ch = str[pos];
+
+        if (tok->type == CJ_TOKEN_INVALID)
+        {
+            switch (ch)
+            {
+                case '{': tok->type = CJ_TOKEN_OBJECT_BEG; tok->len = 1; return ++pos;
+                case '}': tok->type = CJ_TOKEN_OBJECT_END; tok->len = 1; return ++pos;
+                case '[': tok->type = CJ_TOKEN_ARRAY_BEG;  tok->len = 1; return ++pos;
+                case ']': tok->type = CJ_TOKEN_ARRAY_END;  tok->len = 1; return ++pos;
+                case ',': tok->type = CJ_TOKEN_ITEM_SEP;   tok->len = 1; return ++pos;
+                case ':': tok->type = CJ_TOKEN_NAME_SEP;   tok->len = 1; return ++pos;
+                case '\"': tok->type = CJ_TOKEN_STRING; tok->pos++; break;
+                default:
+                    break;
+            }
+
+            if (tok->type != CJ_TOKEN_INVALID)
+                continue;
+
+            prim_state = CJ_PRIM_STATE_INIT;
+            tok->type = CJ_TOKEN_PRIMITIVE;
+            tok->len = 0;
+            pos--;
+        }
+        else if (tok->type == CJ_TOKEN_STRING)
+        {
+            if (esc == 0)
+            {
+                if (ch == '\"') /* end of string */
+                    return ++pos;
+
+                if (ch < 0x20) /* needs to be escaped */
+                {
+                    tok->type = CJ_TOKEN_INVALID;
+                    return pos;
+                }
+
+                if (ch == '\\')
+                    esc = 1;
+            }
+            else if (esc == 1)
+            {
+                switch (ch)
+                {
+                case '"':
+                case 'n':
+                case '\\':
+                case '/':
+                case 't':
+                case 'r':
+                case 'b':
+                case 'f':
+                    esc = 0;
+                    break;
+
+                case 'u':
+                    esc = 2;
+                    break;
+
+                default:
+                    tok->type = CJ_TOKEN_INVALID;
+                    return pos;
+                }
+            }
+            else if (esc >= 2)
+            {
+                if ((ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F') || (ch >= '0' && ch <= '9'))
+                {
+                    esc++;
+                    if (esc == 6)
+                        esc = 0;
+                }
+                else
+                {
+                    tok->type = CJ_TOKEN_INVALID;
+                    return pos;
+                }
+            }
+
+            tok->len++;
+        }
+        else if (tok->type == CJ_TOKEN_PRIMITIVE)
+        {
+            prim_state_next = CJ_PRIM_STATE_INIT;
+
+            if (ch == '\0') /* zero terrminator not allowed */
+                goto invalid_primitive;
+
+            switch (prim_state)
+            {
+            case CJ_PRIM_STATE_INIT:
+            {
+                switch (ch)
+                {
+                case 'n': prim_state_next = CJ_PRIM_STATE_NULL_N; break;
+                case 't': prim_state_next = CJ_PRIM_STATE_TRUE_T; break;
+                case 'f': prim_state_next = CJ_PRIM_STATE_FALSE_F; break;
+                case '-': prim_state_next = CJ_PRIM_STATE_NUMBER_SIGN; break;
+                case '0': prim_state_next = CJ_PRIM_STATE_NUMBER_INITIAL_ZERO; break;
+                default:
+                    if (ch >= '1' && ch <= '9')
+                        prim_state_next = CJ_PRIM_STATE_NUMBER_DIGIT;
+                    break;
+                }
+            }
+                break;
+
+            case CJ_PRIM_STATE_NUMBER_SIGN:
+                if      (ch == '0')              prim_state_next = CJ_PRIM_STATE_NUMBER_INITIAL_ZERO;
+                else if (ch >= '1' && ch <= '9') prim_state_next = CJ_PRIM_STATE_NUMBER_DIGIT;
+                break;
+
+            case CJ_PRIM_STATE_NUMBER_DIGIT:
+                if      (ch >= '0' && ch <= '9') prim_state_next = CJ_PRIM_STATE_NUMBER_DIGIT;
+                else if (ch == '.')              prim_state_next = CJ_PRIM_STATE_NUMBER_DOT;
+                else if (ch == 'e' || ch == 'E') prim_state_next = CJ_PRIM_STATE_NUMBER_EXP_E;
+                break;
+
+            case CJ_PRIM_STATE_NUMBER_INITIAL_ZERO:
+                if      (ch == '.')              prim_state_next = CJ_PRIM_STATE_NUMBER_DOT;
+                else if (ch == 'e' || ch == 'E') prim_state_next = CJ_PRIM_STATE_NUMBER_EXP_E;
+                break;
+
+
+            case CJ_PRIM_STATE_NUMBER_DOT:
+                if      (ch >= '0' && ch <= '9') prim_state_next = CJ_PRIM_STATE_NUMBER_FRACT_DIGIT;
+                break;
+
+            case CJ_PRIM_STATE_NUMBER_FRACT_DIGIT:
+                if      (ch >= '0' && ch <= '9') prim_state_next = CJ_PRIM_STATE_NUMBER_FRACT_DIGIT;
+                else if (ch == 'e' || ch == 'E') prim_state_next = CJ_PRIM_STATE_NUMBER_EXP_E;
+                break;
+
+            case CJ_PRIM_STATE_NUMBER_EXP_E:
+                if      (ch >= '0' && ch <= '9') prim_state_next = CJ_PRIM_STATE_NUMBER_EXP_DIGIT;
+                else if (ch == '+' || ch == '-') prim_state_next = CJ_PRIM_STATE_NUMBER_EXP_SIGN;
+                break;
+
+            case CJ_PRIM_STATE_NUMBER_EXP_SIGN:
+                if      (ch >= '0' && ch <= '9') prim_state_next = CJ_PRIM_STATE_NUMBER_EXP_DIGIT;
+                break;
+
+            case CJ_PRIM_STATE_NUMBER_EXP_DIGIT:
+                if      (ch >= '0' && ch <= '9') prim_state_next = CJ_PRIM_STATE_NUMBER_EXP_DIGIT;
+                break;
+
+            case CJ_PRIM_STATE_NULL_N:  if (ch == 'u') prim_state_next = CJ_PRIM_STATE_NULL_U; break;
+            case CJ_PRIM_STATE_NULL_U:  if (ch == 'l') prim_state_next = CJ_PRIM_STATE_NULL_L1; break;
+            case CJ_PRIM_STATE_NULL_L1: if (ch == 'l') prim_state_next = CJ_PRIM_STATE_FINISH; break;
+
+            case CJ_PRIM_STATE_TRUE_T:  if (ch == 'r') prim_state_next = CJ_PRIM_STATE_TRUE_R; break;
+            case CJ_PRIM_STATE_TRUE_R:  if (ch == 'u') prim_state_next = CJ_PRIM_STATE_TRUE_U; break;
+            case CJ_PRIM_STATE_TRUE_U:  if (ch == 'e') prim_state_next = CJ_PRIM_STATE_FINISH; break;
+
+            case CJ_PRIM_STATE_FALSE_F:  if (ch == 'a') prim_state_next = CJ_PRIM_STATE_FALSE_A; break;
+            case CJ_PRIM_STATE_FALSE_A:  if (ch == 'l') prim_state_next = CJ_PRIM_STATE_FALSE_L; break;
+            case CJ_PRIM_STATE_FALSE_L:  if (ch == 's') prim_state_next = CJ_PRIM_STATE_FALSE_S; break;
+            case CJ_PRIM_STATE_FALSE_S:  if (ch == 'e') prim_state_next = CJ_PRIM_STATE_FINISH; break;
+
+            default:
+                break;
+            }
+
+            if (prim_state_next == CJ_PRIM_STATE_INIT)
+            {
+                switch (prim_state) /* test valid end states */
+                {
+                case CJ_PRIM_STATE_NUMBER_EXP_DIGIT:
+                case CJ_PRIM_STATE_NUMBER_FRACT_DIGIT:
+                case CJ_PRIM_STATE_NUMBER_INITIAL_ZERO:
+                case CJ_PRIM_STATE_NUMBER_DIGIT:
+                    return pos;
+                    break;
+
+                default:
+                    goto invalid_primitive;
+                }
+            }
+
+            tok->len++;
+            if (prim_state_next == CJ_PRIM_STATE_FINISH)
+                return ++pos;
+
+            prim_state = prim_state_next;
+            continue;
+
+invalid_primitive:
+            tok->type = CJ_TOKEN_INVALID;
+            break;
+        }
+        else
+        {
+            break;
+        }
+    }
+
+    /* string end is detected above and returns */
+    if (tok->type == CJ_TOKEN_STRING)
+        tok->type = CJ_TOKEN_INVALID;
+
+    return pos;
+}
+
+static void cj_trim_trailing_whitespace(cj_ctx *ctx)
+{
+    for (;ctx->size > 0;)
+    {
+        switch(ctx->buf[ctx->size - 1])
+        {
+        case ' ':
+        case '\t':
+        case '\r':
+        case '\n':
+            ctx->size--;
+            break;
+        default:
+            return;
+        }
+    }
+}
+
+void cj_parse_init(cj_ctx *ctx, const char *json, cj_size len,
+                   cj_token *tokens, cj_size tokens_size)
+{
+    if (!ctx)
+        return;
+
+    ctx->buf = (const unsigned char*)json;
+    ctx->pos = 0;
+    ctx->size = len;
+
+    ctx->tokens = tokens;
+    ctx->tokens_pos = 0;
+    ctx->tokens_size = tokens_size;
+
+    if (!json || len == 0 || !tokens || tokens_size < 8)
+        ctx->status = CJ_ERROR;
+    else
+        ctx->status = CJ_OK;
+}
+
+void cj_parse(cj_ctx *ctx)
+{
+    int obj_depth;
+    int arr_depth;
+    cj_size pos;
+    unsigned ncommas;
+    unsigned ncolons;
+    cj_size nstructures;
+    cj_token_ref tok_index;
+    cj_token_ref tok_parent;
+    cj_token *tok;
+    const unsigned char *p;
+
+    if (!ctx || ctx->status != CJ_OK)
+        return;
+
+    ctx->status = cj_is_valid_utf8(ctx->buf, ctx->size);
+    if (ctx->status != CJ_OK)
+        return;
+
+    cj_trim_trailing_whitespace(ctx);
+
+    /* to track valid objects */
+    ncolons = 0;
+    ncommas = 0;
+
+    nstructures = 0;
+    obj_depth = 0;
+    arr_depth = 0;
+    pos = 0;
+    p = ctx->buf;
+    tok_parent = CJ_INVALID_TOKEN_INDEX;
+
+    do
+    {
+        tok_index = cj_alloc_token(ctx, &tok);
+        if (tok_index == CJ_INVALID_TOKEN_INDEX || tok == 0)
+        {
+            ctx->status = CJ_PARSE_TOKENS_EXHAUSTED;
+            break;
+        }
+
+        pos = cj_next_token(p, ctx->size, pos, tok);
+
+        if (tok->type == CJ_TOKEN_INVALID)
+        {
+            ctx->status = CJ_PARSE_INVALID_TOKEN;
+            break;
+        }
+
+        tok->parent = tok_parent;
+        CJ_ASSERT(tok->parent == CJ_INVALID_TOKEN_INDEX || tok->parent < ctx->tokens_pos);
+
+        if (tok->type == CJ_TOKEN_OBJECT_BEG)
+        {
+            if (ctx->tokens_pos > 1 && arr_depth == 0 && obj_depth == 0)
+            {
+                ctx->status = CJ_PARSE_MULTI_TOP_THINGS;
+                break;
+            }
+            nstructures++;
+            obj_depth++;
+            tok_parent = tok_index;
+            CJ_ASSERT(tok_parent < ctx->tokens_pos);
+        }
+        else if (tok->type == CJ_TOKEN_ARRAY_BEG)
+        {
+            if (ctx->tokens_pos > 1 && arr_depth == 0 && obj_depth == 0)
+            {
+                ctx->status = CJ_PARSE_MULTI_TOP_THINGS;
+                break;
+            }
+            nstructures++;
+            arr_depth++;
+            tok_parent = tok_index;
+            CJ_ASSERT(tok_parent < ctx->tokens_pos);
+        }
+        else if (tok->type == CJ_TOKEN_OBJECT_END)
+        {
+            obj_depth--;
+            if (obj_depth < 0 || tok_index < 1)
+            {
+                ctx->status = CJ_PARSE_PARENT_CLOSING;
+                break;
+            }
+
+            CJ_ASSERT(tok->parent < ctx->tokens_pos);
+            tok_parent = ctx->tokens[tok->parent].parent;
+            tok->parent = tok_parent;
+            CJ_ASSERT(tok->parent == CJ_INVALID_TOKEN_INDEX || tok_parent < ctx->tokens_pos);
+        }
+        else if (tok->type == CJ_TOKEN_ARRAY_END)
+        {
+            arr_depth--;
+            if (arr_depth < 0 || tok_index < 1)
+            {
+                ctx->status = CJ_PARSE_PARENT_CLOSING;
+                break;
+            }
+            CJ_ASSERT(tok->parent < ctx->tokens_pos);
+            tok_parent = ctx->tokens[tok->parent].parent;
+            tok->parent = tok_parent;
+            CJ_ASSERT(tok->parent == CJ_INVALID_TOKEN_INDEX || tok_parent < ctx->tokens_pos);
+        }
+
+#if 0
+        if (tok->type == CJ_TOKEN_STRING || tok->type == CJ_TOKEN_PRIMITIVE)
+        {
+            printf("JSON TOKEN[%d] (%c) pos: %u, len: %u, parent: %d, obj_depth: %d, arr_depth: %d, %.*s\n",
+                tok_index, (char)tok->type, tok->pos, tok->len, tok->parent, obj_depth, arr_depth,
+                tok->len, &ctx->buf[tok->pos]);
+        }
+        else
+        {
+            printf("JSON TOKEN[%d] (%c) pos: %u, len: %u, parent: %d, obj_depth: %d, arr_depth: %d\n",
+                tok_index, (char)tok->type, tok->pos, tok->len, tok->parent, obj_depth, arr_depth);
+        }
+#endif
+
+        if (tok->type == CJ_TOKEN_NAME_SEP)
+        {
+            if (tok_index < 2 || tok->parent == CJ_INVALID_TOKEN_INDEX || tok[-1].type != CJ_TOKEN_STRING)
+            {
+                ctx->status = CJ_PARSE_INVALID_TOKEN;
+                break;
+            }
+
+            if (ctx->tokens[tok->parent].type != CJ_TOKEN_OBJECT_BEG)
+            {
+                ctx->status = CJ_PARSE_INVALID_TOKEN;
+                break;
+            }
+            ncolons++;
+        }
+
+        if (tok->type == CJ_TOKEN_ITEM_SEP)
+        {
+            if (tok_index < 2 || tok->parent == CJ_INVALID_TOKEN_INDEX ||
+                tok[-1].type == CJ_TOKEN_OBJECT_BEG || tok[-1].type == CJ_TOKEN_ARRAY_BEG)
+            {
+                ctx->status = CJ_PARSE_INVALID_TOKEN;
+                break;
+            }
+
+            if (ctx->tokens[tok->parent].type == CJ_TOKEN_OBJECT_BEG)
+            {
+                ncommas++;
+            }
+        }
+
+        if (tok_index >= 1)
+        {
+            if (tok[-1].type == CJ_TOKEN_NAME_SEP &&
+                !(tok->type == CJ_TOKEN_STRING ||
+                  tok->type == CJ_TOKEN_PRIMITIVE ||
+                  tok->type == CJ_TOKEN_OBJECT_BEG ||
+                  tok->type == CJ_TOKEN_ARRAY_BEG))
+            {
+                ctx->status = CJ_PARSE_INVALID_TOKEN;
+                break;
+            }
+
+            if (tok[-1].type == CJ_TOKEN_ITEM_SEP &&
+                !(tok->type == CJ_TOKEN_STRING ||
+                  tok->type == CJ_TOKEN_PRIMITIVE ||
+                  tok->type == CJ_TOKEN_OBJECT_BEG ||
+                  tok->type == CJ_TOKEN_ARRAY_BEG))
+            {
+                pos = tok[-1].pos;
+                ctx->status = CJ_PARSE_INVALID_TOKEN;
+                break;
+            }
+
+            if (tok[-1].type == CJ_TOKEN_PRIMITIVE &&
+                !(tok->type == CJ_TOKEN_ITEM_SEP ||
+                  tok->type == CJ_TOKEN_OBJECT_END ||
+                  tok->type == CJ_TOKEN_ARRAY_END))
+            {
+                ctx->status = CJ_PARSE_INVALID_TOKEN;
+                break;
+            }
+
+            if (tok[-1].type == CJ_TOKEN_STRING &&
+                !(tok->type == CJ_TOKEN_ITEM_SEP ||
+                  tok->type == CJ_TOKEN_NAME_SEP ||
+                  tok->type == CJ_TOKEN_OBJECT_END ||
+                  tok->type == CJ_TOKEN_ARRAY_END))
+            {
+                ctx->status = CJ_PARSE_INVALID_TOKEN;
+                break;
+            }
+        }
+    }
+    while (pos < ctx->size);
+
+    ctx->pos = pos;
+
+    if (ctx->status == CJ_OK)
+    {
+        if (obj_depth != 0 || arr_depth != 0)
+        {
+            ctx->status = CJ_PARSE_PARENT_CLOSING;
+        }
+        else if (nstructures > 0)
+        {
+            tok = &ctx->tokens[ctx->tokens_pos - 1];
+            if (tok->type != CJ_TOKEN_OBJECT_END && tok->type != CJ_TOKEN_ARRAY_END)
+            {
+                ctx->status = CJ_PARSE_INVALID_TOKEN;
+            }
+            else if (ncommas && ncommas >= ncolons)
+            {
+                ctx->status = CJ_PARSE_INVALID_OBJECT;
+            }
+        }
+    }
+}
+
+cj_token_ref cj_value_ref(cj_ctx *ctx, cj_token_ref obj, const char *key)
+{
+    cj_token_ref i;
+    unsigned k;
+    unsigned len;
+    cj_token_ref result;
+    cj_token *tok;
+
+    result = CJ_INVALID_TOKEN_INDEX;
+
+    if (!ctx || ctx->status != CJ_OK || !key)
+        return result;
+
+    if (obj < 0 || obj >= (cj_token_ref)ctx->tokens_pos)
+        return result;
+
+    for (len = 0; key[len]; len++)
+    {}
+
+    for (i = obj + 1; i < (cj_token_ref)ctx->tokens_pos; i++)
+    {
+        tok = &ctx->tokens[i];
+        if (tok->type != CJ_TOKEN_NAME_SEP)
+            continue;
+
+        tok = &tok[-1];
+
+        if (tok->parent != obj)
+            continue;
+
+        if (tok->len != len)
+            continue;
+
+        for (k = 0; k < len; k++)
+        {
+            if (ctx->buf[tok->pos + k] != (unsigned char)key[k])
+                break;
+        }
+
+        if (k == len)
+        {
+            result = i + 1;
+            break;
+        }
+    }
+
+    return result;
+}
+
+int cj_copy_value(cj_ctx *ctx, char *buf, unsigned size, cj_token_ref obj, const char *key)
+{
+    cj_size i;
+    cj_token_ref ref;
+    cj_token *tok;
+    unsigned char *out;
+
+    out = (unsigned char*)buf;
+    out[0] = '\0';
+    ref = cj_value_ref(ctx, obj, key);
+
+    if (ref >= 0 && ref < (cj_token_ref)ctx->tokens_pos)
+    {
+        tok = &ctx->tokens[ref];
+        if (tok->len < size)
+        {
+            for (i = 0; i < tok->len; i++)
+                out[i] = ctx->buf[tok->pos + i];
+            out[tok->len] = '\0';
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+int cj_copy_ref(cj_ctx *ctx, char *buf, unsigned size, cj_token_ref ref)
+{
+    unsigned i;
+    cj_token *tok;
+    unsigned char *out;
+
+    out = (unsigned char*)buf;
+    out[0] = '\0';
+
+    if (ref >= 0 && ref < (cj_token_ref)ctx->tokens_pos)
+    {
+        tok = &ctx->tokens[ref];
+        if (tok->len < size)
+        {
+            for (i = 0; i < tok->len; i++)
+                out[i] = ctx->buf[tok->pos + i];
+            out[tok->len] = '\0';
+            return 1;
+        }
+    }
+
+    return 0;
+}

--- a/cj/cj.h
+++ b/cj/cj.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2023 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ */
+
+#ifndef _CJSON_H
+#define _CJSON_H
+
+#ifdef CJ_USE_64BIT_SIZE_T
+  #ifdef __LP64__
+    typedef unsigned long cj_size;
+  #endif
+
+  #ifndef __LP64__ /* needs at least C99 and C++11 */
+    typedef unsigned long long cj_size;
+  #endif
+#else /* 32-bit (default) */
+  #ifdef __LP64__
+    typedef unsigned cj_size;
+  #endif
+
+  #ifndef __LP64__
+      typedef unsigned long cj_size;
+  #endif
+#endif
+
+#define CJ_INVALID_TOKEN_INDEX ((cj_size)~0)
+
+typedef cj_size cj_token_ref;
+
+typedef enum cj_status
+{
+    CJ_OK                     = 0,
+    CJ_ERROR                  = 1,
+    CJ_INVALID_UTF8           = 2,
+    CJ_PARSE_TOKENS_EXHAUSTED = 3,
+    CJ_PARSE_PARENT_CLOSING   = 4,
+    CJ_PARSE_INVALID_TOKEN    = 5,
+    CJ_PARSE_INVALID_OBJECT   = 6,
+    CJ_PARSE_MULTI_TOP_THINGS = 7
+} cj_status;
+
+typedef enum cj_token_type
+{
+    CJ_TOKEN_INVALID    = 'i',
+    CJ_TOKEN_STRING     = 'S',
+    CJ_TOKEN_PRIMITIVE  = 'P',
+    CJ_TOKEN_ARRAY_BEG  = '[',
+    CJ_TOKEN_ARRAY_END  = ']',
+    CJ_TOKEN_OBJECT_BEG = '{',
+    CJ_TOKEN_OBJECT_END = '}',
+    CJ_TOKEN_ITEM_SEP   = ',',
+    CJ_TOKEN_NAME_SEP   = ':'
+} cj_token_type;
+
+typedef struct cj_token
+{
+    cj_token_type type;
+    cj_size pos; /* position in JSON string */
+    cj_size len; /* length of the token in bytes */
+    cj_token_ref parent;
+} cj_token;
+
+typedef struct cj_ctx
+{
+    /* input JSON */
+    const unsigned char *buf;
+    cj_size pos;
+    cj_size size;
+
+    /* parse */
+    cj_token *tokens;
+    cj_size tokens_pos;
+    cj_size tokens_size;
+
+    cj_status status;
+} cj_ctx;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Initialize the parse context.
+ *
+ * \param ctx the CJ context.
+ * \param json a JSON string.
+ * \param len strlen of the JSON string.
+ * \param tokens an array of tokens which can be filled by the parser.
+ * \param tokens_size count of tokens.
+ */
+void cj_parse_init(cj_ctx *ctx, const char *json, cj_size len, cj_token *tokens, cj_size tokens_size);
+
+/** Parses the formerly initialzed context.
+ *
+ * \param ctx the CJ context.
+ * \return ctx->status as result
+ */
+void cj_parse(cj_ctx *ctx);
+
+/** Get the token reference of a key in an object.
+ *
+ * \param ctx the CJ context.
+ * \param obj the token reference of the parent object.
+ * \param key the key to find.
+ *
+ * \return a valid token reference on success
+ *         CJ_INVALID_TOKEN_INDEX on failure
+ */
+cj_token_ref cj_value_ref(cj_ctx *ctx, cj_token_ref obj, const char *key);
+
+/** Copy the value of an object key as string into a buffer.
+ *
+ * \param ctx the CJ context.
+ * \param buf destination buffer.
+ * \param size size of the destination buffer.
+ * \param obj the token reference of the parent object.
+ * \param key the key of the value.
+ *
+ * \return 1 on success
+ *         0 on failure
+ */
+int cj_copy_value(cj_ctx *ctx, char *buf, unsigned size, cj_token_ref obj, const char *key);
+
+/** Copy the value of a token as string into a buffer.
+ *
+ * \param ctx the CJ context.
+ * \param buf destination buffer.
+ * \param size size of the destination buffer.
+ * \param ref the token reference of the value.
+ *
+ * \return 1 on success
+ *         0 on failure
+ */
+int cj_copy_ref(cj_ctx *ctx, char *buf, unsigned size, cj_token_ref ref);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _CJSON_H */

--- a/cj/cj_all.c
+++ b/cj/cj_all.c
@@ -1,0 +1,10 @@
+/*
+ * CJ combined with extra modules
+ */
+
+#include "cj.c"
+#include "extra/cj_copy_ref_utf8.c"
+#include "extra/cj_ref_to_boolean.c"
+#include "extra/cj_ref_to_double.c"
+#include "extra/cj_ref_to_long.c"
+#include "extra/cj_ref_to_null.c"

--- a/cj/extra/cj_copy_ref_utf8.c
+++ b/cj/extra/cj_copy_ref_utf8.c
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2023 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ */
+
+enum cj_unicode_state
+{
+    CJ_UC_STATE_NONE,
+    CJ_UC_STATE_ESC,
+    CJ_UC_STATE_NUM0,
+    CJ_UC_STATE_NUM1,
+    CJ_UC_STATE_NUM2,
+    CJ_UC_STATE_NUM3,
+    CJ_UC_STATE_CHK_NUM
+};
+
+/* The buffer must be of size 5, the string gets zero terminated.
+*/
+int cj_unicode_to_utf8(unsigned long codepoint, unsigned char *buf, cj_size size)
+{
+    if (codepoint <= 0x7F && size > 1)
+    {
+        /* 1-byte ASCII */
+        buf[0] = (char)codepoint;
+        buf[1] = '\0';
+        return 1;
+    }
+
+    if (codepoint > 0x10FFFF)
+        codepoint = 0xFFFD; /* codepoint replacement character */
+
+    if (codepoint >= 0x80 && codepoint <= 0x7FF && size > 2) /*  110 prefix 2-byte char */
+    {
+        buf[1] = 0x80 | (codepoint & 0x3F);
+        codepoint >>= 6;
+        buf[0] = 0xC0 | (codepoint & 0x1F);
+        buf[2] = '\0';
+        return 2;
+    }
+    else if (codepoint >= 0x800 && codepoint <= 0xFFFF && size > 3) /*  1110 prefix 3-byte char */
+    {
+        /* 1110xxxx 10xxxxxx 10xxxxxx */
+        buf[2] = 0x80 | (codepoint & 0x3F);
+        codepoint >>= 6;
+        buf[1] = 0x80 | (codepoint & 0x3F);
+        codepoint >>= 6;
+        buf[0] = 0xE0 | (codepoint & 0x0F);
+        buf[3] = '\0';
+        return 3;
+    }
+    else if (codepoint >= 0x10000 && codepoint <= 0x10FFFF && size > 4) /*  11110 prefix 4-byte char */
+    {
+        /* 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx */
+        buf[3] = 0x80 | (codepoint & 0x3F);
+        codepoint >>= 6;
+        buf[2] = 0x80 | (codepoint & 0x3F);
+        codepoint >>= 6;
+        buf[1] = 0x80 | (codepoint & 0x3F);
+        codepoint >>= 6;
+        buf[0] = 0xF0 | (codepoint & 0x07);
+        buf[4] = '\0';
+        return 4;
+    }
+
+    return 0;
+}
+
+/** Copy the value of a token as UTF-8 string into a buffer.
+ *
+ * Values that are escaped as UTF-16 \uXXXX or surrogate pair
+ * \uXXXX\uXXXX will be converted to UTF-8 representation.
+ *
+ * Surrogate paires are verified to be complete.
+ *
+ * \param ctx the CJ context.
+ * \param buf destination buffer.
+ * \param size size of the destination buffer.
+ * \param ref the token reference of the value.
+ *
+ * \return 1 on success
+ *         0 on failure
+ */
+int cj_copy_ref_utf8(cj_ctx *ctx, char *buf, unsigned size, cj_token_ref ref)
+{
+    int n;
+    unsigned i;
+    cj_token *tok;
+    const unsigned char *ch;
+    unsigned char *wr;
+    const unsigned char *wr_end;
+    enum cj_unicode_state state;
+    int need_low_surrogate;
+    unsigned long c;
+    unsigned long num0;
+    unsigned long high_surrogate;
+
+    if (size)
+        buf[0] = '\0';
+
+    if (size > 1 && ref >= 0 && ref < (cj_token_ref)ctx->tokens_pos)
+    {
+        tok = &ctx->tokens[ref];
+
+        if (tok->type != CJ_TOKEN_STRING)
+            return cj_copy_ref(ctx, buf, size, ref);
+
+        num0 = 0;
+        high_surrogate = 0;
+        need_low_surrogate = 0;
+        ch = &ctx->buf[tok->pos];
+        state = CJ_UC_STATE_NONE;
+        wr = (unsigned char*)buf;
+        wr_end = wr + size;
+
+        for (i = 0; i < tok->len; i++, ch++)
+        {
+            if ((wr_end - wr) == 1) /* not enough space to copy more and '\0' */
+                goto err;
+
+            c = *ch;
+
+            switch (state)
+            {
+            case CJ_UC_STATE_NONE:
+                if (c == '\\') state = CJ_UC_STATE_ESC;
+                else           *wr++ = c;
+                break;
+
+            case CJ_UC_STATE_ESC:
+                if (c == 'u')
+                    state = CJ_UC_STATE_NUM0;
+                else /* not an unicode escape */
+                {
+                    switch (c)
+                    {
+                    case 'n':  *wr++ = '\n'; break;
+                    case '"':  *wr++ = '"';  break;
+                    case '\\': *wr++ = '\\'; break;
+                    case 't':  *wr++ = '\t'; break;
+                    case '/':  *wr++ = '/';  break;
+                    case 'r':  *wr++ = 'r';  break;
+                    case 'b':  *wr++ = 'b';  break;
+                    case 'f':  *wr++ = 'f';  break;
+                    default:
+                        goto err; /* unsupported escaped character */
+                    }
+                    state = CJ_UC_STATE_NONE;
+                }
+                break;
+
+            case CJ_UC_STATE_NUM0:
+            case CJ_UC_STATE_NUM1:
+            case CJ_UC_STATE_NUM2:
+            case CJ_UC_STATE_NUM3: /* fall through */
+                if      (c >= 'a' && c <= 'f') c = c - 'a' + 10; /* 10..15 */
+                else if (c >= 'A' && c <= 'F') c = c - 'A' + 10; /* 10..15 */
+                else if (c >= '0' && c <= '9') c = c - '0';      /*  0..9  */
+                else goto err;
+
+                num0 <<= 4;
+                num0 |= c;
+                state = (enum cj_unicode_state)((int)state + 1);
+                /* if we are the last char in sequence fall through! */
+                if (state != CJ_UC_STATE_CHK_NUM)
+                    break;
+
+            case CJ_UC_STATE_CHK_NUM:
+                {
+                    if (need_low_surrogate == 0)
+                    {
+                        if (num0 >= 0xDC00 && num0 <= 0xDFFF)
+                            goto err; /* isolated low-surrogate is invalid */
+
+                        if (num0 >= 0xD800 && num0 <= 0xDBFF)
+                        {
+                            need_low_surrogate = 1;
+                            high_surrogate = (num0 - 0xD800) * 0x400;
+
+                            if ((tok->len - i) < 6 || ch[1] != '\\' || ch[2] != 'u')
+                                goto err; /* low-surrogate must be next */
+                        }
+                    }
+                    else
+                    {
+                        if (num0 < 0xDC00 || num0 > 0xDFFF)
+                            goto err;
+
+                        num0 -= 0xDC00;
+                        num0 = high_surrogate + num0 + 0x10000;
+                        need_low_surrogate = 0;
+                    }
+
+                    if (need_low_surrogate == 0)
+                    {
+                        n = cj_unicode_to_utf8(num0, wr, wr_end - wr);
+                        if (n == 0)
+                            goto err;
+                        wr += n;
+                    }
+
+                    num0 = 0;
+                    state = CJ_UC_STATE_NONE;
+                }
+                break;
+
+            default:
+                goto err; /* should never happen */
+            }
+        }
+    }
+    else
+    {
+        goto err;
+    }
+
+    if (wr < wr_end)
+        *wr = '\0';
+
+    if (state != CJ_UC_STATE_NONE)
+        goto err;
+
+    return 1;
+
+err:
+    if (size)
+        buf[0] = '\0';
+    return 0;
+}

--- a/cj/extra/cj_ref_to_boolean.c
+++ b/cj/extra/cj_ref_to_boolean.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ */
+
+/** Converts a JSON token reference to boolean.
+ *
+ * \param ctx the CJ context.
+ * \param result pointer: set to 1 for true and 0 for false.
+ * \param ref the token reference of the value.
+ *
+ * \return 1 on success
+ *         0 on failure
+ */
+int cj_ref_to_boolean(cj_ctx *ctx, int *result, cj_token_ref ref)
+{
+    cj_token *tok;
+    const char *p;
+
+    if (result && ref >= 0 && ref < (cj_token_ref)ctx->tokens_pos)
+    {
+        tok = &ctx->tokens[ref];
+        if (tok->type != CJ_TOKEN_PRIMITIVE)
+            return 0;
+
+        p = (const char*)&ctx->buf[tok->pos];
+        if (tok->len == 4 && p[0] == 't' && p[1] == 'r' && p[2] == 'u' && p[3] == 'e')
+        {
+            *result = 1;
+            return 1;
+        }
+        else if (tok->len == 5 && p[0] == 'f' && p[1] == 'a' && p[2] == 'l' && p[3] == 's' && p[4] == 'e')
+        {
+            *result = 0;
+            return 1;
+        }
+        else
+        {
+            *result = 0;
+            return 0; /* not a JSON boolean */
+        }
+    }
+
+    return 0;
+}

--- a/cj/extra/cj_ref_to_double.c
+++ b/cj/extra/cj_ref_to_double.c
@@ -1,0 +1,169 @@
+/* custom pow() */
+static double cj_pow_helper(double base, int exponent)
+{
+    int i;
+    int count;
+    double result;
+
+    count = exponent < 0 ? -exponent : exponent;
+
+    result = 1.0;
+
+    if (exponent < 0)
+        base = 1.0 / base;
+
+    for (i = 0; i < count; i++)
+        result *= base;
+
+    return result;
+}
+
+/** Converts a floating point number string to double.
+ *
+ * The err variable is a bitmap:
+ *
+ *   0x01 invalid input
+ *
+ * \param s pointer to string, doesn't have to be '\0' terminated.
+ * \param len length of s ala strlen(s).
+ * \param endp pointer which will be set to first non 0-9 character (must NOT be NULL).
+ * \param err pointer to error variable (must NOT be NULL).
+ *
+ * \return If the conversion is successful the number is returned and err set to 0.
+ *         On failure err has a non zero value.
+ */
+static double cj_strtod(const char *str, unsigned len, const char **endp, int *err)
+{
+    int sign;
+    int exponent;
+    int exp_sign;
+    int exp_num;
+    int decimal_places;
+    double num;
+    int required;
+
+    sign = 1;
+    exponent = 0;
+    exp_sign = 1;
+    exp_num = 0;
+    decimal_places = 0;
+    num = 0.0;
+    required = 0;
+
+    /* skip whitespace */
+    while (len && (*str == ' ' || *str == '\t'))
+    {
+        str++;
+        len--;
+    }
+
+    if (len)
+    {
+        if (*str == '-')
+        {
+            sign = -1;
+            str++;
+            len--;
+        }
+        else if (*str == '+')
+        {
+            str++;
+            len--;
+        }
+    }
+
+    /* integer part */
+    while (len && *str >= '0' && *str <= '9')
+    {
+        required = 1;
+        num = num * 10 + (*str - '0');
+        str++;
+        len--;
+    }
+
+    /* decimal part */
+    if (len && *str == '.')
+    {
+        str++;
+        len--;
+        while (len && *str >= '0' && *str <= '9')
+        {
+            required = 1;
+            num = num * 10 + (*str - '0');
+            decimal_places++;
+            str++;
+            len--;
+        }
+    }
+
+    /* handle exponent */
+    if (len && (*str == 'e' || *str == 'E'))
+    {
+        str++;
+        len--;
+        if (len)
+        {
+            if (*str == '-')
+            {
+                exp_sign = -1;
+                str++;
+                len--;
+            }
+            else if (*str == '+')
+            {
+                str++;
+                len--;
+            }
+        }
+
+        while (len && *str >= '0' && *str <= '9')
+        {
+            exp_num = exp_num * 10 + (*str - '0');
+            str++;
+            len--;
+        }
+        exponent = exp_sign * exp_num;
+    }
+
+    /* calculate final result */
+    num *= cj_pow_helper(10.0, exponent);
+    num /= cj_pow_helper(10.0, decimal_places);
+
+    *endp = str;
+    *err = required == 0 ? 1 : 0;
+
+    return sign * num;
+}
+
+/** Converts a JSON token reference to double.
+ *
+ * \param ctx the CJ context.
+ * \param result pointer to result double variable.
+ * \param ref the token reference of the value.
+ *
+ * \return 1 on success
+ *         0 on failure
+ */
+int cj_ref_to_double(cj_ctx *ctx, double *result, cj_token_ref ref)
+{
+    int err;
+    cj_token *tok;
+    const char *p;
+    const char *endptr;
+
+    if (result && ref >= 0 && ref < (cj_token_ref)ctx->tokens_pos)
+    {
+        tok = &ctx->tokens[ref];
+        if (tok->type != CJ_TOKEN_PRIMITIVE || tok->len == 0)
+            return 0;
+
+        p = (const char*)&ctx->buf[tok->pos];
+
+        *result = cj_strtod(p, tok->len, &endptr, &err);
+        if (endptr == p + tok->len && err == 0)
+            return 1;
+    }
+
+    return 0;
+}
+

--- a/cj/extra/cj_ref_to_long.c
+++ b/cj/extra/cj_ref_to_long.c
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2023 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ */
+
+/** Converts a base 10 number string to signed long.
+ *
+ * This is a naive potentially slow function (no use of libc).
+ *
+ * Depending on sizeof(long) 4/8 the valid numeric range is:
+ *
+ *   32-bit: -2147483648 ... 2147483647
+ *   64-bit: -9223372036854775808 ... 9223372036854775807
+ *
+ * The err variable is a bitmap:
+ *
+ *   0x01 invalid input
+ *   0x02 range overflow
+ *   0x04 range underflow
+ *
+ * \param s pointer to string, doesn't have to be '\0' terminated.
+ * \param len length of s ala strlen(s).
+ * \param endp pointer which will be set to first non 0-9 character (must NOT be NULL).
+ * \param err pointer to error variable (must NOT be NULL).
+ *
+ * \return If the conversion is successful the number is returned and err set to 0.
+ *         On failure err has a non zero value.
+ */
+long cj_parse_long(const char *s, cj_size len, const char **endp, int *err)
+{
+    int i;
+    int e;
+    long ch;
+    unsigned long max;
+    unsigned long result;
+
+    e = 0;
+    ch = 0;
+    result = 0;
+
+    max = ~0;
+    max >>= 1;
+
+    if (len == 0)
+    {
+        *err = 1;
+        *endp = s;
+        return 0;
+    }
+
+    i = *s == '-' ? 1 : 0;
+
+    for (; i < len; i++)
+    {
+        ch = s[i];
+        if (ch < '0' || ch > '9')
+            break;
+
+        ch = ch - '0';
+        e |= (result * 10 + ch < result) ? 2 : 0; /* overflow */
+        result *= 10;
+
+        result += ch;
+    }
+
+    if      (i == 1 && *s == '-') e |= 1;
+    else if (i == 0)              e |= 1;
+
+    if (result > max)
+    {
+        if      (*s != '-')           e |= 2; /* overflow */
+        else if (result > max + 1)    e |= 4; /* underflow */
+    }
+
+    *endp = &s[i];
+    *err = e;
+
+    if (*s == '-')
+        return -(long)result;
+
+    return (long)result;
+}
+
+/** Converts a JSON token reference to signed long.
+ *
+ * This is NOT using libc but a custom implementation.
+ *
+ * Note depending on the architecture long is either 32-bit
+ * or 64-bit with sizeof(long) either 4 or 8. The numeric
+ * range therefore varies by this.
+ *
+ * If the conversion ends up in overflow or underflow,
+ * 0 is returned with an error bitmap in result:
+ *
+ *   0x01 invalid input
+ *   0x02 range overflow
+ *   0x04 range underflow
+ *
+ * \param ctx the CJ context.
+ * \param result pointer to result long variable.
+ * \param ref the token reference of the value.
+ *
+ * \return 1 on success
+ *         0 on failure
+ */
+int cj_ref_to_long(cj_ctx *ctx, long *result, cj_token_ref ref)
+{
+    int err;
+    long conv;
+    cj_token *tok;
+    const char *p;
+    const char *endptr;
+
+    if (result && ref >= 0 && ref < (cj_token_ref)ctx->tokens_pos)
+    {
+        tok = &ctx->tokens[ref];
+        if (tok->type != CJ_TOKEN_PRIMITIVE || tok->len == 0)
+            return 0;
+
+        p = (const char*)&ctx->buf[tok->pos];
+
+        conv = cj_parse_long(p, tok->len, &endptr, &err);
+
+        if (err)
+        {
+            *result = err;
+            return 0;
+        }
+
+        if (endptr == p + tok->len)
+        {
+            *result = conv;
+            return 1;
+        }
+    }
+
+    return 0;
+}

--- a/cj/extra/cj_ref_to_null.c
+++ b/cj/extra/cj_ref_to_null.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ */
+
+/** Tests if JSON token reference is null.
+ *
+ * \param ctx the CJ context.
+ * \param ref the token reference of the value.
+ *
+ * \return 1 on success the token is 'null'
+ *         0 on failure
+ */
+int cj_ref_to_null(cj_ctx *ctx, cj_token_ref ref)
+{
+    cj_token *tok;
+    const char *p;
+
+    if (ref >= 0 && ref < (cj_token_ref)ctx->tokens_pos)
+    {
+        tok = &ctx->tokens[ref];
+        if (tok->type != CJ_TOKEN_PRIMITIVE)
+            return 0;
+
+        p = (const char*)&ctx->buf[tok->pos];
+        if (tok->len == 4 && p[0] == 'n' && p[1] == 'u' && p[2] == 'l' && p[3] == 'l')
+            return 1;
+    }
+
+    return 0;
+}

--- a/json.h
+++ b/json.h
@@ -1,5 +1,11 @@
-/**
- * \file json.h
+/*
+ * Copyright (c) 2013-2024 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
  */
 
 #ifndef JSON_H
@@ -7,6 +13,29 @@
 
 #include <QVariant>
 #include <QString>
+
+/* CJ
+ * Low level JSON module
+ */
+#include "cj/cj.h"
+
+/*
+ * CJ extra modules, have no header thus declare protoypes here.
+ */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int cj_copy_ref_utf8(cj_ctx *ctx, char *buf, unsigned size, cj_token_ref ref);
+int cj_ref_to_boolean(cj_ctx *ctx, int *result, cj_token_ref ref);
+int cj_ref_to_double(cj_ctx *ctx, double *result, cj_token_ref ref);
+int cj_ref_to_long(cj_ctx *ctx, long *result, cj_token_ref ref);
+int cj_ref_to_null(cj_ctx *ctx, cj_token_ref ref);
+
+#ifdef __cplusplus
+}
+#endif
+
 
 /**
  * \enum JsonToken
@@ -165,6 +194,31 @@ class Json
 		 * \return int The next JSON token
 		 */
 		static int nextToken(const QString &json, int &index);
+};
+
+
+/*!
+ * \class JsonBuilder
+ * \brief JSON builder class that uses scratch allocator under the hood.
+ */
+class JsonBuilderPrivate;
+
+class JsonBuilder
+{
+public:
+    JsonBuilder() = delete;
+    explicit JsonBuilder(unsigned bufsize);
+
+    void startArray();
+    void endArray();
+    void startObject();
+    void endObject();
+    void addKey(const char *key);
+    void addNumber(double num);
+    void addString(const char *str);
+
+private:
+    JsonBuilderPrivate *d = nullptr;
 };
 
 #endif //JSON_H


### PR DESCRIPTION
CJ is a very fast low level zero allocation JSON parser. Used instead of Qt and ArduinoJson parsers for new code to parse DDFs and bundles.

Currently there is no C++ interface, the C API is a bit clunky but that way it is as fast as it can get with non SIMD parsers. A later C++ wrapper will be made compatible with the Qt parser since that is used mostly in REST-API code.