### PR TITLE
Help needed: DDF for Ubisys H1 Version 1.7

### DIFF
--- a/devices/ubisys/h1_v1.7.json
+++ b/devices/ubisys/h1_v1.7.json
@@ -173,20 +173,24 @@
         {
           "name": "config/windowopendetectionenabled",
           "read": {
+            "fn": "zcl:attr",
             "at": "0x0015",
             "cl": "0x0201",
             "ep": 1,
             "mf": "0x10f2"
           },
           "write": {
+            "fn": "zcl:attr",
             "at": "0x0015",
             "cl": "0x0201",
             "dt": "0x10",
             "ep": 1,
-            "eval": "Item.val",
+            "eval": "if (Item.val) { 1 } else { 0 }",
+            "fn": "zcl:attr",
             "mf": "0x10f2"
           },
           "parse": {
+            "fn": "zcl:attr",
             "at": "0x0015",
             "cl": "0x0201",
             "ep": 1,
@@ -236,6 +240,7 @@
         {
           "name": "state/windowopen",
           "read": {
+            "fn": "zcl:attr",
             "at": "0x0016",
             "cl": "0x0201",
             "ep": 1,
@@ -245,6 +250,7 @@
             "fn": "None"
           },
           "parse": {
+            "fn": "zcl:attr",
             "at": "0x0016",
             "cl": "0x0201",
             "ep": 1,


### PR DESCRIPTION
This is for the new Version 1.7 which supports detection of open windows.

I added `config/externalsensortemp` in another pull request. This is not needed anymore. Ubisys changed it. Now the temperature is reported as external temperature sensor which makes more sense IMO. No need for a second attribute.

- added config/windowopendetectionenabled

Reading works. But writing does not. I know know why, maybe there is something I miss...?

- added state/windowopen

Works fine for me. Tested by cooling down my external sensor.

I wanted to make this a DDF just for Version 1.7. @SwoopX helped me and told me I should add:

`"matchexpr": "var v = R.item('attr/otaversion').val; (v != 0 && v < 0x0170044D);"`

but when I add this my DDF is not selected but the "stock" one. What's wrong with this?

What about the UUID? Should I just generate a new one?
