### PR TITLE
DDF clone for the Livarno covering (_TZB000_yqjaollc)

### DIFF
--- a/devices/tuya/_TZB000_42ha4rsc_window_blinds.json
+++ b/devices/tuya/_TZB000_42ha4rsc_window_blinds.json
@@ -1,8 +1,7 @@
 {
   "schema": "devcap1.schema.json",
-  "uuid": "165aea49-d5c1-4418-a479-cdad4dfe1600",
-  "manufacturername": "_TZB000_42ha4rsc",
-  "modelid": "TS030F",
+  "manufacturername": ["_TZB000_42ha4rsc", "_TZB000_yqjaollc"],
+  "modelid": ["TS030F", "TS030F"],
   "vendor": "Livarno",
   "product": "Window blinds (TS030F)",
   "sleeper": true,

--- a/devices/tuya/_TZB000_42ha4rsc_window_blinds.json
+++ b/devices/tuya/_TZB000_42ha4rsc_window_blinds.json
@@ -1,5 +1,6 @@
 {
   "schema": "devcap1.schema.json",
+  "uuid": "165aea49-d5c1-4418-a479-cdad4dfe1600",
   "manufacturername": ["_TZB000_42ha4rsc", "_TZB000_yqjaollc"],
   "modelid": ["TS030F", "TS030F"],
   "vendor": "Livarno",


### PR DESCRIPTION
Product name : LIVARNO home Automatik-Verdunkelungsrollo, »Zigbee Smart Home«
Manufacturer : _TZB000_yqjaollc
Model identifier : TS030F

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7912