### PR TITLE
Make ResourceItemDescriptors index based

### DIFF
--- a/device_js/device_js_duktape.cpp
+++ b/device_js/device_js_duktape.cpp
@@ -1210,6 +1210,12 @@ JsEvalResult DeviceJs::testCompile(const QString &expr)
     d->errFatal = 0;
     d->isReset = false;
 
+    ResourceItemDescriptor rInvalidItemDescriptor;
+
+    if (!getResourceItemDescriptor(RInvalidSuffix, rInvalidItemDescriptor))
+    {
+        return result;
+    }
     ResourceItem dummyItem(rInvalidItemDescriptor);
     d->ritem = &dummyItem;
 

--- a/resource.cpp
+++ b/resource.cpp
@@ -364,17 +364,16 @@ const QStringList RConfigLastChangeSourceValues({
     "manual", "schedule", "zigbee"
 });
 
-static std::vector<const char*> rPrefixes;
 static std::vector<ResourceItemDescriptor> rItemDescriptors;
 static const QString rInvalidString; // is returned when string is asked but not available
-const ResourceItemDescriptor rInvalidItemDescriptor(DataTypeUnknown, QVariant::Invalid, RInvalidSuffix);
 
 R_Stats rStats;
 
 void initResourceDescriptors()
 {
-    rPrefixes.clear();
     rItemDescriptors.clear();
+
+    rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUnknown, QVariant::Invalid, RInvalidSuffix));
 
     // init resource lookup
     rItemDescriptors.emplace_back(ResourceItemDescriptor(DataTypeUInt32, QVariant::Double, RAttrAppVersion));
@@ -776,8 +775,9 @@ ResourceItem::ResourceItem(const ResourceItem &other)
 
 bool ResourceItem::setItemString(const QString &str)
 {
-    if (!(m_rid->type == DataTypeString ||
-          m_rid->type == DataTypeTimePattern))
+    const ResourceItemDescriptor *rid = &descriptor();
+    if (!(rid->type == DataTypeString ||
+          rid->type == DataTypeTimePattern))
     {
         return false;
     }
@@ -785,7 +785,7 @@ bool ResourceItem::setItemString(const QString &str)
     const auto utf8 = str.toUtf8();
 
     // for now keep all attr/* items also as atoms
-    if (utf8.size() <= int(m_istr.maxSize()) && m_rid->suffix[0] != 'a' && m_rid->suffix[1] != 't')
+    if (utf8.size() <= int(m_istr.maxSize()) && rid->suffix[0] != 'a' && rid->suffix[1] != 't')
     {
         m_istr.setString(utf8.constData());
         m_strHandle = STRING_CACHE_INVALID_HANDLE;
@@ -810,7 +810,8 @@ ResourceItem::~ResourceItem() noexcept
         delete m_str;
         m_str = nullptr;
     }
-    m_rid = &rInvalidItemDescriptor;
+
+    m_ridIndex = 0;
 }
 
 /*! Returns true when a value has been set but not pushed upstream. */
@@ -949,7 +950,7 @@ ResourceItem &ResourceItem::operator=(const ResourceItem &other)
     m_num = other.m_num;
     m_numPrev = other.m_numPrev;
     m_lastZclReport = other.m_lastZclReport;
-    m_rid = other.m_rid;
+    m_ridIndex = other.m_ridIndex;
     m_lastSet = other.m_lastSet;
     m_lastChanged = other.m_lastChanged;
     m_rulesInvolved = other.m_rulesInvolved;
@@ -992,7 +993,7 @@ ResourceItem &ResourceItem::operator=(ResourceItem &&other) noexcept
     m_num = other.m_num;
     m_numPrev = other.m_numPrev;
     m_lastZclReport = other.m_lastZclReport;
-    m_rid = other.m_rid;
+    m_ridIndex = other.m_ridIndex;
     m_lastSet = std::move(other.m_lastSet);
     m_lastChanged = std::move(other.m_lastChanged);
     m_rulesInvolved = std::move(other.m_rulesInvolved);
@@ -1003,7 +1004,7 @@ ResourceItem &ResourceItem::operator=(ResourceItem &&other) noexcept
     m_ddfItemHandle = other.m_ddfItemHandle;
     m_istr = other.m_istr;
     m_strHandle = other.m_strHandle;
