### PR TITLE
DDF add support for Neo _TZE200_t1blo2bj

### DIFF
--- a/devices/tuya/_TZE200_t1blo2bj_neo_siren.json
+++ b/devices/tuya/_TZE200_t1blo2bj_neo_siren.json
@@ -1,0 +1,231 @@
+{
+  "schema": "devcap1.schema.json",
+  "uuid": "78685bfe-85cf-462a-bff9-059a876ffbb0",
+  "manufacturername": [
+    "_TZE200_t1blo2bj",
+    "_TZE204_t1blo2bj"
+  ],
+  "modelid": [
+    "TS0601",
+    "TS0601"
+  ],
+  "product": "Neo (Tuya) smart siren",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_ON_OFF_LIGHT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "refresh.interval": 86400,
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x0001",
+            "script": "tuya_swversion.js"
+          },
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x0001"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/tuya_unlock",
+          "public": false,
+          "refresh.interval": 86400,
+          "default": false
+        },
+        {
+          "name": "state/alert",
+          "default": "none"
+        },
+        {
+          "name": "state/on",
+          "write": {
+            "dpid": 13,
+            "dt": "0x10",
+            "eval": "Item.val == 1 ? 1 : 0;",
+            "fn": "tuya"
+          },
+          "parse": {
+            "dpid": 13,
+            "eval": "Item.val == 1 ? 0 : 1;",
+            "fn": "tuya"
+          },
+          "default": false
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "ZHAAlarm",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0500"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0403",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0004",
+          "0x0005",
+          "0xEF00"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "refresh.interval": 86400,
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x0001",
+            "script": "tuya_swversion.js"
+          },
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x0001"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "parse": {
+            "dpid": 15,
+            "eval": "Item.val = Attr.val;",
+            "fn": "tuya"
+          },
+          "default": 0
+        },
+        {
+          "name": "config/duration",
+          "description": "Alarm duration in seconds",
+          "write": {
+            "dpid": 7,
+            "dt": "0x2b",
+            "eval": "Attr.val = Item.val;",
+            "fn": "tuya"
+          },
+          "parse": {
+            "dpid": 7,
+            "eval": "Item.val = Attr.val;",
+            "fn": "tuya"
+          }
+        },
+        {
+          "name": "config/melody",
+          "description": "Melody used by siren (between 1 to 18)",
+          "write": {
+            "dpid": 21,
+            "dt": "0x30",
+            "eval": "Attr.val = Item.val;",
+            "fn": "tuya"
+          },
+          "parse": {
+            "dpid": 21,
+            "eval": "Item.val = Attr.val;",
+            "fn": "tuya"
+          },
+          "default": 0
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "config/volume",
+          "description": "Volume of the siren, 0:low, 1:medium, 2:High",
+          "write": {
+            "dpid": 5,
+            "dt": "0x30",
+            "eval": "Attr.val = Item.val;",
+            "fn": "tuya"
+          },
+          "parse": {
+            "dpid": 5,
+            "eval": "Item.val = Attr.val;",
+            "fn": "tuya"
+          },
+          "default": 0
+        },
+        {
+          "name": "state/alarm"
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0xEF00"
+    }
+  ]
+}


### PR DESCRIPTION
Product name: Neo siren alarm with battery
Manufacturer: _TZE200_t1blo2bj
Model identifier: TS0601
Device type to add: Siren, but recognized as light

#6112 with help of @Smanar 