### PR TITLE
DDF add tuya clone for Soil sensor

### DIFF
--- a/devices/tuya/_TZE200_myd45weu_soil_sensor.json
+++ b/devices/tuya/_TZE200_myd45weu_soil_sensor.json
@@ -1,7 +1,7 @@
 {
   "schema": "devcap1.schema.json",
-  "manufacturername": "_TZE200_myd45weu",
-  "modelid": "TS0601",
+  "manufacturername": ["_TZE200_myd45weu", "_TZE200_9cqcpkgb", "_TZE200_ga1maeof"],
+  "modelid": ["TS0601", "TS0601", "TS0601"],
   "product": "Tuya Soil Sensor",
   "sleeper": true,
   "status": "Gold",


### PR DESCRIPTION
Product name : Luminea Home Control ZX-8588 (Pearl)
Manufacturer : _TZE200_9cqcpkgb
Model identifier : TS0601

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7752