### PR TITLE
Use modelid.toLatin1String() in sendConfigureReportingRequest()

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -927,7 +927,7 @@ bool DeRestPluginPrivate::sendConfigureReportingRequest(BindingTask &bt)
         return false;
     }
 
-    const QString modelId = r->item(RAttrModelId)->toString();
+    const QLatin1String modelId = r->item(RAttrModelId)->toLatin1String();
     const quint16 manufacturerCode = bt.restNode->node()->nodeDescriptor().manufacturerCode();
 
     if (bt.binding.clusterId == BOSCH_AIR_QUALITY_CLUSTER_ID && manufacturerCode == VENDOR_BOSCH2)


### PR DESCRIPTION
Prevents dynamic QString allocation.