### PR TITLE
Log which modelid / manufacturer names lookup DDFs

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -7032,6 +7032,20 @@ std::vector<DB_IdentifierPair> DB_LoadIdentifierPairs()
 
     DeRestPluginPrivate::instance()->closeDb();
 
+    if (DBG_IsEnabled(DBG_DDF))
+    {
+        for (size_t i = 0; i < result.size(); i++)
+        {
+            AT_Atom mfname = AT_GetAtomByIndex({result[i].mfnameAtomIndex});
+            AT_Atom modelid = AT_GetAtomByIndex({result[i].modelIdAtomIndex});
+
+            U_ASSERT(mfname.data && mfname.len);
+            U_ASSERT(modelid.data && modelid.len);
+
+            DBG_Printf(DBG_DDF, "DDF identifier pair: %s | %s\n", (const char*)mfname.data, (const char*)modelid.data);
+        }
+    }
+
     return result;
 }
 


### PR DESCRIPTION
On startup the modelid and manufacturername pairs are queried from the database of already paired devices to speedup DDF and bundle lookups.

Logging these is only for debugging purpose and on startup quickly shows which devices are present.

Needs `--dbg-ddf=1` debug switch set.