### PR TITLE
DDF for Woox water leak sensor R7050 (_TZ3000_arw23zcs)

### DIFF
--- a/devices/tuya/_TZ3000_TS0207_water_leak_sensor.json
+++ b/devices/tuya/_TZ3000_TS0207_water_leak_sensor.json
@@ -17,9 +17,11 @@
     "_TZ3000_upgcbody",
     "_TZ3000_k4ej3ww2",
     "_TZ3000_awvmkayh",
-    "_TZ3000_kstbkt6a"
+    "_TZ3000_kstbkt6a",
+    "_TZ3000_arw23zcs"
   ],
   "modelid": [
+    "TS0207",
     "TS0207",
     "TS0207",
     "TS0207",


### PR DESCRIPTION
Product name : Woox R7050
Manufacturer : _TZ3000_arw23zcs
Model identifier : TS0207


Just one more clone, see https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7872
