### PR TITLE
Update 4512737_thermostat.json to support 4512752

### DIFF
--- a/devices/namron/4512737_thermostat.json
+++ b/devices/namron/4512737_thermostat.json
@@ -1,7 +1,7 @@
 {
   "schema": "devcap1.schema.json",
   "manufacturername": ["NAMRON AS", "NAMRON AS"],
-  "modelid": ["4512737", "4512738"],
+  "modelid": ["4512737", "4512738", "4512752"],
   "product": "Thermostat Touch Zigbee 16A",
   "sleeper": false,
   "status": "Gold",


### PR DESCRIPTION
New Namron Zigbee Touch Thermostat 16A 2.0 with model id 4512752 (https://www.namron.com/products/namron-zigbee-touch-termostat-16a-hvit-11/)