### PR TITLE
DDF add support for HEIMAN IR control HS2IRC

### DIFF
--- a/devices/generic/items/config_learnkey_item.json
+++ b/devices/generic/items/config_learnkey_item.json
@@ -1,0 +1,8 @@
+{
+  "schema": "resourceitem1.schema.json",
+  "id": "config/learnkey",
+  "datatype": "String",
+  "access": "RW",
+  "public": true,
+  "description": "Memorise code."
+}

--- a/devices/generic/items/config_sendkey_item.json
+++ b/devices/generic/items/config_sendkey_item.json
@@ -1,0 +1,8 @@
+{
+  "schema": "resourceitem1.schema.json",
+  "id": "config/sendkey",
+  "datatype": "String",
+  "access": "RW",
+  "public": true,
+  "description": "Send a code."
+}

--- a/devices/heiman/HS2IRC_IR_control.json
+++ b/devices/heiman/HS2IRC_IR_control.json
@@ -1,0 +1,72 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "HEIMAN",
+  "modelid": "IRControl-EM",
+  "vendor": "HEIMAN",
+  "product": "HS2IRC",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_SWITCH",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0xFC82"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/sendkey",
+          "write": {
+            "fn": "zcl:cmd",
+            "ep": "0x01",
+            "cl": "0xfc82",
+            "cmd": "0xf0",
+            "eval": "('0'+parseInt(Item.val.split(',')[0]).toString(16)).slice(-2) + ('0'+parseInt(Item.val.split(',')[1]).toString(16)).slice(-2);"
+          }
+        },
+        {
+          "name": "config/learnkey",
+          "write": {
+            "fn": "zcl:cmd",
+            "ep": "0x01",
+            "cl": "0xfc82",
+            "cmd": "0xf1",
+            "eval": "('0'+parseInt(Item.val.split(',')[0]).toString(16)).slice(-2) + ('0'+parseInt(Item.val.split(',')[1]).toString(16)).slice(-2);"
+          }
+        },
+        {
+          "name": "config/reachable"
+        }
+      ]
+    }
+  ]
+}

--- a/general.xml
+++ b/general.xml
@@ -5253,6 +5253,62 @@ These devices can operate on either battery or mains power, and can have a wide 
       </server>
     </cluster>
 
+    <!-- HEIMAN  -->
+    <cluster id="0xfc82" name="Heiman specific" mfcode="0x120b">
+      <description>Heiman specific attributes for the device HS2IRC.</description>
+      <server>
+        <command id="0xf4" dir="recv" name="Create ID" required="m" response="0xf5">
+          <description>Create model ID</description>
+          <payload>
+             <attribute id="0x0000" name="Model type" type="u8" default="0" required="m"></attribute>
+          </payload>
+        </command>
+        <command id="0xf1" dir="recv" name="Learn key" required="m" response="0xf2">
+          <description>Learn new code</description>
+          <payload>
+             <attribute id="0x0000" name="Id" type="u8" default="0" required="m"></attribute>
+             <attribute id="0x0001" name="Keycode" type="u8" default="0" required="m"></attribute>
+          </payload>
+        </command>
+        <command id="0xf0" dir="recv" name="Send key" required="m">
+          <description>Send a code</description>
+          <payload>
+             <attribute id="0x0000" name="Id" type="u8" default="0" required="m"></attribute>
+             <attribute id="0x0001" name="Keycode" type="u8" default="0" required="m"></attribute>
+          </payload>
+        </command>
+        <command id="0xf6" dir="recv" name="Get list" required="m" response="0xf7">
+          <description>Get list code</description>
+        </command>
+      </server>
+      <client>
+        <command id="0xf2" dir="recv" name="Learn key response" required="m">
+          <description>The Response to the learn key request.</description>
+          <payload>
+            <attribute id="0x0000" type="u8" name="Id" required="m" default="0x00"></attribute>
+            <attribute id="0x0001" type="u8" name="Key Code" required="m" default="0x00"></attribute>
+            <attribute id="0x0002" type="u8" name="Result" required="m" default="0x00"></attribute>
+          </payload>
+        </command>
+        <command id="0xf7" dir="recv" name="Get list response" required="m">
+          <description>The Response to the Get list request.</description>
+          <payload>
+            <attribute id="0x0000" type="u8" name="Total" required="m" default="0x00"></attribute>
+            <attribute id="0x0001" type="u8" name="Number" required="m" default="0x00"></attribute>
+            <attribute id="0x0002" type="u8" name="Length" required="m" default="0x00"></attribute>
+            <attribute id="0x0003" type="ostring" name="Payload" required="m"></attribute>
+          </payload>
+        </command>
+        <command id="0xf5" dir="recv" name="Create model response" required="m">
+          <description>The Response to the Create model request.</description>
+          <payload>
+            <attribute id="0x0000" type="u8" name="ID" required="m" default="0x00"></attribute>
+            <attribute id="0x0001" type="u8" name="Model type" required="m" default="0x00"></attribute>
+          </payload>
+        </command>
+      </client>
+    </cluster>
+
     <!-- Tuya -->
     <cluster id="0xe001" name="Tuya specific" mfcode="0x1141">
 			<description>Tuya Specific switch mode cluster.</description>


### PR DESCRIPTION
Product name : IR control HS2IRC
Manufacturer : HEIMAN
Model identifier : HS2IRC

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7814.

For the moment the device work with a mix, API + GUI.

To add a device :
- Use "Create ID" using a value from 1 to 255, it will be your "model type", this fonction will return you your "ID" (from 1 to 15)
- Use "Learn key" with your ID + code, code is a value from 1 to 30
- Use "Send key" with same value to send a request

"Get list response" is still WIP.

Can use it with API using field 
```
    config/learnkey
    config/sendkey
```
With data as form "x,y"

`curl -H 'Content-Type: application/json' -X PUT -d '{"learnkey": "2.3"}' http://IP:PORT/api/KEY/sensors/ID/config`