### PR TITLE
Fix Ikea Rodret group bindings/button events

### DIFF
--- a/devices/ikea/rodret_dimmer.json
+++ b/devices/ikea/rodret_dimmer.json
@@ -28,6 +28,7 @@
           "0x0008"
         ]
       },
+      "meta": {"group.endpoints": [1] },
       "items": [
         {
           "name": "attr/id"
@@ -99,7 +100,8 @@
           "refresh.interval": 86400
         },
         {
-          "name": "config/group"
+          "name": "config/group",
+          "default": "auto"
         },
         {
           "name": "config/on"


### PR DESCRIPTION
There was a case described on Discord where the dimmer apparently did not fire any button events and there were also no traces of any button presses in the debug log. With the modifications of the DDF and a re-pair of the device, the device was brought to a working state.

Presumably, the added `meta` item was missing and required to actually make the bindings work. However, this is just a guess, as I'm not fully sure about its importance.