### PR TITLE
lidl/hg08673 / TS011F -  Removed stray ";" that stopped consumption from working 

### DIFF
--- a/devices/lidl/hg08673.json
+++ b/devices/lidl/hg08673.json
@@ -181,7 +181,7 @@
             "at": "0x0000",
             "cl": "0x0702",
             "ep": 1,
-            "eval": "Item.val = Attr.val * 10;"
+            "eval": "Item.val = Attr.val * 10"
           }
         },
         {


### PR DESCRIPTION
Got a few of these devices and noticed that power was reading fine but consumption was always 0. Noticed a stray ";" in the DDF. After removing it the consumption reading is working.

And maybe a small request: I know this is not the homeassistant Community but i am sure someone can point me to the right place: I noticed that in the output of the REST call for this device is the voltage reading as well. That does not show up in HA. Where in this process is decided what part of the REST output is included in the HA Entitites ? 