### PR TITLE
Fix Aqara Dual Relay Module T2 (DCM-K01) consumption values

### DIFF
--- a/devices/xiaomi/xiaomi_dcm-k01_t2_dual_relay.json
+++ b/devices/xiaomi/xiaomi_dcm-k01_t2_dual_relay.json
@@ -304,7 +304,7 @@
           "parse": {
             "at": "0x00F7",
             "ep": "0x01",
-            "eval": "Item.val = Math.round(Attr.val * 1000);",
+            "eval": "Item.val = Math.round(Attr.val);",
             "fn": "xiaomi:special",
             "idx": "0x95",
             "mf": "0x115F"


### PR DESCRIPTION
Apparently, the consumption values are 1000 times too high, so the device already sends Wh.