### PR TITLE
DDF Editor add File -> Close menu entry

### DIFF
--- a/ui/device_widget.cpp
+++ b/ui/device_widget.cpp
@@ -67,6 +67,10 @@ DDF_EditorDialog::DDF_EditorDialog(DeviceWidget *parent) :
     hotReload->setShortcut(tr("Ctrl+R"));
     connect(hotReload, &QAction::triggered, parent, &DeviceWidget::hotReload);
 
+    QAction *close = fileMenu->addAction(tr("&Close"));
+    close->setShortcut(QKeySequence::Close);
+    connect(close, &QAction::triggered, this, &QMainWindow::close);
+
     QMenu *helpMenu = menuBar()->addMenu(tr("&Help"));
     QAction *docAction = helpMenu->addAction(tr("DDF documentation"));
     connect(docAction, &QAction::triggered, [](){


### PR DESCRIPTION
There is an ongoing issue that the DDF Editor can't be closed due the window title bar is out of screen.

This PR adds the File -> Close action as menu entry with Shortcut Ctrl-W as an workaround.

Forum: https://forum.phoscon.de/t/new-deconz-gui-windows-control-dwm-issues/5097

![image](https://github.com/user-attachments/assets/982a104c-96b3-4903-83f4-1e7732dfd703)
