### PR TITLE
Change DDF bundle file extension to .ddb

### DIFF
--- a/device_descriptions.cpp
+++ b/device_descriptions.cpp
@@ -2663,7 +2663,7 @@ void DeviceDescriptions::readAllBundles()
 
                 U_sstream_init(&ss, dir.entry.name, strlen(dir.entry.name));
 
-                if (U_sstream_find(&ss, ".ddf") == 0)
+                if (U_sstream_find(&ss, ".ddf") == 0 && U_sstream_find(&ss, ".ddb") == 0)
                     continue;
 
                 ScratchMemRewind(scratchPosPerBundle);


### PR DESCRIPTION
Previously it was .ddf but confused users since in the UI raw JSON DDF are shown with DDF label and bundles with DDB label.

The code still supports loading .ddf. New uploaded bundles get .ddb file extension.