### PR TITLE
DDF update for xiaomi_zncz04lm_smart_plug to add temperature sensor

### DIFF
--- a/devices/xiaomi/xiaomi_zncz04lm_smart_plug.json
+++ b/devices/xiaomi/xiaomi_zncz04lm_smart_plug.json
@@ -260,6 +260,74 @@
           "name": "state/lastupdated"
         }
       ]
+    },
+    {
+      "type": "$TYPE_TEMPERATURE_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0402"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/offset",
+          "description": "Relative offset to the main measured value.",
+          "default": 0
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/temperature",
+          "refresh.interval": 60,
+          "read": {
+            "at": "0x0000",
+            "cl": "0x0002",
+            "fn": "zcl:attr"
+          },
+          "parse": {
+            "at": "0x0000",
+            "cl": "0x0002",
+            "eval": "Item.val = (Attr.val * 100) + R.item('config/offset').val",
+            "fn": "zcl:attr"
+          },
+          "default": 0
+        }
+      ]
     }
   ],
   "bindings": [


### PR DESCRIPTION
I've added a TYPE_TEMPERATURE_SENSOR to xiaomi_zncz04lm_smart_plug. The value is published here "at":"0x0000", "cl": "0x0002", "fn": "zcl:attr". In the parsing, it is very important to multiply the Attr.val by 100.