### PR TITLE
DDF clone for Tuya temperature and humidity sensor (_TZ3000_bjawzodf)

### DIFF
--- a/devices/tuya/_TZ3000_TS0201_temp_hum_sensor.json
+++ b/devices/tuya/_TZ3000_TS0201_temp_hum_sensor.json
@@ -2,7 +2,7 @@
   "schema": "devcap1.schema.json",
   "uuid": "d20fd95e-3343-4898-adc3-59111f4812af",
   "manufacturername": ["_TZ3000_yd2e749y", "_TZ3000_fllyghyj", "_TZ3000_fie1dpkm", "_TZ3000_lbtpiody", "_TZ3000_5nrcorgu", "_TZ3000_ena8vgqb", "_TZ3000_xr3htd96", "_TZ3000_0s1izerx", "_TZ3000_saiqcn0y", "_TZ3000_bjawzodf"],
-  "modelid": ["TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201"],
+  "modelid": ["TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TY0201"],
   "vendor": "Tuya",
   "product": "Temperature and humidity sensor (TS0201)",
   "sleeper": true,

--- a/devices/tuya/_TZ3000_TS0201_temp_hum_sensor.json
+++ b/devices/tuya/_TZ3000_TS0201_temp_hum_sensor.json
@@ -1,8 +1,8 @@
 {
   "schema": "devcap1.schema.json",
   "uuid": "d20fd95e-3343-4898-adc3-59111f4812af",
-  "manufacturername": ["_TZ3000_yd2e749y", "_TZ3000_fllyghyj", "_TZ3000_fie1dpkm", "_TZ3000_lbtpiody", "_TZ3000_5nrcorgu", "_TZ3000_ena8vgqb", "_TZ3000_xr3htd96", "_TZ3000_0s1izerx", "_TZ3000_saiqcn0y"],
-  "modelid": ["TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201"],
+  "manufacturername": ["_TZ3000_yd2e749y", "_TZ3000_fllyghyj", "_TZ3000_fie1dpkm", "_TZ3000_lbtpiody", "_TZ3000_5nrcorgu", "_TZ3000_ena8vgqb", "_TZ3000_xr3htd96", "_TZ3000_0s1izerx", "_TZ3000_saiqcn0y", "_TZ3000_bjawzodf"],
+  "modelid": ["TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201"],
   "vendor": "Tuya",
   "product": "Temperature and humidity sensor (TS0201)",
   "sleeper": true,


### PR DESCRIPTION
Product name : Tuya Smart Zigbee Temp and Humidity Sensor
Manufacturer : _TZ3000_bjawzodf
Model identifier : TS0201

see https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7884