### PR TITLE
Fix raw JSON DDF load order for user location

### DIFF
--- a/device_descriptions.cpp
+++ b/device_descriptions.cpp
@@ -1180,6 +1180,11 @@ const DeviceDescription &DeviceDescriptions::get(const Resource *resource, DDF_M
                 {
                     rawJsonIndex = matchedIndices[i];
                 }
+                else if (ddf1.storageLocation == deCONZ::DdfUserLocation && d->descriptions[rawJsonIndex].storageLocation == deCONZ::DdfLocation)
+                {
+                    // already had a match but user location has more precedence than system location
+                    rawJsonIndex = matchedIndices[i];
+                }
                 continue;
             }
 


### PR DESCRIPTION
If a system location DDF already existed the user location DDF wasn't picket up correctly.
The problem occurred only for raw JSON DDFs not bundles.

Part of https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7845