### PR TITLE
Add UUID for all DDF files

### DIFF
--- a/devices/3A-Nue/Lxn59-2s7lX1.0.json
+++ b/devices/3A-Nue/Lxn59-2s7lX1.0.json
@@ -1,5 +1,6 @@
 {
   "schema":"devcap1.schema.json",
+  "uuid":"417af879-4d80-4816-ba08-b1b74aeead77",
   "manufacturername":"3A Smart Home DE",
   "modelid":"LXN59-2S7LX1.0",
   "product":"2 gang switch",

--- a/devices/3A-Nue/lxn59-1s7lx1.0.json
+++ b/devices/3A-Nue/lxn59-1s7lx1.0.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "724fdfb6-6e4b-4247-9d91-d3a92bf41622",
   "manufacturername": "3A Smart Home DE",
   "modelid": "LXN59-1S7LX1.0",
   "product": "Another Smart socket plug",

--- a/devices/3A-Nue/lxt56-ls27lx1.7.json
+++ b/devices/3A-Nue/lxt56-ls27lx1.7.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "73cc635e-9c11-4623-af5a-e6a7a8fb68f8",
   "manufacturername": "3A Smart Home DE",
   "modelid": "LXT56-LS27LX1.7",
   "vendor": "Zemismart",

--- a/devices/Jasco-GE/GE45856_wall_switch.json
+++ b/devices/Jasco-GE/GE45856_wall_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "548bbc95-bc25-40b6-86a8-161a2edba487",
   "manufacturername": "Jasco Products",
   "modelid": "45856",
   "vendor": "GE",

--- a/devices/adeo/ldsenk08_door_vibration_sensor.json
+++ b/devices/adeo/ldsenk08_door_vibration_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "44f204d4-9d48-440e-8ff7-bc1f72eb00c6",
   "manufacturername": "ADEO",
   "modelid": "LDSENK08",
   "vendor": "Adeo",

--- a/devices/adeo/ldsenk09_keyfob.json
+++ b/devices/adeo/ldsenk09_keyfob.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "7113fa6e-cf32-43a2-a9ba-8836ef9c226e",
   "manufacturername": "ADEO",
   "modelid": "LDSENK09",
   "product": "LDSENK09",

--- a/devices/aeotec/WG001-Z01_range_extender.json
+++ b/devices/aeotec/WG001-Z01_range_extender.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "b2f57433-5a72-4fcf-9a67-3fb092863948",
   "manufacturername": "AL001",
   "modelid": "WG001-Z01",
   "product": "Aeotec Range Extender Zi",

--- a/devices/aubess/aubess_multi_sensor_TZ3000_bguser20.json
+++ b/devices/aubess/aubess_multi_sensor_TZ3000_bguser20.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "a069007b-ba8a-4b8d-b76c-6d8ea492544c",
   "manufacturername": "_TZ3000_bguser20",
   "modelid": "TS0201",
   "vendor": "Aubess",

--- a/devices/aubess/aubess_plug_TZ3000_hdopuwv6.json
+++ b/devices/aubess/aubess_plug_TZ3000_hdopuwv6.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "2e59bb74-2555-4de7-a458-8041eabb5924",
   "manufacturername": "_TZ3000_hdopuwv6",
   "modelid": "TS011F",
   "sleeper": false,

--- a/devices/blitzwolf/bw_is4_multisensor.json
+++ b/devices/blitzwolf/bw_is4_multisensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "2492f20f-5bff-4f59-9ba5-f4767a5ccd42",
   "manufacturername": "_TYZB01_hjsgdkfl",
   "modelid": "TS0201",
   "product": "BW-IS4",

--- a/devices/blitzwolf/bw_shp13_smart_plug.json
+++ b/devices/blitzwolf/bw_shp13_smart_plug.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "0ba557b8-580f-43a0-b0e3-ce76f4f71b96",
   "manufacturername": ["_TZ3000_g5xawfcq", "_TZ3000_amdymr7l"],
   "modelid": ["TS0121", "TS011F"],
   "product": "BW-SHP13",

--- a/devices/blitzwolf/bw_shp15_smart_plug.json
+++ b/devices/blitzwolf/bw_shp15_smart_plug.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "90a67336-789a-4284-89a9-6f07bcbd2c9a",
   "manufacturername": ["_TZ3000_mraovvmm", "_TZ3000_u5u4cakc"],
   "modelid": ["TS011F", "TS011F"],
   "product": "BW-SHP15",

--- a/devices/bosch/bmct-slz_shutter_light_control2.json
+++ b/devices/bosch/bmct-slz_shutter_light_control2.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "39410b10-dfa0-4b25-aad3-b1d170d11b36",
   "manufacturername": "Bosch",
   "modelid": "RBSH-MMS-ZB-EU",
   "vendor": "Bosch",

--- a/devices/bosch/bsd-2-smoke-alarm.json
+++ b/devices/bosch/bsd-2-smoke-alarm.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "858d5b64-10c9-4458-874f-d4a6a2bf6b14",
   "manufacturername": "$MF_BOSCH",
   "modelid": "RBSH-SD-ZB-EU",
   "vendor": "Bosch",

--- a/devices/bosch/bwa-1_water_sensor.json
+++ b/devices/bosch/bwa-1_water_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "8ae9c4d7-d4f9-40cb-924d-fbad9b39d692",
   "manufacturername": "$MF_BOSCH",
   "modelid": "RBSH-WS-ZB-EU",
   "vendor": "Bosch",

--- a/devices/bosch/plug_compact.json
+++ b/devices/bosch/plug_compact.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "cc8da80e-f922-45ab-b94c-954c64f1d045",
   "manufacturername": "BOSCH",
   "modelid": "RBSH-SP-ZB-EU",
   "vendor": "Bosch",

--- a/devices/bosch/room_thermostat2.json
+++ b/devices/bosch/room_thermostat2.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "dc42c5ce-5f0e-42aa-9937-e05e08f23b57",
   "manufacturername": "BOSCH",
   "modelid": "RBSH-RTH0-BAT-ZB-EU",
   "vendor": "Bosch",

--- a/devices/bosch/room_thermostat2_230V.json
+++ b/devices/bosch/room_thermostat2_230V.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "e8cc4eba-5ec0-4cc5-91c7-4edd19c94438",
   "manufacturername": "BOSCH",
   "modelid": "RBSH-RTH0-ZB-EU",
   "vendor": "Bosch",

--- a/devices/bosch/thermostat2.json
+++ b/devices/bosch/thermostat2.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "a29c3216-a9eb-49ae-a62b-c604c3167b41",
   "manufacturername": "BOSCH",
   "modelid": "RBSH-TRV0-ZB-EU",
   "vendor": "Bosch",

--- a/devices/centralite/motion_sensor-a.json
+++ b/devices/centralite/motion_sensor-a.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "f9941e52-4b42-4f5c-9d12-c8ea7843051e",
   "manufacturername": "CentraLite",
   "modelid": "Motion Sensor-A",
   "product": "Motion Sensor-A",

--- a/devices/computime-salus/ss909zb_temp_sensor.json
+++ b/devices/computime-salus/ss909zb_temp_sensor.json
@@ -1,6 +1,7 @@
 
 {
   "schema": "devcap1.schema.json",
+  "uuid": "27bc348d-0253-40be-9983-b93d33636e3f",
   "manufacturername": "Computime",
   "modelid": "SS909ZB",
   "product": "Salus PS600 Temperature Sensor",

--- a/devices/danalock/danalock_v3.json
+++ b/devices/danalock/danalock_v3.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "36df5973-1a5f-497e-9b3d-0078a5178432",
   "ddfvalidate": false,
   "manufacturername": [
     "Danalock",

--- a/devices/danfoss/ally_temp_hum_sensor.json
+++ b/devices/danfoss/ally_temp_hum_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "26f6abcd-01a6-462c-b789-6f2d66c2ff4e",
   "manufacturername": "_TZ3000_mxzo5rhf",
   "modelid": "TS0201",
   "vendor": "Danfoss",

--- a/devices/danfoss/etrv0100_thermostat.json
+++ b/devices/danfoss/etrv0100_thermostat.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "76d8605f-9699-439f-bed0-52757d62cff1",
   "manufacturername": ["Danfoss", "Danfoss", "D5X84YU", "D5X84YU", "Danfoss"],
   "modelid": ["eTRV0100", "eTRV0103", "eT093WRO", "eT093WRG", "TRV001"],
   "vendor": "Danfoss",

--- a/devices/develco/aqszb-110_voc_sensor.json
+++ b/devices/develco/aqszb-110_voc_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "bf113ff9-a8c5-4e1e-9088-33cc0d5f4daf",
   "manufacturername": "Develco Products A/S",
   "modelid": "AQSZB-110",
   "vendor": "Develco Products",

--- a/devices/develco/heszb-120_heat_detector.json
+++ b/devices/develco/heszb-120_heat_detector.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "c454ada3-b192-4c58-89da-4a8a4319760a",
   "manufacturername": "Develco Products A/S",
   "modelid": "HESZB-120",
   "vendor": "Develco Products",

--- a/devices/develco/hmszb_temp_hum_sensor.json
+++ b/devices/develco/hmszb_temp_hum_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "f8f891ec-fd3d-4053-b574-cd9769caa488",
   "manufacturername": ["Develco Products A/S", "Develco Products A/S"],
   "modelid": ["HMSZB-110", "HMSZB-120"],
   "vendor": "Develco Products",

--- a/devices/develco/iomzb-110_switch_module.json
+++ b/devices/develco/iomzb-110_switch_module.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "316cc916-be3f-43e3-956c-ac379e6da4c3",
   "manufacturername": "Develco Products A/S",
   "modelid": "IOMZB-110",
   "product": "IOMZB-110 switch module",

--- a/devices/develco/moszb-140_motion_sensor.json
+++ b/devices/develco/moszb-140_motion_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "25076a0e-dc89-4730-ad98-fd06fb303e76",
   "manufacturername": ["Develco Products A/S", "Develco Products A/S"],
   "modelid": ["MOSZB-130", "MOSZB-140"],
   "vendor": "Develco Products",

--- a/devices/develco/moszb-141_motion_sensor.json
+++ b/devices/develco/moszb-141_motion_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "ee657811-3f43-499e-8f71-05ff152d3940",
   "manufacturername": ["Develco Products A/S", "frient A/S"],
   "modelid": ["MOSZB-141", "MOSZB-141"],
   "vendor": "Develco Products",

--- a/devices/develco/smszb-120_smoke_detector.json
+++ b/devices/develco/smszb-120_smoke_detector.json
@@ -1,5 +1,6 @@
 {
     "schema": "devcap1.schema.json",
+    "uuid": "216c300b-5bef-4788-ac87-1261829af0ea",
     "manufacturername": "Develco Products A/S",
     "modelid": "SMSZB-120",
     "vendor": "Develco Products",

--- a/devices/develco/splzb-131_smart_plug.json
+++ b/devices/develco/splzb-131_smart_plug.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "dd823579-f81e-4c0e-8d9e-28c27990866a",
   "manufacturername": "Develco Products A/S",
   "modelid": "SPLZB-131",
   "vendor": "Develco Products",

--- a/devices/develco/wiszb-120_open_close_sensor.json
+++ b/devices/develco/wiszb-120_open_close_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "2ae558b8-cad9-4cba-b3ab-7365dd24eac2",
   "manufacturername": "Develco Products A/S",
   "modelid": "WISZB-120",
   "vendor": "Develco Products",

--- a/devices/develco/wiszb-121_open_close_sensor.json
+++ b/devices/develco/wiszb-121_open_close_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "ace27d47-f9da-4016-a4f0-a3d8e1a93771",
   "manufacturername": "Develco Products A/S",
   "modelid": "WISZB-121",
   "vendor": "Develco Products",

--- a/devices/develco/zhemi101_external_meter_interface.json
+++ b/devices/develco/zhemi101_external_meter_interface.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "fccf500b-00d4-4bf6-b42d-27784e3803c2",
   "manufacturername": ["Develco Products A/S", "frient A/S", "Develco"],
   "modelid": ["ZHEMI101", "ZHEMI101", "ZHEMI101"],
   "vendor": "Develco products",

--- a/devices/dresden_elektronik/fls_pp3.json
+++ b/devices/dresden_elektronik/fls_pp3.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "330ac513-ca70-4a25-8a28-9ae251e7107e",
   "manufacturername": ["dresden elektronik", "dresden elektronik"],
   "modelid": ["FLS-PP3", "FLS-PP3 White"],
   "product": "FLS-PP lp",

--- a/devices/dresden_elektronik/hive.json
+++ b/devices/dresden_elektronik/hive.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "ba595349-3541-41d6-a79f-965115d547a7",
   "manufacturername": "Phoscon",
   "modelid": "Hive",
   "product": "Hive",

--- a/devices/dresden_elektronik/kobold.json
+++ b/devices/dresden_elektronik/kobold.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "a90a76fe-21d3-488d-968d-1a1e86c95741",
   "manufacturername": "dresden elektronik",
   "modelid": "Kobold",
   "product": "Kobold",

--- a/devices/dresden_elektronik/lighting_switch.json
+++ b/devices/dresden_elektronik/lighting_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "bd19625b-6d14-4843-b69f-971bf6585348",
   "manufacturername": "dresden elektronik",
   "modelid": "Lighting Switch",
   "product": "Lighting Switch",

--- a/devices/dresden_elektronik/scene_switch.json
+++ b/devices/dresden_elektronik/scene_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "57f972c5-ead9-4ee2-be54-2b89b0deedf2",
   "manufacturername": "dresden elektronik",
   "modelid": "Scene Switch",
   "product": "Scene Switch",

--- a/devices/easyaccess/easyfingertouch_doorlock.json
+++ b/devices/easyaccess/easyfingertouch_doorlock.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "01f14344-531a-4b8a-831c-7dbdb134f755",
   "manufacturername": ["Onesti Products AS", "Onesti Products AS", "Onesti Products AS", "Onesti Products AS", "Onesti Products AS", "Onesti Products AS"],
   "modelid": ["EasyFingerTouch", "EasyCodeTouch", "NimlyPRO", "NimlyCode", "NimlyTouch", "NimlyIn"],
   "vendor": "Onesti Products AS",

--- a/devices/elko/thermostat_16_a.json
+++ b/devices/elko/thermostat_16_a.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "e4ee14c0-c6a8-431c-8bff-4b4aa32d5de3",
   "manufacturername": "Schneider Electric",
   "modelid": "EKO07259",
   "product": "Elko Smart ZB Thermostat 16 A",

--- a/devices/eva/powermeter.json
+++ b/devices/eva/powermeter.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "dab331b6-f764-46f3-87df-ce99a70f0972",
   "manufacturername": "Eva",
   "modelid": "Meter Reader",
   "vendor": "Eva",

--- a/devices/fantem/zb003-x_multi_sensor.json
+++ b/devices/fantem/zb003-x_multi_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "69a81d7b-0fcf-41a7-96f0-15a8216c0e24",
   "manufacturername": "_TZ3210_wuhzzfqg",
   "modelid": "TS0202",
   "vendor": "Fantem",

--- a/devices/frient/aqszb-110_voc_sensor.json
+++ b/devices/frient/aqszb-110_voc_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "14bd9844-c3e9-4831-a92d-91093da03de8",
   "manufacturername": "frient A/S",
   "modelid": "AQSZB-110",
   "vendor": "Develco Products",

--- a/devices/frient/heszb-120_heat_detector.json
+++ b/devices/frient/heszb-120_heat_detector.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "027828c2-c94a-44fc-ac44-b948e50174e1",
   "manufacturername": "frient A/S",
   "modelid": "HESZB-120",
   "vendor": "Develco Products",

--- a/devices/frient/hmszb_temp_hum_sensor.json
+++ b/devices/frient/hmszb_temp_hum_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "74183c57-8b6f-42e8-b564-ec4930f7596f",
   "manufacturername": ["frient A/S", "frient A/S"],
   "modelid": ["HMSZB-110", "HMSZB-120"],
   "vendor": "Develco Products",

--- a/devices/frient/kepzb-110_keypad.json
+++ b/devices/frient/kepzb-110_keypad.json
@@ -1,5 +1,6 @@
 {
    "schema":"devcap1.schema.json",
+   "uuid":"cb65ebbd-876d-4f46-9167-3a6cb183ede4",
    "manufacturername": ["Develco Products A/S", "frient A/S"],
    "product":"KEPZB-110 Keypad",
    "vendor": "Develco Products",

--- a/devices/frient/moszb-140_motion_sensor.json
+++ b/devices/frient/moszb-140_motion_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "09c704bf-e3a1-4a45-abf2-7b8420ec4031",
   "manufacturername": "frient A/S",
   "modelid": "MOSZB-140",
   "vendor": "Develco Products",

--- a/devices/frient/moszb-154_motion_sensor.json
+++ b/devices/frient/moszb-154_motion_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "ae54681f-9243-47b3-95f2-58b1a3c19451",
   "manufacturername": "frient A/S",
   "modelid": "MOSZB-154",
   "vendor": "Develco Products",

--- a/devices/frient/smszb-120_smoke_detector.json
+++ b/devices/frient/smszb-120_smoke_detector.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "b755930f-483c-481f-ba64-4afe439869b2",
   "manufacturername": "frient A/S",
   "modelid": "SMSZB-120",
   "vendor": "Develco Products",

--- a/devices/frient/splzb-131_smart_plug.json
+++ b/devices/frient/splzb-131_smart_plug.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "ca5aa4de-3709-4d5f-9cb4-6748d155798f",
   "manufacturername": ["frient A/S", "frient A/S", "frient A/S"],
   "modelid": ["SPLZB-131", "SPLZB-134", "SPLZB-141"],
   "product": "SPLZB-131, SPLZB-134 and SPLZB-141 smart plug",

--- a/devices/frient/wiszb-120_open_close_sensor.json
+++ b/devices/frient/wiszb-120_open_close_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "32b8cf7f-77c7-4887-9782-467158c9dc60",
   "manufacturername": "frient A/S",
   "modelid": "WISZB-120",
   "vendor": "Develco Products",

--- a/devices/frient/wiszb-121_open_close_sensor.json
+++ b/devices/frient/wiszb-121_open_close_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "7a0b8719-70b6-42d5-b430-14d38f87bfd4",
   "manufacturername": "frient A/S",
   "modelid": "WISZB-121",
   "vendor": "Develco Products",

--- a/devices/gledopto/gl-sd-002_switch.json
+++ b/devices/gledopto/gl-sd-002_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "d0cde800-0de6-4189-b5c7-bda17882ee0f",
   "manufacturername": "GLEDOPTO",
   "modelid": "GL-SD-002",
   "product": "GL-SD-002",

--- a/devices/gledopto/gledopto.json
+++ b/devices/gledopto/gledopto.json
@@ -1,5 +1,6 @@
 {
     "schema": "devcap1.schema.json",
+    "uuid": "fe02db4a-01e9-423e-9e56-b9db67dac193",
     "manufacturername": [
         "GLEDOPTO",
         "GLEDOPTO"

--- a/devices/greeble/jz-rgbw-z01.json
+++ b/devices/greeble/jz-rgbw-z01.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "e8018b76-1282-4299-b796-c0028638a213",
   "manufacturername": "GREEBLE",
   "modelid": "JZ-RGBW-Z01",
   "product": "JZ-RGBW-Z01",

--- a/devices/heiman/HS3AQ_air_quality_sensor.json
+++ b/devices/heiman/HS3AQ_air_quality_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "b90bdc10-b593-4ea1-b837-757cb7cf1d33",
   "manufacturername": "HEIMAN",
   "modelid": "HS3AQ-EFA-3.0",
   "product": "HHS3AQ carbondioxide detector",

--- a/devices/heiman/hs1rc_keyfob.json
+++ b/devices/heiman/hs1rc_keyfob.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "5e3b0947-9e85-4919-94f9-6c277820cb8f",
   "manufacturername": ["HEIMAN", "Heiman", "HEIMAN"],
   "modelid": ["RC-EF-3.0", "RC_V14", "RC-EM"],
   "vendor": "Heiman",

--- a/devices/heiman/hs1sa_smoke_sensor.json
+++ b/devices/heiman/hs1sa_smoke_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "2787627b-76fe-43d4-97d4-9e93236ef963",
   "manufacturername": "Heiman",
   "modelid": "SmokeSensor-EF-3.0",
   "vendor": "Heiman",

--- a/devices/heiman/hs2wd-e_smart_siren.json
+++ b/devices/heiman/hs2wd-e_smart_siren.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "c8065d03-28e8-424a-ab06-92ec06cfb3a1",
   "manufacturername": [
     "Heiman",
     "HEIMAN"

--- a/devices/heiman/smartplug.json
+++ b/devices/heiman/smartplug.json
@@ -1,5 +1,6 @@
 {
     "schema": "devcap1.schema.json",
+    "uuid": "14938c50-2781-41e4-80a4-d38b3a996ca1",
     "manufacturername": "Heiman",
     "modelid": "SmartPlug",
     "product": "SmartPlug",

--- a/devices/home2link/H2L-ZBPH-RS.json
+++ b/devices/home2link/H2L-ZBPH-RS.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "d9ed5ba0-4957-47b5-9e75-d7f7bf1fa153",
   "manufacturername": "H2L-ZBPH-RS",
   "modelid": "H2L-ZBPH-RS",
   "product": "H2L-ZBPH-RS",

--- a/devices/hzc_electric/s900w-zg_water_leak_sensor.json
+++ b/devices/hzc_electric/s900w-zg_water_leak_sensor.json
@@ -1,5 +1,6 @@
 {
     "schema": "devcap1.schema.json",
+    "uuid": "8f8b987f-fb65-4d21-8f44-df439c916d91",
     "manufacturername": "Shyugj",
     "modelid": "WaterLeakageSensor-ZB3.0",
     "vendor": "HZC electric",

--- a/devices/icasa/ICZB-IW11D.json
+++ b/devices/icasa/ICZB-IW11D.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "979778dc-e197-425e-8d44-4ccddc00b433",
   "manufacturername": "icasa",
   "modelid": "ICZB-IW11D",
   "product": "AC Dimmer",

--- a/devices/ikea/askvader_on_off_switch.json
+++ b/devices/ikea/askvader_on_off_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "31959321-1591-4893-9bd0-e46f80201afa",
   "manufacturername": "$MF_IKEA",
   "modelid": "ASKVADER on/off switch",
   "vendor": "IKEA",

--- a/devices/ikea/badring_water_leak_sensor.json
+++ b/devices/ikea/badring_water_leak_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "90d10a96-9cf9-4639-bd04-74feb26aec9a",
   "manufacturername": "$MF_IKEA",
   "modelid": "BADRING Water Leakage Sensor",
   "vendor": "IKEA",

--- a/devices/ikea/blind.json
+++ b/devices/ikea/blind.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "b6e5fb8d-50ee-4c6a-9526-01ef58219853",
   "manufacturername": [
     "$MF_IKEA",
     "$MF_IKEA",

--- a/devices/ikea/e14_ws_opal_400lm_light.json
+++ b/devices/ikea/e14_ws_opal_400lm_light.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "8ecd84ad-4015-4b9e-bee2-311e750ee974",
   "manufacturername": "$MF_IKEA",
   "modelid": "TRADFRI bulb E14 WS opal 400lm",
   "product": "TRÅDFRI bulb E14 WS opal 400lm",

--- a/devices/ikea/gu10_ws_400lm_light.json
+++ b/devices/ikea/gu10_ws_400lm_light.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "fa44b7d1-6b46-4bae-9264-2dea7c216d9e",
   "manufacturername": "$MF_IKEA",
   "modelid": "TRADFRI bulb GU10 WS 400lm",
   "product": "TRÅDFRI bulb GU10 WS 400lm",

--- a/devices/ikea/ormanas_led_strip.json
+++ b/devices/ikea/ormanas_led_strip.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "6b05491f-10ed-40e3-9fd2-d2f7758cb5a1",
   "manufacturername": "$MF_IKEA",
   "modelid": "ORMANAS LED Strip",
   "product": "ORMANAS LED Strip",

--- a/devices/ikea/parasoll_open_close_sensor.json
+++ b/devices/ikea/parasoll_open_close_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "9cc2db31-a047-4431-b646-1e72d9a3fd0f",
   "manufacturername": "$MF_IKEA",
   "modelid": "PARASOLL Door/Window Sensor",
   "product": "PARASOLL Door/Window Sensor",

--- a/devices/ikea/rodret_dimmer.json
+++ b/devices/ikea/rodret_dimmer.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "3d671c73-06da-4adc-99f1-076b3dfb3122",
   "manufacturername": "$MF_IKEA",
   "modelid": "RODRET Dimmer",
   "product": "RODRET Dimmer - E2201",

--- a/devices/ikea/somrig_shortcut_button.json
+++ b/devices/ikea/somrig_shortcut_button.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "d55d8889-d7b5-476f-9d88-be86348f0ca4",
   "manufacturername": "IKEA of Sweden",
   "modelid": "SOMRIG shortcut button",
   "product": "SOMRIG Shortcut Button",

--- a/devices/ikea/starkvind_air_purifier.json
+++ b/devices/ikea/starkvind_air_purifier.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "11beee69-0025-48cd-be1c-1355301c61a1",
   "manufacturername": [
     "$MF_IKEA",
     "$MF_IKEA"

--- a/devices/ikea/styrbar_remote_control.json
+++ b/devices/ikea/styrbar_remote_control.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "a21e11e2-f595-4703-9cb2-83c89e1bb59e",
   "manufacturername": "$MF_IKEA",
   "modelid": "Remote Control N2",
   "product": "STYRBAR remote control - E2002",

--- a/devices/ikea/symfonisk_sound_contoller.json
+++ b/devices/ikea/symfonisk_sound_contoller.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "bc0e6601-5492-4a98-b5e8-687923af249b",
   "manufacturername": "$MF_IKEA",
   "modelid": "SYMFONISK Sound Controller",
   "product": "SYMFONISK Sound Controller - E1744",

--- a/devices/ikea/symfonisk_sound_remote_gen2.json
+++ b/devices/ikea/symfonisk_sound_remote_gen2.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "644ac55d-0763-41f3-9e22-42690b720512",
   "manufacturername": "$MF_IKEA",
   "modelid": "SYMFONISK sound remote gen2",
   "product": "SYMFONISK sound remote gen2 - E2123",

--- a/devices/ikea/tradfri_bulb_cws_A.json
+++ b/devices/ikea/tradfri_bulb_cws_A.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "f5a8ab8c-fdf8-4e38-a933-c78e6bd2003b",
   "manufacturername": [
     "$MF_IKEA",
     "$MF_IKEA"

--- a/devices/ikea/tradfri_bulb_e14_w_opal_400lm.json
+++ b/devices/ikea/tradfri_bulb_e14_w_opal_400lm.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "c10e59de-f978-46ac-b7b2-14a1de9415d9",
   "manufacturername": "$MF_IKEA",
   "modelid": "TRADFRI bulb E14 W op/ch 400lm",
   "product": "TRADFRI bulb E14 W op/ch 400lm",

--- a/devices/ikea/tradfri_bulb_e14_ws_opal_600lm.json
+++ b/devices/ikea/tradfri_bulb_e14_ws_opal_600lm.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "605e6c67-92fb-4c0e-a195-7e0261a012d2",
   "manufacturername": "$MF_IKEA",
   "modelid": "TRADFRI bulb E14 WS opal 600lm",
   "product": "TRADFRI bulb E14 WS opal 600lm",

--- a/devices/ikea/tradfri_bulb_e14_ww_clear_250lm.json
+++ b/devices/ikea/tradfri_bulb_e14_ww_clear_250lm.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "70d4ffdd-afdc-476d-8d5d-c217ac240b8f",
   "manufacturername": "$MF_IKEA",
   "modelid": "TRADFRIbulbE14WWclear250lm",
   "product": "TRÅDFRI LED bulb E14 250lm warm white clear chandelier",

--- a/devices/ikea/tradfri_bulb_e27_cws_opal_600lm.json
+++ b/devices/ikea/tradfri_bulb_e27_cws_opal_600lm.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "81c78560-e623-4741-b7e4-340174df83f7",
   "manufacturername": "$MF_IKEA",
   "modelid": "TRADFRI bulb E27 CWS opal 600lm",
   "product": "TRADFRI bulb E27 CWS opal 600lm",

--- a/devices/ikea/tradfri_bulb_e27_w_opal_1000lm.json
+++ b/devices/ikea/tradfri_bulb_e27_w_opal_1000lm.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "1b8d58d2-1487-4b10-8c4a-23e6e83ca51d",
   "manufacturername": "$MF_IKEA",
   "modelid": "TRADFRI bulb E27 W opal 1000lm",
   "product": "TRADFRI bulb E27 W opal 1000lm",

--- a/devices/ikea/tradfri_bulb_e27_ws_opal_1000lm.json
+++ b/devices/ikea/tradfri_bulb_e27_ws_opal_1000lm.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "75aad11e-f313-4ce0-a5b1-5c62566ed1d6",
   "manufacturername": "$MF_IKEA",
   "modelid": "TRADFRI bulb E27 WS opal 1000lm",
   "product": "TRADFRI bulb E27 WS opal 1000lm",

--- a/devices/ikea/tradfri_bulb_e27_ws_opal_980lm.json
+++ b/devices/ikea/tradfri_bulb_e27_ws_opal_980lm.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "43b5d1f9-25c9-4ca9-bd89-0300571221fc",
   "manufacturername": "$MF_IKEA",
   "modelid": "TRADFRI bulb E27 WS opal 980lm",
   "product": "TRADFRI bulb E27 WS opal 980lm",

--- a/devices/ikea/tradfri_bulb_e27_ww_806lm.json
+++ b/devices/ikea/tradfri_bulb_e27_ww_806lm.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "833cf9e4-5d14-407a-a3c4-deff36c22a49",
   "manufacturername": "$MF_IKEA",
   "modelid": "TRADFRI bulb E27 WW 806lm",
   "product": "TRADFRI bulb E27 WW 806lm",

--- a/devices/ikea/tradfri_bulb_gu10_w_400lm.json
+++ b/devices/ikea/tradfri_bulb_gu10_w_400lm.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "5dcc0fdc-fa3a-40a7-9598-96f2801195b6",
   "manufacturername": "$MF_IKEA",
   "modelid": "TRADFRI bulb GU10 W 400lm",
   "product": "TRADFRI bulb GU10 W 400lm",

--- a/devices/ikea/tradfri_bulb_gu10_ww_400lm.json
+++ b/devices/ikea/tradfri_bulb_gu10_ww_400lm.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "9c445b95-57d9-4364-8c29-09f556659886",
   "manufacturername": "$MF_IKEA",
   "modelid": "TRADFRI bulb GU10 WW 400lm",
   "product": "TRADFRI bulb GU10 WW 400lm",

--- a/devices/ikea/tradfri_control_outlet.json
+++ b/devices/ikea/tradfri_control_outlet.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "e35a7968-ef48-4c5f-9a7c-1c63aaf7e74a",
   "manufacturername": "$MF_IKEA",
   "modelid": "TRADFRI control outlet",
   "vendor": "IKEA",

--- a/devices/ikea/tradfri_driver_30w.json
+++ b/devices/ikea/tradfri_driver_30w.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "ff9f8ad1-4527-4004-896b-4ef947eb382b",
   "manufacturername": "$MF_IKEA",
   "modelid": "TRADFRI Driver 30W",
   "product": "TRADFRI Driver 30W",

--- a/devices/ikea/tradfri_motion_sensor.json
+++ b/devices/ikea/tradfri_motion_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "3b5a1753-f33f-468b-85d0-73eb8d7e5606",
   "manufacturername": "$MF_IKEA",
   "modelid": "TRADFRI motion sensor",
   "product": "TRADFRI motion sensor - E1525, E1745",

--- a/devices/ikea/tradfri_on_off_switch.json
+++ b/devices/ikea/tradfri_on_off_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "e950d4c7-56ba-4de3-81f4-99a5619b942b",
   "manufacturername": "$MF_IKEA",
   "modelid": "TRADFRI on/off switch",
   "product": "TRADFRI on/off switch - E1743",

--- a/devices/ikea/tradfri_on_off_switch_old_fw.json
+++ b/devices/ikea/tradfri_on_off_switch_old_fw.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "152ae8be-878d-4d55-ba19-39a34b082b59",
   "manufacturername": "$MF_IKEA",
   "modelid": "TRADFRI on/off switch",
   "product": "TRADFRI on/off switch - E1743",

--- a/devices/ikea/tradfri_open_close_remote.json
+++ b/devices/ikea/tradfri_open_close_remote.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "7d2b2eb7-d0f7-42a1-a792-cfa74c40d435",
   "manufacturername": "$MF_IKEA",
   "modelid": "TRADFRI open/close remote",
   "product": "TRADFRI open/close remote - E1766",

--- a/devices/ikea/tradfri_remote_control.json
+++ b/devices/ikea/tradfri_remote_control.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "dadf3618-a75d-4e65-9675-6c44e22c584d",
   "manufacturername": "$MF_IKEA",
   "modelid": "TRADFRI remote control",
   "product": "TRADFRI remote control - E1810",

--- a/devices/ikea/tradfri_shortcut_button.json
+++ b/devices/ikea/tradfri_shortcut_button.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "28edf641-4709-484c-b0c7-c8255154348a",
   "manufacturername": "$MF_IKEA",
   "modelid": "TRADFRI SHORTCUT Button",
   "product": "TRADFRI SHORTCUT Button - E1812",

--- a/devices/ikea/tradfri_signal_repeater.json
+++ b/devices/ikea/tradfri_signal_repeater.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "a2ba8dae-84af-4464-b263-e91d3473d9f6",
   "manufacturername": [
     "$MF_IKEA",
     "$MF_IKEA"

--- a/devices/ikea/tradfri_wireless_dimmer.json
+++ b/devices/ikea/tradfri_wireless_dimmer.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "5405897a-0084-45bc-8150-533acd5b7fb3",
   "manufacturername": "$MF_IKEA",
   "modelid": "TRADFRI wireless dimmer",
   "product": "TRADFRI wireless dimmer - E1724",

--- a/devices/ikea/tradfribulbe14wscandleopal470lm.json
+++ b/devices/ikea/tradfribulbe14wscandleopal470lm.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "5d4a970d-3a95-4e2b-8aa8-82a885221fe1",
   "manufacturername": "$MF_IKEA",
   "modelid": "TRADFRIbulbE14WScandleopal470lm",
   "product": "TRADFRIbulbE14WScandleopal470lm",

--- a/devices/ikea/tradfribulbe27wsglobeopal1055lm.json
+++ b/devices/ikea/tradfribulbe27wsglobeopal1055lm.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "50f0db9d-c73d-4d65-aae1-64976334323f",
   "manufacturername": "$MF_IKEA",
   "modelid": "TRADFRIbulbE27WSglobeopal1055lm",
   "product": "Tradfri LED bulb E27 1055 lumen",

--- a/devices/ikea/vallhorn_wireless_motion_sensor.json
+++ b/devices/ikea/vallhorn_wireless_motion_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "2ad3b0f4-f70a-4775-a1b1-b5cc4f927903",
   "manufacturername": "$MF_IKEA",
   "modelid": "VALLHORN Wireless Motion Sensor",
   "product": "VALLHORN Wireless Motion Sensor",

--- a/devices/ikea/vindstyrka_air_quality_sensor.json
+++ b/devices/ikea/vindstyrka_air_quality_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "ac5adf59-1be3-47a3-9de2-4657d0583331",
   "manufacturername": "$MF_IKEA",
   "modelid": "VINDSTYRKA",
   "product": "Vindstyrka Air Quality Sensor",

--- a/devices/iluminize/roller_shutter_actuator_mini.json
+++ b/devices/iluminize/roller_shutter_actuator_mini.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "243652d7-2e83-4241-a7b9-cd8ae2d9f7aa",
   "manufacturername": "iluminize",
   "modelid": "5128.10",
   "vendor": "iluminize",

--- a/devices/immax/07046L_keyfob.json
+++ b/devices/immax/07046L_keyfob.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "80a358eb-56ce-4fdd-8dfe-374693301d17",
   "manufacturername": "Immax",
   "modelid": "Keyfob-ZB3.0",
   "vendor": "Immax Neo",

--- a/devices/immax/07048L_smart_plug.json
+++ b/devices/immax/07048L_smart_plug.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "f821d929-ee1a-44e0-97d8-ef5d68dc281b",
   "manufacturername": "Immax",
   "modelid": "Plug-230V-ZB3.0",
   "vendor": "Immax Neo",

--- a/devices/innr/rc_250.json
+++ b/devices/innr/rc_250.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "8bcc2fce-08f5-44df-a094-77c60a2c7180",
   "manufacturername": "innr",
   "modelid": "RC 250",
   "product": "Battery switch",

--- a/devices/innr/sp_120.json
+++ b/devices/innr/sp_120.json
@@ -1,5 +1,6 @@
 {
     "schema": "devcap1.schema.json",
+    "uuid": "5a2c2e2d-c5b6-41c6-977a-3d4aeb327499",
     "manufacturername": "innr",
     "modelid": "SP 120",
     "vendor": "innr",

--- a/devices/innr/sp_234.json
+++ b/devices/innr/sp_234.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "609f1078-242f-44b3-9c1b-1af687b9d819",
   "manufacturername": "innr",
   "modelid": "SP 234",
   "vendor": "innr",

--- a/devices/innr/sp_240.json
+++ b/devices/innr/sp_240.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "4b16f6c7-b57e-4d7a-9eff-894c5023ab9e",
   "manufacturername": "innr",
   "modelid": "SP 240",
   "product": "SP 240",

--- a/devices/innr/xx_110.json
+++ b/devices/innr/xx_110.json
@@ -1,5 +1,6 @@
 {
     "schema": "devcap1.schema.json",
+    "uuid": "0b37e1cd-e112-4ae2-b759-2c6ed1caf6d6",
     "manufacturername": [
         "innr",
         "innr"

--- a/devices/konke/3AFE280100510001_battery_switch.json
+++ b/devices/konke/3AFE280100510001_battery_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "4fe1326d-8697-45ab-aa72-2a8a0e8d8c83",
   "manufacturername": "Konke",
   "modelid": "3AFE280100510001",
   "product": "Konke Kit Pro Multi Function Button",

--- a/devices/lds/ZBT-DIMSwitch-D0000_remote.json
+++ b/devices/lds/ZBT-DIMSwitch-D0000_remote.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "ee6cc184-94bf-48c9-80d6-ca8eb0d974d0",
   "manufacturername": "LDS",
   "modelid": "ZBT-DIMSwitch-D0000",
   "product": "LDS battery switch",

--- a/devices/legrand/Remote_switch_Wakeup_sleep.json
+++ b/devices/legrand/Remote_switch_Wakeup_sleep.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "3666edf3-7d38-4c80-857b-94610b5ef239",
   "manufacturername": "Legrand",
   "modelid": "Remote switch Wake up / Sleep",
   "product": "Remote switch Sleep / Wake - 064884",

--- a/devices/legrand/Remote_switch_home_away.json
+++ b/devices/legrand/Remote_switch_home_away.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "9b705c23-87d1-4a69-8f2f-10f452a6bdf9",
   "manufacturername": "Legrand",
   "modelid": "Master remote SW Home / Away",
   "product": "Master remote SW Home / Away",

--- a/devices/legrand/cable_outlet.json
+++ b/devices/legrand/cable_outlet.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "505e4a2f-5bde-46b2-a149-2fc536d7c2f7",
   "ddfvalidate": false,
   "manufacturername": "Legrand",
   "modelid": "Cable outlet",

--- a/devices/legrand/wireless_scenes_command.json
+++ b/devices/legrand/wireless_scenes_command.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "be154dd8-8225-4a88-b4a0-49c8b4dacbd6",
   "manufacturername": "Legrand",
   "modelid": "Wireless Scenes Command",
   "product": "Wireless Scenes Command",

--- a/devices/lidl/hg06338.json
+++ b/devices/lidl/hg06338.json
@@ -1,5 +1,6 @@
 {
     "schema": "devcap1.schema.json",
+    "uuid": "a417ba23-2ea6-417e-9093-8110edb20413",
     "manufacturername": [
         "LIDL Silvercrest",
         "_TZ3000_1obwwnmq"

--- a/devices/lidl/hg08673.json
+++ b/devices/lidl/hg08673.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "6fc0fda8-a625-46fd-97ca-e985b79c73fd",
   "manufacturername": ["_TZ3000_nkcobies","_TZ3000_j1v25l17","_TZ3000_ynmowqk2"],
   "modelid": ["TS011F","TS011F","TS011F"],
   "product": "HG08673 LIDL SilverCrest smart plug with monitoring (DK, EU, FR)",

--- a/devices/linkind/001082_water_leak_sensor.json
+++ b/devices/linkind/001082_water_leak_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "50a7905a-8eee-4ed7-bc4b-7c6b19bbe68b",
   "manufacturername": "LK",
   "modelid": "A001082",
   "vendor": "Linkind",

--- a/devices/linkind/ZBT-CCTLight-D0106.json
+++ b/devices/linkind/ZBT-CCTLight-D0106.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "0f0290cb-4791-49c2-8b6b-a1a519163c74",
   "manufacturername": "lk",
   "modelid": "ZBT-CCTLight-D0106",
   "product": "Linkind A60 LED Tunable White Bulb 800 lumen",

--- a/devices/linkind/ZBT-CCTLight-M3500107.json
+++ b/devices/linkind/ZBT-CCTLight-M3500107.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "b0f2c040-b837-4b4e-baa6-4f112e3f0d68",
   "manufacturername": "lk",
   "modelid": "ZBT-CCTLight-M3500107",
   "product": "Linkind 4.8W GU10 Bulb Dimmable & Tunable",

--- a/devices/lixee/zlinky_tic_histo_tri_hphc.json
+++ b/devices/lixee/zlinky_tic_histo_tri_hphc.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "2e605f01-fbd7-457e-b351-bb53043fd882",
   "manufacturername": "LiXee",
   "modelid": "ZLinky_TIC",
   "vendor": "LiXee",

--- a/devices/lixee/zlinky_tic_historique_mono_base.json
+++ b/devices/lixee/zlinky_tic_historique_mono_base.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "55133b78-5c06-4df4-94ac-2748d4f155d9",
   "manufacturername": "LiXee",
   "modelid": "ZLinky_TIC",
   "product": "ZLinky_TIC historique+base",

--- a/devices/lixee/zlinky_tic_historique_mono_hphc.json
+++ b/devices/lixee/zlinky_tic_historique_mono_hphc.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "71da8cd7-eea9-4798-8a63-a527469354cf",
   "manufacturername": "LiXee",
   "modelid": "ZLinky_TIC",
   "vendor": "LiXee",

--- a/devices/lixee/zlinky_tic_standard_mono_base.json
+++ b/devices/lixee/zlinky_tic_standard_mono_base.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "778be623-5395-4a1a-9e8a-48c3149f6828",
   "manufacturername": "LiXee",
   "modelid": "ZLinky_TIC",
   "product": "ZLinky_TIC Standard+Base",

--- a/devices/lixee/zlinky_tic_standard_tri_hphc.json
+++ b/devices/lixee/zlinky_tic_standard_tri_hphc.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "275cc5bb-0708-4a8b-a46e-4f271e122d24",
   "manufacturername": "LiXee",
   "modelid": "ZLinky_TIC",
   "vendor": "LiXee",

--- a/devices/lutron/lutron_aurora_foh.json
+++ b/devices/lutron/lutron_aurora_foh.json
@@ -1,5 +1,6 @@
 {
     "schema": "devcap1.schema.json",
+    "uuid": "524fadcb-a83c-4f33-acfa-81eb41e22978",
     "manufacturername": "$MF_LUTRON",
     "modelid": "Z3-1BRL",
     "product": "Aurora",

--- a/devices/merten/meg5113-0300_cover_controller.json
+++ b/devices/merten/meg5113-0300_cover_controller.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "cc3b7ff9-2867-4f6a-af90-fd40441a0304",
   "manufacturername": "Schneider Electric",
   "modelid": "1GANG/SHUTTER/1",
   "vendor": "Merten Wiser",

--- a/devices/mhcozy/ts0004.json
+++ b/devices/mhcozy/ts0004.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "bfd918c6-53f3-44b8-97fd-b5c00100cab8",
   "manufacturername": "_TZ3000_u3oupgdy",
   "modelid": "TS0004",
   "product": "MHCOZY 4-Channel Dry Contact Smart Wireless Zigbee Switch Relay Module",

--- a/devices/mli/tint_gu10_spot_zbt-colortemperature.json
+++ b/devices/mli/tint_gu10_spot_zbt-colortemperature.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "be9f99a8-0c76-41cb-ad2b-37405b0f968c",
   "manufacturername": "MLI",
   "modelid": "ZBT-ColorTemperature",
   "vendor": "Müller Licht",

--- a/devices/mli/zbt-extendedcolor.json
+++ b/devices/mli/zbt-extendedcolor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "62a57ed7-8ddd-4e86-bd8f-03f7822a50cd",
   "manufacturername": ["MLI"],
   "modelid": ["ZBT-ExtendedColor"],
   "product": "Tint by Mueller Light GU10 spot",

--- a/devices/moes/Moes_MS-104BZ_wired_switch_2_gangs.json
+++ b/devices/moes/Moes_MS-104BZ_wired_switch_2_gangs.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "58de429d-7b30-468c-9c0b-47b1dbed178d",
   "manufacturername": [
     "_TZ3000_pmz6mjyu",
     "_TZ3000_zmy1waw6"

--- a/devices/moes/Moes_MS-105-M_1_gang_dimmer_module.json
+++ b/devices/moes/Moes_MS-105-M_1_gang_dimmer_module.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "09286594-6296-427e-9919-8eb9c31ac189",
   "manufacturername": ["_TZE200_la2c2uo9", "_TZE204_dcnsggvz"],
   "modelid": ["TS0601", "TS0601"],
   "vendor": "Moes",

--- a/devices/moes/Moes_TZ3000_TS0012_2_gang_switches.json
+++ b/devices/moes/Moes_TZ3000_TS0012_2_gang_switches.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "1c23b01a-f9c0-4131-aa84-d1539f03f2e5",
   "manufacturername": "_TZ3000_18ejxno0",
   "modelid": "TS0012",
   "product": "2 gang switches",

--- a/devices/moes/Moes_TZ3000_TS0201_temp_hum_with_LCD.json
+++ b/devices/moes/Moes_TZ3000_TS0201_temp_hum_with_LCD.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "9f506d1d-a34c-4788-9a36-75b6d0b4643c",
   "manufacturername": ["_TZ3000_ywagc4rj","_TZ3000_itnrsufe"],
   "modelid": ["TS0201","TS0201"],
   "vendor": "Moes",

--- a/devices/moes/Moes_ZM-105-M_1_gang_dimmer.json
+++ b/devices/moes/Moes_ZM-105-M_1_gang_dimmer.json
@@ -1,5 +1,6 @@
 {
     "schema": "devcap1.schema.json",
+    "uuid": "699b5ac1-dfad-48a3-88b7-f01ed9847ca9",
     "manufacturername": "_TZE204_dcnsggvz",
     "modelid": "TS0601",
     "product": "TS0601",

--- a/devices/namron/4512737_thermostat.json
+++ b/devices/namron/4512737_thermostat.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "1d156ff9-89d3-4441-ad0f-f7b8fe96cfe8",
   "manufacturername": ["NAMRON AS", "NAMRON AS"],
   "modelid": ["4512737", "4512738"],
   "product": "Thermostat Touch Zigbee 16A",

--- a/devices/namron/4512762_open_close_sensor.json
+++ b/devices/namron/4512762_open_close_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "df910571-c59a-47a7-8564-b61daadd1370",
   "manufacturername": "Namron AS",
   "modelid": "4512762",
   "vendor": "Namron AS",

--- a/devices/namron/4512765_hum_temp.json
+++ b/devices/namron/4512765_hum_temp.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "f95a027d-57d5-4dc5-800e-f06ee5ea0404",
   "manufacturername": "Namron AS",
   "modelid": "4512765",
   "product": "S903TH-ZG",

--- a/devices/namron/5401395_heater.json
+++ b/devices/namron/5401395_heater.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "6f36f014-8ed9-40ea-9301-05d55797bd3e",
   "manufacturername": ["NAMRON AS", "NAMRON AS"],
   "modelid": ["5401395", "5401399"],
   "vendor": "Namron",

--- a/devices/nedis/nedis_zbrc10wt.json
+++ b/devices/nedis/nedis_zbrc10wt.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "be72689b-cfc6-4968-a146-d9f92da3a225",
   "manufacturername": "_TZ3000_fsiepnrh",
   "modelid": "TS0215A",
   "vendor": "Nedis",

--- a/devices/nedis/nedis_zbsm10wt_motion_sensor.json
+++ b/devices/nedis/nedis_zbsm10wt_motion_sensor.json
@@ -1,5 +1,6 @@
 {
    "schema":"devcap1.schema.json",
+   "uuid":"05069614-e8f7-4ec3-b036-d321ea6713db",
    "manufacturername":"_TZ3000_nss8amz9",
    "modelid":"TS0202",
    "product":"Zigbee motion sensor ZBSM10WT",

--- a/devices/neo/NAS-WR01B_TS011F.json
+++ b/devices/neo/NAS-WR01B_TS011F.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "da98ceeb-581b-4e7f-ac9b-8bc4a6eb9975",
   "manufacturername": [
     "_TZ3000_gjnozsaz",
     "_TZ3000_w0qqde0g",

--- a/devices/neo/TS0012_Immax_smart_controller.json
+++ b/devices/neo/TS0012_Immax_smart_controller.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "076dc726-f9b8-4ffd-bb9e-1f9c48556416",
   "manufacturername": "_TZ3000_llfaquvp",
   "modelid": "TS0012",
   "vendor": "NEO",

--- a/devices/nexentro/nexentro_blinds_actuator_mini.json
+++ b/devices/nexentro/nexentro_blinds_actuator_mini.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "ccefc9fd-e527-42d9-85c4-fc50756052a4",
   "manufacturername": "Insta GmbH",
   "modelid": "NEXENTRO Blinds Actuator",
   "vendor": "NEXENTRO",

--- a/devices/niko/170-33505_170-33605_smart_socket.json
+++ b/devices/niko/170-33505_170-33605_smart_socket.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "92ca3e7c-3d01-446f-814f-e231b4153e1b",
   "manufacturername": "NIKO NV",
   "modelid": "Connected socket outlet",
   "vendor": "Niko NV",

--- a/devices/orvibo/CM10ZW.json
+++ b/devices/orvibo/CM10ZW.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "0f74c8d3-085d-4a91-9464-ae9db879ef27",
   "manufacturername": "ORVIBO",
   "modelid": "396483ce8b3f4e0d8e9d79079a35a420",
   "vendor": "Orvibo",

--- a/devices/orvibo/sf21_smoke_sensor.json
+++ b/devices/orvibo/sf21_smoke_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "c891a13b-0c02-452c-93dd-08428fa0d290",
   "manufacturername": "HEIMAN",
   "modelid": "98293058552c49f38ad0748541ee96ba",
   "vendor": "Orvibo",

--- a/devices/osram/cla60_tw.json
+++ b/devices/osram/cla60_tw.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "f2700e57-348a-470a-83bc-b4fccdeff4f8",
   "manufacturername": "OSRAM",
   "modelid": "CLA60 TW OSRAM",
   "product": "CLA60 TW OSRAM",

--- a/devices/osram/classic_a60_fil_dim_t.json
+++ b/devices/osram/classic_a60_fil_dim_t.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "c559de53-91b1-459c-890e-b8a24c006332",
   "manufacturername": "LEDVANCE",
   "modelid": "A60 FIL DIM T",
   "product": "Filament Classic A 52",

--- a/devices/osram/classic_a60_rgbw.json
+++ b/devices/osram/classic_a60_rgbw.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "5769d071-f5e7-4f13-a894-cece8f801c25",
   "manufacturername": "OSRAM",
   "modelid": "Classic A60 RGBW",
   "product": "Classic A60 RGBW",

--- a/devices/osram/classic_a60_tw.json
+++ b/devices/osram/classic_a60_tw.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "4cb8ab04-0f78-4867-883a-204b8e8bcebc",
   "manufacturername": "OSRAM",
   "modelid": "Classic A60 TW",
   "product": "Classic A60 TW",

--- a/devices/osram/classic_a60_w_clear.json
+++ b/devices/osram/classic_a60_w_clear.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "b9d54d61-57ed-4472-bc66-fa03b21ef533",
   "manufacturername": "OSRAM",
   "modelid": "Classic A60 W clear - LIGHTIFY",
   "product": "Classic A60 W clear - LIGHTIFY",

--- a/devices/osram/classic_b40_tw.json
+++ b/devices/osram/classic_b40_tw.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "6d99ff61-ec81-4398-85bf-e091e7de2b1a",
   "manufacturername": "OSRAM",
   "modelid": "Classic B40 TW - LIGHTIFY",
   "product": "Classic B40 TW - LIGHTIFY",

--- a/devices/osram/par16_50_tw.json
+++ b/devices/osram/par16_50_tw.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "a179c62e-6765-43e4-b24d-9cc849dd499e",
   "manufacturername": "OSRAM",
   "modelid": "PAR16 50 TW",
   "product": "PAR16 50 TW",

--- a/devices/osram/plug_01.json
+++ b/devices/osram/plug_01.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "7d02b7c0-456a-48ee-b690-eae30c3b7c46",
   "manufacturername": "OSRAM",
   "modelid": "Plug 01",
   "product": "Plug 01",

--- a/devices/ouellet/OTH4000-ZB.json
+++ b/devices/ouellet/OTH4000-ZB.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "a523df0f-0b8a-4950-92b7-293f30423e29",
   "manufacturername": "Sinope Technologies",
   "modelid": "OTH4000-ZB",
   "vendor": "Ouellet",

--- a/devices/owon/PIR313-E_sensor_multi.json
+++ b/devices/owon/PIR313-E_sensor_multi.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "01178dcc-3cae-426b-851c-ea705dd03b3a",
   "manufacturername": "OWON",
   "modelid": "PIR313",
   "vendor": "OWON",

--- a/devices/owon/THS317-ET_temperature_sensor.json
+++ b/devices/owon/THS317-ET_temperature_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "1bda6f99-1465-4bc4-bff7-8e2f9c604830",
   "manufacturername": "OWON",
   "modelid": "THS317-ET",
   "product": "THS317-ET",

--- a/devices/owon/ac201.json
+++ b/devices/owon/ac201.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "bd497bc5-c997-450d-a2db-e4c219f863f3",
   "manufacturername": "OWON",
   "modelid": "AC201",
   "product": "AC201",

--- a/devices/paulmann/501_34_battery_switch.json
+++ b/devices/paulmann/501_34_battery_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "e8f0ae5b-e1c5-4a7b-bebc-2e91becb6f81",
   "manufacturername": "Paulmann LichtGmbH",
   "modelid": "501.34",
   "product": "Paulmann Battery Switch",

--- a/devices/philips/light_zb3_C.json
+++ b/devices/philips/light_zb3_C.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "713ce317-9b1a-41b7-b48b-7519fceac4c0",
   "manufacturername": [
     "$MF_PHILIPS",
     "$MF_PHILIPS",

--- a/devices/philips/light_zb3_C_festavia.json
+++ b/devices/philips/light_zb3_C_festavia.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "e7de8f0e-bf48-4ea0-b655-7e04fb6bdfa9",
   "manufacturername": [
     "$MF_SIGNIFY",
     "$MF_PHILIPS"

--- a/devices/philips/light_zb3_C_gradient.json
+++ b/devices/philips/light_zb3_C_gradient.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "b14ab051-43c3-40d5-97ee-813684f05d09",
   "manufacturername": [
     "$MF_SIGNIFY",
     "$MF_SIGNIFY",

--- a/devices/philips/light_zb3_white.json
+++ b/devices/philips/light_zb3_white.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "5c48148f-ac93-414a-b564-064d40567c0b",
   "manufacturername": [
     "$MF_PHILIPS",
     "$MF_PHILIPS",

--- a/devices/philips/light_zb3_white_ambiance.json
+++ b/devices/philips/light_zb3_white_ambiance.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "a0a48701-fe78-46e4-b0e3-696815188cef",
   "manufacturername": [
     "$MF_PHILIPS",
     "$MF_PHILIPS",

--- a/devices/philips/light_zll_A.json
+++ b/devices/philips/light_zll_A.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "525e56e1-3fe2-4462-bea1-790f6499e476",
   "manufacturername": [
     "$MF_PHILIPS",
     "$MF_PHILIPS",

--- a/devices/philips/light_zll_B.json
+++ b/devices/philips/light_zll_B.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "2417ef92-f638-443b-b841-a91a707accbd",
   "manufacturername": [
     "$MF_PHILIPS",
     "$MF_PHILIPS",

--- a/devices/philips/light_zll_C.json
+++ b/devices/philips/light_zll_C.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "793888d6-2257-45e3-b4c5-9c792a5bc47f",
   "manufacturername": [
     "$MF_PHILIPS",
     "$MF_PHILIPS",

--- a/devices/philips/light_zll_white_ambiance.json
+++ b/devices/philips/light_zll_white_ambiance.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "38d455c1-f1d6-43ea-81ec-df46b7a6ddc3",
   "manufacturername": [
     "$MF_PHILIPS",
     "$MF_PHILIPS",

--- a/devices/philips/lom007_smart_plug.json
+++ b/devices/philips/lom007_smart_plug.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "408ae252-d9bd-4a5a-92e1-2c945a73dde8",
   "manufacturername": [
     "$MF_PHILIPS",
     "$MF_SIGNIFY"

--- a/devices/philips/rdm001_wall_switch_module.json
+++ b/devices/philips/rdm001_wall_switch_module.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "3355c7e2-e99f-4eaa-a632-776e2b6d4396",
   "manufacturername": [
     "$MF_SIGNIFY",
     "$MF_SIGNIFY",

--- a/devices/philips/rdm002_tap_dial_switch.json
+++ b/devices/philips/rdm002_tap_dial_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "86a0db54-f38b-4b45-8ab4-37369b0840f5",
   "manufacturername": [
     "$MF_PHILIPS",
     "$MF_SIGNIFY"

--- a/devices/philips/rom001_smart_button.json
+++ b/devices/philips/rom001_smart_button.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "7c9fd37f-ecb0-4cb1-b3d7-6bcae1ecc5ee",
   "manufacturername": [
     "$MF_SIGNIFY",
     "$MF_SIGNIFY",

--- a/devices/philips/rwl022_dimmer_switch.json
+++ b/devices/philips/rwl022_dimmer_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "620dfbd0-bc62-4639-a6a1-19dc3f54e36c",
   "manufacturername": [
     "$MF_PHILIPS",
     "$MF_SIGNIFY"

--- a/devices/philips/rwl02_dimmer_switch.json
+++ b/devices/philips/rwl02_dimmer_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "6c139639-5743-497d-b7b9-9d5f03d1ddde",
   "manufacturername": [
     "$MF_PHILIPS",
     "$MF_PHILIPS"

--- a/devices/philips/sml001_motion_sensor.json
+++ b/devices/philips/sml001_motion_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "a9d19305-bad6-4256-909c-78e069a8253d",
   "manufacturername": "$MF_PHILIPS",
   "modelid": "SML001",
   "vendor": "Philips",

--- a/devices/philips/sml002_motion_sensor.json
+++ b/devices/philips/sml002_motion_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "cf578c9a-7c8c-4bf1-b176-d4ec69c0c0b7",
   "manufacturername": "$MF_PHILIPS",
   "modelid": "SML002",
   "vendor": "Philips",

--- a/devices/philips/sml003_motion_sensor.json
+++ b/devices/philips/sml003_motion_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "1d56b2c1-1f23-4361-b887-f1a0153fa1ef",
   "manufacturername": [
     "$MF_PHILIPS",
     "$MF_SIGNIFY"

--- a/devices/philips/sml004_motion_sensor.json
+++ b/devices/philips/sml004_motion_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "5b5cae8a-2cf9-4ae2-b849-1930916e4155",
   "manufacturername": [
     "$MF_PHILIPS",
     "$MF_SIGNIFY"

--- a/devices/philips/soc001_contact_sensor.json
+++ b/devices/philips/soc001_contact_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "93b3e200-6a52-4ee6-9e0d-54e84536895c",
   "manufacturername": [
     "$MF_SIGNIFY",
     "$MF_PHILIPS"

--- a/devices/plaid_systems/ps-sprzms-slp3_soil_sensor.json
+++ b/devices/plaid_systems/ps-sprzms-slp3_soil_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "7bb7c15c-9129-40f4-9c8a-617d847f5ed9",
   "manufacturername": "PLAID SYSTEMS",
   "modelid": "PS-SPRZMS-SLP3",
   "vendor": "Plaid Systems",

--- a/devices/robb_smarrt/rob_200-017-0_plug.json
+++ b/devices/robb_smarrt/rob_200-017-0_plug.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "8e815937-47fb-47c8-a20b-db46f9a6c2c7",
   "manufacturername": "ROBB smarrt",
   "modelid": "ROB_200-017-0",
   "product": "Smart plug 3680 Watt",

--- a/devices/robb_smarrt/rob_200-029-0_covering.json
+++ b/devices/robb_smarrt/rob_200-029-0_covering.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "c3e59819-892b-4d41-bbe1-31d7c8a72835",
   "manufacturername": "ROBB smarrt",
   "modelid": "ROB_200-029-0",
   "product": "Roller Shutter Switch",

--- a/devices/samsung/samjin_button_switch.json
+++ b/devices/samsung/samjin_button_switch.json
@@ -1,5 +1,6 @@
 {
     "schema": "devcap1.schema.json",
+    "uuid": "23740b64-7f71-4edb-9141-69307741fe75",
     "doc:path": "samsung/samjin_button_switch.md",
     "doc:hdr": "Samsung Button",
     "manufacturername": "$MF_SAMJIN",

--- a/devices/samsung/samjin_multi_sensor.json
+++ b/devices/samsung/samjin_multi_sensor.json
@@ -1,5 +1,6 @@
 {
     "schema": "devcap1.schema.json",
+    "uuid": "7de168f6-a43d-4692-9013-aecaa33ee7c9",
     "manufacturername": "$MF_SAMJIN",
     "modelid": "multi",
     "product": "Multipurpose Sensor (IM6001-OTP01)",

--- a/devices/schwaiger/zhs20_smoke_detector.json
+++ b/devices/schwaiger/zhs20_smoke_detector.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "7dbd20aa-7b02-4f0f-bb48-b9aaaf8122cb",
   "manufacturername": "Heiman",
   "modelid": "SMOK_YDLV10",
   "vendor": "Schwaiger",

--- a/devices/sengled/E12-N1E.json
+++ b/devices/sengled/E12-N1E.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "3df1f61f-b3e7-40f0-ac8c-2578bc2e235d",
   "manufacturername": "sengled",
   "modelid": "E12-N1E",
   "vendor": "sengled",

--- a/devices/sengled/e1c-nb7.json
+++ b/devices/sengled/e1c-nb7.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "977d449e-6cb9-4ab4-a498-09ac6e566700",
   "manufacturername": "sengled",
   "modelid": "E1C-NB7",
   "product": "E1C-NB7",

--- a/devices/sengled/e1d-g73.json
+++ b/devices/sengled/e1d-g73.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "07aafb01-be70-4a9b-8cb4-7939014cd107",
   "manufacturername": "sengled",
   "modelid": "E1D-G73",
   "vendor": "Sengled",

--- a/devices/siglis/zigfred_plus_wired_switch.json
+++ b/devices/siglis/zigfred_plus_wired_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "14fd6af8-b8bd-4b11-8eee-135341040fdb",
   "manufacturername": "Siglis",
   "modelid": "zigfred plus",
   "product": "zigfred plus",

--- a/devices/siglis/zigfred_uno_wired_switch.json
+++ b/devices/siglis/zigfred_uno_wired_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "e42353b6-fa6c-4c47-82d1-61d5dbc13102",
   "manufacturername": "Siglis",
   "modelid": "zigfred uno",
   "product": "zigfred uno",

--- a/devices/sinope/sp2610zb_smart_switch.json
+++ b/devices/sinope/sp2610zb_smart_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "34ba6cbd-2798-4ac2-b5d4-9918b3bd89c5",
   "manufacturername": "Sinope Technologies",
   "modelid": "SP2610ZB",
   "product": "SP2610ZB",

--- a/devices/sinope/th1124zb.json
+++ b/devices/sinope/th1124zb.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "955538c2-6cb3-4e73-8a48-248c94aab6a1",
   "manufacturername": "Sinope Technologies",
   "modelid": "TH1124ZB",
   "product": "TH1124ZB",

--- a/devices/smabit/AV201021C_door_sensor.json
+++ b/devices/smabit/AV201021C_door_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "ecd28fe6-2e26-4f0d-9f6d-3e9e956229f2",
   "manufacturername": "SMaBiT",
   "modelid": "AV2010/21C",
   "vendor": "SMaBiT",

--- a/devices/sonoff/ck-bl702-swp-01(7020)_plug.json
+++ b/devices/sonoff/ck-bl702-swp-01(7020)_plug.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "53f3ec54-fa3f-4479-8312-aecdf3c52ac2",
   "manufacturername": "eWeLink",
   "modelid": "CK-BL702-SWP-01(7020)",
   "vendor": "WOOLLEY ",

--- a/devices/sonoff/snzb-01p_switch_wireless.json
+++ b/devices/sonoff/snzb-01p_switch_wireless.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "b724fa99-e7d5-4738-8f68-1395bd0483e1",
   "manufacturername": "eWeLink",
   "modelid": "SNZB-01P",
   "product": "SNZB-01P",

--- a/devices/sonoff/snzb-02-multisensor.json
+++ b/devices/sonoff/snzb-02-multisensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "52815a37-6180-4ab8-83ef-021d75496a7b",
   "manufacturername": ["eWeLink","SONOFF","SONOFF"],
   "modelid": ["TH01","SNZB-02D","SNZB-02P"],
   "vendor": "SONOFF",

--- a/devices/sonoff/snzb-04_open_close_sensor.json
+++ b/devices/sonoff/snzb-04_open_close_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "cd25fbd8-9b9b-4051-9c01-1c08a9d65203",
   "manufacturername": ["eWeLink", "zbeacon"],
   "modelid": ["DS01", "DS01"],
   "vendor": "SONOFF",

--- a/devices/sonoff/snzb-06p.json
+++ b/devices/sonoff/snzb-06p.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "3c8bf87a-c713-40f4-81f5-794668662737",
   "manufacturername": "SONOFF",
   "modelid": "SNZB-06P",
   "vendor": "Sonoff",

--- a/devices/sonoff/trvzb-thermostat.json
+++ b/devices/sonoff/trvzb-thermostat.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "762fa019-837e-4d90-9147-1e9bd841b807",
   "manufacturername": "SONOFF",
   "modelid": "TRVZB",
   "vendor": "SONOFF",

--- a/devices/sonoff/zbmini-l_relay.json
+++ b/devices/sonoff/zbmini-l_relay.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "beb540be-7ed3-4380-be1c-042b7898f74e",
   "manufacturername": ["SONOFF", "SONOFF"],
   "modelid": ["ZBMINI-L", "ZBMINIL2"],
   "product": "ZBMINI-L or ZBMINIL2",

--- a/devices/stelpro/smt402ad.json
+++ b/devices/stelpro/smt402ad.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "f1c4277b-f0bc-4d08-93ae-5010230b66ec",
   "manufacturername": "Stelpro",
   "modelid": "SMT402AD",
   "product": "SMT402AD Thermostat",

--- a/devices/sunricher/2button_switch.json
+++ b/devices/sunricher/2button_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "fd8925a0-1ec6-439b-abe1-3ba354f8b5a3",
   "manufacturername": [
     "EcoDim",
     "EcoDim",

--- a/devices/sunricher/4button_switch.json
+++ b/devices/sunricher/4button_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "d835ceb3-dc5c-4f8a-80cc-84f5d3900319",
   "manufacturername": [
     "EcoDim",
     "EcoDim",

--- a/devices/sunricher/8button_switch.json
+++ b/devices/sunricher/8button_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "6becf9d0-8d55-4ac9-8366-5125d9a595bf",
   "manufacturername": [
     "EcoDim",
     "EcoDim",

--- a/devices/sunricher/SR-ZG9030A-MW.json
+++ b/devices/sunricher/SR-ZG9030A-MW.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "74a1179a-a69a-4219-9196-fa6e5fdc5d1d",
   "manufacturername": "Sunricher",
   "modelid": "HK-DIM",
   "vendor": "Sunricher",

--- a/devices/sunricher/SR-ZG9080A.json
+++ b/devices/sunricher/SR-ZG9080A.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "7a66015b-448c-422a-8b00-cc6eed60447b",
   "manufacturername": "Sunricher",
   "modelid": "Motor Controller",
   "product": "SR-ZG9080A",

--- a/devices/sunricher/vivares_pbc4_01.json
+++ b/devices/sunricher/vivares_pbc4_01.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "79821f3d-00a0-4e4d-811b-bb1357a6aeed",
   "manufacturername": "Sunricher",
   "modelid": "VIVARES_PBC4_01",
   "vendor": "Sunricher",

--- a/devices/sunricher/zg2855-rgb_button.json
+++ b/devices/sunricher/zg2855-rgb_button.json
@@ -1,5 +1,6 @@
 {
    "schema":"devcap1.schema.json",
+   "uuid":"f0903584-b715-414b-88e4-db5ee8939507",
    "manufacturername":"Sunricher",
    "modelid":"ZG2855-RGB",
    "product":"3 in 1 zigbee push button remote",

--- a/devices/tapestry/tapestry_presence_z1.json
+++ b/devices/tapestry/tapestry_presence_z1.json
@@ -1,5 +1,6 @@
 {
     "schema": "devcap1.schema.json",
+    "uuid": "f7d352e6-19d6-4c4c-98ba-d0dbcda40b2b",
     "manufacturername": "Tapestry",
     "modelid": "THPZ1",
     "vendor": "Tapestry",

--- a/devices/terncy/terncy_dc01_contact_sensor.json
+++ b/devices/terncy/terncy_dc01_contact_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "ae49b1d3-2ad4-432e-8a59-474edd3a9fb8",
   "manufacturername": "Sunricher",
   "modelid": "TERNCY-DC01",
   "product": "TERNCY-DC01 contact sensor",

--- a/devices/terncy/terncy_sd01.json
+++ b/devices/terncy/terncy_sd01.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "96f18b8e-88d4-44cb-b30e-63cc958c2c96",
   "manufacturername": ["Xiaoyan", "TERNCY"],
   "modelid": ["TERNCY-SD01", "TERNCY-SD01"],
   "vendor": "Terncy",

--- a/devices/tesla/TSL-SEN-TAH_multi_sensor.json
+++ b/devices/tesla/TSL-SEN-TAH_multi_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "f9973a48-846a-4cee-b1ae-6a202331bdf6",
   "manufacturername": "_TZ3000_j5fbnjeh",
   "modelid": "TS0201",
   "vendor": "Tesla Global Limited",

--- a/devices/third_reality/3RMS16BZ_motion_sensor.json
+++ b/devices/third_reality/3RMS16BZ_motion_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "240fb1b8-8965-4549-a7eb-df13c38678e1",
   "manufacturername": "Third Reality, Inc",
   "modelid": "3RMS16BZ",
   "product": "Wireless Motion Sensor",

--- a/devices/third_reality/3RSP02028BZ_smart_plug.json
+++ b/devices/third_reality/3RSP02028BZ_smart_plug.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "9e051320-4fbb-43d1-a201-d3991f42bbd2",
   "manufacturername": "Third Reality, Inc",
   "modelid": "3RSP02028BZ",
   "vendor": "Third Reality",

--- a/devices/third_reality/3RTHS24BZ_multi_sensor.json
+++ b/devices/third_reality/3RTHS24BZ_multi_sensor.json
@@ -1,5 +1,6 @@
 {
    "schema":"devcap1.schema.json",
+   "uuid":"03cafb19-0a86-4881-bfb3-ad83eb6ba28f",
    "manufacturername":"Third Reality, Inc",
    "modelid":"3RTHS24BZ",
    "vendor":"ThirdReality",

--- a/devices/third_reality/3RWS18BZ_water_sensor.json
+++ b/devices/third_reality/3RWS18BZ_water_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "825c658a-7923-45d9-87a5-1fa36eb2cfa8",
   "manufacturername": "Third Reality, Inc",
   "modelid": "3RWS18BZ",
   "product": "3RWS18BZ",

--- a/devices/tuya/ZY-M100_human_breathing_presence.json
+++ b/devices/tuya/ZY-M100_human_breathing_presence.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "6ed73563-62f9-4ff2-99e7-feb6755209f1",
   "manufacturername": [
     "_TZE200_ztc6ggyl",
     "_TZE204_ztc6ggyl",

--- a/devices/tuya/_TS0012_2gangs_wired_no_neutral_not_locked.json
+++ b/devices/tuya/_TS0012_2gangs_wired_no_neutral_not_locked.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "dae97704-62d0-42d6-8652-d8ea6020a0de",
   "manufacturername": "_TZ3000_lupfd8zu",
   "modelid": "TS0012",
   "product": "Tuya 2 gangs wired without neutral",

--- a/devices/tuya/_TS0601_TZE204_ijxvkhd0_mmwave_radar.json
+++ b/devices/tuya/_TS0601_TZE204_ijxvkhd0_mmwave_radar.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "6f0fcd39-28ba-44b1-a01f-4a00cf942192",
   "manufacturername": "_TZE204_ijxvkhd0",
   "modelid": "TS0601",
   "product": "Tuya Human Presence Detector",

--- a/devices/tuya/_TS0601_TZE204_qasjif9e_mmwave_radar.json
+++ b/devices/tuya/_TS0601_TZE204_qasjif9e_mmwave_radar.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "7f423a6d-8c5d-4995-8b74-30588ae6184f",
   "manufacturername": "_TZE204_qasjif9e",
   "modelid": "TS0601",
   "product": "Tuya MmwRadar Mini human breathe sensor",

--- a/devices/tuya/_TYZB01_SM0201_temp_hum_sensor.json
+++ b/devices/tuya/_TYZB01_SM0201_temp_hum_sensor.json
@@ -1,5 +1,6 @@
 {
    "schema":"devcap1.schema.json",
+   "uuid":"08dc1145-5065-4dbd-a0dc-3433984f7088",
    "manufacturername":["_TYZB01_cbiezpds", "_TYZB01_zqvwka4k"],
    "modelid":["SM0201","SM0201"],
    "product":"SM0201 Temperature and Humidity Sensor with LCD Display",

--- a/devices/tuya/_TYZB01_TS0011_1gang_wired_no_neutral.json
+++ b/devices/tuya/_TYZB01_TS0011_1gang_wired_no_neutral.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "fcea0ffe-581e-4ccf-ae5a-188930ab14b8",
   "manufacturername": "TYZB01_xfpdrwvc",
   "modelid": "TS0011",
   "product": "TS0011",

--- a/devices/tuya/_TZ1800_ladpngdx_lild_doorbell.json
+++ b/devices/tuya/_TZ1800_ladpngdx_lild_doorbell.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "eb971e80-0096-4734-9d37-63a360b8c860",
   "manufacturername": ["_TZ1800_ladpngdx", "LIDL Silvercrest", "LIDL Silvercrest"],
   "modelid": ["TS0211", "TS0211", "HG06668"],
   "product": "Silvercrest Doorbell",

--- a/devices/tuya/_TZ3000_2channel_module.json
+++ b/devices/tuya/_TZ3000_2channel_module.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "f3712a57-907d-4db9-8a52-76ee1842f83c",
   "manufacturername": [
     "_TZ3000_zmy4lslw",
     "_TZ3000_lmlsduws",

--- a/devices/tuya/_TZ3000_4fjiwweb_smart_knob.json
+++ b/devices/tuya/_TZ3000_4fjiwweb_smart_knob.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "4d24a6d9-924e-4a02-bbe3-c9d82eb899a5",
   "manufacturername": "_TZ3000_4fjiwweb",
   "modelid": "TS004F",
   "vendor": "Tuya",

--- a/devices/tuya/_TZ3000_TS0011_1gang_switch_module.json
+++ b/devices/tuya/_TZ3000_TS0011_1gang_switch_module.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "dff3219b-6a94-454f-a71c-00b8391b15e7",
   "manufacturername": ["_TZ3000_txpirhfq","_TZ3000_qmi1cfuq", "_TZ3000_ji4araar","_TZ3000_v7sopte0","_TYZB01_qeqvmvti","_TZ3000_7jsk6lxz", "_TZ3000_hhiodade"],
   "modelid": ["TS0011", "TS0011", "TS0011","TS0011","TS0011","TS0011", "TS0011"],
   "product": "1 gang switch module",

--- a/devices/tuya/_TZ3000_TS0041_1gang_remote.json
+++ b/devices/tuya/_TZ3000_TS0041_1gang_remote.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "eb70937d-16de-48f6-9aef-e50a6c0831f6",
   "manufacturername": [" _TZ3000_itb0omhv", "_TZ3000_4upl1fcj","_TZ3000_wqcbzbae", "_TZ3000_tk3s5tyg", "_TZ3000_mrpevh8p", "_TZ3000_qgwcxxws", "_TZ3000_yj6k7vfo", "_TZ3000_axpdxqgu"],
   "modelid": ["TS0041", "TS0041", "TS0041", "TS0041", "TS0041", "TS0041", "TS0041", "TS0041"],
   "product": "Tuya 1-gang remote",

--- a/devices/tuya/_TZ3000_TS0042_2gang_remote.json
+++ b/devices/tuya/_TZ3000_TS0042_2gang_remote.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "a1e3894c-d259-4235-852e-2aea617df251",
   "manufacturername": ["_TZ3000_5e235jpa", "_TZ3000_t8hzpgnd", "_TZ3000_tzvbimpq", "_TZ3000_i3rjdrwu"],
   "modelid": ["TS0042", "TS0042", "TS0042", "TS0042"],
   "product": "Tuya 2-gang remote",

--- a/devices/tuya/_TZ3000_TS0043_3gang_remote.json
+++ b/devices/tuya/_TZ3000_TS0043_3gang_remote.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "d333ea82-790f-42e4-ac3b-c255f67a95be",
   "manufacturername": ["_TZ3000_gbm10jnj", "_TZ3000_sj7jbgks", "_TZ3000_w8jwkczz", "_TZ3000_famkxci2", "_TZ3000_w3c7ouru", "_TZ3000_yw5tvzsk", "_TZ3000_pkeqinnt"],
   "modelid": ["TS0043", "TS0043", "TS0043", "TS0043", "TS0043", "TS0043", "TS0043"],
   "product": "Tuya 3-gang remote",

--- a/devices/tuya/_TZ3000_TS0044_4gang_remote.json
+++ b/devices/tuya/_TZ3000_TS0044_4gang_remote.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "da3c3112-7dcd-419f-9e4b-cc9f32bf6e56",
   "manufacturername": [
     "_TZ3000_ygvf9xzp",
     "_TZ3000_ee8nrt2l",

--- a/devices/tuya/_TZ3000_TS004F_switch.json
+++ b/devices/tuya/_TZ3000_TS004F_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "0a13c865-4c4b-4264-9a32-ba438027c477",
   "manufacturername": ["_TZ3000_rco1yzb1","_TZ3000_czuyt8lz"],
   "modelid": ["TS004F","TS004F"],
   "product": "TS004F Scene Switch",

--- a/devices/tuya/_TZ3000_TS011F_PowerStrip.json
+++ b/devices/tuya/_TZ3000_TS011F_PowerStrip.json
@@ -1,5 +1,6 @@
 {
    "schema":"devcap1.schema.json",
+   "uuid":"692c7676-9365-4ec4-9549-9d7c114986f2",
    "manufacturername": [
       "_TZ3000_cfnprab5",
       "_TZ3000_o005nuxx",

--- a/devices/tuya/_TZ3000_TS011F_smart_plug.json
+++ b/devices/tuya/_TZ3000_TS011F_smart_plug.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "0b14b62e-ba7e-4b8d-9ede-f9e92497104f",
   "manufacturername": ["_TZ3000_okaz9tjs", "_TZ3000_dksbtrzs", "_TZ3000_gvn91tmx"],
   "modelid": ["TS011F", "TS011F", "TS011F"],
   "product": "Smart Plug Power Monitor",

--- a/devices/tuya/_TZ3000_TS0201_temp_hum_sensor.json
+++ b/devices/tuya/_TZ3000_TS0201_temp_hum_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "d20fd95e-3343-4898-adc3-59111f4812af",
   "manufacturername": ["_TZ3000_yd2e749y", "_TZ3000_fllyghyj", "_TZ3000_fie1dpkm", "_TZ3000_lbtpiody", "_TZ3000_5nrcorgu", "_TZ3000_ena8vgqb", "_TZ3000_xr3htd96", "_TZ3000_0s1izerx", "_TZ3000_saiqcn0y"],
   "modelid": ["TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201"],
   "vendor": "Tuya",

--- a/devices/tuya/_TZ3000_TS0203_door_sensor.json
+++ b/devices/tuya/_TZ3000_TS0203_door_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "1076594e-6f2f-42eb-bade-e1b41c7dbe78",
   "manufacturername": ["_TZ3000_n2egfsli", "_TZ3000_oxslv1c9", "_TZ3000_7tbsruql", "_TZ3000_7d8yme6f", "_TZ3000_rgchmad8", "_TZ3000_bzxlofth","_TZ3000_au1rjicn", "_TZ3000_4ugnzsli", "_TZ3000_decxrtwa", "_TZ3000_2mbfxlzr", "_TZ3000_6zvw8ham", "_TZ3000_v7chgqso", "_TZ3000_yxqnffam", "_TZ3000_zgrffiwg","_TZ3000_1bwpjvlz"],
   "modelid": ["TS0203", "TS0203", "TS0203", "TS0203", "TS0203", "TS0203","TS0203","TS0203","TS0203", "TS0203", "TS0203", "TS0203", "TS0203", "TS0203", "TS0203"],
   "vendor": "Tuya",

--- a/devices/tuya/_TZ3000_TS0207_water_leak_sensor.json
+++ b/devices/tuya/_TZ3000_TS0207_water_leak_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "35e0da16-c0f6-46a9-a122-900404043bcb",
   "manufacturername": [
     "_TZ3000_d16y6col",
     "_TZ3000_ww9i3e0y",

--- a/devices/tuya/_TZ3000_TS0210_vibration_sensor.json
+++ b/devices/tuya/_TZ3000_TS0210_vibration_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "a4ade039-8213-47cc-8f92-09b04d7557cd",
   "manufacturername": ["_TZ3000_bmfw9ykl", "_TZ3000_lzdjjfss", "_TZ3000_lqpt3mvr"],
   "modelid": ["TS0210","TS0210","TS0210"],
   "vendor": "Tuya",

--- a/devices/tuya/_TZ3000__TS0207_range_extender.json
+++ b/devices/tuya/_TZ3000__TS0207_range_extender.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "9d273448-b13a-41a8-9dfe-1e1de9927214",
   "manufacturername": ["_TZ3000_m0vaazab","_TZ3000_ufttklsz","_TZ3000_5k5vh43t","_TZ3000_gszjt2xx"],
   "modelid": ["TS0207","TS0207","TS0207","TS0207"],
   "product": "Range Extender",

--- a/devices/tuya/_TZ3000_cehuw1lw_smartplug_EU.json
+++ b/devices/tuya/_TZ3000_cehuw1lw_smartplug_EU.json
@@ -1,5 +1,6 @@
 {
     "schema": "devcap1.schema.json",
+    "uuid": "37f521f8-bcb4-41ca-a865-961258d96ca9",
     "manufacturername": "_TZ3000_cehuw1lw",
     "modelid": "TS011F",
     "product": "Random tuya plug",

--- a/devices/tuya/_TZ3000_gzvniqjb_din_rail_switch.json
+++ b/devices/tuya/_TZ3000_gzvniqjb_din_rail_switch.json
@@ -1,5 +1,6 @@
 {
 	"schema": "devcap1.schema.json",
+	"uuid": "f66ebd4f-7da9-40a0-b06b-eb6327b73abb",
 	"manufacturername": "_TZ3000_gzvniqjb",
 	"modelid": "TS0011",
 	"product": "TO-Q-SY1-ZT",

--- a/devices/tuya/_TZ3000_hkkkuk7k_mini_switch.json
+++ b/devices/tuya/_TZ3000_hkkkuk7k_mini_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "a6d2c96b-43b7-4e6b-9884-350191c770bb",
   "manufacturername": "_TZ3000_hkkkuk7k",
   "modelid": "TS0012",
   "product": "Tuya 2 output module",

--- a/devices/tuya/_TZ3000_i8jfiezr_temp_hum_sensor.json
+++ b/devices/tuya/_TZ3000_i8jfiezr_temp_hum_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "fb9f9e4f-e1dc-46d7-9d5d-ebe6d54af094",
   "manufacturername": "_TZ3000_i8jfiezr",
   "modelid": "TS0201",
   "vendor": "RTX",

--- a/devices/tuya/_TZ3000_ja5osu5g_smart_button.json
+++ b/devices/tuya/_TZ3000_ja5osu5g_smart_button.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "656d7e98-18d8-472f-a462-2c8ca7f0b702",
   "manufacturername": ["_TZ3000_ja5osu5g", "_TZ3000_fa9mlvja"],
   "modelid": ["TS004F", "TS0041"],
   "vendor": "Tuya",

--- a/devices/tuya/_TZ3000_jl7qyupf_2gangs_switch_locked.json
+++ b/devices/tuya/_TZ3000_jl7qyupf_2gangs_switch_locked.json
@@ -1,5 +1,6 @@
 {
    "schema":"devcap1.schema.json",
+   "uuid":"e8976fdf-293d-4da2-8408-64b9b043c6f9",
    "manufacturername":"_TZ3000_jl7qyupf",
    "modelid":"TS0012",
    "product":"Wired Switch 2 gangs, locked by tuya",

--- a/devices/tuya/_TZ3000_pfc7i3kt_smart_switch_3gangs_locked.json
+++ b/devices/tuya/_TZ3000_pfc7i3kt_smart_switch_3gangs_locked.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "bb9f0394-adc0-4361-bf65-2a8efe1ff741",
   "manufacturername": "_TZ3000_pfc7i3kt",
   "modelid": "TS0003",
   "product": "Wired Switch 3 gangs (locked)",

--- a/devices/tuya/_TZ3000_qewo8dlz_wired_switch_3gangs.json
+++ b/devices/tuya/_TZ3000_qewo8dlz_wired_switch_3gangs.json
@@ -1,5 +1,6 @@
 {
    "schema":"devcap1.schema.json",
+   "uuid":"15e1102b-831e-431b-bb8c-c1d53c4f5490",
    "manufacturername":"_TZ3000_qewo8dlz",
    "modelid":"TS0013",
    "product":"Wired Switch 3 gangs",

--- a/devices/tuya/_TZ3000_typdpbpg_smart_plug_eu.json
+++ b/devices/tuya/_TZ3000_typdpbpg_smart_plug_eu.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "447891a5-bc6c-4daa-a8ee-9e5f2b2a898c",
   "manufacturername": "_TZ3000_typdpbpg",
   "modelid": "TS011F",
   "vendor": "Tuya",

--- a/devices/tuya/_TZ3000_wkr3jqmr_4channel_module.json
+++ b/devices/tuya/_TZ3000_wkr3jqmr_4channel_module.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "3a7cad20-0c89-4f6a-b629-dd696f59eab8",
   "manufacturername": "_TZ3000_wkr3jqmr",
   "modelid": "TS0004",
   "product": "Tuya 4 output module",

--- a/devices/tuya/_TZ3210_dse8ogfy_fingerbot.json
+++ b/devices/tuya/_TZ3210_dse8ogfy_fingerbot.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "aeb64a3c-50c7-45c7-9dca-6378a5004200",
   "manufacturername": ["_TZ3210_dse8ogfy", "_TZ3210_j4pdtz9v"],
   "modelid": ["TS0001", "TS0001"],
   "vendor": "Tuya",

--- a/devices/tuya/_TZ3210_up3pngle_TS0205_smoke_sensor.json
+++ b/devices/tuya/_TZ3210_up3pngle_TS0205_smoke_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "34e7ba38-6b11-4e13-9a82-110260b9f3c2",
   "manufacturername": "_TZ3210_up3pngle",
   "modelid": "TS0205",
   "vendor": "Tuya",

--- a/devices/tuya/_TZB000_42ha4rsc_window_blinds.json
+++ b/devices/tuya/_TZB000_42ha4rsc_window_blinds.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "165aea49-d5c1-4418-a479-cdad4dfe1600",
   "manufacturername": "_TZB000_42ha4rsc",
   "modelid": "TS030F",
   "product": "Livarno blinds",

--- a/devices/tuya/_TZE200_2ekuz3dz_trv.json
+++ b/devices/tuya/_TZE200_2ekuz3dz_trv.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "edfadfce-d2d8-481a-967d-c46972c5b642",
   "manufacturername": "_TZE200_2ekuz3dz",
   "modelid": "TS0601",
   "vendor": "Tuya",

--- a/devices/tuya/_TZE200_2wg5qrjy_valve.json
+++ b/devices/tuya/_TZE200_2wg5qrjy_valve.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "1d0e1b23-c414-4ad4-bb8a-1736cb9f977e",
   "manufacturername": "_TZE200_2wg5qrjy",
   "modelid": "TS0601",
   "vendor": "Mercator",

--- a/devices/tuya/_TZE200_3towulqd_motion_lux_sensor.json
+++ b/devices/tuya/_TZE200_3towulqd_motion_lux_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "6d1725ae-df24-4918-a858-be58c4c3e6f5",
   "manufacturername": "_TZE200_3towulqd",
   "modelid": "TS0601",
   "vendor": "Tuya",

--- a/devices/tuya/_TZE200_9cxuhakf_wired_dimmer.json
+++ b/devices/tuya/_TZE200_9cxuhakf_wired_dimmer.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "2762e581-9e0c-4586-9cab-d636b7c3e5aa",
   "manufacturername": "_TZE200_9cxuhakf",
   "modelid": "TS0601",
   "vendor": "Mercator",

--- a/devices/tuya/_TZE200_TS0601_humidity_temp.json
+++ b/devices/tuya/_TZE200_TS0601_humidity_temp.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "2a639a12-22c6-4a1c-b2a3-90ae3a68a837",
   "manufacturername": ["_TZE200_nnrfa68v","_TZE200_znbl8dj5", "_TZE200_qoy0ekbd", "_TZE200_a8sdabtg", "_TZE200_whkgqxse","_TZE200_yjjdcqsq", "_TZE200_9yapgbuv", "_TZE200_utkemkbs", "_TZE200_locansqn"],
   "modelid": ["TS0601","TS0601", "TS0601", "TS0601", "TS0601", "TS0601", "TS0601", "TS0601", "TS0601"],
   "vendor": "Tuya",

--- a/devices/tuya/_TZE200_TS0601_mmWave_Radar.json
+++ b/devices/tuya/_TZE200_TS0601_mmWave_Radar.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "eadb2b6f-aeb8-4695-923d-ba0eb42fd003",
   "manufacturername": ["_TZE200_v6ossqfy","_TZE200_mx6u6l4y","_TZE200_0u3bj3rc"],
   "modelid": ["TS0601","TS0601","TS0601"],
   "product": "2.4GHz mmWave radar w/LED",

--- a/devices/tuya/_TZE200_TS0601_smoke_detector.json
+++ b/devices/tuya/_TZE200_TS0601_smoke_detector.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "0d0e2021-e61c-49fc-8d7c-f54533815996",
   "manufacturername": ["_TZE200_m9skfctm","_TZE200_vzekyi4c"],
   "modelid": ["TS0601","TS0601"],
   "vendor": "Tuya",

--- a/devices/tuya/_TZE200_TS0601_trv.json
+++ b/devices/tuya/_TZE200_TS0601_trv.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "88f07be9-48ca-454c-b764-d0587138d094",
   "manufacturername": ["_TZE200_bvu2wnxz", "_TZE200_6rdj8dzm", "_TZE200_gd4rvykv", "_TZE200_rxntag7i", "_TZE200_p3dbf6qs"],
   "modelid": ["TS0601", "TS0601", "TS0601", "TS0601", "TS0601"],
   "vendor": "Tuya",

--- a/devices/tuya/_TZE200_amp6tsvy_wired_switch_1gang.json
+++ b/devices/tuya/_TZE200_amp6tsvy_wired_switch_1gang.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "05836394-be13-49dd-9bec-68f962076311",
   "manufacturername": "_TZE200_amp6tsvy",
   "modelid": "TS0601",
   "product": "Tuya 1 gang wired switch",

--- a/devices/tuya/_TZE200_bjawzodf_humidity_temp.json
+++ b/devices/tuya/_TZE200_bjawzodf_humidity_temp.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "c7017086-082a-4c0b-baae-5a55171f3733",
   "manufacturername": ["_TZE200_bjawzodf", "_TZE200_zl1kmjqx"],
   "modelid": ["TS0601", "TS0601"],
   "product": "Tuya multi sensor",

--- a/devices/tuya/_TZE200_byzdayie_din_enrgy_meter.json
+++ b/devices/tuya/_TZE200_byzdayie_din_enrgy_meter.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "438898c5-16f6-44f4-9768-22ac33490d69",
   "manufacturername": ["_TZE200_byzdayie", "_TZE200_fsb6zw01", "_TZE200_ewxhg6o9"],
   "modelid": ["TS0601", "TS0601", "TS0601"],
   "product": "Single Phase 65A Din Rail Smart Energy Meter",

--- a/devices/tuya/_TZE200_dq1mfjug_smoke_sensor.json
+++ b/devices/tuya/_TZE200_dq1mfjug_smoke_sensor.json
@@ -1,6 +1,7 @@
 
 {
   "schema": "devcap1.schema.json",
+  "uuid": "e8f3e015-6c02-478c-a51e-7730a86293cc",
   "manufacturername": "_TZE200_dq1mfjug",
   "modelid": "TS0601",
   "vendor": "Tuya",

--- a/devices/tuya/_TZE200_dwcarsat_air_sensor.json
+++ b/devices/tuya/_TZE200_dwcarsat_air_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "85009be3-61c1-4c97-a12b-ca646f7952bb",
   "manufacturername": "_TZE200_dwcarsat",
   "modelid": "TS0601",
   "vendor": "Tuya",

--- a/devices/tuya/_TZE200_e3oitdyu_smart_dimmer_module.json
+++ b/devices/tuya/_TZE200_e3oitdyu_smart_dimmer_module.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "3c38d64a-5192-4183-882c-e4320e914bb5",
   "manufacturername": "_TZE200_e3oitdyu",
   "modelid": "TS0601",
   "vendor": "$MF_TUYA",

--- a/devices/tuya/_TZE200_h4cgnbzg_trv.json
+++ b/devices/tuya/_TZE200_h4cgnbzg_trv.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "61757e9c-92d5-431f-a28f-22b2f30116dc",
   "manufacturername": ["_TZE200_h4cgnbzg", "_TZE200_exfrnlow", "_TZE200_9m4kmbfu", "_TZE200_3yp57tby", "_TZE200_9gvruqf5", "_TZE200_zr9c0day", "_TZE200_0dvm9mva"],
   "modelid": ["TS0601", "TS0601", "TS0601", "TS0601", "TS0601", "TS0601", "TS0601"],
   "vendor": "Tuya",

--- a/devices/tuya/_TZE200_hhrtiq0x_nedis_trv.json
+++ b/devices/tuya/_TZE200_hhrtiq0x_nedis_trv.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "f2401df5-5635-4878-b176-e3246192b02c",
   "manufacturername": ["_TZE200_hhrtiq0x", "_TZE200_ps5v5jor", "_TZE200_2cs6g9i7"],
   "modelid": ["TS0601", "TS0601", "TS0601"],
   "vendor": "Tuya",

--- a/devices/tuya/_TZE200_htnnfasr_water_valve.json
+++ b/devices/tuya/_TZE200_htnnfasr_water_valve.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "7b06366d-9e69-471f-b703-a3e0212e833d",
   "manufacturername": "_TZE200_htnnfasr",
   "modelid": "TS0601",
   "vendor": "LIDL",

--- a/devices/tuya/_TZE200_myd45weu_soil_sensor.json
+++ b/devices/tuya/_TZE200_myd45weu_soil_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "d32fe4d8-def4-4bd0-9d6e-8822d793f387",
   "manufacturername": ["_TZE200_myd45weu", "_TZE200_9cqcpkgb", "_TZE200_ga1maeof"],
   "modelid": ["TS0601", "TS0601", "TS0601"],
   "product": "Tuya Soil Sensor",

--- a/devices/tuya/_TZE200_pay2byax_openclose_sensor.json
+++ b/devices/tuya/_TZE200_pay2byax_openclose_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "fc4a79fe-ccd4-4973-b167-ceba1e0d8db2",
   "manufacturername": ["_TZE200_pay2byax", "_TZE200_kltffuzl", "_TZE200_fwoorn8y"],
   "modelid": ["TS0601", "TS0601", "TS0601"],
   "product": "ZG-102Z or TM001-ZA or TM081 open/close sensor",

--- a/devices/tuya/_TZE200_thbr5z34_awow__trv.json
+++ b/devices/tuya/_TZE200_thbr5z34_awow__trv.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "ad397c3b-9008-48d9-942c-8e41d4cbae16",
   "manufacturername": "_TZE200_thbr5z34",
   "modelid": "TS0601",
   "vendor": "Tuya",

--- a/devices/tuya/_TZE200_ztvwu4nk_thermostat.json
+++ b/devices/tuya/_TZE200_ztvwu4nk_thermostat.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "90e437ea-e697-4490-8944-e0d8ef0dc1d0",
   "manufacturername": ["_TZE200_ztvwu4nk", "_TZE204_5toc8efa", "_TZE200_5toc8efa", "_TZE200_ye5jkfsb", "_TZE204_aoclfnxz", "_TZE200_u9bfwha0"],
   "modelid": ["TS0601", "TS0601", "TS0601", "TS0601", "TS0601", "TS0601"],
   "vendor": "Tuya",

--- a/devices/tuya/_TZE204_ac0fhfiq_energy_meter.json
+++ b/devices/tuya/_TZE204_ac0fhfiq_energy_meter.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "ad471d48-8ab4-4d20-a854-56f8423f568d",
   "manufacturername": "_TZE204_ac0fhfiq",
   "modelid": "TS0601",
   "product": "BiDirectional ZigBee Energy Meter",

--- a/devices/tuya/_TZE204_sxm7l9xa_mmwave_radar.json
+++ b/devices/tuya/_TZE204_sxm7l9xa_mmwave_radar.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "63378e16-6840-4b37-9e9e-ac17c8462e08",
   "manufacturername": "_TZE204_sxm7l9xa",
   "modelid": "TS0601",
   "product": "Tuya Human Presence Detector",

--- a/devices/tuya/ih-f001_door_sensor.json
+++ b/devices/tuya/ih-f001_door_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "1d617334-5601-4e19-894d-f2a6ea7feec8",
   "manufacturername": "_TZ3000_oxslv1c9",
   "modelid": "TS0203",
   "vendor": "Tuya",

--- a/devices/tuya/ih-k009_temp_hum_sensor.json
+++ b/devices/tuya/ih-k009_temp_hum_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "5f124e57-55fc-42c8-821f-c89854d1f031",
   "manufacturername": "_TZ3000_dowj6gyi",
   "modelid": "TS0201",
   "vendor": "Tuya",

--- a/devices/tuya/nous_a1z_smart_plug.json
+++ b/devices/tuya/nous_a1z_smart_plug.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "c2c9821b-310d-4d66-887e-49ca30163591",
   "manufacturername": ["_TZ3000_ksw8qtmt", "_TZ3000_2putqrmw"],
   "modelid": ["TS011F", "TS011F"],
   "vendor": "Nous",

--- a/devices/tuya/rh3040_motion_sensor.json
+++ b/devices/tuya/rh3040_motion_sensor.json
@@ -1,5 +1,6 @@
 {
     "schema": "devcap1.schema.json",
+    "uuid": "b6e27b28-6397-4dfe-b640-ec3ccf32e0ce",
     "doc:path": "tuya/rh3040_motion_sensor.md",
     "doc:hdr": "Motion sensor RH3040",
     "manufacturername": ["TUYATEC-zn9wyqtr", "TUYATEC-lakq7nse", "TUYATEC-53o41joc"],

--- a/devices/tuya/ts0202_presence_sensor.json
+++ b/devices/tuya/ts0202_presence_sensor.json
@@ -1,5 +1,6 @@
 {
    "schema":"devcap1.schema.json",
+   "uuid":"13e89e44-1f42-4e5d-8d29-995d394451ac",
    "manufacturername": ["_TYZB01_tv3wxhcz","_TYZB01_hqbdru35","TZ3000_tiwq83wk","_TZ3000_ykwcwxmz","_TZ3000_hgu1dlak","_TZ3000_hktqahrq","_TZ3000_kmh5qpmb",
                         "_TZ3000_jmrgyl7o","_TZ3000_msl6wxk9", "_TZ3000_otvn3lne", "_TZ3000_6ygjfyll", "_TZ3040_6ygjfyll", "_TZ3000_mcxw5ehu","_TYZB01_ef5xlc9q",
                         "_TYZB01_vwqnz1sn","_TYZB01_2b8f6cio","_TZE200_bq5c8xfe","_TYZB01_dl7cejts","_TYZB01_qjqgmqxr","_TZ3000_mmtwjmaq","_TYZB01_zwvaj5wy",

--- a/devices/ubisys/c4_5504.json
+++ b/devices/ubisys/c4_5504.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "c4d31091-6713-4c79-af25-5e9830d1e9a0",
   "manufacturername": "ubisys",
   "modelid": "C4 (5504)",
   "vendor": "ubisys",

--- a/devices/ubisys/d1_5503_d1r_5603.json
+++ b/devices/ubisys/d1_5503_d1r_5603.json
@@ -1,5 +1,6 @@
 {
     "schema": "devcap1.schema.json",
+    "uuid": "651042bb-371c-4964-abaa-f4277f4ea9d5",
     "manufacturername": ["ubisys", "ubisys"],
     "modelid": ["D1 (5503)", "D1-R (5603)"],
     "product": "D1 (5503)/D1-R (5603)",

--- a/devices/ubisys/h1.json
+++ b/devices/ubisys/h1.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "3a22aa89-e2e1-4586-aad9-c35dbe031b46",
   "manufacturername": "ubisys",
   "modelid": "H1",
   "vendor": "ubisys",

--- a/devices/ubisys/j1_5502.json
+++ b/devices/ubisys/j1_5502.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "c8b0f213-303a-41c7-980f-fca9ef952953",
   "manufacturername": "ubisys",
   "modelid": "J1 (5502)",
   "vendor": "ubisys",

--- a/devices/ubisys/j1r_5602.json
+++ b/devices/ubisys/j1r_5602.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "808d01ee-4817-4e13-ab3e-ecb540bb566b",
   "manufacturername": "ubisys",
   "modelid": "J1-R (5602)",
   "vendor": "ubisys",

--- a/devices/ubisys/ld6.json
+++ b/devices/ubisys/ld6.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "7f333034-1cf4-41a4-aa3f-00a600b12a92",
   "manufacturername": "ubisys",
   "modelid": "LD6",
   "product": "Lighting Driver LD6",

--- a/devices/ubisys/s1_5501_s1r_5601.json
+++ b/devices/ubisys/s1_5501_s1r_5601.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "d275912e-9490-4deb-9225-c17b882703ae",
   "manufacturername": ["ubisys", "ubisys"],
   "modelid": ["S1 (5501)", "S1-R (5601)"],
   "vendor": "ubisys",

--- a/devices/ubisys/s2_5502.json
+++ b/devices/ubisys/s2_5502.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "837628a0-9669-4a08-8f81-5a6d6acfaec2",
   "manufacturername": "ubisys",
   "modelid": "S2 (5502)",
   "vendor": "ubisys",

--- a/devices/ubisys/s2r_5602.json
+++ b/devices/ubisys/s2r_5602.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "5036d75b-a26b-4377-8628-44adeaa3bc5a",
   "manufacturername": "ubisys",
   "modelid": "S2-R (5602)",
   "vendor": "ubisys",

--- a/devices/wattle/hc-slm-1_doorlock.json
+++ b/devices/wattle/hc-slm-1_doorlock.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "02e93675-afbe-435c-b071-399c4d53a643",
   "manufacturername": "Home Control AS",
   "modelid": "HC-SLM-1",
   "vendor": "Wattle",

--- a/devices/wiser/contact_sensor_cct591011_as.json
+++ b/devices/wiser/contact_sensor_cct591011_as.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "5ee1ec56-058c-409e-a0b1-21dc4254203c",
   "manufacturername": "Schneider Electric",
   "modelid": "CCT591011_AS",
   "vendor": "LK Wiser",

--- a/devices/wiser/dimmer_module.json
+++ b/devices/wiser/dimmer_module.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "91302945-48e9-448e-94c9-4aa1286441dc",
   "manufacturername": "Schneider Electric",
   "modelid": "CH/DIMMER/1",
   "product": "40/300-Series Module Dimmer",

--- a/devices/wiser/dimmer_switch_1Gang.json
+++ b/devices/wiser/dimmer_switch_1Gang.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "fe300f6a-22ec-41fb-9658-43483f6e1e10",
   "manufacturername": "Schneider Electric",
   "modelid": "1GANG/DIMMER/1",
   "product": "Merten - Schneider Dimmer 1 GANG",

--- a/devices/wiser/dimmer_switch_2Gang.json
+++ b/devices/wiser/dimmer_switch_2Gang.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "7d0ca1ce-a7c9-4d3c-a26f-bae789a5a4bd",
   "manufacturername": "Schneider Electric",
   "modelid": "1GANG/DIMMER/1",
   "product": "Merten - Schneider Dimmer 2 GANG",

--- a/devices/wiser/fuga_4button_battery_switch.json
+++ b/devices/wiser/fuga_4button_battery_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "6520f051-3aca-4197-8bb1-882398107fc9",
   "manufacturername": ["Schneider Electric", "Schneider Electric"],
   "modelid": ["FLS/AIRLINK/4", "FLS/SYSTEM-M/4"],
   "product": "4 or 2 Button Switch wireless",

--- a/devices/wiser/fuga_dimmer_switch.json
+++ b/devices/wiser/fuga_dimmer_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "de597758-80a6-4f63-84b4-c8497821f6e1",
   "manufacturername": "Schneider Electric",
   "modelid": "LK Dimmer",
   "product": "LK Fuga Dimmer Switch",

--- a/devices/wiser/fuga_double_relay_switch.json
+++ b/devices/wiser/fuga_double_relay_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "244aa7fa-af3d-489b-afc1-a277311338ed",
   "manufacturername": "Schneider Electric",
   "modelid": "LK Switch",
   "product": "LK Fuga Double Relay Switch",

--- a/devices/wiser/fuga_socket_outlet.json
+++ b/devices/wiser/fuga_socket_outlet.json
@@ -1,5 +1,6 @@
 {
    "schema":"devcap1.schema.json",
+   "uuid":"223dea85-638b-4489-bec4-3eabea01dba4",
    "manufacturername":["Schneider Electric", "Schneider Electric"],
    "modelid":["LK/OUTLET/1", "SOCKET/OUTLET/1"],
    "product":"Connected socket outlet 16A",

--- a/devices/wiser/smart-plug-single-16A.json
+++ b/devices/wiser/smart-plug-single-16A.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "c8ed8ec9-cab9-4b7f-a917-a94282887a07",
   "manufacturername": "Schneider Electric",
   "modelid": "SMARTPLUG/1",
   "product": "SMARTPLUG/1",

--- a/devices/wiser/socket-outlet-double-16A-connected.json
+++ b/devices/wiser/socket-outlet-double-16A-connected.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "93faf7ca-97e1-4d92-857b-7c311ddab4f7",
   "manufacturername": "Schneider Electric",
   "modelid": "SOCKET/OUTLET/2",
   "product": "SOCKET/OUTLET/2",

--- a/devices/wiser/switch_1Gang.json
+++ b/devices/wiser/switch_1Gang.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "15c66594-8515-480a-9ba4-05ce912fe5a9",
   "manufacturername": "Schneider Electric",
   "modelid": "1GANG/SWITCH/1",
   "product": "Merten / Schneider Switch 1GANG",

--- a/devices/wiser/wall_switch_shutter.json
+++ b/devices/wiser/wall_switch_shutter.json
@@ -1,5 +1,6 @@
 {
     "schema": "devcap1.schema.json",
+    "uuid": "1d90bd73-6292-4387-bf0f-a4a87ad4701b",
     "manufacturername": "Schneider Electric",
     "modelid": "NHPB/SHUTTER/1",
     "vendor": "Wiser Odace",

--- a/devices/woox/Woox_R7049_Smart_Smoke_Alarm.json
+++ b/devices/woox/Woox_R7049_Smart_Smoke_Alarm.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "3e0e9169-ca6c-4a47-9d70-b35e703eb71f",
   "manufacturername": "_TZE200_aycxwiau",
   "modelid": "TS0601",
   "vendor": "WOOX",

--- a/devices/woox/woox_r7048_hum_temp_sensor.json
+++ b/devices/woox/woox_r7048_hum_temp_sensor.json
@@ -1,5 +1,6 @@
 {
    "schema":"devcap1.schema.json",
+   "uuid":"8eff3666-a36d-4a24-a0aa-82396593332a",
    "manufacturername":"_TZ3000_amqudjr0",
    "modelid":"TS0201",
    "product":"R7048 Temperature & Humidity Sensor",

--- a/devices/woox/woox_r7052_ts0215a.json
+++ b/devices/woox/woox_r7052_ts0215a.json
@@ -1,5 +1,6 @@
 {
    "schema":"devcap1.schema.json",
+   "uuid":"efb902e6-1d18-4c58-b1ee-c5dc05574c3b",
    "manufacturername":["_TZ3000_ssp0maqm", "_TZ3000_zsh6uat3"],
    "modelid":["TS0215A", "TS0215A"],
    "vendor":"Woox",

--- a/devices/woox/woox_r7054_remote.json
+++ b/devices/woox/woox_r7054_remote.json
@@ -1,5 +1,6 @@
 {
    "schema":"devcap1.schema.json",
+   "uuid":"8f5efd13-fd87-4f67-acdf-fe02bde82d3d",
    "manufacturername":["_TZ3000_0zrccfgx", "_TZ3000_p6ju8myv"],
    "modelid":["TS0215A", "TS0215A"],
    "vendor":"Woox",

--- a/devices/woox/woox_r7060_ts0101.json
+++ b/devices/woox/woox_r7060_ts0101.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "13a63ec0-34c7-43b7-96e2-e9d33348642e",
   "manufacturername": "_TZ3210_eymunffl",
   "modelid": "TS0101",
   "vendor": "WOOX",

--- a/devices/xfinity/THK1_keypad.json
+++ b/devices/xfinity/THK1_keypad.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "6aa5a6c3-8bd0-4cf8-8f02-279cb0bf4ee2",
   "manufacturername": ["Technicolor","Universal Electronics Inc","Universal Electronics Inc"],
   "modelid": ["TKA105","URC4450BC0-X-R","H34450BA00-00007"],
   "product": "Xfinity security keypad",

--- a/devices/xiaomi/lumi_airmonitor_acn01.json
+++ b/devices/xiaomi/lumi_airmonitor_acn01.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "f2680399-a74e-4099-9b7e-922805e14023",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.airmonitor.acn01",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/lumi_curtain.json
+++ b/devices/xiaomi/lumi_curtain.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "5c04457c-fde5-45e7-8342-07d15ffaae44",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.curtain",
   "product": "Xiaomi Aqara Smart Curtain Controller",

--- a/devices/xiaomi/lumi_curtain_acn002.json
+++ b/devices/xiaomi/lumi_curtain_acn002.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "35795459-326d-4e16-a202-05195107ca61",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.curtain.acn002",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/lumi_light_acn132.json
+++ b/devices/xiaomi/lumi_light_acn132.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "0c2352ed-e57d-40df-9cd8-2ed8e34101b9",
   "manufacturername": [
     "$MF_AQARA",
     "$MF_LUMI"

--- a/devices/xiaomi/lumi_motion_ac01.json
+++ b/devices/xiaomi/lumi_motion_ac01.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "72b706a6-2bc0-4a52-ac56-619f7c20ce71",
   "manufacturername": "aqara",
   "modelid": "lumi.motion.ac01",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/lumi_sensor_wleak_aq1.json
+++ b/devices/xiaomi/lumi_sensor_wleak_aq1.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "1bb80228-e651-4a46-990b-f738ddd28d4a",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.sensor_wleak.aq1",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/lumi_vibration_aq1.json
+++ b/devices/xiaomi/lumi_vibration_aq1.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "8dd6bec7-40c0-4da3-bf26-e875f4d35b17",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.vibration.aq1",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_dw-s03d_t1_openclose_sensor.json
+++ b/devices/xiaomi/xiaomi_dw-s03d_t1_openclose_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "8fd50f36-98c3-4e75-8e51-4644f90dd043",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.magnet.agl02",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_gzcgq01lm_light_sensor.json
+++ b/devices/xiaomi/xiaomi_gzcgq01lm_light_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "a582a579-709e-4480-bf6c-08c639d3cb84",
   "doc:path": "xiaomi/xiaomi_gzcgq01lm_light_sensor.md",
   "doc:hdr": "Light sensor GZCGQ01LM",
   "manufacturername": ["$MF_XIAOMI", "$MF_LUMI"],

--- a/devices/xiaomi/xiaomi_gzcgq11lm_light_sensor.json
+++ b/devices/xiaomi/xiaomi_gzcgq11lm_light_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "21d1b07f-3780-4cc6-9151-968f7bb0646d",
   "manufacturername": ["$MF_LUMI"],
   "modelid": ["lumi.sen_ill.agl01"],
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_jtqj-bf-01lm_gas_leak_detector.json
+++ b/devices/xiaomi/xiaomi_jtqj-bf-01lm_gas_leak_detector.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "5d354301-8bb8-4c5f-9741-edcccc367510",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.sensor_natgas",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_jtyj-gd-01lm_smoke_detector.json
+++ b/devices/xiaomi/xiaomi_jtyj-gd-01lm_smoke_detector.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "c6d2cc27-f9d1-4c93-8c6e-0beb6c97e682",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.sensor_smoke",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_lumi.airrtc.agl001.json
+++ b/devices/xiaomi/xiaomi_lumi.airrtc.agl001.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "7e3db69a-d38c-4f71-b9c3-fdbd807333fa",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.airrtc.agl001",
   "vendor": "Aqara",

--- a/devices/xiaomi/xiaomi_lumi.light.aqcn02_TunableWhite_Bulb.json
+++ b/devices/xiaomi/xiaomi_lumi.light.aqcn02_TunableWhite_Bulb.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "ebd6369b-7956-4d64-b0d3-57c70d2002ad",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.light.aqcn02",
   "product": "Aqara Tunable White LED Bulb (ZNLDP12LM)",

--- a/devices/xiaomi/xiaomi_lumi.relay.c2acn01.json
+++ b/devices/xiaomi/xiaomi_lumi.relay.c2acn01.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "4fc4be68-d226-4fca-b249-885f3c52b8b4",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.relay.c2acn01",
   "product": "wireless relay with neutral",

--- a/devices/xiaomi/xiaomi_lywsd03mmc.json
+++ b/devices/xiaomi/xiaomi_lywsd03mmc.json
@@ -1,5 +1,6 @@
 {
     "schema": "devcap1.schema.json",
+    "uuid": "ab855acd-56bb-45df-a127-b796c4b3e547",
     "manufacturername": "Xiaomi",
     "modelid": "LYWSD03MMC",
     "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_mccgq01lm_openclose_sensor.json
+++ b/devices/xiaomi/xiaomi_mccgq01lm_openclose_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "17905b83-4763-44bd-bed5-a7c898601c6d",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.sensor_magnet",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_mccgq11lm_openclose_sensor.json
+++ b/devices/xiaomi/xiaomi_mccgq11lm_openclose_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "1ace8d48-1cd9-42bb-92a1-1ae158715bb5",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.sensor_magnet.aq2",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_mccgq14lm_e1_openclose_sensor.json
+++ b/devices/xiaomi/xiaomi_mccgq14lm_e1_openclose_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "790755f4-7320-42ee-8334-f9fa8c80cdc3",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.magnet.acn001",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_mfkzq01lm_cube.json
+++ b/devices/xiaomi/xiaomi_mfkzq01lm_cube.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "637ed291-d6e1-4a32-880f-0893516fb425",
   "manufacturername": ["$MF_LUMI", "$MF_LUMI"],
   "modelid": ["lumi.sensor_cube", "lumi.sensor_cube.aqgl01"],
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_mfkzq11lm_t1_cube.json
+++ b/devices/xiaomi/xiaomi_mfkzq11lm_t1_cube.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "77ce001f-0fa9-4da8-973f-9d5d8e7c7fdc",
   "manufacturername": ["$MF_LUMI"],
   "modelid": ["lumi.remote.cagl01"],
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_mfkzq12lm_t1_pro_cube.json
+++ b/devices/xiaomi/xiaomi_mfkzq12lm_t1_pro_cube.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "f601e062-83a5-4ad1-b2e3-e15af0c6fc70",
   "manufacturername": ["$MF_LUMI"],
   "modelid": ["lumi.remote.cagl02"],
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_mho-c401n_temp_hum_sensor.json
+++ b/devices/xiaomi/xiaomi_mho-c401n_temp_hum_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "63fe16a6-dfe3-4872-8428-5070ff618c30",
   "manufacturername": "MiaMiaoCe",
   "modelid": "MHO-C401N",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_qbkg03lm_switch.json
+++ b/devices/xiaomi/xiaomi_qbkg03lm_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "16208f88-8b30-49f5-9e2b-eda0cd3901a7",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.ctrl_neutral2",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_qbkg04lm_switch.json
+++ b/devices/xiaomi/xiaomi_qbkg04lm_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "7c6d3f22-6a85-4955-bfbf-91b98d1a4237",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.ctrl_neutral1",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_rtcgq13lm_presence_sensor.json
+++ b/devices/xiaomi/xiaomi_rtcgq13lm_presence_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "55fea19c-d877-45da-b7e1-13ebaafc8050",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.motion.agl04",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_rtcgq14lm_p1_presence_sensor.json
+++ b/devices/xiaomi/xiaomi_rtcgq14lm_p1_presence_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "c6f3115f-9219-41d0-b318-b3ec1a18b586",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.motion.ac02",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_rtcgqq11lm_presence_sensor.json
+++ b/devices/xiaomi/xiaomi_rtcgqq11lm_presence_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "85676803-9d00-47fe-838f-ce76dfafc276",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.sensor_motion.aq2",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_sjcgq13lm_e1_wleak_sensor.json
+++ b/devices/xiaomi/xiaomi_sjcgq13lm_e1_wleak_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "e16fcda9-dd0e-46e2-aaee-938e8eb69a2b",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.flood.acn001",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_sp-euc01_smart_plug.json
+++ b/devices/xiaomi/xiaomi_sp-euc01_smart_plug.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "711cfee9-6235-4db7-be0e-52b5a976a231",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.plug.maeu01",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_ssm-u01_t1_switch.json
+++ b/devices/xiaomi/xiaomi_ssm-u01_t1_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "d9e2a290-e2b4-42de-bd95-4b46b4f0a142",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.switch.n0agl1",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_ssm-u02_t1_switch.json
+++ b/devices/xiaomi/xiaomi_ssm-u02_t1_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "a13006cd-e75e-4693-aaa4-dfae5aabba52",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.switch.l0agl1",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_wb-r02d_t1_wireless_mini_switch.json
+++ b/devices/xiaomi/xiaomi_wb-r02d_t1_wireless_mini_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "ec850765-323e-4837-8bc6-9695a2d2fa46",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.remote.b1acn02",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_wrs-r02_h1_switch.json
+++ b/devices/xiaomi/xiaomi_wrs-r02_h1_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "7608923f-e09a-46ba-86e5-f22498b668bf",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.remote.b28ac1",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_ws-euk01_h1_switch.json
+++ b/devices/xiaomi/xiaomi_ws-euk01_h1_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "73afe387-7620-4f8e-8515-a3a961882965",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.switch.l1aeu1",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_ws-euk02_h1_switch.json
+++ b/devices/xiaomi/xiaomi_ws-euk02_h1_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "ec6892b3-359f-4e7d-9665-da3435259b07",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.switch.l2aeu1",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_ws-euk03_h1_switch.json
+++ b/devices/xiaomi/xiaomi_ws-euk03_h1_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "4013c222-9aaf-4c19-9bb3-d3a2c57a8d31",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.switch.n1aeu1",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_ws-euk04_h1_switch.json
+++ b/devices/xiaomi/xiaomi_ws-euk04_h1_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "2cd32483-30a8-4692-8f75-d9e6c0bb1ff7",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.switch.n2aeu1",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_wsdcgq01lm_temp_hum_sensor.json
+++ b/devices/xiaomi/xiaomi_wsdcgq01lm_temp_hum_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "e17bc41f-1554-4498-a758-843c922ee449",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.sensor_ht",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_wsdcgq11lm_temp_hum_sensor.json
+++ b/devices/xiaomi/xiaomi_wsdcgq11lm_temp_hum_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "2ef565de-2b5d-4550-9d6a-e1f99899244a",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.weather",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_wsdcgq12lm_t1_temp_hum_sensor.json
+++ b/devices/xiaomi/xiaomi_wsdcgq12lm_t1_temp_hum_sensor.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "89456203-1e4a-49e4-860c-5b34fa54b4a7",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.sensor_ht.agl02",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_wxkg01lm_mini_switch.json
+++ b/devices/xiaomi/xiaomi_wxkg01lm_mini_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "3e294f3c-e684-4620-9c05-508b545cb523",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.sensor_switch",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_wxkg11lm_mini_switch.json
+++ b/devices/xiaomi/xiaomi_wxkg11lm_mini_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "e7dfca99-3df4-4c7f-abf3-5381a6782874",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.sensor_switch.aq2",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_wxkg17lm_e1_switch.json
+++ b/devices/xiaomi/xiaomi_wxkg17lm_e1_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "18f34296-3284-4d97-9765-85d3f09c7962",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.remote.acn004",
   "matchexpr": "R.endpoints.length === 3",

--- a/devices/xiaomi/xiaomi_wxkg20lm_mini_switch.json
+++ b/devices/xiaomi/xiaomi_wxkg20lm_mini_switch.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "8095c9c6-3a3d-42c4-81bb-ef3b11660d35",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.remote.acn007",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_zncz04lm_smart_plug.json
+++ b/devices/xiaomi/xiaomi_zncz04lm_smart_plug.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "d699395b-4e78-4649-b9db-1c537041b70d",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.plug.mmeu01",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_zncz04lm_smart_plug_v24.json
+++ b/devices/xiaomi/xiaomi_zncz04lm_smart_plug_v24.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "f140dad4-5c36-4001-84f9-4a9f7e524baa",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.plug.mmeu01",
   "vendor": "Xiaomi",

--- a/devices/xiaomi/xiaomi_zncz12lm_smart_plug.json
+++ b/devices/xiaomi/xiaomi_zncz12lm_smart_plug.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "006efd51-4464-45b8-836b-97e846db5106",
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.plug.maus01",
   "vendor": "Xiaomi",


### PR DESCRIPTION
The UUID has been appended to all existing DDFs in the repository.

The pull request was created using the following command:
```bash
for dir in $(find . -type d);
  do   ddf-tools bulk uuid --store-url {URL} --store-token {TOKEN} $dir;
done
```

The UUID was inserted immediately after the schema. Maintaining the formatting and using the same newline character, either \r\n or \n

For new DDFs that are currently in a pull request, they will be updated by the new validation action at a later stage.