-    other.m_rid = &rInvalidItemDescriptor;
+    other.m_ridIndex = 0;
 
     if (m_str)
     {
@@ -1021,12 +1022,22 @@ ResourceItem &ResourceItem::operator=(ResourceItem &&other) noexcept
 }
 
 /*! Initial main constructor to create a valid ResourceItem. */
-ResourceItem::ResourceItem(const ResourceItemDescriptor &rid) :
-    m_rid(&rid)
+ResourceItem::ResourceItem(const ResourceItemDescriptor &rid)
 {
-    if (m_rid->type == DataTypeString ||
-        m_rid->type == DataTypeTime ||
-        m_rid->type == DataTypeTimePattern)
+    m_ridIndex = 0;
+
+    for (size_t i = 0; i < rItemDescriptors.size(); i++)
+    {
+        if (rItemDescriptors[i].suffix == rid.suffix)
+        {
+            m_ridIndex = static_cast<uint16_t>(i);
+            break;
+        }
+    }
+
+    if (rid.type == DataTypeString ||
+        rid.type == DataTypeTime ||
+        rid.type == DataTypeTimePattern)
     {
         m_str = new QString;
     }
@@ -1039,15 +1050,17 @@ const QString &ResourceItem::toString() const
 {
     rStats.toString++;
 
-    if (m_rid->type == DataTypeString ||
-        m_rid->type == DataTypeTimePattern)
+    const ResourceItemDescriptor *rid = &descriptor();
+
+    if (rid->type == DataTypeString ||
+        rid->type == DataTypeTimePattern)
     {
         if (m_str)
         {
             return *m_str;
         }
     }
-    else if (m_rid->type == DataTypeTime)
+    else if (rid->type == DataTypeTime)
     {
         U_ASSERT(m_str);
         if (m_num > 0 && m_str)
@@ -1057,25 +1070,25 @@ const QString &ResourceItem::toString() const
             // default: local time in sec resolution
             QString format = QLatin1String("yyyy-MM-ddTHH:mm:ss");
 
-            if (m_rid->suffix == RStateLastUpdated || m_rid->suffix == RStateLastCheckin)
+            if (rid->suffix == RStateLastUpdated || rid->suffix == RStateLastCheckin)
             {
                 // UTC in msec resolution
                 format = QLatin1String("yyyy-MM-ddTHH:mm:ss.zzz"); // TODO add Z
                 dt.setOffsetFromUtc(0);
             }
-            else if (m_rid->suffix == RAttrLastAnnounced || m_rid->suffix == RStateLastSet || m_rid->suffix == RStateUtc || m_rid->suffix == RConfigLastChangeTime)
+            else if (rid->suffix == RAttrLastAnnounced || rid->suffix == RStateLastSet || rid->suffix == RStateUtc || rid->suffix == RConfigLastChangeTime)
             {
                 // UTC in sec resolution
                 format = QLatin1String("yyyy-MM-ddTHH:mm:ssZ");
                 dt.setOffsetFromUtc(0);
             }
-            else if (m_rid->suffix == RAttrLastSeen)
+            else if (rid->suffix == RAttrLastSeen)
             {
                 // UTC in min resolution
                 format = QLatin1String("yyyy-MM-ddTHH:mmZ");
                 dt.setOffsetFromUtc(0);
             }
-            else if (m_rid->suffix == RStateSunrise || m_rid->suffix == RStateSunset)
+            else if (rid->suffix == RStateSunrise || rid->suffix == RStateSunset)
             {
                 // UTC in sec resulution
                 format = QLatin1String("yyyy-MM-ddTHH:mm:ss"); // TODO add Z
@@ -1172,10 +1185,12 @@ bool ResourceItem::setValue(const QString &val, ValueSource source)
 
 bool ResourceItem::setValue(qint64 val, ValueSource source)
 {
-    if (m_rid->validMin != 0 || m_rid->validMax != 0)
+    const ResourceItemDescriptor *rid = &descriptor();
+
+    if (rid->validMin != 0 || rid->validMax != 0)
     {
         // range check
-        if (val < m_rid->validMin || val > m_rid->validMax)
+        if (val < rid->validMin || val > rid->validMax)
         {
             return false;
         }
@@ -1210,9 +1225,10 @@ bool ResourceItem::setValue(const QVariant &val, ValueSource source)
     const auto now = QDateTime::currentDateTime();
     m_valueSource = source;
 
+    const ResourceItemDescriptor *rid = &descriptor();
 
-    if (m_rid->type == DataTypeString ||
-        m_rid->type == DataTypeTimePattern)
+    if (rid->type == DataTypeString ||
+        rid->type == DataTypeTimePattern)
     {
         // TODO validate time pattern
         if (m_str)
@@ -1231,7 +1247,7 @@ bool ResourceItem::setValue(const QVariant &val, ValueSource source)
             return true;
         }
     }
-    else if (m_rid->type == DataTypeBool)
+    else if (rid->type == DataTypeBool)
     {
         m_lastSet = now;
         m_numPrev = m_num;
@@ -1246,7 +1262,7 @@ bool ResourceItem::setValue(const QVariant &val, ValueSource source)
         }
         return true;
     }
-    else if (m_rid->type == DataTypeTime)
+    else if (rid->type == DataTypeTime)
     {
         if (val.type() == QVariant::String)
         {
@@ -1288,7 +1304,7 @@ bool ResourceItem::setValue(const QVariant &val, ValueSource source)
             return true;
         }
     }
-    else if (m_rid->type == DataTypeReal)
+    else if (rid->type == DataTypeReal)
     {
         bool ok = false;
         double d = val.toDouble(&ok);
@@ -1316,9 +1332,9 @@ bool ResourceItem::setValue(const QVariant &val, ValueSource source)
 
         if (ok)
         {
-            if (m_rid->validMin == 0 && m_rid->validMax == 0)
+            if (rid->validMin == 0 && rid->validMax == 0)
             { /* no range check */ }
-            else if (n >= m_rid->validMin && n <= m_rid->validMax)
+            else if (n >= rid->validMin && n <= rid->validMax)
             {   /* range check: ok*/ }
             else {
                 m_valueSource = SourceUnknown;
@@ -1409,8 +1425,13 @@ bool ResourceItem::equalsString(const char *str, int length) const
 
 const ResourceItemDescriptor &ResourceItem::descriptor() const
 {
-    Q_ASSERT(m_rid);
-    return *m_rid;
+    U_ASSERT(m_ridIndex < rItemDescriptors.size());
+    if (rItemDescriptors.size() <= m_ridIndex)
+    {
+        // invalid descriptor, note if this triggers there is likely a bug lurking somewhere
+        return rItemDescriptors[0];
+    }
+    return rItemDescriptors[m_ridIndex];
 }
 
 const QDateTime &ResourceItem::lastSet() const
@@ -1436,8 +1457,10 @@ QVariant ResourceItem::toVariant() const
         return QVariant();
     }
 
-    if (m_rid->type == DataTypeString ||
-        m_rid->type == DataTypeTimePattern)
+    const ResourceItemDescriptor *rid = &descriptor();
+
+    if (rid->type == DataTypeString ||
+        rid->type == DataTypeTimePattern)
     {
         if (m_str)
         {
@@ -1445,15 +1468,15 @@ QVariant ResourceItem::toVariant() const
         }
         return QString();
     }
-    else if (m_rid->type == DataTypeBool)
+    else if (rid->type == DataTypeBool)
     {
         return (bool)m_num;
     }
-    else if (m_rid->type == DataTypeTime)
+    else if (rid->type == DataTypeTime)
     {
         return toString();
     }
-    else if (m_rid->type == DataTypeReal)
+    else if (rid->type == DataTypeReal)
     {
         return (double)m_double;
     }

--- a/resource.h
+++ b/resource.h
@@ -433,8 +433,6 @@ class ResourceItem;
 
 using ItemString = BufString<16>;
 
-extern const ResourceItemDescriptor rInvalidItemDescriptor;
-
 class ResourceItem
 {
 public:
@@ -536,6 +534,7 @@ private:
     ValueSource m_valueSource = SourceUnknown;
     bool m_isPublic = true;
     uint16_t m_flags = 0; // bitmap of ResourceItem::ItemFlags
+    uint16_t m_ridIndex = 0; // index into rItemDescriptors[]
     union
     {
         struct {
@@ -553,7 +552,6 @@ private:
     ItemString m_istr; // internal embedded small string
     deCONZ::TimeSeconds m_refreshInterval;
     QString *m_str = nullptr;
-    const ResourceItemDescriptor *m_rid = &rInvalidItemDescriptor;
     QDateTime m_lastSet;
     QDateTime m_lastChanged;
     std::vector<int> m_rulesInvolved; // the rules a resource item is trigger


### PR DESCRIPTION
The underlying std::vector<> can invalidate pointers into it when it gets resized  due dynamically added JSON items.

This has shown to cause SEGV.

By using indices instead of pointers we always get valid data.