### PR TITLE
DDF, Create a DDF to reverse tuya covering using covering cluster.

### DIFF
--- a/devices/tuya/_TS130F_standard_covering_reversed.json
+++ b/devices/tuya/_TS130F_standard_covering_reversed.json
@@ -1,0 +1,90 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "_TZ3000_iaxvag8w",
+  "modelid": "TS130F",
+  "product": "TS130F",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_WINDOW_COVERING_DEVICE",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "refresh.interval": 86400,
+          "parse": {"fn": "zcl:attr", "ep": 1, "cl": "0x0000", "at": "0x0001", "script": "tuya_swversion.js"},
+          "read": {"fn": "zcl:attr", "ep": 1, "cl": "0x0000", "at": "0x0001"}
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/lift",
+          "parse": {
+            "at": "0x0008",
+            "cl": "0x0102",
+            "ep": 1,
+            "eval": "Item.val = 100 - Attr.val;",
+            "fn": "zcl:attr"
+          }
+        },
+        {
+          "name": "state/open",
+          "parse": {
+            "at": "0x0008",
+            "cl": "0x0102",
+            "ep": 1,
+            "eval": "Item.val = Attr.val > 1",
+            "fn": "zcl:attr"
+          }
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0102",
+      "report": [
+        {
+          "at": "0x0008",
+          "dt": "0x20",
+          "min": 1,
+          "max": 300,
+          "change": "0x00000001"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7737

This DDF can be used to reverse return for all Tuya covering that use the covering cluster.
Used ATM for 

Product name : roller shutter
Manufacturer : _TZ3000_iaxvag8w
Model identifier : TS130F