### PR TITLE
Revert "DDF clone for Namron Touch thermostat 16A (4512752)"

### DIFF
--- a/devices/namron/4512737_thermostat.json
+++ b/devices/namron/4512737_thermostat.json
@@ -1,7 +1,7 @@
 {
   "schema": "devcap1.schema.json",
-  "manufacturername": ["NAMRON AS", "NAMRON AS", "NAMRON AS"],
-  "modelid": ["4512737", "4512738", "4512752"],
+  "manufacturername": ["NAMRON AS", "NAMRON AS"],
+  "modelid": ["4512737", "4512738"],
   "product": "Thermostat Touch Zigbee 16A",
   "sleeper": false,
   "status": "Gold",


### PR DESCRIPTION
Reverts dresden-elektronik/deconz-rest-plugin#7731

Revert as this was not tested by user. 