### PR TITLE
DDF for Legrand Contactor

### DIFF
--- a/devices/legrand/Contactor.json
+++ b/devices/legrand/Contactor.json
@@ -121,7 +121,7 @@
             "at": "0x0000",
             "cl": "0xFC01",
             "ep": "0x01",
-            "eval": "if (Attr.val == 4) { Item.val = 'auto'; }  else if (Attr.val == 3) { Item.val = 'manu'; }",
+            "eval": "if (Attr.val == 4) {Item.val = 'auto';} else if (Attr.val == 3) {Item.val = 'manu';}",
             "fn": "zcl:attr"
           },
           "write": {
@@ -129,7 +129,7 @@
             "cl": "0xFC01",
             "dt": "0x09",
             "ep": "0x01",
-            "eval": "if (Item.val == 'auto') { 4 } else if (Item.val == 'manu') { 3 };",
+            "eval": "if (Item.val == 'auto') {4} else if (Item.val == 'manu') {3};",
             "fn": "zcl:attr"
           }
         },

--- a/devices/legrand/Contactor.json
+++ b/devices/legrand/Contactor.json
@@ -1,0 +1,173 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "Legrand",
+  "modelid": "Contactor",
+  "product": "Contactor",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_ON_OFF_PLUGIN_UNIT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/on"
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_POWER_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0b04"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0001",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0B04"
+        ]
+      },
+      "meta": {
+        "values": {
+          "config/mode": {"auto": 4, "manu" : 3}
+        }
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "config/mode",
+          "refresh.interval": 86400,
+          "read": {
+            "at": "0x0000",
+            "cl": "0xFC01",
+            "ep": "0x01",
+            "fn": "zcl:attr"
+          },
+          "parse": {
+            "at": "0x0000",
+            "cl": "0xFC01",
+            "ep": "0x01",
+            "eval": "if (Attr.val == 4) { Item.val = 'auto'; }  else if (Attr.val == 3) { Item.val = 'manu'; }",
+            "fn": "zcl:attr"
+          },
+          "write": {
+            "at": "0x0000",
+            "cl": "0xFC01",
+            "dt": "0x09",
+            "ep": "0x01",
+            "eval": "if (Item.val == 'auto') { 4 } else if (Item.val == 'manu') { 3 };",
+            "fn": "zcl:attr"
+          }
+        },
+        {
+          "name": "state/power",
+          "refresh.interval": 800,
+          "default": 0
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0006",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 300
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0B04",
+      "report": [
+        {
+          "at": "0x050B",
+          "dt": "0x29",
+          "min": 5,
+          "max": 300,
+          "change": "0x00000002"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This device is already supported by legacy core, but miss a feature to enable/disable the "Auto" mode using the API.

Manufacture Name : Legrand
Model ID : Contactor

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/3040#issuecomment-2115759508