### PR TITLE
Remove unnecessary permissions definition

### DIFF
--- a/.github/workflows/ci-ddf-store.yml
+++ b/.github/workflows/ci-ddf-store.yml
@@ -2,12 +2,6 @@
 
 name: Continuous integration DDF Bundles
 
-permissions: write-all
-#permissions:
-#  contents: write
-#  issues: write
-#  pull-requests: write
-
 # Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
@@ -89,8 +83,6 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     name: Continuous integration DDF Bundles
-
-    permissions: write-all
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
After all this is not the issue.
The 403 error is still here but not related to that permission setting in the workflow