### PR TITLE
DDF for Aqara wall outlet H2 EU (WP-P01D)

### DIFF
--- a/devices/xiaomi/xiaomi_wp-p01d_h2_wall_outlet.json
+++ b/devices/xiaomi/xiaomi_wp-p01d_h2_wall_outlet.json
@@ -244,7 +244,7 @@
           "parse": {
             "at": "0x00F7",
             "ep": "0x01",
-            "eval": "Item.val = Math.round(Attr.val);",
+            "eval": "Item.val = Math.round(Attr.val * 1000);",
             "fn": "xiaomi:special",
             "idx": "0x95",
             "mf": "0x115F"

--- a/devices/xiaomi/xiaomi_wp-p01d_h2_wall_outlet.json
+++ b/devices/xiaomi/xiaomi_wp-p01d_h2_wall_outlet.json
@@ -1,0 +1,262 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "$MF_AQARA",
+  "modelid": "lumi.plug.aeu001",
+  "vendor": "Xiaomi",
+  "product": "Aqara wall outlet H2 EU (WP-P01D)",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_SMART_PLUG",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {
+            "at": "0x00F7",
+            "ep": "0x01",
+            "eval": "Item.val = '0.0.0_' + ('0000' + (Attr.val & 0xFF).toString()).slice(-4)",
+            "fn": "xiaomi:special",
+            "idx": "0x0D",
+            "mf": "0x115F"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/alert",
+          "default": "none"
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 300
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_POWER_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x15",
+        "0x000c"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0051",
+        "endpoint": "0x15",
+        "in": [
+          "0x000C",
+          "0x0000"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {
+            "at": "0x00F7",
+            "ep": "0x01",
+            "eval": "Item.val = '0.0.0_' + ('0000' + (Attr.val & 0xFF).toString()).slice(-4)",
+            "fn": "xiaomi:special",
+            "idx": "0x0D",
+            "mf": "0x115F"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/current",
+          "parse": {
+            "at": "0x00F7",
+            "ep": "0x01",
+            "eval": "Item.val = Math.round(Attr.val);",
+            "fn": "xiaomi:special",
+            "idx": "0x97",
+            "mf": "0x115F"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/power",
+          "refresh.interval": 10,
+          "read": {
+            "at": "0x0055",
+            "cl": "0x000C",
+            "ep": "0x15",
+            "fn": "zcl:attr"
+          },
+          "parse": {
+            "at": "0x0055",
+            "cl": "0x000C",
+            "ep": "0x15",
+            "eval": "Item.val = Math.round(Attr.val);"
+          }
+        },
+        {
+          "name": "state/voltage",
+          "parse": {
+            "at": "0x00F7",
+            "ep": "0x01",
+            "eval": "Item.val = Math.round(Attr.val / 10);",
+            "fn": "xiaomi:special",
+            "idx": "0x96",
+            "mf": "0x115F"
+          },
+          "read": {
+            "fn": "none"
+          }
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_CONSUMPTION_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0xfcc0"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0000",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0xFCC0"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {
+            "at": "0x00F7",
+            "ep": "0x01",
+            "eval": "Item.val = '0.0.0_' + ('0000' + (Attr.val & 0xFF).toString()).slice(-4)",
+            "fn": "xiaomi:special",
+            "idx": "0x0D",
+            "mf": "0x115F"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/consumption",
+          "parse": {
+            "at": "0x00F7",
+            "ep": "0x01",
+            "eval": "Item.val = Math.round(Attr.val);",
+            "fn": "xiaomi:special",
+            "idx": "0x95",
+            "mf": "0x115F"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fully working DDF for the device at hand. However, if the device was paired prior to availability of this DDF, the weird side effect of duplicate power and consumption sensors may occur. This is primarily an issue how deconz treats available legacy sensors.