### PR TITLE
Support for DDF bundles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ set(PLUGIN_INCLUDE_FILES
     device.h
     device_access_fn.h
     device_compat.h
+    device_ddf_bundle.h
     device_ddf_init.h
     device_descriptions.h
     device_tick.h
@@ -92,6 +93,7 @@ set(PLUGIN_INCLUDE_FILES
     resourcelinks.h
     rest_alarmsystems.h
     rest_api.h
+    rest_ddf.h
     rest_devices.h
     rest_node_base.h
     rule.h
@@ -153,6 +155,7 @@ add_library(${PROJECT_NAME} SHARED
     device_access_fn.cpp
     device_compat.cpp
     device.cpp
+    device_ddf_bundle.cpp
     device_ddf_init.cpp
     device_descriptions.cpp
     device_js/duktape.c
@@ -193,6 +196,7 @@ add_library(${PROJECT_NAME} SHARED
     rest_api.cpp
     rest_capabilities.cpp
     rest_configuration.cpp
+    rest_ddf.cpp
     rest_devices.cpp
     rest_gateways.cpp
     rest_groups.cpp

--- a/database.h
+++ b/database.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2016-2024 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -71,10 +71,19 @@ class Resource;
 class ResourceItem;
 
 
+ // TODO(mpi) deprecated for DB_ResourceItem2
 struct DB_ResourceItem
 {
     BufString<64> name;
     QVariant value;
+    qint64 timestampMs = 0; // milliseconds since Epoch
+};
+
+struct DB_ResourceItem2
+{
+    BufString<64> name;
+    unsigned valueSize;
+    char value[160];
     qint64 timestampMs = 0; // milliseconds since Epoch
 };
 
@@ -98,12 +107,22 @@ struct DB_ZclValue
     uint8_t loaded;
 };
 
+struct DB_IdentifierPair
+{
+    unsigned modelIdAtomIndex;
+    unsigned mfnameAtomIndex;
+};
+
 int DB_StoreDevice(const deCONZ::Address &addr);
 
 int DB_GetSubDeviceItemCount(QLatin1String uniqueId);
 bool DB_LoadZclValue(DB_ZclValue *val);
 bool DB_StoreZclValue(const DB_ZclValue *val);
-bool DB_StoreSubDevice(const QString &parentUniqueId, const QString &uniqueId);
+bool DB_StoreSubDevice(const char *uniqueId);
+bool DB_StoreDeviceItem(int deviceId, const DB_ResourceItem2 &item);
+bool DB_LoadDeviceItems(int deviceId, std::vector<DB_ResourceItem2> &items);
+bool DB_ResourceItem2DbItem(const ResourceItem *rItem, DB_ResourceItem2 *dbItem);
+std::vector<DB_IdentifierPair> DB_LoadIdentifierPairs();
 bool DB_StoreSubDeviceItem(const Resource *sub, ResourceItem *item);
 bool DB_StoreSubDeviceItems(Resource *sub);
 std::vector<DB_ResourceItem> DB_LoadSubDeviceItemsOfDevice(QLatin1String deviceUniqueId);

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -48,6 +48,7 @@
 #include "poll_control.h"
 #include "poll_manager.h"
 #include "product_match.h"
+#include "rest_ddf.h"
 #include "rest_devices.h"
 #include "rest_alarmsystems.h"
 #include "read_files.h"
@@ -649,8 +650,6 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
         deviceDescriptions->setEnabledStatusFilter(filter);
     }
 
-    deviceDescriptions->readAll();
-
     connect(databaseTimer, SIGNAL(timeout()),
             this, SLOT(saveDatabaseTimerFired()));
 
@@ -724,6 +723,10 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
     ttlDataBaseConnection = 0;
     openDb();
     initDb();
+
+    deviceDescriptions->prepare();
+    deviceDescriptions->readAll();
+
     readDb();
 
     DB_LoadAlarmSystemDevices(alarmSystemDeviceTable.get());
@@ -16068,6 +16071,10 @@ int DeRestPlugin::handleHttpRequest(const QHttpRequestHeader &hdr, QTcpSocket *s
                 if (apiModule == QLatin1String("devices"))
                 {
                     ret = d->restDevices->handleApi(req, rsp);
+                }
+                else if (apiModule == QLatin1String("ddf"))
+                {
+                    ret = REST_DDF_HandleApi(req, rsp);
                 }
                 else if (apiModule == QLatin1String("lights"))
                 {

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -16743,6 +16743,29 @@ void DEV_AllocateGroup(const Device *device, Resource *rsub, ResourceItem *item)
     }
 }
 
+/*! Callback when new DDF bundle is uploaded.
+    For each matching device trigger a DDF reload event.
+ */
+void DEV_ReloadDeviceIdendifier(unsigned atomIndexMfname, unsigned atomIndexModelid)
+{
+    for (auto &dev : plugin->m_devices)
+    {
+        {
+            const ResourceItem *mfname = dev->item(RAttrManufacturerName);
+            if (!mfname || mfname->atomIndex() != atomIndexMfname)
+                continue;
+        }
+
+        {
+            const ResourceItem *modelid = dev->item(RAttrModelId);
+            if (!modelid || modelid->atomIndex() != atomIndexModelid)
+                continue;
+        }
+
+        enqueueEvent(Event(RDevices, REventDDFReload, 0, dev->key()));
+    }
+}
+
 /*! Returns deCONZ core node for a given \p extAddress.
  */
 const deCONZ::Node *DEV_GetCoreNode(uint64_t extAddress)

--- a/device.cpp
+++ b/device.cpp
@@ -845,13 +845,20 @@ void DEV_GetDeviceDescriptionHandler(Device *device, const Event &event)
     {
         DEV_PublishToCore(device);
 
-        if (event.num() == 1)
+        if (event.num() == 1 || event.num() == 3)
         {
             d->managed = true;
             d->flags.hasDdf = 1;
             d->setState(DEV_IdleStateHandler);
             // TODO(mpi): temporary forward this info here, gets replaced by device actor later
-            DEV_ForwardNodeChange(device, QLatin1String("hasddf"), QLatin1String("1"));
+            if (event.num() == 1)
+            {
+                DEV_ForwardNodeChange(device, QLatin1String("hasddf"), QLatin1String("1"));
+            }
+            else if (event.num() == 3)
+            {
+                DEV_ForwardNodeChange(device, QLatin1String("hasddf"), QLatin1String("2"));
+            }
         }
         else
         {

--- a/device.cpp
+++ b/device.cpp
@@ -2147,6 +2147,8 @@ Device::Device(DeviceKey key, deCONZ::ApsController *apsCtrl, QObject *parent) :
     addItem(DataTypeString, RAttrUniqueId)->setValue(generateUniqueId(key, 0, 0));
     addItem(DataTypeString, RAttrManufacturerName);
     addItem(DataTypeString, RAttrModelId);
+    addItem(DataTypeString, RAttrDdfPolicy);
+    addItem(DataTypeString, RAttrDdfHash);
     addItem(DataTypeUInt32, RAttrOtaVersion);
 
     // lazy init since the event handler is connected after the constructor

--- a/device_ddf_bundle.cpp
+++ b/device_ddf_bundle.cpp
@@ -108,6 +108,27 @@ int IsValidDDFBundle(U_BStream *bs, unsigned char sha256[U_SHA256_HASH_SIZE])
     return 1;
 }
 
+bool DDFB_SanitizeBundleHashString(char *str, unsigned len)
+{
+    if (len != 64)
+        return false;
+
+    for (unsigned i = 0; i < len; i++)
+    {
+        char ch = str[i];
+
+        if      (ch >= '0' && ch <= '9') { } // ok
+        else if (ch >= 'a' && ch <= 'f') { } // ok
+        else if (ch >= 'A' && ch <= 'F') { str[i] = ch + ('a' - 'A'); } // convert to lower case
+        else
+        {
+            return false; // invalid hex char
+        }
+    }
+
+    return true;
+}
+
 int DDFB_ReadExtfChunk(U_BStream *bs, DDFB_ExtfChunk *extf)
 {
     U_BStream bs1;

--- a/device_ddf_bundle.cpp
+++ b/device_ddf_bundle.cpp
@@ -1,0 +1,185 @@
+#include "deconz/u_assert.h"
+#include "device_ddf_bundle.h"
+
+int DDFB_FindChunk(U_BStream *bs, const char *tag, unsigned *size)
+{
+    char fourcc[4];
+    unsigned sz;
+    unsigned long origPos = bs->pos;
+
+    for (;bs->pos < bs->size && bs->status == U_BSTREAM_OK;)
+    {
+        fourcc[0] = U_bstream_get_u8(bs);
+        fourcc[1] = U_bstream_get_u8(bs);
+        fourcc[2] = U_bstream_get_u8(bs);
+        fourcc[3] = U_bstream_get_u8(bs);
+        sz = U_bstream_get_u32_le(bs);
+
+        if (bs->pos + sz > bs->size)
+        {
+            break; // invalid size
+        }
+
+        if (fourcc[0] == tag[0] && fourcc[1] == tag[1] && fourcc[2] == tag[2] && fourcc[3] == tag[3])
+        {
+            *size = sz;
+            return 1;
+        }
+
+        bs->pos += sz;
+    }
+
+    bs->pos = origPos;
+    *size = 0;
+    return 0;
+}
+
+int DDFB_IsChunk(U_BStream *bs, const char *tag)
+{
+    unsigned char *fourcc;
+    if (bs->pos + 4 < bs->size)
+    {
+        fourcc = &bs->data[bs->pos];
+        return fourcc[0] == tag[0] && fourcc[1] == tag[1] && fourcc[2] == tag[2] && fourcc[3] == tag[3];
+    }
+
+    return 0;
+}
+
+int DDFB_SkipChunk(U_BStream *bs)
+{
+    char fourcc[4];
+    unsigned sz;
+
+    fourcc[0] = U_bstream_get_u8(bs);
+    fourcc[1] = U_bstream_get_u8(bs);
+    fourcc[2] = U_bstream_get_u8(bs);
+    fourcc[3] = U_bstream_get_u8(bs);
+    sz = U_bstream_get_u32_le(bs);
+
+    if (bs->status == U_BSTREAM_OK)
+    {
+        if (bs->pos + sz <= bs->size)
+        {
+            bs->pos += sz;
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+/*
+    https://github.com/deconz-community/ddf-tools/blob/main/packages/bundler/README.md
+*/
+int IsValidDDFBundle(U_BStream *bs, unsigned char sha256[U_SHA256_HASH_SIZE])
+{
+    unsigned chunkSize;
+
+    if (DDFB_FindChunk(bs, "RIFF", &chunkSize) == 0)
+    {
+        return 0;
+    }
+
+    if (DDFB_FindChunk(bs, "DDFB", &chunkSize) == 0)
+    {
+        return 0;
+    }
+
+    {
+        // Bundle hash over DDFB chunk (header + data)
+        if (U_Sha256(&bs->data[bs->pos - 8], chunkSize + 8, sha256) == 0)
+        {
+            return 0; // this
+        }
+    }
+
+    U_BStream bsDDFB;
+    U_bstream_init(&bsDDFB, &bs->data[bs->pos], chunkSize);
+
+    // check DESC JSON has required fields
+    if (DDFB_FindChunk(&bsDDFB, "DESC", &chunkSize) == 0)
+    {
+        return 0;
+    }
+
+    // DBG_Printf(DBG_INFO, "DESC: %.*s\n", chunkSize, &bsDDFB.data[bsDDFB.pos]);
+
+    return 1;
+}
+
+int DDFB_ReadExtfChunk(U_BStream *bs, DDFB_ExtfChunk *extf)
+{
+    U_BStream bs1;
+    char fourcc[4];
+    unsigned chunkSize;
+    unsigned long origPos = bs->pos;
+
+    extf->emptyString = '\0';
+
+    fourcc[0] = U_bstream_get_u8(bs);
+    fourcc[1] = U_bstream_get_u8(bs);
+    fourcc[2] = U_bstream_get_u8(bs);
+    fourcc[3] = U_bstream_get_u8(bs);
+    chunkSize = U_bstream_get_u32_le(bs);
+
+    if (bs->status != U_BSTREAM_OK)
+    {
+        return 0;
+    }
+
+    if (bs->size < bs->pos + chunkSize)
+    {
+        return 0;
+    }
+
+    U_ASSERT(fourcc[0] == 'E');
+    U_ASSERT(fourcc[1] == 'X');
+    U_ASSERT(fourcc[2] == 'T');
+    U_ASSERT(fourcc[3] == 'F');
+
+    U_bstream_init(&bs1, &bs->data[bs->pos], chunkSize);
+    bs->pos += chunkSize; // move bs behind chunk
+
+    extf->fileType[0] = (char)U_bstream_get_u8(&bs1);
+    extf->fileType[1] = (char)U_bstream_get_u8(&bs1);
+    extf->fileType[2] = (char)U_bstream_get_u8(&bs1);
+    extf->fileType[3] = (char)U_bstream_get_u8(&bs1);
+    extf->fileType[4] = '\0';
+
+    // file path string
+    extf->pathLength = U_bstream_get_u16_le(&bs1);
+    if (bs1.size < bs1.pos + extf->pathLength)
+    {
+        return 0;
+    }
+    extf->path = (const char*)&bs1.data[bs1.pos];
+    bs1.pos += extf->pathLength;
+
+    // modification time string
+    extf->modificationTimeLength = U_bstream_get_u16_le(&bs1);
+    if (bs1.size < bs1.pos + extf->modificationTimeLength)
+    {
+        return 0;
+    }
+    if (extf->modificationTimeLength == 0) // optional
+    {
+        extf->modificationTime = &extf->emptyString;
+    }
+    else
+    {
+        extf->modificationTime = (const char*)&bs1.data[bs1.pos];
+    }
+
+    bs1.pos += extf->modificationTimeLength;
+
+    // file content
+    extf->fileSize = U_bstream_get_u32_le(&bs1);
+    if (bs1.size < bs1.pos + extf->fileSize)
+    {
+        return 0;
+    }
+    extf->fileData = &bs1.data[bs1.pos];
+
+    return 1;
+}

--- a/device_ddf_bundle.h
+++ b/device_ddf_bundle.h
@@ -24,6 +24,7 @@ int DDFB_IsChunk(U_BStream *bs, const char *tag);
 int DDFB_SkipChunk(U_BStream *bs);
 int DDFB_ReadExtfChunk(U_BStream *bs, DDFB_ExtfChunk *extf);
 int IsValidDDFBundle(U_BStream *bs, unsigned char sha256[U_SHA256_HASH_SIZE]);
+bool DDFB_SanitizeBundleHashString(char *str, unsigned len);
 
 
 #endif // DEVICE_DDF_BUNDLE_H

--- a/device_ddf_bundle.h
+++ b/device_ddf_bundle.h
@@ -1,0 +1,29 @@
+#ifndef DEVICE_DDF_BUNDLE_H
+#define DEVICE_DDF_BUNDLE_H
+
+#include "deconz/u_bstream.h"
+#include "deconz/u_sha256.h"
+
+#define MAX_BUNDLE_SIZE (1 << 20) // 1 MB
+
+struct DDFB_ExtfChunk
+{
+    struct DDFB_ExtfChunk *next;
+    char fileType[5]; // fourcc + '\0'
+    char emptyString;
+    unsigned pathLength;
+    const char *path;
+    unsigned modificationTimeLength;
+    const char *modificationTime;
+    unsigned fileSize;
+    unsigned char *fileData;
+};
+
+int DDFB_FindChunk(U_BStream *bs, const char *tag, unsigned *size);
+int DDFB_IsChunk(U_BStream *bs, const char *tag);
+int DDFB_SkipChunk(U_BStream *bs);
+int DDFB_ReadExtfChunk(U_BStream *bs, DDFB_ExtfChunk *extf);
+int IsValidDDFBundle(U_BStream *bs, unsigned char sha256[U_SHA256_HASH_SIZE]);
+
+
+#endif // DEVICE_DDF_BUNDLE_H

--- a/device_ddf_init.cpp
+++ b/device_ddf_init.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2021-2024 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -8,6 +8,7 @@
  *
  */
 
+#include "deconz/u_assert.h"
 #include "device.h"
 #include "device_compat.h"
 #include "device_descriptions.h"
@@ -34,8 +35,6 @@ static QString uniqueIdFromTemplate(const QStringList &templ, const Device *devi
 
        ["$address.ext", <endpoint>]
        ["$address.ext", <endpoint>, <cluster>]
-       ["$address.ext", <endpoint>, "out.cluster", <cluster1>, <cluster2>, ...]
-       ["$address.ext", <endpoint>, "in.cluster", <cluster1>, <cluster2>, ...]
     */
 
     if (templ.size() > 1 && templ.first() == QLatin1String("$address.ext"))
@@ -49,34 +48,6 @@ static QString uniqueIdFromTemplate(const QStringList &templ, const Device *devi
             if (pos2.at(0).isDigit())
             {
                 clusterId = pos2.toUInt(&ok, 0);
-            }
-            else if (device->node() && (pos2 == QLatin1String("out.cluster") || pos2 == QLatin1String("in.cluster")))
-            {
-                // select clusterId if endpoint contains cluster from list
-                // the cluster list, ordered by priority
-                const auto clusterSide = pos2.at(0) == 'o' ? deCONZ::ClientCluster : deCONZ::ServerCluster;
-                const  auto &simpleDescriptors = device->node()->simpleDescriptors();
-                const auto sd = std::find_if(simpleDescriptors.cbegin(), simpleDescriptors.cend(),
-                                             [endpoint](const auto &x) { return x.endpoint() == endpoint; });
-                if (sd != simpleDescriptors.cend())
-                {
-                    const auto &clusters = sd->clusters(clusterSide);
-
-                    for (int i = 3; i < templ.size(); i++)
-                    {
-                        clusterId = templ.at(i).toUInt(&ok, 0);
-                        if (!ok) { break; } // no clusterId, maybe in future other commands follow (doh)
-
-                        const auto cl = std::find_if(clusters.cbegin(), clusters.cend(),
-                                                     [clusterId](const auto &x){ return x.id() == clusterId; });
-
-                        ok = cl != clusters.cend();
-                        if (ok)
-                        {
-                            break;
-                        }
-                    }
-                }
             }
         }
     }
@@ -93,12 +64,12 @@ static QString uniqueIdFromTemplate(const QStringList &templ, const Device *devi
  */
 static ResourceItem *DEV_InitDeviceDescriptionItem(const DeviceDescription::Item &ddfItem, const std::vector<DB_ResourceItem> &dbItems, Resource *rsub)
 {
-    Q_ASSERT(rsub);
-    Q_ASSERT(ddfItem.isValid());
+    U_ASSERT(rsub);
+    U_ASSERT(ddfItem.isValid());
 
     auto *item = rsub->item(ddfItem.descriptor.suffix);
     const char *uniqueId = rsub->item(RAttrUniqueId)->toCString();
-    Q_ASSERT(uniqueId);
+    U_ASSERT(uniqueId);
 
     if (item)
     {
@@ -116,7 +87,7 @@ static ResourceItem *DEV_InitDeviceDescriptionItem(const DeviceDescription::Item
         }
     }
 
-    Q_ASSERT(item);
+    U_ASSERT(item);
 
     const auto dbItem = std::find_if(dbItems.cbegin(), dbItems.cend(), [&ddfItem](const auto &dbItem)
     {
@@ -248,7 +219,7 @@ bool DEV_InitDeviceFromDescription(Device *device, const DeviceDescription &ddf)
         }
 
         // TODO storing should be done else where, since this is init code
-        DB_StoreSubDevice(device->item(RAttrUniqueId)->toLatin1String(), rsub->item(RAttrUniqueId)->toString());
+        DB_StoreSubDevice(rsub->item(RAttrUniqueId)->toCString());
         DB_StoreSubDeviceItem(rsub, rsub->item(RAttrManufacturerName));
         DB_StoreSubDeviceItem(rsub, rsub->item(RAttrModelId));
 
@@ -425,7 +396,7 @@ bool DEV_InitBaseDescriptionForDevice(Device *device, DeviceDescription &ddf)
         {
             const ResourceItem *item = r->itemForIndex(i);
 
-            DeviceDescription::Item ddfItem = DeviceDescriptions::instance()->getItem(item);
+            DeviceDescription::Item ddfItem = dd->getGenericItem(item->descriptor().suffix);
 
             if (!ddfItem.isValid())
             {
@@ -448,6 +419,61 @@ bool DEV_InitBaseDescriptionForDevice(Device *device, DeviceDescription &ddf)
 
 bool DEV_InitDeviceBasic(Device *device)
 {
+    {
+        ResourceItem *ddfPolicy = device->item(RAttrDdfPolicy);
+        U_ASSERT(ddfPolicy);
+
+        {
+            // load attr/ddf_policy and attr/ddf_hash from database if exists
+
+            std::vector<DB_ResourceItem2> dbItems2;
+
+            if (DB_LoadDeviceItems(device->deviceId(), dbItems2))
+            {
+                for (const auto &dbItem : dbItems2)
+                {
+                    U_ASSERT(dbItem.valueSize != 0);
+                    if (dbItem.valueSize == 0)
+                    {
+                        continue;
+                    }
+
+                    if (dbItem.name == RAttrDdfPolicy && ddfPolicy)
+                    {
+                        ddfPolicy->setValue(dbItem.value, (int)dbItem.valueSize);
+                        ddfPolicy->setTimeStamps(QDateTime::fromMSecsSinceEpoch(dbItem.timestampMs));
+                    }
+                    else if (dbItem.name == RAttrDdfHash)
+                    {
+                        U_ASSERT(dbItem.valueSize == 32);
+                        if (dbItem.valueSize == 32)
+                        {
+                            ResourceItem *ddfHash = device->item(RAttrDdfPolicy);
+                            ddfHash->setValue(dbItem.value, (int)dbItem.valueSize);
+                            ddfHash->setTimeStamps(QDateTime::fromMSecsSinceEpoch(dbItem.timestampMs));
+                        }
+                    }
+                }
+            }
+        }
+
+        // if no attr/ddf_policy is set, use the default
+        if (ddfPolicy && ddfPolicy->toLatin1String().size() == 0)
+        {
+            ddfPolicy->setValue("latest_prefer_stable", -1);
+
+            // DB_ResourceItem2 dbItem;
+
+            // if (DB_ResourceItem2DbItem(ddfPolicy, &dbItem))
+            // {
+            //     if (DB_StoreDeviceItem(device->deviceId(), dbItem))
+            //     {
+
+            //     }
+            // }
+        }
+    }
+
     const auto dbItems = DB_LoadSubDeviceItemsOfDevice(device->item(RAttrUniqueId)->toLatin1String());
 
     size_t found = 0;

--- a/device_descriptions.cpp
+++ b/device_descriptions.cpp
@@ -2621,7 +2621,7 @@ void DeviceDescriptions::handleDDFInitRequest(const Event &event)
 
     if (resource)
     {
-        const auto ddf = get(resource, DDF_EvalMatchExpr);
+        const DeviceDescription &ddf = get(resource, DDF_EvalMatchExpr);
 
         if (ddf.isValid())
         {
@@ -2638,6 +2638,10 @@ void DeviceDescriptions::handleDDFInitRequest(const Event &event)
                 if (ddf.status == QLatin1String("Draft"))
                 {
                     result = 2;
+                }
+                else if (ddf.storageLocation == deCONZ::DdfBundleLocation || ddf.storageLocation == deCONZ::DdfBundleUserLocation)
+                {
+                    result = 3;
                 }
             }
         }

--- a/device_descriptions.cpp
+++ b/device_descriptions.cpp
@@ -2478,10 +2478,11 @@ void DeviceDescriptions::readAllBundles()
                 if (DDFB_FindChunk(&bs, "DESC", &chunkSize) == 0)
                     continue;
 
+                /*
+                 * Only load bundles into memory for devices which are present.
+                 */
                 if (DDF_IsBundleScheduled(pctx, (char*)&bs.data[bs.pos], chunkSize, d->ddfLoadRecords) == 0)
-                {
-                    // continue; // TODO TEMP ONLY
-                }
+                    continue;
 
                 // limit to DDFB content
                 U_bstream_init(&bs, &fileData[ddfbChunkOffset], ddfbChunkSize);

--- a/device_descriptions.cpp
+++ b/device_descriptions.cpp
@@ -157,12 +157,6 @@ static void DDF_UpdateItemHandles(std::vector<DeviceDescription> &descriptions, 
 static void DDF_TryCompileAndFixJavascript(QString *expr, const QString &path);
 DeviceDescription DDF_LoadScripts(const DeviceDescription &ddf);
 
-// TODO(mpi): this needs to go in memory/string module
-static unsigned U_strlen(const char *str)
-{
-    return strlen(str);
-}
-
 /*! Constructor. */
 DeviceDescriptions::DeviceDescriptions(QObject *parent) :
     QObject(parent),

--- a/device_descriptions.cpp
+++ b/device_descriptions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2022-2024 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -8,6 +8,7 @@
  *
  */
 
+#include <array>
 #include <QDirIterator>
 #include <QFile>
 #include <QJsonArray>
@@ -15,12 +16,27 @@
 #include <QJsonObject>
 #include <QJsonValue>
 #include <QSettings>
+#include <deconz/atom_table.h>
 #include <deconz/dbg_trace.h>
+#include <deconz/file.h>
+#include <deconz/u_assert.h>
+#include <deconz/u_sstream.h>
+#include <deconz/buffer_pool.h>
+#include <deconz/u_memory.h>
+#include <deconz/u_time.h>
+#include <deconz/u_ecc.h>
+#include "database.h"
+#include "device_ddf_bundle.h"
 #include "device_ddf_init.h"
 #include "device_descriptions.h"
 #include "device_js/device_js.h"
+#include "utils/scratchmem.h"
+#include "json.h"
 #include "event.h"
 #include "resource.h"
+
+#define DDF_MAX_PATH_LENGTH 1024
+#define DDF_MAX_PUBLIC_KEYS 64
 
 #define HND_MIN_LOAD_COUNTER 1
 #define HND_MAX_LOAD_COUNTER 15
@@ -44,17 +60,70 @@ union ItemHandlePack
         unsigned int subDevice: 4;     //! Max: 15, index into description -> subdevices[]
         unsigned int item : 10;        //! Max: 1023, index into subdevice -> items[]
     };
-    quint32 handle;
+    uint32_t handle;
 };
+
+static unsigned atDDFPolicyLatestPreferStable;
+static unsigned atDDFPolicyLatest;
+static unsigned atDDFPolicyPin;
+static unsigned atDDFPolicyRawJson;
 
 static DeviceDescriptions *_instance = nullptr;
 static DeviceDescriptionsPrivate *_priv = nullptr;
+
+class DDF_ParseContext
+{
+public:
+    deCONZ::StorageLocation fileLocation;
+    char filePath[DDF_MAX_PATH_LENGTH];
+    unsigned filePathLength = 0;
+    uint8_t *fileData = nullptr;
+    unsigned fileDataSize = 0;
+    std::array<cj_token, 8192> tokens;
+    DDFB_ExtfChunk *extChunks;
+    int64_t bundleLastModified;
+    uint64_t signatures; // bitmap as index in publicKeys[] array
+
+    uint32_t scratchPos = 0;
+    std::array<unsigned char, 1 << 20> scratchMem; // 1.05 MB
+
+    // stats
+    int n_rawDDF = 0;
+    int n_devIdentifiers = 0;
+};
+
+struct ConstantEntry
+{
+    AT_AtomIndex key;
+    AT_AtomIndex value;
+};
+
+
+/*
+ * Lookup which DDFs already have been queried.
+ *
+ */
+enum DDF_LoadState
+{
+    DDF_LoadStateScheduled,
+    DDF_LoadStateNotFound,
+    DDF_LoadStateLoadedRawJson,
+    DDF_LoadStateLoadedBundle
+};
+
+struct DDF_LoadRecord
+{
+    AT_AtomIndex modelid;
+    AT_AtomIndex mfname;
+    DDF_LoadState loadState;
+};
 
 class DeviceDescriptionsPrivate
 {
 public:
     uint loadCounter = HND_MIN_LOAD_COUNTER;
-    std::map<QString,QString> constants;
+
+    std::vector<ConstantEntry> constants2;
     std::vector<DeviceDescription::Item> genericItems;
     std::vector<DeviceDescription> descriptions;
 
@@ -69,17 +138,30 @@ public:
     std::vector<DDF_FunctionDescriptor> readFunctions;
     std::vector<DDF_FunctionDescriptor> writeFunctions;
     std::vector<DDF_FunctionDescriptor> parseFunctions;
+
+    std::vector<DDF_LoadRecord> ddfLoadRecords;
+    std::vector<U_ECC_PublicKeySecp256k1> publicKeys;
 };
 
-static bool DDF_ReadConstantsJson(const QString &path, std::map<QString,QString> *constants);
-static DeviceDescription::Item DDF_ReadItemFile(const QString &path);
-static std::vector<DeviceDescription> DDF_ReadDeviceFile(const QString &path);
-static DDF_SubDeviceDescriptor DDF_ReadSubDeviceFile(const QString &path);
+static int DDF_ReadFileInMemory(DDF_ParseContext *pctx);
+static int DDF_ReadConstantsJson(DDF_ParseContext *pctx, std::vector<ConstantEntry> & constants);
+static DeviceDescription::Item DDF_ReadItemFile(DDF_ParseContext *pctx);
+static DeviceDescription DDF_ReadDeviceFile(DDF_ParseContext *pctx);
+static DDF_SubDeviceDescriptor DDF_ReadSubDeviceFile(DDF_ParseContext *pctx);
 static DeviceDescription DDF_MergeGenericItems(const std::vector<DeviceDescription::Item> &genericItems, const DeviceDescription &ddf);
+static int DDF_MergeGenericBundleItems(DeviceDescription &ddf, DDF_ParseContext *pctx);
+static int DDF_ProcessSignatures(DDF_ParseContext *pctx, std::vector<U_ECC_PublicKeySecp256k1> &publicKeys, U_BStream *bs, uint32_t *bundleHash);
 static DeviceDescription::Item *DDF_GetItemMutable(const ResourceItem *item);
+static void DDF_UpdateItemHandlesForIndex(std::vector<DeviceDescription> &descriptions, uint loadCounter, size_t index);
 static void DDF_UpdateItemHandles(std::vector<DeviceDescription> &descriptions, uint loadCounter);
 static void DDF_TryCompileAndFixJavascript(QString *expr, const QString &path);
 DeviceDescription DDF_LoadScripts(const DeviceDescription &ddf);
+
+// TODO(mpi): this needs to go in memory/string module
+static unsigned U_strlen(const char *str)
+{
+    return strlen(str);
+}
 
 /*! Constructor. */
 DeviceDescriptions::DeviceDescriptions(QObject *parent) :
@@ -88,6 +170,50 @@ DeviceDescriptions::DeviceDescriptions(QObject *parent) :
 {
     _instance = this;
     _priv = d_ptr2;
+
+
+    {
+        // register DDF policy atoms used later on for fast comparisons
+        AT_AtomIndex ati;
+        const char *str;
+
+        str = "latest_prefer_stable";
+        AT_AddAtom(str, U_strlen(str), &ati);
+        atDDFPolicyLatestPreferStable = ati.index;
+
+        str = "latest";
+        AT_AddAtom(str, U_strlen(str), &ati);
+        atDDFPolicyLatest = ati.index;
+
+        str = "pin";
+        AT_AddAtom(str, U_strlen(str), &ati);
+        atDDFPolicyPin = ati.index;
+
+        str = "raw_json";
+        AT_AddAtom(str, U_strlen(str), &ati);
+        atDDFPolicyRawJson = ati.index;
+    }
+
+    {
+        /*
+         * Register offical public keys for beta and stable signed bundles.
+         * These are used to to select bundles according to the attr/ddf_policy
+         */
+        U_ECC_PublicKeySecp256k1 pk;
+        uint8_t stable_key[33] = {
+            0x03, 0x93, 0x2D, 0x60, 0xA3, 0x35, 0x44, 0xFD, 0xB9, 0x20, 0x2B, 0x41, 0xA7, 0x68, 0xCD, 0xD8,
+            0x70, 0x90, 0x82, 0xBD, 0xE8, 0xCD, 0x85, 0x47, 0x21, 0x68, 0xC5, 0x2A, 0xD8, 0xC3, 0xE5, 0x76, 0xF6 };
+
+        uint8_t beta_key[33] = {
+            0x02, 0xAB, 0x93, 0x42, 0x38, 0x60, 0xD3, 0x9D, 0x2C, 0xDC, 0xBC, 0xA0, 0xF9, 0x04, 0x2B, 0xD1,
+            0xA2, 0x45, 0xED, 0xB6, 0xDC, 0xC1, 0x0C, 0x4C, 0xFF, 0x1B, 0x78, 0xE9, 0xF2, 0x43, 0xF5, 0x3F, 0x1E };
+
+        U_memcpy(pk.key, stable_key, sizeof(pk.key));
+        d_ptr2->publicKeys.push_back(pk);
+
+        U_memcpy(pk.key, beta_key, sizeof(pk.key));
+        d_ptr2->publicKeys.push_back(pk);
+    }
 
     {  // Parse function as shown in the DDF editor.
         DDF_FunctionDescriptor fn;
@@ -705,6 +831,37 @@ DeviceDescriptions::DeviceDescriptions(QObject *parent) :
     }
 }
 
+/*! Query the database which mfname/modelid pairs are present.
+    Use these to load only DDFs and bundles which are in use.
+ */
+void DeviceDescriptions::prepare()
+{
+    auto &records = _priv->ddfLoadRecords;
+    const auto res = DB_LoadIdentifierPairs();
+
+    for (size_t i = 0; i < res.size(); i++)
+    {
+        size_t j = 0;
+        for (j = 0; j < records.size(); j++)
+        {
+            if (records[j].mfname.index == res[i].mfnameAtomIndex &&
+                records[j].modelid.index == res[i].modelIdAtomIndex)
+            {
+                break;
+            }
+        }
+
+        if (j == records.size())
+        {
+            DDF_LoadRecord rec;
+            rec.mfname.index = res[i].mfnameAtomIndex;
+            rec.modelid.index = res[i].modelIdAtomIndex;
+            rec.loadState = DDF_LoadStateScheduled;
+            records.push_back(rec);
+        }
+    }
+}
+
 /*! Destructor. */
 DeviceDescriptions::~DeviceDescriptions()
 {
@@ -881,33 +1038,84 @@ void DeviceDescriptions::handleEvent(const Event &event)
 /*! Get the DDF object for a \p resource.
     \returns The DDF object, DeviceDescription::isValid() to check for success.
  */
-const DeviceDescription &DeviceDescriptions::get(const Resource *resource, DDF_MatchControl match) const
+const DeviceDescription &DeviceDescriptions::get(const Resource *resource, DDF_MatchControl match)
 {
-    Q_ASSERT(resource);
-    Q_ASSERT(resource->item(RAttrModelId));
-    Q_ASSERT(resource->item(RAttrManufacturerName));
+    U_ASSERT(resource);
 
     Q_D(const DeviceDescriptions);
 
-    const auto modelId = resource->item(RAttrModelId)->toString();
-    const auto manufacturer = resource->item(RAttrManufacturerName)->toString();
-    const auto manufacturerConstant = stringToConstant(manufacturer);
+    const ResourceItem *modelidItem = resource->item(RAttrModelId);
+    const ResourceItem *mfnameItem = resource->item(RAttrManufacturerName);
+    const ResourceItem *typeItem = resource->item(RAttrType);
 
+    /*
+     * Collect all matching DDFs.
+     * The result is than sorted and according to the attr/ddf_policy the best candidate
+     * will be selected.
+     */
+    unsigned matchedCount = 0;
+    static std::array<int, 16> matchedIndices;
+
+    U_ASSERT(modelidItem);
+    U_ASSERT(mfnameItem);
+
+    if (typeItem)
+    {
+        const char *type = typeItem->toCString();
+        if (type[0] == 'Z' && type[1] == 'G')
+        {
+            return d->invalidDescription; // TODO(mpi): For now ZGP devices aren't supported in DDF
+        }
+
+        if (type[0] == 'C' && type[1] == 'o' && type[2] == 'n')
+        {
+            return d->invalidDescription; // filter "Configuration tool" aka the coordinator
+        }
+    }
+
+    unsigned modelidAtomIndex = modelidItem->atomIndex();
+    unsigned mfnameAtomIndex = mfnameItem->atomIndex();
+
+    if (modelidAtomIndex == 0 || mfnameAtomIndex == 0)
+    {
+        return d->invalidDescription; // should not happen
+    }
+
+    U_ASSERT(modelidAtomIndex != 0);
+    U_ASSERT(mfnameAtomIndex != 0);
+
+
+    /*
+     * Filter matching DDFs, there can be multiple entries for the same modelid and manufacturer name.
+     * Further sorting for the 'best' match according to attr/ddf_policy is done afterwards.
+     */
     auto i = d->descriptions.begin();
 
-    for (;;)
+    for (;matchedCount < matchedIndices.size();)
     {
-        i = std::find_if(i, d->descriptions.end(), [&modelId, &manufacturer, &manufacturerConstant](const DeviceDescription &ddf)
+        i = std::find_if(i, d->descriptions.end(), [modelidAtomIndex, mfnameAtomIndex](const DeviceDescription &ddf)
         {
-            // compare manufacturer name case insensitive
-            const auto m = std::find_if(ddf.manufacturerNames.cbegin(), ddf.manufacturerNames.cend(),
-                                       [&](const auto &x){ return x.compare(manufacturer, Qt::CaseInsensitive) == 0; });
+            if (ddf.mfnameAtomIndices.size() != ddf.modelidAtomIndices.size())
+            {
+                return false; // should not happen
+            }
 
-            return (ddf.modelIds.contains(modelId) && (m != ddf.manufacturerNames.cend() || ddf.manufacturerNames.contains(manufacturerConstant)));
+            for (size_t j = 0; j < ddf.modelidAtomIndices.size(); j++)
+            {
+                if (ddf.modelidAtomIndices[j] == modelidAtomIndex && ddf.mfnameAtomIndices[j] == mfnameAtomIndex)
+                    return true;
+            }
+
+            return false;
         });
 
         if (i == d->descriptions.end())
         {
+            // nothing found, try to load further DDFs
+            if (loadDDFAndBundlesFromDisc(resource))
+            {
+                continue; // found DDFs or bundles, try again
+            }
             break;
         }
 
@@ -922,22 +1130,217 @@ const DeviceDescription &DeviceDescriptions::get(const Resource *resource, DDF_M
                 DBG_Printf(DBG_DDF, "matchexpr: %s --> %s\n", qPrintable(i->matchExpr), qPrintable(res.toString()));
                 if (res.toBool()) // needs to evaluate to true
                 {
-                    return *i;
+                    matchedIndices[matchedCount] = i->handle;
+                    matchedCount++;
                 }
             }
             else
             {
                 DBG_Printf(DBG_DDF, "failed to evaluate matchexpr for %s: %s, err: %s\n", qPrintable(resource->item(RAttrUniqueId)->toString()), qPrintable(i->matchExpr), qPrintable(djs->errorString()));
             }
-            i++; // proceed search
         }
         else
         {
-            return *i;
+            matchedIndices[matchedCount] = i->handle;
+            matchedCount++;
         }
+
+        i++; // proceed search
+    }
+
+    if (matchedCount != 0)
+    {
+        /*
+         * Now split the matches up in categories sorted by latest timestamp.
+         */
+        unsigned invalidIndex = 0xFFFFFFFF;
+        unsigned rawJsonIndex = invalidIndex;
+        unsigned latestStableBundleIndex = invalidIndex;
+        unsigned latestBetaBundleIndex = invalidIndex;
+        unsigned latestUserBundleIndex = invalidIndex;
+
+        for (size_t i = 0; i < matchedCount; i++)
+        {
+            const DeviceDescription &ddf1 = d->descriptions[matchedIndices[i]];
+
+            if (ddf1.storageLocation == deCONZ::DdfLocation || ddf1.storageLocation == deCONZ::DdfUserLocation)
+            {
+                rawJsonIndex = matchedIndices[i];
+                continue;
+            }
+
+            if (ddf1.storageLocation == deCONZ::DdfBundleUserLocation || ddf1.storageLocation == deCONZ::DdfBundleLocation)
+            {
+                if (ddf1.signedBy & 1) // has stable signature
+                {
+                    if (latestStableBundleIndex == invalidIndex)
+                    {
+                        latestStableBundleIndex = matchedIndices[i];
+                    }
+                    else
+                    {
+                        const DeviceDescription &ddf0 = d->descriptions[latestStableBundleIndex];
+                        if (ddf0.lastModified < ddf1.lastModified)
+                        {
+                            latestStableBundleIndex = matchedIndices[i]; // newer
+                        }
+                    }
+                }
+
+                if (ddf1.signedBy & 2) // has beta signature
+                {
+                    if (latestBetaBundleIndex == invalidIndex)
+                    {
+                        latestBetaBundleIndex = matchedIndices[i];
+                    }
+                    else
+                    {
+                        const DeviceDescription &ddf0 = d->descriptions[latestBetaBundleIndex];
+                        if (ddf0.lastModified < ddf1.lastModified)
+                        {
+                            latestBetaBundleIndex = matchedIndices[i]; // newer
+                        }
+                    }
+                }
+
+                if ((ddf1.signedBy & 3) == 0) // has neither beta or stable signature
+                {
+                    if (latestUserBundleIndex == invalidIndex)
+                    {
+                        latestUserBundleIndex = matchedIndices[i];
+                    }
+                    else
+                    {
+                        const DeviceDescription &ddf0 = d->descriptions[latestUserBundleIndex];
+                        if (ddf0.lastModified < ddf1.lastModified)
+                        {
+                            latestUserBundleIndex = matchedIndices[i]; // newer
+                        }
+                    }
+                }
+            }
+        }
+
+        unsigned policy = atDDFPolicyLatestPreferStable; // default
+
+        {
+            const Resource *rParent = resource->parentResource() ? resource->parentResource() : resource;
+            const ResourceItem *ddfPolicyItem = rParent->item(RAttrDdfPolicy);
+
+            if (ddfPolicyItem)
+            {
+                policy = ddfPolicyItem->atomIndex();
+            }
+        }
+
+        if (policy == atDDFPolicyRawJson && rawJsonIndex != invalidIndex)
+        {
+            return d->descriptions[rawJsonIndex];
+        }
+
+        if (policy == atDDFPolicyLatestPreferStable)
+        {
+            if (latestStableBundleIndex != invalidIndex)
+                return d->descriptions[latestStableBundleIndex];
+        }
+
+        if (policy == atDDFPolicyLatest || policy == atDDFPolicyLatestPreferStable)
+        {
+            unsigned bundleCount = 0;
+            std::array<unsigned, 3> bundleIndices;
+
+            if (latestStableBundleIndex != invalidIndex)
+                bundleIndices[bundleCount++] = latestStableBundleIndex;
+
+            if (latestBetaBundleIndex != invalidIndex)
+                bundleIndices[bundleCount++] = latestBetaBundleIndex;
+
+            if (latestUserBundleIndex != invalidIndex)
+                bundleIndices[bundleCount++] = latestUserBundleIndex;
+
+            if (bundleCount != 0)
+            {
+                unsigned bestMatch = bundleIndices[0];
+                for (unsigned i = 1; i < bundleCount; i++)
+                {
+                    const DeviceDescription &ddf0 = d->descriptions[bestMatch];
+                    const DeviceDescription &ddf1 = d->descriptions[i];
+
+                    if (ddf0.lastModified < ddf1.lastModified)
+                        bestMatch = i;
+                }
+
+                return d->descriptions[bestMatch];
+            }
+        }
+
+        if (policy == atDDFPolicyPin)
+        {
+
+        }
+
+        /*
+         * Fallback: If none of above matches pick your poison.
+         */
+
+        if (latestStableBundleIndex != invalidIndex)
+            return d->descriptions[latestStableBundleIndex];
+
+        if (latestBetaBundleIndex != invalidIndex)
+            return d->descriptions[latestBetaBundleIndex];
+
+        if (latestUserBundleIndex != invalidIndex)
+            return d->descriptions[latestUserBundleIndex];
+
+        if (rawJsonIndex != invalidIndex)
+            return d->descriptions[rawJsonIndex];
     }
 
     return d->invalidDescription;
+}
+
+bool DeviceDescriptions::loadDDFAndBundlesFromDisc(const Resource *resource)
+{
+    Q_D(DeviceDescriptions);
+
+    const ResourceItem *modelidItem = resource->item(RAttrModelId);
+    const ResourceItem *mfnameItem = resource->item(RAttrManufacturerName);
+
+    U_ASSERT(modelidItem);
+    U_ASSERT(mfnameItem);
+
+    unsigned modelidAtomIndex = modelidItem->atomIndex();
+    unsigned mfnameAtomIndex = mfnameItem->atomIndex();
+
+    U_ASSERT(modelidAtomIndex != 0);
+    U_ASSERT(mfnameAtomIndex != 0);
+
+    if (modelidAtomIndex == 0 || mfnameAtomIndex == 0)
+    {
+        return false;
+    }
+
+    for (const DDF_LoadRecord &loadRecord : d->ddfLoadRecords)
+    {
+        if (loadRecord.mfname.index == mfnameAtomIndex && loadRecord.modelid.index == modelidAtomIndex)
+        {
+            return false; // been here before
+        }
+    }
+
+    DBG_Printf(DBG_DDF, "try load DDF from disc for %s -- %s\n", mfnameItem->toCString(), modelidItem->toCString());
+
+    // mark for loading
+    DDF_LoadRecord loadRecord;
+    loadRecord.modelid.index = modelidAtomIndex;
+    loadRecord.mfname.index = mfnameAtomIndex;
+    loadRecord.loadState = DDF_LoadStateScheduled;
+    d->ddfLoadRecords.push_back(loadRecord);
+
+    unsigned countBefore = d->descriptions.size();
+    readAll();
+
+    return countBefore < d->descriptions.size();
 }
 
 const DeviceDescription &DeviceDescriptions::getFromHandle(DeviceDescription::Item::Handle hnd) const
@@ -974,7 +1377,7 @@ void DeviceDescriptions::put(const DeviceDescription &ddf)
         {
             DBG_Printf(DBG_DDF, "update ddf %s index %d\n", qPrintable(ddf0.modelIds.front()), ddf.handle);
             ddf0 = ddf;
-            DDF_UpdateItemHandles(d->descriptions, d->loadCounter);
+            DDF_UpdateItemHandlesForIndex(d->descriptions, d->loadCounter, static_cast<size_t>(ddf.handle));
             return;
         }
     }
@@ -982,7 +1385,13 @@ void DeviceDescriptions::put(const DeviceDescription &ddf)
 
 const DeviceDescription &DeviceDescriptions::load(const QString &path)
 {
+    Q_UNUSED(path)
+
+    // TODO(mpi) implement
+
     Q_D(DeviceDescriptions);
+
+#if 0
 
     auto i = std::find_if(d->descriptions.begin(), d->descriptions.end(), [&path](const auto &ddf){ return ddf.path == path; });
     if (i != d->descriptions.end())
@@ -1022,6 +1431,8 @@ const DeviceDescription &DeviceDescriptions::load(const QString &path)
             return *i;
         }
     }
+
+#endif
 
     return d->invalidDescription;
 }
@@ -1080,11 +1491,29 @@ QString DeviceDescriptions::constantToString(const QString &constant) const
 
     if (constant.startsWith('$'))
     {
-        const auto i = d->constants.find(constant);
+        char buf[128];
+        AT_AtomIndex key;
 
-        if (i != d->constants.end())
+        int len;
+        for (len = 0; len < constant.size() && len < 127; len++)
         {
-            return i->second;
+            buf[len] = constant.at(len).toLatin1();
+        }
+        buf[len] = '\0';
+
+        if (AT_GetAtomIndex(buf, (unsigned)len, &key))
+        {
+            for (size_t i = 0; i < d->constants2.size(); i++)
+            {
+                if (d->constants2[i].key.index == key.index)
+                {
+                    AT_Atom a = AT_GetAtomByIndex(d->constants2[i].value);
+                    if (a.len)
+                    {
+                        return QString::fromUtf8((const char*)a.data, a.len);
+                    }
+                }
+            }
         }
     }
 
@@ -1100,33 +1529,36 @@ QString DeviceDescriptions::stringToConstant(const QString &str) const
         return str;
     }
 
-    const auto end = d->constants.cend();
-    for (auto p = d->constants.begin(); p != end; ++p)
+    char buf[128];
+    AT_AtomIndex val;
+
+    int len;
+    for (len = 0; len < str.size() && len < 127; len++)
     {
-        if (p->second == str)
+        buf[len] = str.at(len).toLatin1();
+    }
+    buf[len] = '\0';
+
+    if (len)
+    {
+        if (AT_GetAtomIndex(buf, (unsigned)len, &val))
         {
-            return p->first;
+            for (size_t i = 0; i < d->constants2.size(); i++)
+            {
+                if (d->constants2[i].value.index == val.index)
+                {
+                    AT_Atom a = AT_GetAtomByIndex(d->constants2[i].key);
+                    if (a.len)
+                    {
+                        return QString::fromUtf8((const char*)a.data, a.len);
+                    }
+                    break;
+                }
+            }
         }
     }
 
     return str;
-}
-
-QStringList DeviceDescriptions::constants(const QString &prefix) const
-{
-    Q_D(const DeviceDescriptions);
-    QStringList result;
-
-    const auto end = d->constants.cend();
-    for (auto p = d->constants.begin(); p != end; ++p)
-    {
-        if (prefix.isEmpty() || p->first.startsWith(prefix))
-        {
-            result.push_back(p->first);
-        }
-    }
-
-    return result;
 }
 
 static DeviceDescription::Item *DDF_GetItemMutable(const ResourceItem *item)
@@ -1264,41 +1696,83 @@ const std::vector<DDF_SubDeviceDescriptor> &DeviceDescriptions::getSubDevices() 
     return d_ptr2->subDevices;
 }
 
+static void DDF_UpdateItemHandlesForIndex(std::vector<DeviceDescription> &descriptions, uint loadCounter, size_t index)
+{
+    U_ASSERT(index < descriptions.size());
+    if (descriptions.size() <= index)
+    {
+        return; // should not happen
+    }
+
+    U_ASSERT(index < HND_MAX_DESCRIPTIONS);
+    U_ASSERT(loadCounter >= HND_MIN_LOAD_COUNTER);
+    U_ASSERT(loadCounter <= HND_MAX_LOAD_COUNTER);
+
+    ItemHandlePack handle;
+    DeviceDescription &ddf = descriptions[index];
+
+    ddf.handle = static_cast<int>(index);
+
+    handle.description = static_cast<unsigned>(index);
+    handle.loadCounter = loadCounter;
+    handle.subDevice = 0;
+
+    for (DeviceDescription::SubDevice &sub : ddf.subDevices)
+    {
+        handle.item = 0;
+
+        for (DeviceDescription::Item &item : sub.items)
+        {
+            item.handle = handle.handle;
+            U_ASSERT(handle.item < HND_MAX_ITEMS);
+            handle.item++;
+        }
+
+        U_ASSERT(handle.subDevice < HND_MAX_SUB_DEVS);
+        handle.subDevice++;
+    }
+}
+
 /*! Updates all DDF item handles to point to correct location.
     \p loadCounter - the current load counter.
  */
 static void DDF_UpdateItemHandles(std::vector<DeviceDescription> &descriptions, uint loadCounter)
 {
-    int index = 0;
-    Q_ASSERT(loadCounter >= HND_MIN_LOAD_COUNTER);
-    Q_ASSERT(loadCounter <= HND_MAX_LOAD_COUNTER);
-
-    ItemHandlePack handle;
-    handle.description = 0;
-    handle.loadCounter = loadCounter;
-
-    for (auto &ddf : descriptions)
+    for (size_t index = 0; index < descriptions.size(); index++)
     {
-        ddf.handle = index++;
-        handle.subDevice = 0;
-        for (auto &sub : ddf.subDevices)
-        {
-            handle.item = 0;
-
-            for (auto &item : sub.items)
-            {
-                item.handle = handle.handle;
-                Q_ASSERT(handle.item < HND_MAX_ITEMS);
-                handle.item++;
-            }
-
-            Q_ASSERT(handle.subDevice < HND_MAX_SUB_DEVS);
-            handle.subDevice++;
-        }
-
-        Q_ASSERT(handle.description < HND_MAX_DESCRIPTIONS);
-        handle.description++;
+        DDF_UpdateItemHandlesForIndex(descriptions, loadCounter, index);
     }
+
+    // int index = 0;
+    // U_ASSERT(loadCounter >= HND_MIN_LOAD_COUNTER);
+    // U_ASSERT(loadCounter <= HND_MAX_LOAD_COUNTER);
+
+    // ItemHandlePack handle;
+    // handle.description = 0;
+    // handle.loadCounter = loadCounter;
+
+    // for (DeviceDescription &ddf : descriptions)
+    // {
+    //     ddf.handle = index++;
+    //     handle.subDevice = 0;
+    //     for (auto &sub : ddf.subDevices)
+    //     {
+    //         handle.item = 0;
+
+    //         for (auto &item : sub.items)
+    //         {
+    //             item.handle = handle.handle;
+    //             U_ASSERT(handle.item < HND_MAX_ITEMS);
+    //             handle.item++;
+    //         }
+
+    //         U_ASSERT(handle.subDevice < HND_MAX_SUB_DEVS);
+    //         handle.subDevice++;
+    //     }
+
+    //     U_ASSERT(handle.description < HND_MAX_DESCRIPTIONS);
+    //     handle.description++;
+    // }
 }
 
 /*! Temporary workaround since DuktapeJS doesn't support 'let', try replace it with 'var'.
@@ -1360,9 +1834,95 @@ static void DDF_TryCompileAndFixJavascript(QString *expr, const QString &path)
 #endif
 }
 
+enum JSON_Schema
+{
+    JSON_SCHEMA_UNKNOWN,
+    JSON_SCHEMA_CONSTANTS_1,
+    JSON_SCHEMA_CONSTANTS_2,
+    JSON_SCHEMA_RESOURCE_ITEM_1,
+    JSON_SCHEMA_SUB_DEVICE_1,
+    JSON_SCHEMA_DEV_CAP_1
+};
+
+/*! Returns the JSON schema of a file.
+
+    The function doesn't actually parse the full JSON document
+    but instead just extracts the "schema": "<SCHEMA>" content.
+*/
+JSON_Schema DDF_GetJsonSchema(uint8_t *data, unsigned dataSize)
+{
+    U_SStream ss[1];
+    unsigned beg = 0;
+    unsigned end = 0;
+    unsigned len;
+
+    U_ASSERT(data);
+    U_ASSERT(dataSize > 0);
+
+    if (*data != '{' && *data != '[') // not JSON object or array
+    {
+        return JSON_SCHEMA_UNKNOWN;
+    }
+
+    U_sstream_init(ss, data, dataSize);
+
+    if (U_sstream_find(ss, "\"schema\""))
+    {
+        U_sstream_seek(ss, ss[0].pos + 8);
+
+        if (U_sstream_find(ss, "\""))
+        {
+            U_sstream_seek(ss, ss[0].pos + 1);
+            beg = ss[0].pos;
+
+            if (U_sstream_find(ss, "\""))
+            {
+                end = ss[0].pos;
+            }
+        }
+    }
+
+    if (beg < end)
+    {
+        len = end - beg;
+        U_sstream_init(ss, &data[beg], len);
+
+        if (len == 19 && U_sstream_starts_with(ss, "devcap1.schema.json"))
+        {
+            return JSON_SCHEMA_DEV_CAP_1;
+        }
+        else if (len == 25 && U_sstream_starts_with(ss, "resourceitem1.schema.json"))
+        {
+            return JSON_SCHEMA_RESOURCE_ITEM_1;
+        }
+        else if (len == 22 && U_sstream_starts_with(ss, "constants1.schema.json"))
+        {
+            return JSON_SCHEMA_CONSTANTS_1;
+        }
+        else if (len == 22 && U_sstream_starts_with(ss, "constants2.schema.json"))
+        {
+            return JSON_SCHEMA_CONSTANTS_2;
+        }
+        else if (len == 22 && U_sstream_starts_with(ss, "subdevice1.schema.json"))
+        {
+            return JSON_SCHEMA_SUB_DEVICE_1;
+        }
+    }
+
+    return JSON_SCHEMA_UNKNOWN;
+}
+
 /*! Reads all DDF related files.
  */
 void DeviceDescriptions::readAll()
+{
+    readAllRawJson();
+    readAllBundles();
+}
+
+/*! Reads all scheduled raw JSON DDF files.
+ */
+void DeviceDescriptions::readAllRawJson()
 {
     Q_D(DeviceDescriptions);
 
@@ -1372,30 +1932,53 @@ void DeviceDescriptions::readAll()
         d->loadCounter = HND_MIN_LOAD_COUNTER;
     }
 
-    DBG_MEASURE_START(DDF_ReadAllFiles);
+    ScratchMemWaypoint swp;
+    uint8_t *ctx_mem = SCRATCH_ALLOC(uint8_t*, sizeof(DDF_ParseContext) + 64);
+    U_ASSERT(ctx_mem);
+    if (!ctx_mem)
+    {
+        DBG_Printf(DBG_ERROR, "DDF not enough memory to create DDF_ParseContext\n");
+        return;
+    }
 
-    std::vector<DeviceDescription> descriptions;
-    std::vector<DeviceDescription::Item> genericItems;
+    DDF_ParseContext *pctx = new(ctx_mem)DDF_ParseContext; // placement new into scratch memory, no further cleanup needed
+    U_ASSERT(pctx);
+    pctx->extChunks = nullptr;
+
+    DBG_MEASURE_START(DDF_ReadRawJson);
+
     std::vector<DDF_SubDeviceDescriptor> subDevices;
 
-    QStringList dirs;
-    dirs.push_back(deCONZ::getStorageLocation(deCONZ::DdfUserLocation));
-    dirs.push_back(deCONZ::getStorageLocation(deCONZ::DdfLocation));
+    std::array<deCONZ::StorageLocation, 2> locations = { deCONZ::DdfUserLocation, deCONZ::DdfLocation};
 
-    while (!dirs.isEmpty())
+    for (size_t dit = 0; dit < locations.size(); dit++)
     {
-        QDirIterator it(dirs.takeFirst(), QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
+        const QString dirpath = deCONZ::getStorageLocation(locations[dit]);
+        QDirIterator it(dirpath, QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
 
         while (it.hasNext())
         {
             it.next();
 
+            pctx->filePath[0] = '\0';
+            pctx->filePathLength = 0;
+            pctx->scratchPos = 0;
+            QString filePath = it.filePath();
+            {
+                U_SStream ss;
+                U_sstream_init(&ss, pctx->filePath, sizeof(pctx->filePath));
+                U_sstream_put_str(&ss, filePath.toUtf8().data());
+                pctx->filePathLength = ss.pos;
+            }
+
             if (it.filePath().endsWith(QLatin1String("generic/constants.json")))
             {
-                std::map<QString,QString> constants;
-                if (DDF_ReadConstantsJson(it.filePath(), &constants))
+                if (DDF_ReadFileInMemory(pctx))
                 {
-                    d->constants = constants;
+                    if (DDF_ReadConstantsJson(pctx, d->constants2))
+                    {
+
+                    }
                 }
             }
             else if (it.fileName() == QLatin1String("button_maps.json"))
@@ -1404,36 +1987,175 @@ void DeviceDescriptions::readAll()
             {
                 if (it.filePath().contains(QLatin1String("generic/items/")))
                 {
-                    auto result = DDF_ReadItemFile(it.filePath());
-                    if (result.isValid())
+                    if (DDF_ReadFileInMemory(pctx))
                     {
-                        result.isGenericRead = !result.readParameters.isNull() ? 1 : 0;
-                        result.isGenericWrite = !result.writeParameters.isNull() ? 1 : 0;
-                        result.isGenericParse = !result.parseParameters.isNull() ? 1 : 0;
-                        genericItems.push_back(std::move(result));
+                        DeviceDescription::Item result = DDF_ReadItemFile(pctx);
+                        if (result.isValid())
+                        {
+                            result.isGenericRead = !result.readParameters.isNull() ? 1 : 0;
+                            result.isGenericWrite = !result.writeParameters.isNull() ? 1 : 0;
+                            result.isGenericParse = !result.parseParameters.isNull() ? 1 : 0;
+
+                            size_t j = 0;
+                            for (j = 0; j < d->genericItems.size(); j++)
+                            {
+                                DeviceDescription::Item  &genItem = d->genericItems[j];
+                                if (genItem.name == result.name)
+                                {
+                                    // replace
+                                    genItem = result;
+                                    break;
+                                }
+                            }
+
+                            if (j == d->genericItems.size())
+                            {
+                                d->genericItems.push_back(result);
+                            }
+                        }
                     }
                 }
                 else if (it.filePath().contains(QLatin1String("generic/subdevices/")))
                 {
-                    auto sub = DDF_ReadSubDeviceFile(it.filePath());
-                    if (isValid(sub))
+                    if (DDF_ReadFileInMemory(pctx))
                     {
-                        subDevices.push_back(sub);
+                        DDF_SubDeviceDescriptor result = DDF_ReadSubDeviceFile(pctx);
+                        if (isValid(result))
+                        {
+                            subDevices.push_back(result);
+                        }
                     }
                 }
                 else
                 {
-                    DBG_Printf(DBG_DDF, "read %s\n", qPrintable(it.fileName()));
-                    std::vector<DeviceDescription> result = DDF_ReadDeviceFile(it.filePath());
-                    std::move(result.begin(), result.end(), std::back_inserter(descriptions));
+                    if (DDF_ReadFileInMemory(pctx))
+                    {
+                        DeviceDescription result = DDF_ReadDeviceFile(pctx);
+                        if (result.isValid())
+                        {
+                            result.storageLocation = locations[dit];
+                            U_Sha256(pctx->fileData, pctx->fileDataSize, (unsigned char*)&result.sha256Hash[0]);
+
+                            unsigned j = 0;
+                            unsigned k = 0;
+                            bool found = false;
+
+                            /*
+                             * Check if this DDF is already loaded.
+                             */
+                            for (j = 0; j < d->descriptions.size(); j++)
+                            {
+                                const DeviceDescription &ddf = d->descriptions[j];
+
+                                for (k = 0; k < 8; k++)
+                                {
+                                    if (ddf.sha256Hash[k] != result.sha256Hash[k])
+                                    {
+                                        break;
+                                    }
+                                }
+
+                                if (k == 8)
+                                {
+                                    found = true;
+                                    break;
+                                }
+                            }
+
+                            if (!found)
+                            {
+                                /*
+                                 * Further check if the DDF is scheduled for loading.
+                                 * That is when an actual possibly matching device exists in the setup.
+                                 */
+                                bool scheduled = false;
+                                if (result.manufacturerNames.size() == result.modelIds.size())
+                                {
+                                    for (j = 0; j < result.manufacturerNames.size(); j++)
+                                    {
+                                        AT_AtomIndex mfnameIndex;
+                                        AT_AtomIndex modelidIndex;
+
+                                        /*
+                                         * Try to get atoms for the mfname/modelid pair.
+                                         * Note: If they don't exist, this isn't the pair we are looking for!
+                                         * We don't add atoms for all strings found in DDFs to safe memory.
+                                         */
+
+                                        {
+                                            const QByteArray m = constantToString(result.manufacturerNames[j]).toUtf8();
+                                            if (AT_GetAtomIndex(m.constData(), (unsigned)m.size(), &mfnameIndex) != 1)
+                                            {
+                                                continue;
+                                            }
+                                        }
+
+                                        {
+                                            const QByteArray m = constantToString(result.modelIds[j]).toUtf8();
+                                            if (AT_GetAtomIndex(m.constData(), (unsigned)m.size(), &modelidIndex) != 1)
+                                            {
+                                                continue;
+                                            }
+                                        }
+
+                                        for (k = 0; k < d->ddfLoadRecords.size(); k++)
+                                        {
+                                            if (d->ddfLoadRecords[k].loadState != DDF_LoadStateScheduled)
+                                            {
+                                                continue;
+                                            }
+
+                                            if (mfnameIndex.index == d->ddfLoadRecords[k].mfname.index &&
+                                                modelidIndex.index == d->ddfLoadRecords[k].modelid.index)
+                                            {
+                                                d->ddfLoadRecords[k].loadState = DDF_LoadStateLoadedRawJson;
+                                                scheduled = true;
+                                                break;
+                                            }
+                                        }
+
+                                        if (scheduled)
+                                        {
+                                            break;
+                                        }
+                                    }
+                                }
+
+                                if (scheduled)
+                                {
+                                    /*
+                                     * The DDF is of interest, now register all atoms for faster lookups.
+                                     */
+                                    for (const auto &mfname : result.manufacturerNames)
+                                    {
+                                        const QString m = DeviceDescriptions::instance()->constantToString(mfname);
+
+                                        AT_AtomIndex ati;
+                                        if (AT_AddAtom(m.toUtf8().data(), m.size(), &ati) && ati.index != 0)
+                                        {
+                                            result.mfnameAtomIndices.push_back(ati.index);
+                                        }
+                                    }
+
+                                    for (const auto &modelId : result.modelIds)
+                                    {
+                                        const QString m = DeviceDescriptions::instance()->constantToString(modelId);
+
+                                        AT_AtomIndex ati;
+                                        if (AT_AddAtom(m.toUtf8().data(), m.size(), &ati) && ati.index != 0)
+                                        {
+                                            result.modelidAtomIndices.push_back(ati.index);
+                                        }
+                                    }
+
+                                    d->descriptions.push_back(std::move(result));
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
-    }
-
-    if (!genericItems.empty())
-    {
-        d->genericItems = std::move(genericItems);
     }
 
     if (!subDevices.empty())
@@ -1445,9 +2167,8 @@ void DeviceDescriptions::readAll()
         d->subDevices = std::move(subDevices);
     }
 
-    if (!descriptions.empty())
+    if (!d->descriptions.empty())
     {
-        d->descriptions = std::move(descriptions);
         DDF_UpdateItemHandles(d->descriptions, d->loadCounter);
 
         for (auto &ddf : d->descriptions)
@@ -1455,9 +2176,381 @@ void DeviceDescriptions::readAll()
             ddf = DDF_MergeGenericItems(d->genericItems, ddf);
             ddf = DDF_LoadScripts(ddf);
         }
+
+        DBG_Printf(DBG_DDF, "loaded %d DDFs\n", (int)d->descriptions.size());
     }
 
-    DBG_MEASURE_END(DDF_ReadAllFiles);
+    DBG_MEASURE_END(DDF_ReadRawJson);
+}
+
+#if 0
+    {
+        U_ECC_PrivateKeySecp256k1 privkey = {0};
+        U_ECC_PublicKeySecp256k1 pubkey = {0};
+        U_ECC_SignatureSecp256k1 sig = {0};
+        unsigned char hash[U_SHA256_HASH_SIZE] = {0};
+
+        if (U_ECC_CreateKeyPairSecp256k1(&privkey, &pubkey) == 1)
+        {
+            DBG_Printf(DBG_INFO, "created keypair\n");
+
+            U_Sha256(&privkey, sizeof(privkey), hash); // just to have some hash
+
+            if (U_ECC_SignSecp256K1(&privkey, hash, sizeof(hash), &sig))
+            {
+                DBG_Printf(DBG_INFO, "created signature\n");
+
+                if (U_ECC_VerifySignatureSecp256k1(&pubkey, &sig, hash, sizeof(hash)))
+                {
+                    DBG_Printf(DBG_INFO, "verified signature\n");
+                }
+
+                sig.sig[6] = sig.sig[6] + 9; // invalidate
+                if (U_ECC_VerifySignatureSecp256k1(&pubkey, &sig, hash, sizeof(hash)) == 0)
+                {
+                    DBG_Printf(DBG_INFO, "invalid signature [OK]\n");
+                }
+            }
+        }
+    }
+
+    {
+        U_HmacSha256Test();
+    }
+#endif
+
+static int DDF_IsBundleScheduled(DDF_ParseContext *pctx, const char *desc, unsigned descSize, const std::vector<DDF_LoadRecord> &ddfLoadRecords)
+{
+    cj_ctx cj[1];
+    char buf[96];
+    cj_token_ref ref;
+    cj_token_ref parent_ref;
+    cj_token_ref deviceids_ref;
+    cj_token_ref last_modified_ref;
+    AT_AtomIndex modelid_ati;
+    AT_AtomIndex mfname_ati;
+    cj_token *tokens = pctx->tokens.data();
+
+    cj_parse_init(cj, desc, descSize, pctx->tokens.data(), (cj_size)pctx->tokens.size());
+    cj_parse(cj);
+
+    if (cj->status != CJ_OK)
+        return 0;
+
+    parent_ref = 0;
+    deviceids_ref = cj_value_ref(cj, parent_ref, "device_identifiers");
+    last_modified_ref = cj_value_ref(cj, parent_ref, "last_modified");
+
+    // array of 2 string element arrays
+    // "device_identifiers":[["LUMI","lumi.sensor_magnet"]]
+
+    if (last_modified_ref == CJ_INVALID_TOKEN_INDEX)
+        return 0;
+
+    if (tokens[last_modified_ref].type != CJ_TOKEN_STRING)
+        return 0;
+
+    {
+        cj_token *tok = &tokens[last_modified_ref];
+        pctx->bundleLastModified = U_TimeFromISO8601(&desc[tok->pos], tok->len);
+    }
+
+    if (deviceids_ref == CJ_INVALID_TOKEN_INDEX)
+        return 0;
+
+    if (tokens[deviceids_ref].type != CJ_TOKEN_ARRAY_BEG)
+        return 0;
+
+    // verify flat string array, and equal size for manufacturer names and modelids
+    for (ref = deviceids_ref + 1; tokens[ref].type != CJ_TOKEN_ARRAY_END && ref < cj[0].tokens_pos; )
+    {
+        if (tokens[ref].type == CJ_TOKEN_ITEM_SEP)
+        {
+            ref++;
+            continue;
+        }
+
+        // inner array for each entry
+        if (tokens[ref].type != CJ_TOKEN_ARRAY_BEG)
+            break;
+
+        if (tokens[ref + 1].type != CJ_TOKEN_STRING) // mfname
+            break;
+
+        if (tokens[ref + 2].type != CJ_TOKEN_ITEM_SEP)
+            break;
+
+        if (tokens[ref + 3].type != CJ_TOKEN_STRING) // modelid
+            break;
+
+        if (tokens[ref + 4].type != CJ_TOKEN_ARRAY_END)
+            break;
+
+        /*
+         * Lookup if the manufacturername and modelid pair has registered atoms.
+         * If not this can't be a bundle of interest.
+         */
+        bool foundAtoms = true;
+
+        if (cj_copy_ref_utf8(cj, buf, sizeof(buf), ref + 1) == 0)
+            break; // this has to be a valid string
+
+        if (AT_GetAtomIndex(buf, U_strlen(buf), &mfname_ati) == 0)
+            foundAtoms = false; // unknown, can be ok
+
+        if (cj_copy_ref_utf8(cj, buf, sizeof(buf), ref + 3) == 0)
+            break; // this has to be a valid string
+
+        if (AT_GetAtomIndex(buf, U_strlen(buf), &modelid_ati) == 0)
+            foundAtoms = false; // unknown, can be ok
+
+        ref += 5;
+        if (!foundAtoms)
+            continue;
+
+        for (size_t j = 0; j < ddfLoadRecords.size(); j++)
+        {
+            const DDF_LoadRecord &rec = ddfLoadRecords[j];
+
+            if (rec.mfname.index != mfname_ati.index)
+                continue;
+
+            if (rec.modelid.index != modelid_ati.index)
+                continue;
+
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+/*! Reads all scheduled DDF bundles.
+ */
+void DeviceDescriptions::readAllBundles()
+{
+    Q_D(DeviceDescriptions);
+
+    ScratchMemWaypoint swp;
+    uint8_t *ctx_mem = SCRATCH_ALLOC(uint8_t*, sizeof(DDF_ParseContext) + 64);
+    U_ASSERT(ctx_mem);
+    if (!ctx_mem)
+    {
+        DBG_Printf(DBG_ERROR, "DDF not enough memory to create DDF_ParseContext\n");
+        return;
+    }
+
+    DDF_ParseContext *pctx = new(ctx_mem)DDF_ParseContext; // placement new into scratch memory, no further cleanup needed
+    U_ASSERT(pctx);
+
+    DBG_MEASURE_START(DDF_ReadBundles);
+
+    FS_Dir dir;
+    FS_File fp;
+    U_SStream ss;
+    U_BStream bs;
+    unsigned chunkSize;
+    unsigned basePathLength;
+    unsigned scratchPosPerBundle;
+
+    deCONZ::StorageLocation locations[2] = { deCONZ::DdfBundleUserLocation, deCONZ::DdfBundleLocation };
+
+    for (int dit = 0; dit < 2; dit++)
+    {
+        {
+            QByteArray loc = deCONZ::getStorageLocation(locations[dit]).toUtf8();
+            U_sstream_init(&ss, pctx->filePath, sizeof(pctx->filePath));
+            U_sstream_put_str(&ss, loc.data());
+            basePathLength = ss.pos;
+        }
+
+        // during processing of a bundle additional memory might be allocated
+        // restore this point for each bundle to be processeed
+        scratchPosPerBundle = ScratchMemPos();
+
+        if (FS_OpenDir(&dir, pctx->filePath))
+        {
+            for (;FS_ReadDir(&dir);)
+            {
+                if (dir.entry.type != FS_TYPE_FILE)
+                    continue;
+
+                U_sstream_init(&ss, dir.entry.name, strlen(dir.entry.name));
+
+                if (U_sstream_find(&ss, ".ddf") == 0)
+                    continue;
+
+                ScratchMemRewind(scratchPosPerBundle);
+
+                U_sstream_init(&ss, pctx->filePath, sizeof(pctx->filePath));
+                ss.pos = basePathLength; // reuse path and append the filename to existing base path
+                U_sstream_put_str(&ss, "/");
+                U_sstream_put_str(&ss, dir.entry.name);
+                pctx->filePathLength = ss.pos;
+                pctx->bundleLastModified = 0;
+                pctx->extChunks = nullptr;
+                pctx->signatures = 0;
+
+                if (DDF_ReadFileInMemory(pctx) == 0)
+                    continue;
+
+                // keep copy here since pcxt vars are adjusted to sub sections during read
+                unsigned ddfbChunkOffset;
+                unsigned ddfbChunkSize;
+                uint32_t ddfbHash[8];
+                unsigned char *fileData;
+                unsigned fileDataSize;
+
+                fileData = pctx->fileData;
+                fileDataSize = pctx->fileDataSize;
+
+                U_bstream_init(&bs, pctx->fileData, pctx->fileDataSize);
+
+                if (DDFB_FindChunk(&bs, "RIFF", &chunkSize) == 0)
+                    continue;
+
+                if (DDFB_FindChunk(&bs, "DDFB", &chunkSize) == 0)
+                    continue;
+
+                ddfbChunkOffset = bs.pos;
+                ddfbChunkSize = chunkSize;
+
+                {   // check if bundle is already loaded
+                    // bundle hash over DDFB chunk (header + data)
+                    U_Sha256(&pctx->fileData[ddfbChunkOffset - 8], ddfbChunkSize + 8, (uint8_t*)&ddfbHash[0]);
+
+                    unsigned i;
+                    unsigned k;
+
+                    for (i = 0; i < d->descriptions.size(); i++)
+                    {
+                        uint32_t *hash0 = d->descriptions[i].sha256Hash;
+
+                        for (k = 0; k < 8; k++)
+                        {
+                            if (hash0[k] != ddfbHash[k])
+                                break;
+                        }
+
+                        if (k == 8)
+                            break; // match
+                    }
+
+                    if (i < d->descriptions.size()) // skip, already known
+                        continue;
+                }
+
+                if (DDFB_FindChunk(&bs, "DESC", &chunkSize) == 0)
+                    continue;
+
+                if (DDF_IsBundleScheduled(pctx, (char*)&bs.data[bs.pos], chunkSize, d->ddfLoadRecords) == 0)
+                {
+                    // continue; // TODO TEMP ONLY
+                }
+
+                // limit to DDFB content
+                U_bstream_init(&bs, &fileData[ddfbChunkOffset], ddfbChunkSize);
+
+                // read external files first
+                for (;bs.status == U_BSTREAM_OK;)
+                {
+                    if (DDFB_IsChunk(&bs, "EXTF"))
+                    {
+                        DDFB_ExtfChunk *extf = SCRATCH_ALLOC(DDFB_ExtfChunk*, sizeof (*extf));
+                        if (extf && DDFB_ReadExtfChunk(&bs, extf))
+                        {
+                            // collect external chunk descriptors in a temporary list
+                            extf->next = pctx->extChunks;
+                            pctx->extChunks = extf;
+                            continue;
+                        }
+                    }
+
+                    DDFB_SkipChunk(&bs);
+                }
+
+                if (DDF_ReadConstantsJson(pctx, d->constants2))
+                {
+
+                }
+
+                // now process the actual DDF content
+                U_bstream_init(&bs, &fileData[ddfbChunkOffset], ddfbChunkSize);
+
+                if (DDFB_FindChunk(&bs, "DDFC", &chunkSize) == 0)
+                {
+                    continue;
+                }
+
+                // tmp swap where data points
+                pctx->fileData = &bs.data[bs.pos];
+                pctx->fileDataSize = chunkSize;
+
+                DeviceDescription ddf = DDF_ReadDeviceFile(pctx);
+                if (!ddf.isValid())
+                {
+                    continue;
+                }
+
+                // process signatures
+                U_bstream_init(&bs, &fileData[8], fileDataSize - 8); // after RIFF header
+                if (DDFB_FindChunk(&bs, "SIGN", &chunkSize) == 1)
+                {
+                    U_bstream_init(&bs, &bs.data[bs.pos], chunkSize);
+                    DDF_ProcessSignatures(pctx, d->publicKeys, &bs, ddfbHash);
+                }
+
+                ddf.storageLocation = locations[dit];
+                ddf.lastModified = pctx->bundleLastModified;
+                ddf.signedBy = pctx->signatures;
+
+                if (DDF_MergeGenericBundleItems(ddf, pctx) == 0)
+                {
+                    continue;
+                }
+
+                // copy bundle hash generated earlier
+                for (unsigned i = 0; i < 8; i++)
+                    ddf.sha256Hash[i] = ddfbHash[i];
+
+                {
+                    /*
+                     * The DDF is of interest, now register all atoms for faster lookups.
+                     */
+                    for (const auto &mfname : ddf.manufacturerNames)
+                    {
+                        const QString m = constantToString(mfname);
+
+                        AT_AtomIndex ati;
+                        if (AT_AddAtom(m.toUtf8().data(), m.size(), &ati) && ati.index != 0)
+                        {
+                            ddf.mfnameAtomIndices.push_back(ati.index);
+                        }
+                    }
+
+                    for (const auto &modelId : ddf.modelIds)
+                    {
+                        const QString m = constantToString(modelId);
+
+                        AT_AtomIndex ati;
+                        if (AT_AddAtom(m.toUtf8().data(), m.size(), &ati) && ati.index != 0)
+                        {
+                            ddf.modelidAtomIndices.push_back(ati.index);
+                        }
+                    }
+
+                    d->descriptions.push_back(std::move(ddf));
+                    DDF_UpdateItemHandlesForIndex(d->descriptions, d->loadCounter, d->descriptions.size() - 1);
+                }
+
+                DBG_Printf(DBG_DDF, "DDF bundle: %s, size: %u bytes\n", ss.str, pctx->fileDataSize);
+            }
+
+            FS_CloseDir(&dir);
+        }
+    }
+
+    DBG_MEASURE_END(DDF_ReadBundles);
 }
 
 /*! Tries to init a Device from an DDF file.
@@ -1498,26 +2591,25 @@ void DeviceDescriptions::handleDDFInitRequest(const Event &event)
 
         if (result >= 0)
         {
-            DBG_Printf(DBG_INFO, "DEV found DDF for 0x%016llX, path: %s\n", event.deviceKey(), qPrintable(ddf.path));
+            DBG_Printf(DBG_INFO, "DEV found DDF for " FMT_MAC ", path: %s\n", FMT_MAC_CAST(event.deviceKey()), qPrintable(ddf.path));
         }
 
         if (result == 0)
         {
-            DBG_Printf(DBG_INFO, "DEV init Device from DDF for 0x%016llX failed\n", event.deviceKey());
+            DBG_Printf(DBG_INFO, "DEV init Device from DDF for " FMT_MAC " failed\n", FMT_MAC_CAST(event.deviceKey()));
         }
         else if (result == -1)
         {
-            DBG_Printf(DBG_INFO, "DEV no DDF for 0x%016llX, modelId: %s\n", event.deviceKey(), qPrintable(resource->item(RAttrModelId)->toString()));
-            DBG_Printf(DBG_INFO, "DEV create on-the-fly DDF for 0x%016llX\n", event.deviceKey());
+            DBG_Printf(DBG_INFO, "DEV no DDF for " FMT_MAC ", modelId: %s\n", FMT_MAC_CAST(event.deviceKey()), resource->item(RAttrModelId)->toCString());
+            DBG_Printf(DBG_INFO, "DEV create on-the-fly DDF for " FMT_MAC "\n", FMT_MAC_CAST(event.deviceKey()));
 
             DeviceDescription ddf1;
-
             Device *device = static_cast<Device*>(resource);
 
             if (DEV_InitBaseDescriptionForDevice(device, ddf1))
             {
-                d->descriptions.push_back(ddf1);
-                DDF_UpdateItemHandles(d->descriptions, d->loadCounter);
+                d->descriptions.push_back(std::move(ddf1));
+                DDF_UpdateItemHandlesForIndex(d->descriptions, d->loadCounter, d->descriptions.size() - 1);
             }
         }
     }
@@ -1527,48 +2619,99 @@ void DeviceDescriptions::handleDDFInitRequest(const Event &event)
 
 /*! Reads constants.json file and places them into \p constants map.
  */
-static bool DDF_ReadConstantsJson(const QString &path, std::map<QString,QString> *constants)
+static int DDF_ReadConstantsJson(DDF_ParseContext *pctx, std::vector<ConstantEntry> &constants)
 {
-    Q_ASSERT(constants);
+    cj_ctx ctx;
+    cj_ctx *cj;
+    cj_token *tok;
+    cj_token_ref ref;
+    ConstantEntry constEntry;
 
-    QFile file(path);
+    const char *fileData = (const char*)pctx->fileData;
+    unsigned fileDataSize = pctx->fileDataSize;
 
-    if (!file.exists())
+    // if this is a bundle point to data within the bundle
+    if (pctx->extChunks)
     {
-        return false;
-    }
+        fileData = nullptr;
+        fileDataSize = 0;
 
-    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
-    {
-        return false;
-    }
-
-    QJsonParseError error;
-    QJsonDocument doc = QJsonDocument::fromJson(file.readAll(), &error);
-    file.close();
-
-    if (!doc.isObject())
-    {
-        DBG_Printf(DBG_INFO, "DDF failed to read device constants: %s, err: %s, offset: %d\n", qPrintable(path), qPrintable(error.errorString()), error.offset);
-        return false;
-    }
-
-    const auto obj = doc.object();
-    const QStringList categories {"manufacturers", "device-types"};
-
-    for (const auto &cat : categories)
-    {
-        if (obj.contains(cat))
+        for (DDFB_ExtfChunk *extf = pctx->extChunks; extf; extf = extf->next)
         {
-            const auto catobj = obj.value(cat).toObject();
-            for (auto &key : catobj.keys())
+            if (extf->fileType[0] != 'J' || extf->fileType[1] != 'S' || extf->fileType[2] != 'O' || extf->fileType[3] != 'N')
+                continue;
+
+            JSON_Schema schema = DDF_GetJsonSchema(extf->fileData, extf->fileSize);
+
+            if (schema == JSON_SCHEMA_CONSTANTS_2)
             {
-                (*constants)[key] = catobj.value(key).toString();
+                fileData = (const char*)extf->fileData;
+                fileDataSize = extf->fileSize;
+                break;
             }
         }
     }
 
-    return !constants->empty();
+    if (!fileData || fileDataSize == 0)
+    {
+        return 0;
+    }
+
+    auto &tokens = pctx->tokens;
+
+    cj = &ctx;
+
+    cj_parse_init(cj, fileData, fileDataSize, tokens.data(), tokens.size());
+    cj_parse(cj);
+
+    if (cj->status == CJ_OK)
+    {
+        for (ref = 0; ref < cj->tokens_pos; ref++)
+        {
+            tok = &cj->tokens[ref];
+
+            if (tok->type == CJ_TOKEN_STRING && (ref + 2) < cj->tokens_pos)
+            {
+                if (cj->buf[tok->pos] == '$' && tok[1].type == CJ_TOKEN_NAME_SEP && tok[2].type == CJ_TOKEN_STRING)
+                {
+                    if (tok[0].len < 2 || tok[2].len < 2)
+                    {
+                        // min size of strings, should perhaps be longer ...
+                    }
+                    else if (tok[0].len > AT_MAX_ATOM_SIZE || tok[2].len > AT_MAX_ATOM_SIZE)
+                    {
+
+                    }
+                    else if (AT_AddAtom(&cj->buf[tok[0].pos], tok[0].len, &constEntry.key) == 1 &&
+                             AT_AddAtom(&cj->buf[tok[2].pos], tok[2].len, &constEntry.value) == 1)
+                    {
+                        // check already known
+                        for (size_t i = 0; i < constants.size(); i++)
+                        {
+                            if (constants[i].key.index == constEntry.key.index && constants[i].value.index == constEntry.value.index)
+                            {
+                                constEntry.key.index = 0;
+                                constEntry.value.index = 0;
+                                break;
+                            }
+                        }
+
+                        // The code allows to add same keys with different values,
+                        // this might be a problem, but so is replacing a existing key.
+                        // When doing a lookup we can iterate in reverse to yield the newest key-value pair.
+                        if (constEntry.key.index != 0 && constEntry.value.index != 0)
+                        {
+                            constants.push_back(constEntry);
+                        }
+                    }
+                }
+            }
+        }
+
+        return 1;
+    }
+
+    return 0;
 }
 
 ApiDataType API_DataTypeFromString(const QString &str)
@@ -1590,12 +2733,51 @@ ApiDataType API_DataTypeFromString(const QString &str)
     return DataTypeUnknown;
 }
 
+static int DDF_ReadFileInMemory(DDF_ParseContext *pctx)
+{
+    FS_File f;
+    long remaining = (pctx->scratchPos < pctx->scratchMem.size()) ? pctx->scratchMem.size() - pctx->scratchPos : 0;
+
+    pctx->scratchPos = 0;
+    pctx->fileData = nullptr;
+    pctx->fileDataSize = 0;
+    if (FS_OpenFile(&f, FS_MODE_R, pctx->filePath))
+    {
+        long fsize = FS_GetFileSize(&f);
+
+        if (fsize + 1 > remaining)
+        {
+
+        }
+        else if (fsize > 0)
+        {
+            unsigned char *data = pctx->scratchMem.data() + pctx->scratchPos;
+            long n = FS_ReadFile(&f, data, remaining);
+            if (n == fsize)
+            {
+                FS_CloseFile(&f);
+                data[n] = '\0';
+                pctx->scratchPos += (n + 1);
+                pctx->fileData = data;
+                pctx->fileDataSize = n;
+                return 1;
+            }
+        }
+
+        FS_CloseFile(&f);
+    }
+
+
+    return 0;
+}
+
 /*! Parses an item object.
     \returns A parsed item, use DeviceDescription::Item::isValid() to check for success.
  */
-static DeviceDescription::Item DDF_ParseItem(const QJsonObject &obj)
+static DeviceDescription::Item DDF_ParseItem(DDF_ParseContext *pctx, const QJsonObject &obj)
 {
     DeviceDescription::Item result{};
+    bool hasSchema = obj.contains(QLatin1String("schema"));
 
     if (obj.contains(QLatin1String("name")))
     {
@@ -1606,10 +2788,13 @@ static DeviceDescription::Item DDF_ParseItem(const QJsonObject &obj)
         result.name = obj.value(QLatin1String("id")).toString().toUtf8().constData();
     }
 
-    // Handle deprecated names/ids
-    if (result.name == RConfigColorCapabilities) { result.name = RCapColorCapabilities; }
-    if (result.name == RConfigCtMax) { result.name = RCapColorCtMax; }
-    if (result.name == RConfigCtMin) { result.name = RCapColorCtMin; }
+    // Handle deprecated names/ids within DDFs, but not in generic/items
+    if (!hasSchema)
+    {
+        if (result.name == RConfigColorCapabilities) { result.name = RCapColorCapabilities; }
+        if (result.name == RConfigCtMax) { result.name = RCapColorCtMax; }
+        if (result.name == RConfigCtMin) { result.name = RCapColorCtMin; }
+    }
 
     if (obj.contains(QLatin1String("description")))
     {
@@ -1625,7 +2810,7 @@ static DeviceDescription::Item DDF_ParseItem(const QJsonObject &obj)
     if (!getResourceItemDescriptor(result.name, result.descriptor))
     {
         QString schema;
-        if (obj.contains(QLatin1String("schema")))
+        if (hasSchema)
         {
             schema = obj.value(QLatin1String("schema")).toString();
         }
@@ -1799,7 +2984,7 @@ static DeviceDescription::Item DDF_ParseItem(const QJsonObject &obj)
 /*! Parses a sub device in a DDF object "subdevices" array.
     \returns The sub device object, use DeviceDescription::SubDevice::isValid() to check for success.
  */
-static DeviceDescription::SubDevice DDF_ParseSubDevice(const QJsonObject &obj)
+static DeviceDescription::SubDevice DDF_ParseSubDevice(DDF_ParseContext *pctx, const QJsonObject &obj)
 {
     DeviceDescription::SubDevice result;
 
@@ -1887,7 +3072,7 @@ static DeviceDescription::SubDevice DDF_ParseSubDevice(const QJsonObject &obj)
         {
             if (i.isObject())
             {
-                const auto item = DDF_ParseItem(i.toObject());
+                const auto item = DDF_ParseItem(pctx, i.toObject());
 
                 if (item.isValid())
                 {
@@ -2115,7 +3300,7 @@ static QStringList DDF_ParseStringOrList(const QJsonObject &obj, QLatin1String k
 /*! Parses an DDF JSON object.
     \returns DDF object, use DeviceDescription::isValid() to check for success.
  */
-static DeviceDescription DDF_ParseDeviceObject(const QJsonObject &obj, const QString &path)
+static DeviceDescription DDF_ParseDeviceObject(DDF_ParseContext *pctx, const QJsonObject &obj)
 {
     DeviceDescription result;
 
@@ -2132,7 +3317,11 @@ static DeviceDescription DDF_ParseDeviceObject(const QJsonObject &obj, const QSt
         return result;
     }
 
-    result.path = path;
+    U_ASSERT(pctx->filePathLength != 0);
+    U_ASSERT(pctx->filePath[pctx->filePathLength] == '\0');
+    result.path = &pctx->filePath[0];
+
+    // TODO(mpi): get rid of QStringLists and only use atoms
     result.manufacturerNames = DDF_ParseStringOrList(obj, QLatin1String("manufacturername"));
     result.modelIds = DDF_ParseStringOrList(obj, QLatin1String("modelid"));
     result.product = obj.value(QLatin1String("product")).toString();
@@ -2173,7 +3362,7 @@ static DeviceDescription DDF_ParseDeviceObject(const QJsonObject &obj, const QSt
     {
         if (i.isObject())
         {
-            const auto sub = DDF_ParseSubDevice(i.toObject());
+            const auto sub = DDF_ParseSubDevice(pctx, i.toObject());
             if (sub.isValid())
             {
                 result.subDevices.push_back(sub);
@@ -2204,32 +3393,27 @@ static DeviceDescription DDF_ParseDeviceObject(const QJsonObject &obj, const QSt
 /*! Reads an item file under (generic/items/).
     \returns A parsed item, use DeviceDescription::Item::isValid() to check for success.
  */
-static DeviceDescription::Item DDF_ReadItemFile(const QString &path)
+static DeviceDescription::Item DDF_ReadItemFile(DDF_ParseContext *pctx)
 {
-    QFile file(path);
-    if (!file.exists())
+    if (!pctx->fileData || pctx->fileDataSize < 16)
     {
         return { };
     }
 
-    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
-    {
-        return { };
-    }
+    const QByteArray data = QByteArray::fromRawData((const char*)pctx->fileData, pctx->fileDataSize);
 
     QJsonParseError error;
-    QJsonDocument doc = QJsonDocument::fromJson(file.readAll(), &error);
-    file.close();
+    QJsonDocument doc = QJsonDocument::fromJson(data, &error);
 
     if (error.error != QJsonParseError::NoError)
     {
-        DBG_Printf(DBG_DDF, "DDF failed to read %s, err: %s, offset: %d\n", qPrintable(path), qPrintable(error.errorString()), error.offset);
+        DBG_Printf(DBG_DDF, "DDF failed to read %s, err: %s, offset: %d\n", pctx->filePath, qPrintable(error.errorString()), error.offset);
         return { };
     }
 
     if (doc.isObject())
     {
-        return DDF_ParseItem(doc.object());
+        return DDF_ParseItem(pctx, doc.object());
     }
 
     return { };
@@ -2238,28 +3422,23 @@ static DeviceDescription::Item DDF_ReadItemFile(const QString &path)
 /*! Reads an subdevice file under (generic/subdevices/).
     \returns A parsed subdevice, use isValid(DDF_SubDeviceDescriptor) to check for success.
  */
-static DDF_SubDeviceDescriptor DDF_ReadSubDeviceFile(const QString &path)
+static DDF_SubDeviceDescriptor DDF_ReadSubDeviceFile(DDF_ParseContext *pctx)
 {
-    DDF_SubDeviceDescriptor result;
+    DDF_SubDeviceDescriptor result = { };
 
-    QFile file(path);
-    if (!file.exists())
+    if (!pctx->fileData || pctx->fileDataSize < 16)
     {
         return result;
     }
 
-    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
-    {
-        return result;
-    }
+    const QByteArray data = QByteArray::fromRawData((const char*)pctx->fileData, pctx->fileDataSize);
 
     QJsonParseError error;
-    QJsonDocument doc = QJsonDocument::fromJson(file.readAll(), &error);
-    file.close();
+    QJsonDocument doc = QJsonDocument::fromJson(data, &error);
 
     if (error.error != QJsonParseError::NoError)
     {
-        DBG_Printf(DBG_DDF, "DDF failed to read %s, err: %s, offset: %d\n", qPrintable(path), qPrintable(error.errorString()), error.offset);
+        DBG_Printf(DBG_DDF, "DDF failed to read %s, err: %s, offset: %d\n", pctx->filePath, qPrintable(error.errorString()), error.offset);
         return result;
     }
 
@@ -2327,7 +3506,7 @@ static DDF_SubDeviceDescriptor DDF_ReadSubDeviceFile(const QString &path)
     return result;
 }
 
-QVariant DDF_ResolveParamScript(const QVariant &param, const QString &path)
+static QVariant DDF_ResolveParamScript(const QVariant &param, const QString &path)
 {
     auto result = param;
 
@@ -2370,6 +3549,75 @@ QVariant DDF_ResolveParamScript(const QVariant &param, const QString &path)
     return result;
 }
 
+static QVariant DDF_ResolveBundleParamScript(const QVariant &param, DDF_ParseContext *pctx)
+{
+    auto result = param;
+
+    if (param.type() != QVariant::Map)
+    {
+        return result;
+    }
+
+    auto map = param.toMap();
+    unsigned fnameStart;
+
+    if (map.contains(QLatin1String("script")))
+    {
+        const std::string script = map["script"].toString().toStdString();
+
+        for (DDFB_ExtfChunk *extf = pctx->extChunks; extf; extf = extf->next)
+        {
+            if (extf->fileType[0] != 'S' || extf->fileType[1] != 'C' || extf->fileType[2] != 'J' || extf->fileType[3] != 'S')
+                continue;
+
+            if (extf->pathLength < 4) // should not happen: a.js
+                continue;
+
+            /*
+             * Lookup just the filename of the Javascript file in the bundle.
+             * While this could be wrong in theory it's unlikely.
+             * If needed we can resolve relative paths later on to be more strict.
+             */
+            fnameStart = extf->pathLength;
+            for (;fnameStart; fnameStart--)
+            {
+                if (extf->path[fnameStart] == '/')
+                    break;
+            }
+
+            unsigned fnameLength = extf->pathLength - fnameStart;
+            if (script.size() < fnameLength)
+                continue;
+
+            if (U_memcmp(script.c_str() + (script.size() - fnameLength), &extf->path[fnameStart], fnameLength) != 0)
+                continue;
+
+            QString content = QString::fromUtf8((const char*)extf->fileData, extf->fileSize);
+
+            if (!content.isEmpty())
+            {
+                map["eval"] = content;
+            }
+
+            break;
+        }
+    }
+
+    if (map.contains(QLatin1String("eval")))
+    {
+        QString content = map[QLatin1String("eval")].toString();
+        if (!content.isEmpty())
+        {
+            QString path; // dummy
+            DDF_TryCompileAndFixJavascript(&content, path);
+            map[QLatin1String("eval")] = content;
+            result = std::move(map);
+        }
+    }
+
+    return result;
+}
+
 DeviceDescription DDF_LoadScripts(const DeviceDescription &ddf)
 {
     auto result = ddf;
@@ -2390,56 +3638,93 @@ DeviceDescription DDF_LoadScripts(const DeviceDescription &ddf)
 /*! Reads a DDF file which may contain one or more device descriptions.
     \returns Vector of parsed DDF objects.
  */
-static std::vector<DeviceDescription> DDF_ReadDeviceFile(const QString &path)
+static DeviceDescription DDF_ReadDeviceFile(DDF_ParseContext *pctx)
 {
-    std::vector<DeviceDescription> result;
+    U_ASSERT(pctx->fileData);
+    U_ASSERT(pctx->fileDataSize > 64);
 
-    QFile file(path);
-    if (!file.exists())
-    {
-        return result;
-    }
-
-    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
-    {
-        return result;
-    }
-
+    const QByteArray data = QByteArray::fromRawData((const char*)pctx->fileData, pctx->fileDataSize);
     QJsonParseError error;
-    QJsonDocument doc = QJsonDocument::fromJson(file.readAll(), &error);
-    file.close();
+    QJsonDocument doc = QJsonDocument::fromJson(data, &error);
 
     if (error.error != QJsonParseError::NoError)
     {
-        DBG_Printf(DBG_DDF, "DDF failed to read %s, err: %s, offset: %d\n", qPrintable(path), qPrintable(error.errorString()), error.offset);
-        return result;
+        DBG_Printf(DBG_DDF, "DDF failed to read %s, err: %s, offset: %d\n", pctx->filePath, qPrintable(error.errorString()), error.offset);
+        return { };
     }
 
     if (doc.isObject())
     {
-        const auto ddf = DDF_ParseDeviceObject(doc.object(), path);
+        DeviceDescription ddf = DDF_ParseDeviceObject(pctx, doc.object());
         if (ddf.isValid())
         {
-            result.push_back(ddf);
-        }
-    }
-    else if (doc.isArray())
-    {
-        const auto arr = doc.array();
-        for (const auto &i : arr)
-        {
-            if (i.isObject())
-            {
-                const auto ddf = DDF_ParseDeviceObject(i.toObject(), path);
-                if (ddf.isValid())
-                {
-                    result.push_back(ddf);
-                }
-            }
+            return ddf;
         }
     }
 
-    return result;
+    return { };
+}
+
+static int DDF_ProcessSignatures(DDF_ParseContext *pctx, std::vector<U_ECC_PublicKeySecp256k1> &publicKeys, U_BStream *bs, uint32_t *bundleHash)
+{
+    unsigned i;
+    unsigned count;
+    uint16_t pubkeyLen;
+    uint16_t sigLen;
+
+    U_ECC_PublicKeySecp256k1 pubkey;
+    U_ECC_SignatureSecp256k1 sig;
+
+    count = 0;
+
+    for (;bs->status == U_BSTREAM_OK && bs->pos < bs->size;)
+    {
+        pubkeyLen = U_bstream_get_u16_le(bs);
+        if (sizeof(pubkey.key) < pubkeyLen)
+        {
+            return 0;
+        }
+
+        for (i = 0; i < pubkeyLen; i++)
+        {
+            pubkey.key[i] = U_bstream_get_u8(bs);
+        }
+
+        sigLen = U_bstream_get_u16_le(bs);
+        if (sizeof(sig.sig) < sigLen)
+        {
+            return 0;
+        }
+
+        for (i = 0; i < sigLen; i++)
+        {
+            sig.sig[i] = U_bstream_get_u8(bs);
+        }
+
+        if (U_ECC_VerifySignatureSecp256k1(&pubkey, &sig, (uint8_t*)bundleHash, U_SHA256_HASH_SIZE))
+        {
+            for (i = 0; i < publicKeys.size(); i++)
+            {
+                U_ECC_PublicKeySecp256k1 &pk = publicKeys[i];
+
+                if (U_memcmp(pk.key, pubkey.key, sizeof(pk.key)) == 0)
+                    break; // already known
+            }
+
+            if (i == publicKeys.size() && publicKeys.size() < DDF_MAX_PUBLIC_KEYS)
+            {
+                publicKeys.push_back(pubkey);
+            }
+
+            pctx->signatures |= (1 << i);
+            count++;
+        }
+    }
+
+    if (count)
+        return 1;
+
+    return 0;
 }
 
 /*! Merge common properties like "read", "parse" and "write" functions from generic items into DDF items.
@@ -2499,6 +3784,99 @@ static DeviceDescription DDF_MergeGenericItems(const std::vector<DeviceDescripti
     }
 
     return result;
+}
+
+static int DDF_MergeGenericBundleItems(DeviceDescription &ddf, DDF_ParseContext *pctx)
+{
+    std::vector<DeviceDescription::Item> genericItems;
+
+    {
+        // preserve parse context
+        uint8_t *fileData = pctx->fileData;
+        unsigned fileDataSize = pctx->fileDataSize;
+
+        /*
+         * Load generic items from bundle.
+         */
+
+        for (DDFB_ExtfChunk *extf = pctx->extChunks; extf; extf = extf->next)
+        {
+            U_SStream ss;
+            U_sstream_init(&ss, (void*)extf->path, extf->pathLength);
+            if (U_sstream_starts_with(&ss, "generic/items") == 0)
+                continue;
+
+            // temp. change where data points
+            pctx->fileData = extf->fileData;
+            pctx->fileDataSize = extf->fileSize;
+
+            DeviceDescription::Item item = DDF_ReadItemFile(pctx);
+            if (item.isValid())
+            {
+                genericItems.push_back(std::move(item));
+            }
+            else
+            {
+                U_ASSERT(0 && "failed to read bundle item file");
+            }
+        }
+
+        // restore parse context
+        pctx->fileData = fileData;
+        pctx->fileDataSize = fileDataSize;
+    }
+
+
+    for (DeviceDescription::SubDevice &sub : ddf.subDevices)
+    {
+        for (DeviceDescription::Item &item : sub.items)
+        {
+            const auto genItem = std::find_if(genericItems.cbegin(), genericItems.cend(),
+                                              [&item](const DeviceDescription::Item &i){ return i.descriptor.suffix == item.descriptor.suffix; });
+            if (genItem == genericItems.cend())
+            {
+                continue;
+            }
+
+            item.isImplicit = genItem->isImplicit;
+            item.isManaged = genItem->isManaged;
+            item.isGenericRead = 0;
+            item.isGenericWrite = 0;
+            item.isGenericParse = 0;
+
+            if (!item.isStatic)
+            {
+                if (item.readParameters.isNull()) { item.readParameters = genItem->readParameters; item.isGenericRead = 1; }
+                if (item.writeParameters.isNull()) { item.writeParameters = genItem->writeParameters; item.isGenericWrite = 1; }
+                if (item.parseParameters.isNull()) { item.parseParameters = genItem->parseParameters; item.isGenericParse = 1; }
+                if (item.refreshInterval == DeviceDescription::Item::NoRefreshInterval && genItem->refreshInterval != item.refreshInterval)
+                {
+                    item.refreshInterval = genItem->refreshInterval;
+                }
+
+                item.parseParameters = DDF_ResolveBundleParamScript(item.parseParameters, pctx);
+                item.readParameters = DDF_ResolveBundleParamScript(item.readParameters, pctx);
+                item.writeParameters = DDF_ResolveBundleParamScript(item.writeParameters, pctx);
+            }
+
+            if (item.descriptor.access == ResourceItemDescriptor::Access::Unknown)
+            {
+                item.descriptor.access = genItem->descriptor.access;
+            }
+
+            if (!item.hasIsPublic)
+            {
+                item.isPublic = genItem->isPublic;
+            }
+
+            if (!item.defaultValue.isValid() && genItem->defaultValue.isValid())
+            {
+                item.defaultValue = genItem->defaultValue;
+            }
+        }
+    }
+
+    return 1;
 }
 
 uint8_t DDF_GetSubDeviceOrder(const QString &type)

--- a/device_descriptions.h
+++ b/device_descriptions.h
@@ -303,4 +303,6 @@ void DDF_AnnoteZclParse1(int line, const char* file, const Resource *resource, R
 const DeviceDescription::Item &DDF_GetItem(const ResourceItem *item);
 Resource::Handle R_CreateResourceHandle(const Resource *r, size_t containerIndex);
 
+void DEV_ReloadDeviceIdendifier(unsigned atomIndexMfname, unsigned atomIndexModelid);
+
 #endif // DEVICEDESCRIPTIONS_H

--- a/device_descriptions.h
+++ b/device_descriptions.h
@@ -94,8 +94,20 @@ class DeviceDescription
 public:
     bool isValid() const { return !manufacturerNames.isEmpty() && !modelIds.empty() && !subDevices.empty(); }
 
+    uint32_t sha256Hash[8] = {}; // either raw .json hash or bundle hash
+    int64_t lastModified = 0;
+    uint64_t signedBy = 0; // each bit is an index into d->publicKeys[] (max. 64)
+
+    // TODO get rid of QStringLists use the atom lists instead
     QStringList modelIds;
     QStringList manufacturerNames; // as reported in Basic cluster
+
+    std::vector<unsigned> modelidAtomIndices;
+    std::vector<unsigned> mfnameAtomIndices;
+
+    int storageLocation = -1; // deCONZ::StorageLocation
+
+    QString path;
     QString vendor; // optional: friendly name of manufacturer
     QString product;
     QString status;
@@ -108,7 +120,7 @@ public:
     class Item
     {
     public:
-        using Handle = quint32;
+        using Handle = uint32_t;
         enum Constants {
             NoRefreshInterval = -1,
             InvalidItemHandle = 0
@@ -180,7 +192,6 @@ public:
         SensorFingerprint fingerPrint;
     };
 
-    QString path;
     std::vector<SubDevice> subDevices;
     std::vector<DDF_Binding> bindings;
 };
@@ -244,16 +255,17 @@ public:
     ~DeviceDescriptions();
     void setEnabledStatusFilter(const QStringList &filter);
     const QStringList &enabledStatusFilter() const;
-    const DeviceDescription &get(const Resource *resource, DDF_MatchControl match = DDF_EvalMatchExpr) const;
+    const DeviceDescription &get(const Resource *resource, DDF_MatchControl match = DDF_EvalMatchExpr);
     const DeviceDescription &getFromHandle(DeviceDescription::Item::Handle hnd) const;
     void put(const DeviceDescription &ddf);
     const DeviceDescription &load(const QString &path);
 
     const DeviceDescription::SubDevice &getSubDevice(const Resource *resource) const;
 
+    void prepare();
+
     QString constantToString(const QString &constant) const;
     QString stringToConstant(const QString &str) const;
-    QStringList constants(const QString &prefix = QString()) const;
 
     const DDF_Items &genericItems() const;
     const DeviceDescription::Item &getItem(const ResourceItem *item) const;
@@ -268,6 +280,8 @@ public:
 public Q_SLOTS:
     void handleEvent(const Event &event);
     void readAll();
+    void readAllRawJson();
+    void readAllBundles();
 
 Q_SIGNALS:
     void eventNotify(const Event&); //! Emitted \p Event needs to be enqueued in a higher layer.
@@ -275,6 +289,7 @@ Q_SIGNALS:
 
 private:
     void handleDDFInitRequest(const Event &event);
+    bool loadDDFAndBundlesFromDisc(const Resource *resource);
 
     Q_DECLARE_PRIVATE_D(d_ptr2, DeviceDescriptions)
     DeviceDescriptionsPrivate *d_ptr2 = nullptr;

--- a/devices/generic/items/attr_ddf_hash_item.json
+++ b/devices/generic/items/attr_ddf_hash_item.json
@@ -1,0 +1,9 @@
+{
+  "schema": "resourceitem1.schema.json",
+  "id": "attr/ddf_hash",
+  "datatype": "String",
+  "access": "RW",
+  "public": true,
+  "implicit": true,
+  "description": "Hash of active DDF bundle."
+}

--- a/devices/generic/items/attr_ddf_policy_item.json
+++ b/devices/generic/items/attr_ddf_policy_item.json
@@ -1,0 +1,28 @@
+{
+  "schema": "resourceitem1.schema.json",
+  "id": "attr/ddf_policy",
+  "datatype": "String",
+  "access": "RW",
+  "public": true,
+  "implicit": true,
+  "description": "Determines how DDF bundle is selected.",
+  "default": "latest_prefer_stable",
+  "values": [
+    [
+      "latest_prefer_stable",
+      "Use latest DDF bundle: Beta signed one if no stable available."
+    ],
+    [
+      "latest",
+      "Use latest DDF bundle either Beta or Stable signed."
+    ],
+    [
+      "pin",
+      "Stay on the pinned version (DDF bundle hash)."
+    ],
+    [
+      "raw_json",
+      "For development just use raw .json DDF."
+    ]
+  ]
+}

--- a/resource.h
+++ b/resource.h
@@ -88,6 +88,8 @@ extern const char *RInvalidSuffix;
 extern const char *RAttrAppVersion;
 extern const char *RAttrClass;
 extern const char *RAttrConfigId;
+extern const char *RAttrDdfHash;
+extern const char *RAttrDdfPolicy;
 extern const char *RAttrExtAddress;
 extern const char *RAttrGroupAddress;
 extern const char *RAttrId;
@@ -493,9 +495,11 @@ public:
     void setZclProperties(const ZCL_Param &param) { m_zclParam = param; }
     void setReadEndpoint(uint8_t ep) { m_readEndpoint = ep; }
     uint8_t readEndpoint() const { return m_readEndpoint; }
+    bool setValue(const char *str, int length, ValueSource source = SourceUnknown);
     bool setValue(const QString &val, ValueSource source = SourceUnknown);
     bool setValue(qint64 val, ValueSource source = SourceUnknown);
     bool setValue(const QVariant &val, ValueSource source = SourceUnknown);
+    bool equalsString(const char *str, int length = -1) const;
     const ResourceItemDescriptor &descriptor() const;
     const QDateTime &lastSet() const;
     const QDateTime &lastChanged() const;

--- a/rest_ddf.cpp
+++ b/rest_ddf.cpp
@@ -588,6 +588,9 @@ int REST_DDF_PostBundles(const ApiRequest &req, ApiResponse &rsp)
                 return REQ_READY_SEND;
             }
 
+            // notify device descriptions to trigger reload
+            DEV_DDF_BundleUpdated((uint8_t*)&data[binStart], binEnd - binStart);
+
             DBG_Printf(DBG_INFO, "DDF bundle written: %s\n", bundlePath);
 
             rsp.httpStatus = HttpStatusOk;

--- a/rest_ddf.cpp
+++ b/rest_ddf.cpp
@@ -130,7 +130,7 @@ int REST_DDF_GetDescriptors(const ApiRequest &req, ApiResponse &rsp)
     unsigned curCursor = 1;
     unsigned nextCursor = 0;
     unsigned nRecords = 0;
-    unsigned maxRecords = 2;
+    unsigned maxRecords = 64;
 
     auto url = req.hdr.url();
 

--- a/rest_ddf.cpp
+++ b/rest_ddf.cpp
@@ -1,0 +1,585 @@
+/*
+ * Copyright (c) 2024 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ */
+
+#include <QTcpSocket>
+#include <deconz/dbg_trace.h>
+#include "device_ddf_bundle.h"
+#include "rest_api.h"
+#include "rest_ddf.h"
+#include "deconz/file.h"
+#include "deconz/u_sstream.h"
+#include "deconz/u_memory.h"
+#include "deconz/util.h"
+#include "utils/scratchmem.h"
+
+#define MAX_PATH_LENGTH 2048
+
+/*!
+    Converts data into hex-ascii string.
+
+    The memory area \p ascii must have at least the
+    size \p 2 * length + 1 bytes.
+
+    A terminating zero will be appended at the end.
+
+    \returns a pointer to the last byte (zero).
+ */
+static unsigned char *BinToHexAscii(const void *hex, unsigned length, void *ascii)
+{
+    unsigned i;
+    unsigned char *h;
+    unsigned char *a;
+
+    static char lookup[] = { '0', '1', '2','3','4','5','6','7','8','9','a','b','c','d','e','f' };
+
+    if (!hex || length == 0 || !ascii)
+        return 0;
+
+    h = (unsigned char*)hex;
+    a = (unsigned char*)ascii;
+
+    for (i = 0; i < length; i++)
+    {
+        *a++ = lookup[(h[i] & 0xf0) >> 4];
+        *a++ = lookup[h[i] & 0xf];
+    }
+
+    *a = '\0';
+
+    return a;
+}
+
+/*
+
+Test upload of .ddf file
+
+curl -F 'data=@/home/mpi/some.ddf' 127.0.0.1:8090/api/12345/ddf
+
+*/
+
+static int WriteBundleDescriptorToResponse(U_BStream *bs, U_SStream *ss, unsigned nRecords)
+{
+    unsigned chunkSize;
+    char sha256Str[(U_SHA256_HASH_SIZE * 2) + 1];
+
+    if (DDFB_FindChunk(bs, "RIFF", &chunkSize) == 0)
+    {
+        return 0;
+    }
+
+    if (DDFB_FindChunk(bs, "DDFB", &chunkSize) == 0)
+    {
+        return 0;
+    }
+
+    {
+        unsigned char sha256[U_SHA256_HASH_SIZE];
+        // Bundle hash over DDFB chunk (header + data)
+        if (U_Sha256(&bs->data[bs->pos - 8], chunkSize + 8, sha256) == 0)
+        {
+            return 0; // should not happen
+        }
+
+        BinToHexAscii(sha256, U_SHA256_HASH_SIZE, sha256Str);
+    }
+
+    U_BStream bsDDFB;
+    U_bstream_init(&bsDDFB, &bs->data[bs->pos], chunkSize);
+
+    // check DESC JSON has required fields
+    if (DDFB_FindChunk(&bsDDFB, "DESC", &chunkSize) == 0)
+    {
+        return 0;
+    }
+
+    // enough space for descriptor plus hash key
+    if ((ss->pos + chunkSize + 128) < ss->len)
+    {
+        if (nRecords > 0)
+            U_sstream_put_str(ss, ",");
+
+        U_sstream_put_str(ss, "\"");
+        U_sstream_put_str(ss, sha256Str);
+        U_sstream_put_str(ss, "\":");
+
+        U_memcpy(&ss->str[ss->pos], &bsDDFB.data[bsDDFB.pos], chunkSize);
+        ss->pos += chunkSize;
+
+        return 1;
+    }
+
+    DBG_Printf(DBG_INFO, "DESC: %.*s\n", chunkSize, &bsDDFB.data[bsDDFB.pos]);
+
+
+    return 0;
+}
+
+int REST_DDF_GetDescriptors(const ApiRequest &req, ApiResponse &rsp)
+{
+    // TEST call
+    // curl -vv 127.0.0.1:8090/api/12345/ddf/descriptors
+    // curl -vv 127.0.0.1:8090/api/12345/ddf/descriptors?next=<token>
+    unsigned reqCursor = 1;
+    unsigned curCursor = 1;
+    unsigned nextCursor = 0;
+    unsigned nRecords = 0;
+    unsigned maxRecords = 2;
+
+    auto url = req.hdr.url();
+
+    { // get page from query string if exist
+        U_SStream ss;
+        U_sstream_init(&ss, (void*)url.data(), (unsigned)url.size());
+
+        if (U_sstream_find(&ss, "?next="))
+        {
+            U_sstream_find(&ss, "=");
+            ss.pos++;
+            long n = U_sstream_get_long(&ss);
+            if (ss.status == U_SSTREAM_OK && n > 0)
+            {
+                reqCursor = (unsigned)n;
+            }
+            else
+            {
+                rsp.httpStatus = HttpStatusBadRequest;
+                return REQ_READY_SEND;
+            }
+        }
+    }
+
+    unsigned maxResponseSize = 1 << 20;  // 1 MB
+    char *bundleData = SCRATCH_ALLOC(char*, MAX_BUNDLE_SIZE);
+    char *path = SCRATCH_ALLOC(char*, MAX_PATH_LENGTH);
+    char *rspData = SCRATCH_ALLOC(char*, maxResponseSize);
+
+    if (!bundleData || !path || !rspData)
+    {
+        rsp.httpStatus = HttpStatusServiceUnavailable;
+        return REQ_READY_SEND;
+    }
+
+    FS_Dir dir;
+    FS_File fp;
+    U_SStream ss;
+    U_SStream ssRsp;
+    unsigned basePathLength;
+
+    deCONZ::StorageLocation locations[2] = { deCONZ::DdfBundleUserLocation, deCONZ::DdfBundleLocation };
+
+    U_sstream_init(&ssRsp, rspData, maxResponseSize);
+    U_sstream_put_str(&ssRsp, "{");
+
+    for (int locIt = 0; locIt < 2; locIt++)
+    {
+        {
+            QString loc = deCONZ::getStorageLocation(locations[locIt]);
+            U_sstream_init(&ss, path, MAX_PATH_LENGTH);
+            U_sstream_put_str(&ss, qPrintable(loc));
+            basePathLength = ss.pos;
+        }
+
+        if (FS_OpenDir(&dir, path))
+        {
+            for (;FS_ReadDir(&dir);)
+            {
+                if (dir.entry.type != FS_TYPE_FILE)
+                    continue;
+
+                U_sstream_init(&ss, dir.entry.name, strlen(dir.entry.name));
+
+                if (U_sstream_find(&ss, ".ddf") == 0)
+                    continue;
+
+                if (curCursor < reqCursor)
+                {
+                    curCursor++;
+                    continue;
+                }
+
+                if (nRecords < maxRecords)
+                {
+                    U_sstream_init(&ss, path, MAX_PATH_LENGTH);
+                    ss.pos = basePathLength; // reuse path and append the filename to existing base path
+                    U_sstream_put_str(&ss, "/");
+                    U_sstream_put_str(&ss, dir.entry.name);
+
+                    if (FS_OpenFile(&fp, FS_MODE_R, path))
+                    {
+                        long n = FS_ReadFile(&fp, bundleData, MAX_BUNDLE_SIZE);
+                        if (n > 32)
+                        {
+                            U_BStream bs;
+                            U_bstream_init(&bs, bundleData, (unsigned)n);
+                            if (WriteBundleDescriptorToResponse(&bs, &ssRsp, nRecords))
+                            {
+                                curCursor++;
+                                nRecords++;
+                            }
+                        }
+
+                        FS_CloseFile(&fp);
+                    }
+                }
+                else
+                {
+                    nextCursor = curCursor;
+                    break;
+                }
+
+                DBG_Printf(DBG_INFO, "BUNDLE: %s\n", ss.str);
+            }
+
+            if (nextCursor != 0)
+            {
+                U_sstream_put_str(&ssRsp, ",\"next\":");
+                U_sstream_put_long(&ssRsp, (long)nextCursor);
+            }
+
+            FS_CloseDir(&dir);
+        }
+    }
+
+    U_sstream_put_str(&ssRsp, "}");
+
+    rsp.httpStatus = HttpStatusOk;
+    rsp.str = ssRsp.str;
+
+    return REQ_READY_SEND;
+}
+
+int REST_DDF_GetDescriptor(const ApiRequest &req, ApiResponse &rsp)
+{
+    // TEST call
+    // curl -vv 127.0.0.1:8090/api/12345/ddf/descriptors/0a34938f63f0ccb40e1672799c898889989574f617c103fb64496e9ad78c29a2
+
+    auto bundleHash = req.hdr.pathAt(4);
+
+    if (bundleHash.size() != 64)
+    {
+        rsp.httpStatus = HttpStatusBadRequest;
+        return REQ_READY_SEND;
+    }
+
+    rsp.list.append(errorToMap(ERR_RESOURCE_NOT_AVAILABLE,
+                               QString("/ddf/descriptors/%1").arg(bundleHash),
+                               QString("resource, /ddf/descriptors/%1, not available").arg(bundleHash)));
+
+
+    rsp.httpStatus = HttpStatusNotFound;
+
+    return REQ_READY_SEND;
+}
+
+int REST_DDF_GetBundle(const ApiRequest &req, ApiResponse &rsp)
+{
+    // TEST call
+    // curl -vv -O --remote-header-name 127.0.0.1:8090/api/12345/ddf/bundles/0a34938f63f0ccb40e1672799c898889989574f617c103fb64496e9ad78c29a2
+    // wget --content-disposition 127.0.0.1:8090/api/12345/ddf/bundles/0a34938f63f0ccb40e1672799c898889989574f617c103fb64496e9ad78c29a2
+
+    FS_File fp;
+    auto bundleHash = req.hdr.pathAt(4);
+
+    if (bundleHash.size() != 64)
+    {
+        rsp.httpStatus = HttpStatusBadRequest;
+        return REQ_READY_SEND;
+    }
+
+    unsigned maxFileNameLength = 72;
+    char *bundlePath = SCRATCH_ALLOC(char*, MAX_PATH_LENGTH);
+    char *fileName = SCRATCH_ALLOC(char*, maxFileNameLength);
+
+    if (!bundlePath || !fileName)
+    {
+        rsp.httpStatus = HttpStatusServiceUnavailable;
+        return REQ_READY_SEND;
+    }
+
+    {
+        U_SStream ssFileName;
+        U_sstream_init(&ssFileName, fileName, maxFileNameLength);
+        U_sstream_put_str(&ssFileName, bundleHash.data());
+        U_sstream_put_str(&ssFileName, ".ddf");
+    }
+
+    {
+        QString loc = deCONZ::getStorageLocation(deCONZ::DdfBundleUserLocation);
+        U_SStream ssPath;
+        U_sstream_init(&ssPath, bundlePath, MAX_PATH_LENGTH);
+        U_sstream_put_str(&ssPath, qPrintable(loc));
+        U_sstream_put_str(&ssPath, "/");
+        U_sstream_put_str(&ssPath, fileName);
+    }
+
+    if (FS_OpenFile(&fp, FS_MODE_R, bundlePath))
+    {
+        long fileSize = FS_GetFileSize(&fp);
+        if (fileSize > 0 && fileSize <= MAX_BUNDLE_SIZE)
+        {
+            rsp.bin = SCRATCH_ALLOC(char*, fileSize);
+            if (!rsp.bin)
+            {
+                FS_CloseFile(&fp);
+                rsp.httpStatus = HttpStatusServiceUnavailable;
+                return REQ_READY_SEND;
+            }
+
+            if (FS_ReadFile(&fp, rsp.bin, fileSize) == fileSize)
+            {
+                FS_CloseFile(&fp);
+                rsp.contentLength = (unsigned)fileSize;
+                rsp.fileName = fileName;
+                rsp.httpStatus = HttpStatusOk;
+                rsp.contentType = HttpContentOctetStream;
+                return REQ_READY_SEND;
+            }
+        }
+
+        FS_CloseFile(&fp);
+    }
+
+    {
+        rsp.httpStatus = HttpStatusNotFound;
+        rsp.list.append(errorToMap(ERR_RESOURCE_NOT_AVAILABLE,
+                               QString("/ddf/bundles/%1").arg(bundleHash),
+                               QString("resource, /ddf/bundles/%1, not available").arg(bundleHash)));
+    }
+
+    return REQ_READY_SEND;
+}
+
+int REST_DDF_PostBundles(const ApiRequest &req, ApiResponse &rsp)
+{
+    ScratchMemWaypoint swp;
+
+    // TEST call
+    // curl -F 'data=@./starkvind_air_purifier_toolbox.ddf' 127.0.0.1:8090/api/12345/ddf/bundles
+
+    if (req.hdr.contentLength() < 32 || req.hdr.contentLength() > 512000)
+    {
+        return REQ_NOT_HANDLED;
+    }
+
+    // TODO(mpi) upload via multipart/form-data should be moved to generic http handling
+
+    // Content-Type HTTP header contains the boundary:
+    //    "Content-Type: multipart/form-data; boundary=------------------------Y8hknTumhcaM4YjkoVup1T"
+
+    QLatin1String contentType = req.hdr.value(QLatin1String("Content-Type"));
+
+    U_SStream ss;
+    U_sstream_init(&ss, (void*)contentType.data(), contentType.size());
+
+    if (U_sstream_starts_with(&ss, "multipart/form-data") == 0)
+    {
+        rsp.httpStatus = HttpStatusBadRequest;
+        return REQ_READY_SEND;
+    }
+
+    if (U_sstream_find(&ss, "boundary=") == 0) // no boundary marker?
+    {
+        rsp.httpStatus = HttpStatusBadRequest;
+        return REQ_READY_SEND;
+    }
+
+    if (U_sstream_find(&ss, "=") == 0)
+    {
+        rsp.httpStatus = HttpStatusBadRequest;
+        return REQ_READY_SEND;
+    }
+    ss.pos++;
+    const unsigned boundaryLen = ss.len - ss.pos;
+    //boundary = static_cast<char*>(ScratchMemAlloc((boundaryLen) + 8));
+    char *boundary = SCRATCH_ALLOC(char*, boundaryLen + 8);
+
+    if (!boundary)
+    {
+        rsp.httpStatus = HttpStatusServiceUnavailable;
+        return REQ_READY_SEND;
+    }
+    U_memcpy(boundary, &ss.str[ss.pos], boundaryLen);
+    boundary[boundaryLen] = '\0';
+
+    unsigned dataSize = req.hdr.contentLength() + 1;
+    if (MAX_BUNDLE_SIZE < dataSize)
+    {
+        rsp.httpStatus = HttpStatusBadRequest;
+        return REQ_READY_SEND;
+    }
+
+    char *data = SCRATCH_ALLOC(char*, dataSize);
+
+    if (!data)
+    {
+        rsp.httpStatus = HttpStatusServiceUnavailable;
+        return REQ_READY_SEND;
+    }
+
+    unsigned binStart = 0;
+    unsigned binEnd = 0;
+    int n = req.sock->read(data, dataSize - 1);
+
+    if (n > 0)
+    {
+        data[dataSize - 1] = '\0';
+
+        U_sstream_init(&ss, data, n);
+
+        if (U_sstream_find(&ss, boundary) == 0) // there might be a preample before the first boundary
+        {
+            rsp.httpStatus = HttpStatusBadRequest;
+            return REQ_READY_SEND;
+        }
+
+        // actual data starts behind first two CRLF
+        //
+        // --------------------------Y8hknTumhcaM4YjkoVup1T
+        // Content-Disposition: form-data; name="data"; filename="steam.md"
+        // Content-Type: application/octet-stream
+        // \r\n\r\n
+        if (U_sstream_find(&ss, "\r\n\r\n") == 0)
+        {
+            return REQ_NOT_HANDLED;
+        }
+
+        ss.pos += 4;
+        binStart = ss.pos;
+
+        if (U_sstream_find(&ss, boundary) == 0)
+        {
+            rsp.httpStatus = HttpStatusBadRequest;
+            return REQ_READY_SEND;
+        }
+
+        binEnd = ss.pos;
+    }
+
+    if (binStart < binEnd && (binEnd - binStart) > 16) // TODO use some reasonable min. size instead 16
+    {
+        if (data[binEnd - 1] == '-' && data[binEnd - 2] == '-')
+        {
+            binEnd -= 2; // end boundary preceeded by two dashes
+        }
+
+        if (data[binEnd - 1] == '\n' && data[binEnd - 2] == '\r')
+        {
+            binEnd -= 2; // end boundary also preceeded with CRLF
+        }
+
+        data[binEnd] = '\0';
+
+        U_BStream bs;
+
+        U_bstream_init(&bs, &data[binStart], binEnd - binStart);
+
+        // unsigned char bundleHash[U_SHA256_HASH_SIZE] = {0};
+        // char bundleHashStr[(U_SHA256_HASH_SIZE * 2) + 1];
+
+        unsigned char *bundleHash = SCRATCH_ALLOC(unsigned char*, U_SHA256_HASH_SIZE);
+        char *bundleHashStr = SCRATCH_ALLOC(char*, (U_SHA256_HASH_SIZE * 2) + 1);
+
+        if (!bundleHash || !bundleHashStr)
+        {
+            rsp.httpStatus = HttpStatusServiceUnavailable;
+            return REQ_READY_SEND;
+        }
+
+
+        if (IsValidDDFBundle(&bs, bundleHash) == 0)
+        {
+            rsp.httpStatus = HttpStatusBadRequest;
+            return REQ_READY_SEND;
+        }
+
+        BinToHexAscii(bundleHash, U_SHA256_HASH_SIZE, bundleHashStr);
+        DBG_Printf(DBG_INFO, "received %d bytes (binary: %u), bundle-hash: %s\n", n, binEnd - binStart, bundleHashStr);
+
+        QString loc = deCONZ::getStorageLocation(deCONZ::DdfBundleUserLocation);
+
+        FS_File fp;
+        char *bundlePath = SCRATCH_ALLOC(char*, MAX_PATH_LENGTH);
+
+        if (!bundlePath)
+        {
+            rsp.httpStatus = HttpStatusServiceUnavailable;
+            return REQ_READY_SEND;
+        }
+
+        {
+            U_SStream ssPath;
+            U_sstream_init(&ssPath, bundlePath, MAX_PATH_LENGTH);
+            U_sstream_put_str(&ssPath, qPrintable(loc));
+            U_sstream_put_str(&ssPath, "/");
+            U_sstream_put_str(&ssPath, bundleHashStr);
+            U_sstream_put_str(&ssPath, ".ddf");
+        }
+
+        if (FS_OpenFile(&fp, FS_MODE_R, bundlePath))
+        {
+            FS_CloseFile(&fp);
+            // TODO alreadly exists, delete and create fresh one (might have different signatures)
+            FS_DeleteFile(bundlePath);
+        }
+
+        if (FS_OpenFile(&fp, FS_MODE_RW, bundlePath))
+        {
+            long n = FS_WriteFile(&fp, bs.data, bs.size);
+            FS_CloseFile(&fp);
+            if (n != bs.size)
+            {
+                rsp.httpStatus = HttpStatusBadRequest; // TODO different error
+                return REQ_READY_SEND;
+            }
+
+            DBG_Printf(DBG_INFO, "DDF bundle written: %s\n", bundlePath);
+
+            rsp.httpStatus = HttpStatusOk;
+            QVariantMap result;
+            QVariantMap item;
+
+            item["id"] = bundleHashStr;
+            result["success"] = item;
+            rsp.list.append(result);
+            return REQ_READY_SEND;
+        }
+    }
+
+    return REQ_NOT_HANDLED;
+}
+
+int REST_DDF_HandleApi(const ApiRequest &req, ApiResponse &rsp)
+{
+    // GET /api/<apikey>/ddf/descriptors
+    if (req.hdr.pathComponentsCount() == 4 && req.hdr.httpMethod() == HttpGet && req.hdr.pathAt(3) == "descriptors")
+    {
+        return REST_DDF_GetDescriptors(req, rsp);
+    }
+
+    // GET /api/<apikey>/ddf/bundles/<sha256-hash>
+    if (req.hdr.pathComponentsCount() == 5 && req.hdr.httpMethod() == HttpGet && req.hdr.pathAt(3) == "bundles")
+    {
+        return REST_DDF_GetBundle(req, rsp);
+    }
+
+    // GET /api/<apikey>/ddf/descriptors/<sha256-hash>
+    if (req.hdr.pathComponentsCount() == 5 && req.hdr.httpMethod() == HttpGet && req.hdr.pathAt(3) == "descriptors")
+    {
+        return REST_DDF_GetDescriptor(req, rsp);
+    }
+
+    // POST /api/<apikey>/ddf/bundles
+    if (req.hdr.pathComponentsCount() == 4 && req.hdr.httpMethod() == HttpPost && req.hdr.pathAt(3) == "bundles")
+    {
+        return REST_DDF_PostBundles(req, rsp);
+    }
+
+    return REQ_NOT_HANDLED;
+}

--- a/rest_ddf.h
+++ b/rest_ddf.h
@@ -17,4 +17,9 @@ class ApiResponse;
 /*! REST-API endpoint for DDF. */
 int REST_DDF_HandleApi(const ApiRequest &req, ApiResponse &rsp);
 
+/*! Callback for POST DDF bundle request to notify device description code
+    of updated bundle data.
+ */
+void DEV_DDF_BundleUpdated(unsigned char *data, unsigned dataSize);
+
 #endif // REST_DDF_H

--- a/rest_ddf.h
+++ b/rest_ddf.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024 dresden elektronik ingenieurtechnik gmbh.
+ * All rights reserved.
+ *
+ * The software in this package is published under the terms of the BSD
+ * style license a copy of which has been included with this distribution in
+ * the LICENSE.txt file.
+ *
+ */
+
+#ifndef REST_DDF_H
+#define REST_DDF_H
+
+class ApiRequest;
+class ApiResponse;
+
+/*! REST-API endpoint for DDF. */
+int REST_DDF_HandleApi(const ApiRequest &req, ApiResponse &rsp);
+
+#endif // REST_DDF_H

--- a/rest_devices.cpp
+++ b/rest_devices.cpp
@@ -14,8 +14,14 @@
 #include "de_web_plugin.h"
 #include "de_web_plugin_private.h"
 #include "product_match.h"
+#include "database.h"
 #include "device_descriptions.h"
+#include "deconz/u_assert.h"
+#include "deconz/u_sstream_ex.h"
+#include "deconz/u_memory.h"
 #include "rest_devices.h"
+#include "utils/scratchmem.h"
+#include "json.h"
 #include "crypto/mmohash.h"
 #include "utils/ArduinoJson.h"
 #include "utils/utils.h"
@@ -75,6 +81,11 @@ int RestDevices::handleApi(const ApiRequest &req, ApiResponse &rsp)
     {
         return putDeviceReloadDDF(req, rsp);
     }
+    // PUT /api/<apikey>/devices/<uniqueid>/ddf/policy
+    else if (req.path.size() == 6 && req.hdr.method() == QLatin1String("PUT") && req.path[4] == QLatin1String("ddf") && req.path[5] == QLatin1String("policy"))
+    {
+        return putDeviceSetDDFPolicy(req, rsp);
+    }
     // GET /api/<apikey>/devices/<uniqueid>/ddf
     else if (req.hdr.pathComponentsCount() == 5 && req.hdr.httpMethod() == HttpGet && req.hdr.pathAt(4) == QLatin1String("ddf"))
     {
@@ -103,6 +114,38 @@ int RestDevices::handleApi(const ApiRequest &req, ApiResponse &rsp)
     }
 
     return REQ_NOT_HANDLED;
+}
+
+static DeviceKey getDeviceKey(QLatin1String uniqueid)
+{
+    DeviceKey result = 0;
+    const char *str = uniqueid.data();
+
+    if (uniqueid.size() < 23)
+        return result;
+
+    // 00:11:22:33:44:55:66:77
+    for (int pos = 0; pos < 23; pos++)
+    {
+        uint64_t ch = (unsigned)str[pos];
+        if (ch == ':' && (pos % 3) == 2) // ensure color only every 3rd pos
+            continue;
+
+        result <<= 4;
+
+        if      (ch >= '0' && ch <= '9') ch = ch - '0';
+        else if (ch >= 'a' && ch <= 'f') ch = (ch - 'a') + 10;
+        else if (ch >= 'A' && ch <= 'F') ch = (ch - 'A') + 10;
+        else
+        {
+            result = 0;
+            break;
+        }
+
+        result |= (ch & 0x0F);
+    }
+
+    return result;
 }
 
 /*! Deletes a Sensor as a side effect it will be removed from the REST API
@@ -1121,13 +1164,10 @@ int RestDevices::putDeviceReloadDDF(const ApiRequest &req, ApiResponse &rsp)
 
     rsp.httpStatus = HttpStatusOk;
 
-    auto uniqueId = req.path.at(3);
-    uniqueId.remove(QLatin1Char(':'));
+    QLatin1String uniqueId = req.hdr.pathAt(3);
+    DeviceKey deviceKey = getDeviceKey(uniqueId);
 
-    bool ok = false;
-    const auto deviceKey = uniqueId.toULongLong(&ok, 16);
-
-    if (ok)
+    if (deviceKey)
     {
         emit eventNotify(Event(RDevices, REventDDFReload, 0, deviceKey));
 
@@ -1141,6 +1181,197 @@ int RestDevices::putDeviceReloadDDF(const ApiRequest &req, ApiResponse &rsp)
     else
     {
         // TODO
+    }
+
+    return REQ_READY_SEND;
+}
+
+bool sanitizeBundleHashString(char *str, unsigned len)
+{
+    if (len != 64)
+        return false;
+
+    for (unsigned i = 0; i < len; i++)
+    {
+        char ch = str[i];
+
+        if      (ch >= '0' && ch <= '9') { } // ok
+        else if (ch >= 'a' && ch <= 'f') { } // ok
+        else if (ch >= 'A' && ch <= 'F') { str[i] = ch + ('a' - 'A'); } // convert to lower case
+        else
+        {
+            return false; // invalid hex char
+        }
+    }
+
+    return true;
+}
+
+
+/*
+
+    curl -X PUT -H "Content-Type: application/json" -d '{"policy": "nope", "hash":"value"}' 127.0.0.1:8090/api/12345/devices/00.99/ddf/policy
+
+
+*/
+int RestDevices::putDeviceSetDDFPolicy(const ApiRequest &req, ApiResponse &rsp)
+{
+    DBG_Assert(req.path.size() == 6);
+
+    Device *device = nullptr;
+    QLatin1String uniqueId = req.hdr.pathAt(3);
+    DeviceKey deviceKey = getDeviceKey(uniqueId);
+
+    const QByteArray content = req.content.toUtf8();
+    const QString errAddr = QString("/devices/%1/ddf/policy").arg(uniqueId);
+
+    U_SStream ss;
+
+    cj_ctx cj;
+    std::array<cj_token, 16> tokens;
+    cj_token_ref refParent = 0;
+    cj_token_ref refPolicy;
+
+    char policyBuf[32];
+    char bundleHashBuf[96];
+    unsigned bundleHashLen = 0;
+    unsigned policyLen = 0;
+
+    if (deviceKey != 0)
+    {
+        device = DEV_GetDevice(plugin->m_devices, deviceKey);
+    }
+
+    if (!device)
+    {
+        rsp.httpStatus = HttpStatusNotFound;
+        rsp.list.append(errorToMap(ERR_RESOURCE_NOT_AVAILABLE, errAddr, QString("resource, /devices/%1, not available").arg(uniqueId)));
+
+        return REQ_READY_SEND;
+    }
+
+    cj_parse_init(&cj, content.data(), (cj_size)content.size(), tokens.data(), tokens.size());
+    cj_parse(&cj);
+
+    if (cj.status != CJ_OK)
+    {
+
+        rsp.list.append(errorToMap(ERR_INVALID_JSON, errAddr, "body contains invalid JSON"));
+        rsp.httpStatus = HttpStatusBadRequest;
+        return REQ_READY_SEND;
+    }
+
+
+    if (cj_copy_value(&cj, policyBuf, sizeof(policyBuf), refParent, "policy") == 0)
+    {
+        rsp.list.append(errorToMap(ERR_MISSING_PARAMETER, errAddr, "missing parameters in body"));
+        rsp.httpStatus = HttpStatusBadRequest;
+        return REQ_READY_SEND;
+    }
+
+    /*
+     * Verify it's a valid policy value.
+     */
+
+    policyLen = U_strlen(policyBuf);
+    const char *validValues[5] = { "latest_prefer_stable", "latest", "pin", "raw_json", nullptr };
+
+    U_sstream_init(&ss, policyBuf, policyLen);
+
+    int v = 0;
+    for (; validValues[v]; v++)
+    {
+        unsigned len = U_strlen(validValues[v]);
+        if (policyLen == len && U_sstream_starts_with(&ss, validValues[v]))
+            break;
+    }
+
+    if (validValues[v] == nullptr)
+    {
+        rsp.list.append(errorToMap(ERR_INVALID_VALUE, errAddr, QString("invalid value, %1, for parameter, policy").arg(policyBuf)));
+        rsp.httpStatus = HttpStatusBadRequest;
+        return REQ_READY_SEND;
+    }
+
+    /*
+     * The 'pin' policy requires a 'hash' value to be specified.
+     */
+
+    if (U_sstream_starts_with(&ss, "pin"))
+    {
+        if (cj_copy_value(&cj, bundleHashBuf, sizeof(bundleHashBuf), refParent, "hash") == 0)
+        {
+            rsp.list.append(errorToMap(ERR_MISSING_PARAMETER, errAddr, "missing parameters in body"));
+            rsp.httpStatus = HttpStatusBadRequest;
+            return REQ_READY_SEND;
+        }
+
+        bundleHashLen = U_strlen(bundleHashBuf);
+        if (!sanitizeBundleHashString(bundleHashBuf, bundleHashLen))
+        {
+            rsp.list.append(errorToMap(ERR_INVALID_VALUE, errAddr, QString("invalid value, %1, for parameter, hash").arg(bundleHashBuf)));
+            rsp.httpStatus = HttpStatusBadRequest;
+            return REQ_READY_SEND;
+        }
+    }
+
+    bool needReload = false;
+    ResourceItem *ddfPolicyItem = device->item(RAttrDdfPolicy);
+    ResourceItem *ddfHashItem = device->item(RAttrDdfHash);
+    U_ASSERT(ddfPolicyItem);
+    U_ASSERT(ddfHashItem);
+
+    if (!ddfPolicyItem->equalsString(policyBuf, policyLen))
+    {
+        ddfPolicyItem->setValue(policyBuf, policyLen, ResourceItem::SourceApi);
+        needReload = true;
+
+        DB_ResourceItem2 dbItem;
+        dbItem.name = RAttrDdfPolicy;
+        U_memcpy(dbItem.value, policyBuf, policyLen);
+        dbItem.value[policyLen] = '\0';
+        dbItem.valueSize = policyLen;
+        dbItem.timestampMs = ddfPolicyItem->lastSet().toMSecsSinceEpoch();
+        DB_StoreDeviceItem(device->deviceId(), dbItem);
+    }
+
+    if (bundleHashLen != 0 && !ddfHashItem->equalsString(bundleHashBuf, bundleHashLen))
+    {
+        ddfHashItem->setValue(bundleHashBuf, bundleHashLen, ResourceItem::SourceApi);
+        needReload = true;
+
+        DB_ResourceItem2 dbItem;
+        dbItem.name = RAttrDdfHash;
+        U_memcpy(dbItem.value, bundleHashBuf, bundleHashLen);
+        dbItem.value[bundleHashLen] = '\0';
+        dbItem.valueSize = bundleHashLen;
+        dbItem.timestampMs = ddfHashItem->lastSet().toMSecsSinceEpoch();
+        DB_StoreDeviceItem(device->deviceId(), dbItem);
+    }
+
+    rsp.httpStatus = HttpStatusOk;
+
+    {
+        QVariantMap result;
+        QVariantMap item;
+
+        item[QString("/devices/%1/ddf/policy").arg(uniqueId)] = policyBuf;
+        result["success"] = item;
+        rsp.list.append(result);
+    }
+
+    if (bundleHashLen != 0)
+    {
+        QVariantMap result;
+        QVariantMap item;
+        item[QString("/devices/%1/ddf/hash").arg(uniqueId)] = bundleHashBuf;
+        result["success"] = item;
+        rsp.list.append(result);
+    }
+
+    if (needReload)
+    {
+        emit eventNotify(Event(RDevices, REventDDFReload, 0, deviceKey));
     }
 
     return REQ_READY_SEND;

--- a/rest_devices.cpp
+++ b/rest_devices.cpp
@@ -16,6 +16,7 @@
 #include "product_match.h"
 #include "database.h"
 #include "device_descriptions.h"
+#include "device_ddf_bundle.h"
 #include "deconz/u_assert.h"
 #include "deconz/u_sstream_ex.h"
 #include "deconz/u_memory.h"
@@ -1186,28 +1187,6 @@ int RestDevices::putDeviceReloadDDF(const ApiRequest &req, ApiResponse &rsp)
     return REQ_READY_SEND;
 }
 
-bool sanitizeBundleHashString(char *str, unsigned len)
-{
-    if (len != 64)
-        return false;
-
-    for (unsigned i = 0; i < len; i++)
-    {
-        char ch = str[i];
-
-        if      (ch >= '0' && ch <= '9') { } // ok
-        else if (ch >= 'a' && ch <= 'f') { } // ok
-        else if (ch >= 'A' && ch <= 'F') { str[i] = ch + ('a' - 'A'); } // convert to lower case
-        else
-        {
-            return false; // invalid hex char
-        }
-    }
-
-    return true;
-}
-
-
 /*
 
     curl -X PUT -H "Content-Type: application/json" -d '{"policy": "nope", "hash":"value"}' 127.0.0.1:8090/api/12345/devices/00.99/ddf/policy
@@ -1307,7 +1286,7 @@ int RestDevices::putDeviceSetDDFPolicy(const ApiRequest &req, ApiResponse &rsp)
         }
 
         bundleHashLen = U_strlen(bundleHashBuf);
-        if (!sanitizeBundleHashString(bundleHashBuf, bundleHashLen))
+        if (!DDFB_SanitizeBundleHashString(bundleHashBuf, bundleHashLen))
         {
             rsp.list.append(errorToMap(ERR_INVALID_VALUE, errAddr, QString("invalid value, %1, for parameter, hash").arg(bundleHashBuf)));
             rsp.httpStatus = HttpStatusBadRequest;

--- a/rest_devices.cpp
+++ b/rest_devices.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2021 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2013-2024 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -243,11 +243,28 @@ int RestDevices::getDevice(const ApiRequest &req, ApiResponse &rsp)
         return REQ_READY_SEND;
     }
 
-    const DeviceDescription ddf = plugin->deviceDescriptions->get(device);
+    const DeviceDescription &ddf = plugin->deviceDescriptions->get(device);
 
     if (ddf.isValid())
     {
         rsp.map["productid"] = ddf.product;
+    }
+
+    {
+        const ResourceItem *ddfPolicyItem = device->item(RAttrDdfPolicy);
+        if (ddfPolicyItem)
+        {
+            rsp.map["ddf_policy"] = ddfPolicyItem->toString();
+        }
+    }
+
+    if (ddf.storageLocation == deCONZ::DdfBundleLocation || ddf.storageLocation == deCONZ::DdfBundleUserLocation)
+    {
+        const ResourceItem *ddfHashItem = device->item(RAttrDdfHash);
+        if (ddfHashItem && ddfHashItem->toCString()[0] != '\0')
+        {
+            rsp.map["ddf_hash"] = ddfHashItem->toString();
+        }
     }
 
     QVariantList subDevices;

--- a/rest_devices.h
+++ b/rest_devices.h
@@ -49,6 +49,7 @@ private:
     int getDeviceDDF(const ApiRequest &req, ApiResponse &rsp);
     int putDeviceInstallCode(const ApiRequest &req, ApiResponse &rsp);
     int putDeviceReloadDDF(const ApiRequest &req, ApiResponse &rsp);
+    int putDeviceSetDDFPolicy(const ApiRequest &req, ApiResponse &rsp);
 
     DeRestPluginPrivate *plugin = nullptr;
     RestDevicesPrivate *d = nullptr;


### PR DESCRIPTION
**Important:** This larger PR is still work in progress. The PR is meant as tech preview to try out bundles and improve the possible rough edges asap. While the technical side in this PR is almost done, the user facing UI needs to be figured out still.

**Features:**

* Load DDFs from raw JSON files like it has been since DDF introduction.
* Load DDF bundles according to a DDF policy.
* Support multiple versions of a DDF bundle, e.g. to try out new beta of a DDF and revert back to former version if desired.
* Add / update bundles at runtime to a setup via [DDF REST-API](https://dresden-elektronik.github.io/deconz-rest-doc/endpoints/ddf/).
* Device support becomes independent from deCONZ releases.
* Install new bundles without restarting deCONZ, aka hot-reload.

### DDF Bundles

A bundle is just a single file with `.ddf` extension which contains the raw DDF JSON and all JS and JSON files it references. E.g. the files in `generic/items` and `generic/subdevices` etc.

### Unbreakable

Each bundle has a unique SHA-256 hash over its content. The hash is signed by well known public keys, currently one for **stable** and one for **beta** bundles. These signatures are also part of the bundle.

And that makes bundles "unbreakable", for example changing an item in `generic/items` won't accidentally alter a stable bundle. But create a new one, which is only signed as **beta** — with the former stable bundle still existing.

* No more broken devices after updates (a difficult problem all Zigbee projects currently suffer).
* Setups can be kept running on a "never change a running system" per device base.
* The DDF validator already catches common errors and will be sharpened further on to ensure we get "good" bundles.


### DDF load policy

Each device has two new top level API facing items `attr/ddf_policy` and `attr/ddf_hash`. The policy specifies which bundles (or raw JSON DDFs) are loaded for a device. The `attr/ddf_hash` in combination with the `pin` policy can be used to *pin* a specific bundle to a device.

 Policy              | Description
---------------------|--------------------------------
latest_prefer_stable | **(default)** Use latest DDF bundle: beta signed one if no stable available.
latest               | Use latest DDF bundle either beta, stable signed or un-signed.
pin                  | Use and stay on bundle given by its `<sha256-hash>`.
raw_json             | For development like before bundles existed just use raw .json DDF files.


To not cause havoc in the developer community, the raw JSON files, e.g. `devices/` directory, will be still part of deCONZ and are usable as they are used to be.

In the same spirit there are two new directories, a deCONZ packaged `bundles/` and a $USER location `bundles/` from which `.ddf` files are loaded.

### Performance

Loading bundles is ca. twice as fast as loading all raw JSON files. Further new in this PR only those DDFs are loaded into memory for devices which are actually present in the setup. The code was designed to crunch through thousands of DDFs easily since at some point we may end up with 3K to 5K bundles in total. We don't need to load thousands DDFs if a setup only has 30 distinct device types.

