### PR TITLE
Fix pairing Profalux roller shutter in legacy code

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2364,8 +2364,11 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
     auto *device = DEV_GetOrCreateDevice(this, deCONZ::ApsController::instance(), eventEmitter, m_devices, node->address().ext());
     Q_ASSERT(device);
 
-    //Profalux device don't have manufactureName and ModelID
-    if ((node->nodeDescriptor().manufacturerCode() != VENDOR_PROFALUX) && permitJoinFlag)
+    if (node->nodeDescriptor().manufacturerCode() == VENDOR_PROFALUX)
+    {
+        //Profalux device don't have manufactureName and ModelID so can't wait for RAttrManufacturerName or RAttrModelId
+    }
+    else  if (permitJoinFlag)
     {
         // during pairing only proceed when device code has finished query Basic Cluster
         if (device->item(RAttrManufacturerName)->toString().isEmpty() ||

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2364,7 +2364,8 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
     auto *device = DEV_GetOrCreateDevice(this, deCONZ::ApsController::instance(), eventEmitter, m_devices, node->address().ext());
     Q_ASSERT(device);
 
-    if (permitJoinFlag)
+    //Profalux device don't have manufactureName and ModelID
+    if ((node->nodeDescriptor().manufacturerCode() != VENDOR_PROFALUX) && permitJoinFlag)
     {
         // during pairing only proceed when device code has finished query Basic Cluster
         if (device->item(RAttrManufacturerName)->toString().isEmpty() ||

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -2368,7 +2368,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
     {
         //Profalux device don't have manufactureName and ModelID so can't wait for RAttrManufacturerName or RAttrModelId
     }
-    else  if (permitJoinFlag)
+    else if (permitJoinFlag)
     {
         // during pairing only proceed when device code has finished query Basic Cluster
         if (device->item(RAttrManufacturerName)->toString().isEmpty() ||


### PR DESCRIPTION
First PR closed by error https://github.com/dresden-elektronik/deconz-rest-plugin/pull/7510

-------------------

See https://forum.phoscon.de/t/adding-profalux-zigbee-roller-shutters-via-legacy-code/4372

Ok So I m agree this device is "hacky", but without this code no way to support.
It just have no model id and no Manufacture Name, so the legacy code can support it with this hack

```
        //Add missing values for Profalux device
        if (existDevicesWithVendorCodeForMacPrefix(node->address(), VENDOR_PROFALUX))
        {
            //Shutter ?
            if (i->deviceId() == DEV_ID_ZLL_COLOR_LIGHT)
            {
                lightNode.setManufacturerName(QLatin1String("Profalux"));
                lightNode.setModelId(QLatin1String("PFLX Shutter"));
                lightNode.setNeedSaveDatabase(true);
            }
        }
```

But this one is disabled whith the recent code.

PS : Profalux have only this device and since years, with same problem, and no support using DDF planned/possible.
