### PR TITLE
Add public: false to measured_value from Hue Motion SML001

### DIFF
--- a/devices/philips/sml001_motion_sensor.json
+++ b/devices/philips/sml001_motion_sensor.json
@@ -450,6 +450,7 @@
         },
         {
           "name": "state/measured_value",
+          "public": false,
           "awake": true,
           "parse": {
             "fn": "zcl:attr",


### PR DESCRIPTION
Otherwise the value is double.