### PR TITLE
Fix crash on macOS

### DIFF
--- a/device_descriptions.cpp
+++ b/device_descriptions.cpp
@@ -1083,8 +1083,6 @@ const DeviceDescription &DeviceDescriptions::get(const Resource *resource, DDF_M
 
     if (modelidAtomIndex == 0 || mfnameAtomIndex == 0)
     {
-        U_ASSERT(modelidItem->toString().isEmpty());
-        U_ASSERT(mfnameItem->toString().isEmpty());
         return d->invalidDescription; // happens when called from legacy init code addLightNode() etc.
     }
 
@@ -1121,6 +1119,7 @@ const DeviceDescription &DeviceDescriptions::get(const Resource *resource, DDF_M
                 // nothing found, try to load further DDFs
                 if (loadDDFAndBundlesFromDisc(resource))
                 {
+                    i = d->descriptions.begin();
                     continue; // found DDFs or bundles, try again
                 }
                 break;


### PR DESCRIPTION
There are two bugs.

1) After a new DDF is loaded during pairing the DDF matching search must start from beginning of all loaded DDFs.
2) The actual crash happens when calling std::find_if with two end() iterators, but surprisingly only with Apple Clang, not with GCC on other platforms.

Issue: https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7698