### PR TITLE
DDF for Drayton Wiser Radiator Thermostat iTRV

### DIFF
--- a/devices/wiser/itrv_thermostat.json
+++ b/devices/wiser/itrv_thermostat.json
@@ -1,0 +1,258 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "Schneider Electric",
+  "modelid": "iTRV",
+  "product": "iTRV thermostat",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_THERMOSTAT",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0201"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0301",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x0201",
+          "0x0204"
+        ]
+      },
+      "meta": {
+        "values": {
+          "config/mode": {"auto": 1}
+        }
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "refresh.interval": 3660,
+          "parse": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "eval": "Item.val = Attr.val;",
+            "fn": "zcl:attr"
+          },
+          "read": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "fn": "zcl:attr"
+          }
+        },
+        {
+          "name": "config/checkin"
+        },
+        {
+          "name": "config/coolsetpoint",
+          "refresh.interval": 3660,
+          "read": {
+            "at": "0x0011",
+            "cl": "0x0201",
+            "ep": 1,
+            "fn": "zcl:attr"
+          },
+          "write": {
+            "at": "0x0011",
+            "cl": "0x0201",
+            "dt": "0x29",
+            "ep": 1,
+            "eval": "Item.val;",
+            "fn": "zcl:attr"
+          },
+          "parse": {
+            "at": "0x0011",
+            "cl": "0x0201",
+            "ep": 1,
+            "eval": "Item.val = Attr.val;",
+            "fn": "zcl:attr"
+          },
+          "default": 0
+        },
+        {
+          "name": "config/heatsetpoint",
+          "refresh.interval": 3660
+        },
+        {
+          "name": "config/locked",
+          "refresh.interval": 3660
+        },
+        {
+          "name": "config/mode",
+          "static": "auto"
+        },
+        {
+          "name": "config/offset",
+          "refresh.interval": 3660,
+          "read": {
+            "at": "0x0010",
+            "cl": "0x0201",
+            "ep": 1,
+            "fn": "zcl:attr"
+          },
+          "parse": {
+            "at": "0x0010",
+            "cl": "0x0201",
+            "ep": 1,
+            "eval": "Item.val = Attr.val * 10;",
+            "fn": "zcl:attr"
+          },
+          "write": {
+            "at": "0x0010",
+            "cl": "0x0201",
+            "dt": "0x28",
+            "ep": 1,
+            "eval": "Item.val / 10;",
+            "fn": "zcl:attr"
+          },
+          "default": 0
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/on",
+          "parse": {
+            "at": "0x0008",
+            "cl": "0x0201",
+            "ep": 1,
+            "eval": "Item.val = Attr.val > 3;",
+            "fn": "zcl:attr"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "state/temperature",
+          "refresh.interval": 3660,
+          "parse": {
+            "at": "0x0000",
+            "cl": "0x0201",
+            "ep": 1,
+            "eval": "Item.val = Attr.val;",
+            "fn": "zcl:attr"
+          },
+          "read": {
+            "at": "0x0000",
+            "cl": "0x0201",
+            "ep": 1,
+            "fn": "zcl:attr"
+          }
+        },
+        {
+          "name": "state/valve",
+          "refresh.interval": 3660
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 60,
+          "max": 3600,
+          "change": "0x01"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0201",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x29",
+          "min": 300,
+          "max": 3600,
+          "change": "0x00000032"
+        },
+        {
+          "at": "0x0008",
+          "dt": "0x20",
+          "min": 60,
+          "max": 3600,
+          "change": "0x00000001"
+        },
+        {
+          "at": "0x0011",
+          "dt": "0x29",
+          "min": 1,
+          "max": 3600,
+          "change": "0x00000001"
+        },
+        {
+          "at": "0x0012",
+          "dt": "0x29",
+          "min": 1,
+          "max": 3600,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0204",
+      "report": [
+        {
+          "at": "0x0001",
+          "dt": "0x30",
+          "min": 1,
+          "max": 3600
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
DDF is supposed to replace the legacy implementation. Although it is expected the device will be fully functional, somebody owning the thermostat should test in deconz GUI if there are any usable system mode settings. For now, it is statically set to auto, but can be changed if necessary.

Legacy code can be removed in a subsequent PR then.

Closes #4148