### PR TITLE
DDF loader improve logging; load DDFs where mfname constant is unknown

### DIFF
--- a/device_ddf_init.cpp
+++ b/device_ddf_init.cpp
@@ -74,11 +74,17 @@ static ResourceItem *DEV_InitDeviceDescriptionItem(const DeviceDescription::Item
 
     if (item)
     {
-        DBG_Printf(DBG_DDF, "sub-device: %s, has item: %s\n", uniqueId, ddfItem.descriptor.suffix);
+        if (DBG_IsEnabled(DBG_INFO_L2))
+        {
+            DBG_Printf(DBG_DDF, "sub-device: %s, has item: %s\n", uniqueId, ddfItem.descriptor.suffix);
+        }
     }
     else
     {
-        DBG_Printf(DBG_DDF, "sub-device: %s, create item: %s\n", uniqueId, ddfItem.descriptor.suffix);
+        if (DBG_IsEnabled(DBG_INFO_L2))
+        {
+            DBG_Printf(DBG_DDF, "sub-device: %s, create item: %s\n", uniqueId, ddfItem.descriptor.suffix);
+        }
         item = rsub->addItem(ddfItem.descriptor.type, ddfItem.descriptor.suffix);
 
         DBG_Assert(item);


### PR DESCRIPTION
- Reduce noise in `--dbg-ddf` log output
- More error logging while loading DDFs
- Load raw JSON DDFs where manufacturer name constant can't be resolved

This is for the ongoing investigation of https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7783