### PR TITLE
DDF clone for Tuya Soil sensor (_TZE204_myd45weu)

### DIFF
--- a/devices/tuya/_TZE200_myd45weu_soil_sensor.json
+++ b/devices/tuya/_TZE200_myd45weu_soil_sensor.json
@@ -1,8 +1,7 @@
 {
   "schema": "devcap1.schema.json",
-  "uuid": "d32fe4d8-def4-4bd0-9d6e-8822d793f387",
-  "manufacturername": ["_TZE200_myd45weu", "_TZE200_9cqcpkgb", "_TZE200_ga1maeof"],
-  "modelid": ["TS0601", "TS0601", "TS0601"],
+  "manufacturername": ["_TZE200_myd45weu", "_TZE200_9cqcpkgb", "_TZE200_ga1maeof", "_TZE204_myd45weu"],
+  "modelid": ["TS0601", "TS0601", "TS0601", "TS0601"],
   "product": "Tuya Soil Sensor",
   "sleeper": true,
   "status": "Gold",


### PR DESCRIPTION
Product name : Tuya Soil Sensor
Manufacturer : _TZE204_myd45weu
Model identifier : TS0601

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7799