### PR TITLE
Improve bulk upload of DDF bundles and hotreload

### DIFF
--- a/device_descriptions.h
+++ b/device_descriptions.h
@@ -283,6 +283,9 @@ public Q_SLOTS:
     void readAllRawJson();
     void readAllBundles();
 
+    void ddfReloadTimerFired();
+    void reloadAllRawJsonAndBundles(const Resource *resource);
+
 Q_SIGNALS:
     void eventNotify(const Event&); //! Emitted \p Event needs to be enqueued in a higher layer.
     void loaded();

--- a/rest_devices.cpp
+++ b/rest_devices.cpp
@@ -1170,7 +1170,11 @@ int RestDevices::putDeviceReloadDDF(const ApiRequest &req, ApiResponse &rsp)
 
     if (deviceKey)
     {
-        emit eventNotify(Event(RDevices, REventDDFReload, 0, deviceKey));
+        Device *device = DEV_GetDevice(plugin->m_devices, deviceKey);
+        if (device)
+        {
+            DeviceDescriptions::instance()->reloadAllRawJsonAndBundles(device);
+        }
 
         QVariantMap rspItem;
         QVariantMap rspItemState;

--- a/ui/device_widget.cpp
+++ b/ui/device_widget.cpp
@@ -396,26 +396,19 @@ void DeviceWidget::saveAsDDF()
 
 void DeviceWidget::hotReload()
 {
-    const DeviceDescription &ddf = d->ddfWindow->editor->ddf();
-    if (!ddf.isValid())
-    {
-        return;
-    }
     auto *dd = DeviceDescriptions::instance();
-    dd->put(ddf);
 
     for (const std::unique_ptr<Device> &dev : *d->devices)
     {
-        const auto &ddf0 = dd->get(&*dev);
-
-        if (ddf0.handle == ddf.handle)
+        if (d->curNode.ext() == dev->key())
         {
-            DBG_Printf(DBG_INFO, "Hot reload device: %s\n", dev->item(RAttrUniqueId)->toCString());
-            dev->handleEvent(Event(RDevices, REventDDFReload, 0, dev->key()));
+            dd->reloadAllRawJsonAndBundles(dev.get());
+            QString mfname = dev->item(RAttrManufacturerName)->toString();
+            QString modelid = dev->item(RAttrModelId)->toString();
+            d->ddfWindow->showMessage(tr("DDF reloading devices matching: %1 / %2").arg(mfname, modelid));
+            break;
         }
     }
-
-    d->ddfWindow->showMessage(tr("DDF reloaded for devices"));
 }
 
 void DeviceWidget::enablePermitJoin()


### PR DESCRIPTION
Instead of reloading all raw JSON and bundle DDFs after each upload, wait 2 seconds if more is uploaded before reloading everything. The Phoscon App now supports uploading zipped bundles which may contain hundreds of `.ddf` files.

Further improve hotreload via DDF editor.