### PR TITLE
Don't show non-public items in `lights` resources

### DIFF
--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -262,6 +262,10 @@ bool DeRestPluginPrivate::lightToMap(const ApiRequest &req, const LightNode *lig
     {
         const ResourceItem *item = lightNode->itemForIndex(static_cast<size_t>(i));
         DBG_Assert(item);
+        if (!item->isPublic())
+        {
+            continue;
+        }
         const ResourceItemDescriptor &rid = item->descriptor();
 
         if      (rid.suffix == RAttrConfigId) { attr["configid"] = item->toNumber(); }


### PR DESCRIPTION
Suppress non-public items from being displayed in a `lights` resource.  Needed for #7653.

This has been a long-standing omission on my side, refactoring `lightToMap()`.