### PR TITLE
DDF for Tuya water leak clone (_TZ3000_wuep9zng)

### DIFF
--- a/devices/tuya/_TZ3000_TS0207_water_leak_sensor.json
+++ b/devices/tuya/_TZ3000_TS0207_water_leak_sensor.json
@@ -17,9 +17,11 @@
     "_TZ3000_upgcbody",
     "_TZ3000_k4ej3ww2",
     "_TZ3000_awvmkayh",
-    "_TZ3000_kstbkt6a"
+    "_TZ3000_kstbkt6a",
+    "_TZ3000_wuep9zng"
   ],
   "modelid": [
+    "TS0207",
     "TS0207",
     "TS0207",
     "TS0207",


### PR DESCRIPTION
Product name : Water Leak Sensor ZW06
Manufacturer : _TZ3000_wuep9zng
Model identifier : TS0207

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7805