### PR TITLE
Refactor string cache to use atom table

### DIFF
--- a/resource.cpp
+++ b/resource.cpp
@@ -10,6 +10,7 @@
 
 #include <QString>
 
+#include <deconz/u_assert.h>
 #include <deconz/dbg_trace.h>
 #include <utils/stringcache.h>
 #include "resource.h"
@@ -771,18 +772,24 @@ ResourceItem::ResourceItem(const ResourceItem &other)
 
 bool ResourceItem::setItemString(const QString &str)
 {
+    if (!(m_rid->type == DataTypeString ||
+          m_rid->type == DataTypeTimePattern))
+    {
+        return false;
+    }
+
     const auto utf8 = str.toUtf8();
 
-    if (utf8.size() <= int(m_istr.maxSize()))
+    // for now keep all attr/* items also as atoms
+    if (utf8.size() <= int(m_istr.maxSize()) && m_rid->suffix[0] != 'a' && m_rid->suffix[1] != 't')
     {
         m_istr.setString(utf8.constData());
-        m_strHandle = {};
+        m_strHandle = STRING_CACHE_INVALID_HANDLE;
         return true;
     }
 
-    m_strHandle =  GlobalStringCache()->put(utf8.constData(), size_t(utf8.size()), StringCache::Immutable);
-
-    return isValid(m_strHandle);
+    m_strHandle = StringCacheAdd(utf8.constData(), (unsigned)utf8.size(), StringCacheImmutable);
+    return m_strHandle != STRING_CACHE_INVALID_HANDLE;
 }
 
 /*! Move constructor. */
@@ -1081,13 +1088,19 @@ const QString &ResourceItem::toString() const
 
 QLatin1String ResourceItem::toLatin1String() const
 {
-    if (!isValid(m_strHandle))
+    if (m_strHandle == STRING_CACHE_INVALID_HANDLE)
     {
         return m_istr;
     }
-    else if (m_strHandle.base->length > 0)
+    else
     {
-        return QLatin1String(&m_strHandle.base->buf[0], m_strHandle.base->length);
+        const char *str;
+        unsigned length;
+
+        if (StringCacheGet(m_strHandle, &str, &length))
+        {
+            return QLatin1String(str, length);
+        }
     }
 
     return QLatin1String("");
@@ -1095,9 +1108,16 @@ QLatin1String ResourceItem::toLatin1String() const
 
 const char *ResourceItem::toCString() const
 {
-    if (isValid(m_strHandle))
+    if (m_strHandle != STRING_CACHE_INVALID_HANDLE)
     {
-        return &m_strHandle.base->buf[0];
+        const char *str;
+        unsigned length;
+
+        if (StringCacheGet(m_strHandle, &str, &length))
+        {
+            U_ASSERT(str[length] == '\0');
+            return str;
+        }
     }
 
     return m_istr.c_str();

--- a/resource.h
+++ b/resource.h
@@ -481,6 +481,7 @@ public:
     const QString &toString() const;
     QLatin1String toLatin1String() const;
     const char *toCString() const;
+    unsigned atomIndex() const { return m_strHandle; }
     qint64 toNumber() const;
     qint64 toNumberPrevious() const;
     deCONZ::SteadyTimeRef lastZclReport() const { return m_lastZclReport; }
@@ -544,7 +545,7 @@ private:
     };
     deCONZ::SteadyTimeRef m_lastZclReport;
 
-    BufStringCacheHandle m_strHandle; // for strings which don't fit into \c m_istr
+    unsigned m_strHandle = 0; // for strings which don't fit into \c m_istr
     ItemString m_istr; // internal embedded small string
     deCONZ::TimeSeconds m_refreshInterval;
     QString *m_str = nullptr;

--- a/utils/stringcache.h
+++ b/utils/stringcache.h
@@ -11,7 +11,7 @@
 #ifndef STRING_CACHE_H
 #define STRING_CACHE_H
 
-#include <utils/bufstring.h>
+#define STRING_CACHE_INVALID_HANDLE 0
 
 /*! \class StringCache
 
@@ -19,29 +19,17 @@
     Immutable read only strings are only added to the cache but never removed.
     Mutable string can be used for things like per resource names.
 */
-class StringCache
+enum StringCacheMode
 {
-public:
-    enum Mode {Mutable, Immutable};
-
-    /*! Adds a string if not already exists when \p mode is \c Immutable.
-        Adding the same immutable string multiple times will only reference the same slot
-        in the cache (deduplication).
-
-        \returns A valid handle when the entry is added or already exists.
-        \returns Invalid handle if the string is too large or the cache is full.
-     */
-    BufStringCacheHandle put(const char *str, size_t length, Mode mode);
-
-private:
-    // BufStringCache<32, 1024> mutable32; // for names and other strings
-    BufStringCache<32, 1024> immutable32;
-    BufStringCache<64, 1024> immutable64;
-    BufStringCache<128, 512> immutable128;
+    StringCacheMutable,
+    StringCacheImmutable
 };
 
-/*! Returns pointer to the global string cache.
+/*! Adds string to the global string cache.
+
+    \returns non zero handle or STRING_CACHE_INVALID_HANDLE.
  */
-StringCache *GlobalStringCache();
+unsigned StringCacheAdd(const char *str, unsigned length, StringCacheMode mode);
+bool StringCacheGet(unsigned handle, const char **str, unsigned *length);
 
 #endif // STRING_CACHE_H


### PR DESCRIPTION
The atom table only holds at most one copy of any string. Each atom has a 32-bit handle. E.g. 100 lights with same manufacturer name point to the same atom.

This also makes comparisons very fast since only integers are compared.