### PR TITLE
Make DDF manufacturer name matching case insensitive

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -16749,19 +16749,23 @@ void DEV_AllocateGroup(const Device *device, Resource *rsub, ResourceItem *item)
  */
 void DEV_ReloadDeviceIdendifier(unsigned atomIndexMfname, unsigned atomIndexModelid)
 {
+    (void)atomIndexMfname;
+
     for (auto &dev : plugin->m_devices)
     {
-        {
-            const ResourceItem *mfname = dev->item(RAttrManufacturerName);
-            if (!mfname || mfname->atomIndex() != atomIndexMfname)
-                continue;
-        }
-
         {
             const ResourceItem *modelid = dev->item(RAttrModelId);
             if (!modelid || modelid->atomIndex() != atomIndexModelid)
                 continue;
         }
+
+#if 0 // ignore for now since manufacturer name might have case sensitive variations
+        {
+            const ResourceItem *mfname = dev->item(RAttrManufacturerName);
+            if (!mfname || mfname->atomIndex() != atomIndexMfname)
+                continue;
+        }
+#endif
 
         enqueueEvent(Event(RDevices, REventDDFReload, 0, dev->key()));
     }


### PR DESCRIPTION
This fixes a regression from v2.27.0-beta. A DDF should match a manufacturer name regardless if it is given as "HEIMAN", "Heiman", "heiman", etc.

Note this applies only to plain ASCII strings. For manufacturer names which contain multi-byte UTF-8 characters the DDF must have the exact name representation. This should by fine for 99% of all cases.