### PR TITLE
DDF for Nedis smoke sensor (_TYZB01_wqcac7lo)

### DIFF
--- a/devices/nedis/nedis_zbds10wt.json
+++ b/devices/nedis/nedis_zbds10wt.json
@@ -1,0 +1,116 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "_TYZB01_wqcac7lo",
+  "modelid": "TS0205",
+  "vendor": "Tuya",
+  "product": "Smoke Sensor",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_FIRE_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0500"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0402",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x0500"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {"fn": "zcl:attr", "ep": 1, "cl": "0x0000", "at": "0x0001", "script": "tuya_swversion.js"},
+          "read": {"fn": "zcl:attr", "ep": 1, "cl": "0x0000", "at": "0x0001"}
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "parse": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "eval": "Item.val = Attr.val / 2",
+            "fn": "zcl:attr"
+          }
+        },
+        {
+          "name": "config/enrolled"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/pending"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/fire"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/lowbattery"
+        },
+        {
+          "name": "state/test"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 600,
+          "max": 43200,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0500"
+    }
+  ]
+}

--- a/devices/nedis/tuya_swversion.js
+++ b/devices/nedis/tuya_swversion.js
@@ -1,0 +1,2 @@
+var v = Attr.val;
+Item.val = String((v & 192) >> 6) + '.' + String((v & 48) >> 4) + '.' + String(v & 15);


### PR DESCRIPTION
Product name : Nedis zigbee smoke detector zbds10wt
Manufacturer : _TYZB01_wqcac7lo
Model identifier : TS0205

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7812

The device support probably siren (warning device) but the user don't need it