### PR TITLE
DDF for Tuya PIR 24G radar sensor (ZG-204ZM)

### DIFF
--- a/devices/tuya/_TZE200_kb5noeto_motion_sensor.json
+++ b/devices/tuya/_TZE200_kb5noeto_motion_sensor.json
@@ -1,0 +1,332 @@
+{
+    "schema": "devcap1.schema.json",
+    "manufacturername": "_TZE200_kb5noeto",
+    "modelid": "TS0601",
+    "product": "Tuya PIR 24G Radar Sensor",
+    "sleeper": false,
+    "status": "Gold",
+    "subdevices": [
+        {
+            "type": "$TYPE_LIGHT_LEVEL_SENSOR",
+            "restapi": "/sensors",
+            "uuid": [
+                "$address.ext",
+                "0x01",
+                "0x0400"
+            ],
+            "items": [
+                {
+                    "name": "attr/lastseen"
+                },
+                {
+                    "name": "attr/manufacturername"
+                },
+                {
+                    "name": "attr/modelid"
+                },
+                {
+                    "name": "attr/name"
+                },
+                {
+                    "name": "config/battery",
+                    "parse": {
+                        "fn": "tuya",
+                        "dpid": 121,
+                        "eval": "Item.val = Attr.val;"
+                    },
+                    "read": {
+                        "fn": "none"
+                    },
+                    "default": 0
+                },
+                {
+                    "name": "attr/swversion",
+                    "refresh.interval": 86400,
+                    "read": {
+                        "at": "0x0001",
+                        "cl": "0x0000",
+                        "ep": 1,
+                        "fn": "zcl:attr"
+                    },
+                    "parse": {
+                        "at": "0x0001",
+                        "cl": "0x0000",
+                        "ep": 1,
+                        "fn": "zcl:attr",
+                        "script": "tuya_swversion.js"
+                    }
+                },
+                {
+                    "name": "attr/type"
+                },
+                {
+                    "name": "attr/uniqueid"
+                },
+                {
+                    "name": "config/on"
+                },
+                {
+                    "name": "config/reachable"
+                },
+                {
+                    "name": "state/lastupdated"
+                },
+                {
+                    "name": "state/dark"
+                },
+                {
+                    "name": "config/tholddark"
+                },
+                {
+                    "name": "config/tholdoffset"
+                },
+                {
+                    "name": "state/daylight"
+                },
+                {
+                    "name": "state/lightlevel"
+                },
+                {
+                    "name": "state/lux",
+                    "description": "The current light intensity in Lux (max is 2000)",
+                    "read": {
+                        "fn": "none"
+                    },
+                    "parse": {
+                        "dpid": 106,
+                        "script": "lux_to_lightlevel_50.js",
+                        "fn": "tuya"
+                    },
+                    "default": 0
+                }
+            ]
+        },
+        {
+            "type": "$TYPE_PRESENCE_SENSOR",
+            "restapi": "/sensors",
+            "uuid": [
+                "$address.ext",
+                "0x01",
+                "0xef00"
+            ],
+            "items": [
+                {
+                    "name": "attr/id"
+                },
+                {
+                    "name": "attr/lastannounced"
+                },
+                {
+                    "name": "attr/lastseen"
+                },
+                {
+                    "name": "attr/manufacturername"
+                },
+                {
+                    "name": "attr/modelid"
+                },
+                {
+                    "name": "attr/name"
+                },
+                {
+                    "name": "config/battery",
+                    "parse": {
+                        "fn": "tuya",
+                        "dpid": 121,
+                        "eval": "Item.val = Attr.val;"
+                    },
+                    "read": {
+                        "fn": "none"
+                    },
+                    "default": 0
+                },
+                {
+                    "name": "attr/swversion",
+                    "refresh.interval": 86400,
+                    "read": {
+                        "at": "0x0001",
+                        "cl": "0x0000",
+                        "ep": 1,
+                        "fn": "zcl:attr"
+                    },
+                    "parse": {
+                        "at": "0x0001",
+                        "cl": "0x0000",
+                        "ep": 1,
+                        "fn": "zcl:attr",
+                        "script": "tuya_swversion.js"
+                    }
+                },
+                {
+                    "name": "attr/type"
+                },
+                {
+                    "name": "attr/uniqueid"
+                },
+                {
+                    "name": "config/fadingtime",
+                    "range": [
+                        0,
+                        15000
+                    ],
+                    "read": {
+                        "fn": "none"
+                    },
+                    "write": {
+                        "dpid": 102,
+                        "dt": "0x2b",
+                        "eval": "Item.val;",
+                        "fn": "tuya"
+                    },
+                    "parse": {
+                        "dpid": 102,
+                        "eval": "Item.val = Attr.val;",
+                        "fn": "tuya"
+                    },
+                    "default": 90
+                },
+                {
+                    "name": "config/on"
+                },
+                {
+                    "name": "config/reachable"
+                },
+                {
+                    "name": "config/sensitivity",
+                    "range": [
+                        1,
+                        9
+                    ],
+                    "read": {
+                        "fn": "none"
+                    },
+                    "write": {
+                        "dpid": 2,
+                        "dt": "0x2b",
+                        "eval": "Item.val;",
+                        "fn": "tuya"
+                    },
+                    "parse": {
+                        "dpid": 2,
+                        "eval": "Item.val = Attr.val;",
+                        "fn": "tuya"
+                    },
+                    "default": 7
+                },
+                {
+                    "name": "config/triggerdistance",
+                    "description": "Far detection sensitivity",
+                    "read": {
+                        "fn": "none"
+                    },
+                    "write": {
+                        "dpid": 4,
+                        "dt": "0x2b",
+                        "eval": "Far = ['0','1','2','3','4','5','6','7','8','9','10']; Attr.val = Math.max(0,Far.indexOf(Item.val)*100);",
+                        "fn": "tuya"
+                    },
+                    "parse": {
+                        "dpid": 4,
+                        "eval": "Item.val = String(Attr.val/100);",
+                        "fn": "tuya"
+                    },
+                    "values": [
+                        [
+                            "\"1\"",
+                            "1m"
+                        ],
+                        [
+                            "\"2\"",
+                            "2m"
+                        ],
+                        [
+                            "\"3\"",
+                            "3m"
+                        ],
+                        [
+                            "\"4\"",
+                            "4m"
+                        ],
+                        [
+                            "\"5\"",
+                            "5m"
+                        ],
+                        [
+                            "\"6\"",
+                            "6m"
+                        ],
+                        [
+                            "\"7\"",
+                            "7m"
+                        ],
+                        [
+                            "\"8\"",
+                            "8m"
+                        ],
+                        [
+                            "\"9\"",
+                            "9m"
+                        ],
+                        [
+                            "\"10\"",
+                            "10m"
+                        ],
+                        [
+                            "\"0\"",
+                            "Off"
+                        ]
+                    ],
+                    "default": "10"
+                },
+                {
+                    "name": "state/targetdistance",
+                    "description": "Distance from detected target in cm (from 0 to 1000).",
+                    "read": {
+                        "fn": "none"
+                    },
+                    "parse": {
+                        "dpid": 9,
+                        "eval": "Item.val = Attr.val;",
+                        "fn": "tuya"
+                    },
+                    "default": 0
+                },
+                {
+                    "name": "state/errorcode",
+                    "description": "Self check result code. \n0 = checking, 1 = check_success, 2 = check_failure, 3 = others, 4 = comm_fault, 5 = radar_fault",
+                    "read": {
+                        "fn": "none"
+                    },
+                    "parse": {
+                        "dpid": 6,
+                        "eval": "Item.val = String(Attr.val);",
+                        "fn": "tuya"
+                    },
+                    "default": "Unknown"
+                },
+                {
+                    "name": "state/lastupdated"
+                },
+                {
+                    "name": "state/presence",
+                    "read": {
+                        "fn": "none"
+                    },
+                    "parse": {
+                        "dpid": 1,
+                        "eval": "Item.val = Attr.val;",
+                        "fn": "tuya"
+                    },
+                    "default": false
+                }
+            ]
+        }
+    ],
+    "bindings": [
+        {
+            "bind": "unicast",
+            "src.ep": 1,
+            "cl": "0xEF00"
+        }
+    ]
+}

--- a/devices/tuya/lux_to_lightlevel_50.js
+++ b/devices/tuya/lux_to_lightlevel_50.js
@@ -1,0 +1,14 @@
+const tholddark = R.item('config/tholddark').val;
+const tholdoffset = R.item('config/tholdoffset').val;
+const lux = Attr.val/50;
+var ll = 0;
+
+if (lux > 0 && lux < 0xffff) {
+    ll = Math.round(10000 * Math.log10(lux) + 1);
+}
+
+R.item('state/lightlevel').val = ll;
+R.item('state/dark').val = ll <= tholddark;
+R.item('state/daylight').val = ll >= tholddark + tholdoffset;
+
+Item.val = lux;


### PR DESCRIPTION
Product name : ZG-204ZM
Manufacturer : _TZE200_kb5noeto
Model identifier : TS0601
Device type to add : Sensor

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7836

This device is similar to https://github.com/dresden-elektronik/deconz-rest-plugin/blob/master/devices/tuya/ZY-M100_human_breathing_presence.json but have some difference, like a lux convertion, a battery support , ....