### PR TITLE
Additional special effects for Hue lights

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -3253,7 +3253,7 @@ void DeRestPluginPrivate::setLightNodeStaticCapabilities(LightNode *lightNode)
         lightNode->removeItem(RStateY);
         lightNode->addItem(DataTypeUInt16, RStateHue);
         lightNode->addItem(DataTypeUInt8, RStateSat);
-        lightNode->addItem(DataTypeString, RStateEffect)->setValue(RStateEffectValues[R_EFFECT_NONE]);
+        lightNode->addItem(DataTypeString, RStateEffect)->setValue(QVariant("none"));
     }
 }
 

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1430,7 +1430,7 @@ public:
     bool addTaskSimpleMeteringReadWriteAttribute(TaskItem &task, uint8_t readOrWriteCmd, uint16_t attrId, uint8_t attrType, uint32_t attrValue, uint16_t mfrCode=0);
 
     // Advanced features of Hue lights.
-    QStringList getHueEffectNames(quint64 effectBitmap);
+    QStringList getHueEffectNames(quint64 effectBitmap, bool colorloop);
     QStringList getHueGradientStyleNames(quint16 styleBitmap);
     bool addTaskHueEffect(TaskItem &task, QString &effect);
     bool validateHueGradient(const ApiRequest &req, ApiResponse &rsp, QVariantMap &gradient, quint16 styleBitmap);

--- a/devices/philips/fc03_state.js
+++ b/devices/philips/fc03_state.js
@@ -63,6 +63,9 @@ if (attrid === 0x0002) {
           case 0x800C:
             R.item('state/effect').val = 'glisten'
             break
+          case 0x800D:
+            R.item('state/effect').val = 'sunset'
+            break
           default:
             R.item('state/effect').val = '0x' + effect.toString(16)
             break

--- a/devices/philips/light_zb3_C.json
+++ b/devices/philips/light_zb3_C.json
@@ -367,28 +367,6 @@
         },
         {
           "name": "state/effect",
-          "values": [
-            [
-              "\"none\"",
-              "no effect is active"
-            ],
-            [
-              "\"colorloop\"",
-              "colorloop through hue values"
-            ],
-            [
-              "\"candle\"",
-              "candlelight dynamic effect"
-            ],
-            [
-              "\"fireplace\"",
-              "fireplace dynamic effect"
-            ],
-            [
-              "\"prism\"",
-              "prism dynamic effect"
-            ]
-          ],
           "parse": {
             "fn": "zcl:attr",
             "ep": "0x0b",

--- a/devices/philips/light_zb3_C_festavia.json
+++ b/devices/philips/light_zb3_C_festavia.json
@@ -289,44 +289,6 @@
         },
         {
           "name": "state/effect",
-          "values": [
-            [
-              "\"none\"",
-              "no effect is active"
-            ],
-            [
-              "\"colorloop\"",
-              "colorloop through hue values"
-            ],
-            [
-              "\"candle\"",
-              "candlelight dynamic effect"
-            ],
-            [
-              "\"fireplace\"",
-              "fireplace dynamic effect"
-            ],
-            [
-              "\"prism\"",
-              "prism dynamic effect"
-            ],
-            [
-              "\"sunrise\"",
-              "sunrise dynamic effect"
-            ],
-            [
-              "\"sparkle\"",
-              "sparkle dynamic effect"
-            ],
-            [
-              "\"opal\"",
-              "opal dynamic effect"
-            ],
-            [
-              "\"glisten\"",
-              "glisten dynamic effect"
-            ]
-          ],
           "parse": {
             "fn": "zcl:attr",
             "ep": "0x0b",

--- a/devices/philips/light_zb3_C_gradient.json
+++ b/devices/philips/light_zb3_C_gradient.json
@@ -361,32 +361,6 @@
         },
         {
           "name": "state/effect",
-          "values": [
-            [
-              "\"none\"",
-              "no effect is active"
-            ],
-            [
-              "\"colorloop\"",
-              "colorloop through hue values"
-            ],
-            [
-              "\"candle\"",
-              "candlelight dynamic effect"
-            ],
-            [
-              "\"fireplace\"",
-              "fireplace dynamic effect"
-            ],
-            [
-              "\"prism\"",
-              "prism dynamic effect"
-            ],
-            [
-              "\"sunrise\"",
-              "sunrise dynamic effect"
-            ]
-          ],
           "parse": {
             "fn": "zcl:attr",
             "ep": "0x0b",

--- a/devices/philips/light_zb3_white.json
+++ b/devices/philips/light_zb3_white.json
@@ -122,6 +122,9 @@
           "name": "cap/bri/move_with_onoff"
         },
         {
+          "name": "cap/color/effects"
+        },
+        {
           "name": "cap/on/off_with_effect"
         },
         {
@@ -163,16 +166,6 @@
         },
         {
           "name": "state/effect",
-          "values": [
-            [
-              "\"none\"",
-              "no effect is active"
-            ],
-            [
-              "\"candle\"",
-              "candlelight dynamic effect"
-            ]
-          ],
           "read": {
             "fn": "none"
           }

--- a/devices/philips/light_zb3_white_ambiance.json
+++ b/devices/philips/light_zb3_white_ambiance.json
@@ -155,6 +155,9 @@
           "name": "cap/color/ct/min"
         },
         {
+          "name": "cap/color/effects"
+        },
+        {
           "name": "cap/on/off_with_effect"
         },
         {
@@ -246,16 +249,6 @@
         },
         {
           "name": "state/effect",
-          "values": [
-            [
-              "\"none\"",
-              "no effect is active"
-            ],
-            [
-              "\"candle\"",
-              "candlelight dynamic effect"
-            ]
-          ],
           "read": {
             "fn": "none"
           }

--- a/devices/philips/light_zll_C.json
+++ b/devices/philips/light_zll_C.json
@@ -245,28 +245,6 @@
         },
         {
           "name": "state/effect",
-          "values": [
-            [
-              "\"none\"",
-              "no effect is active"
-            ],
-            [
-              "\"colorloop\"",
-              "colorloop through hue values"
-            ],
-            [
-              "\"candle\"",
-              "candlelight dynamic effect"
-            ],
-            [
-              "\"fireplace\"",
-              "fireplace dynamic effect"
-            ],
-            [
-              "\"prism\"",
-              "prism dynamic effect"
-            ]
-          ],
           "parse": {
             "fn": "zcl:attr",
             "ep": "0x0b",

--- a/devices/philips/light_zll_white_ambiance.json
+++ b/devices/philips/light_zll_white_ambiance.json
@@ -111,6 +111,9 @@
           "name": "cap/color/ct/min"
         },
         {
+          "name": "cap/color/effects"
+        },
+        {
           "name": "cap/on/off_with_effect"
         },
         {
@@ -180,16 +183,6 @@
         },
         {
           "name": "state/effect",
-          "values": [
-            [
-              "\"none\"",
-              "no effect is active"
-            ],
-            [
-              "\"candle\"",
-              "candlelight dynamic effect"
-            ]
-          ],
           "parse": {
             "fn": "zcl:attr",
             "ep": "0x0b",

--- a/general.xml
+++ b/general.xml
@@ -2970,8 +2970,6 @@ Note: It does not clear or delete previous weekly schedule programming configura
           <attribute id="0x0002" name="Remaining Time" type="u16" access="r" range="0x0000,0xfffe" default="0x0000" required="o"></attribute>
           <attribute id="0x0003" name="Current X" type="u16" access="r" range="0x0000,0xfeff" default="0x61eb" required="m"></attribute>
           <attribute id="0x0004" name="Current Y" type="u16" access="r" range="0x0000,0xfeff" default="0x607b" required="m"></attribute>
-          <attribute id="0x0003" mfcode="0x100b" name="Hue StartUp Current X" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
-          <attribute id="0x0004" mfcode="0x100b" name="Hue StartUp Current Y" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
           <!-- Haven't yet seen any lights supporting these
           <attribute id="0x0005" name="Drift Compensation" type="enum8" access="r" required="o">
             <value name="None" value="0x00"></value>
@@ -3014,6 +3012,8 @@ Note: It does not clear or delete previous weekly schedule programming configura
           <attribute id="0x400c" name="Color Temperature Max Mireds" type="u16" access="r" range="0x0000,0xfeff" default="0xfeff" required="m"></attribute>
           <attribute id="0x400d" name="Couple Color Temp To Min Mireds" type="u16" access="r" range="0x0000,0xfeff" required="m"></attribute>
           <attribute id="0x4010" name="StartUp Color Temperature Mireds" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
+          <attribute id="0x0003" mfcode="0x100b" name="Hue StartUp Current X" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
+          <attribute id="0x0004" mfcode="0x100b" name="Hue StartUp Current Y" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
         </attribute-set>
         <attribute-set id="0x0010" description="Defined Primaries Information">
           <attribute id="0x0010" name="Number of Primaries" type="u8" access="r" range="0x00,0x06" required="o"></attribute>

--- a/general.xml
+++ b/general.xml
@@ -2970,10 +2970,8 @@ Note: It does not clear or delete previous weekly schedule programming configura
           <attribute id="0x0002" name="Remaining Time" type="u16" access="r" range="0x0000,0xfffe" default="0x0000" required="o"></attribute>
           <attribute id="0x0003" name="Current X" type="u16" access="r" range="0x0000,0xfeff" default="0x61eb" required="m"></attribute>
           <attribute id="0x0004" name="Current Y" type="u16" access="r" range="0x0000,0xfeff" default="0x607b" required="m"></attribute>
-          <!--
           <attribute id="0x0003" mfcode="0x100b" name="Hue StartUp Current X" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
           <attribute id="0x0004" mfcode="0x100b" name="Hue StartUp Current Y" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
-          -->
           <!-- Haven't yet seen any lights supporting these
           <attribute id="0x0005" name="Drift Compensation" type="enum8" access="r" required="o">
             <value name="None" value="0x00"></value>

--- a/general.xml
+++ b/general.xml
@@ -5143,9 +5143,12 @@ These devices can operate on either battery or mains power, and can have a wide 
               <value name="None" value="0x00"/>
               <value name="Candle" value="0x01"/>
               <value name="Fireplace" value="0x02"/>
-              <value name="Loop" value="0x03"/>
+              <value name="Prism" value="0x03"/>
               <value name="Sunrise" value="0x09"/>
               <value name="Sparkle" value="0x0a"/>
+              <value name="Opal" value="0x0b"/>
+              <value name="Glisten" value="0x0c"/>
+              <value name="Sunset" value="0x0d"/>
             </attribute>
           </payload>
         </command>
@@ -5162,9 +5165,12 @@ These devices can operate on either battery or mains power, and can have a wide 
         <attribute id="0x0011" name="Effects" type="bmp64" mfcode="0x100b" access="r" required="o">
           <value name="Candle" value="0x01"/>
           <value name="Fireplace" value="0x02"/>
-          <value name="Loop" value="0x03"/>
+          <value name="Prism" value="0x03"/>
           <value name="Sunrise" value="0x09"/>
           <value name="Sparkle" value="0x0a"/>
+          <value name="Opal" value="0x0b"/>
+          <value name="Glisten" value="0x0c"/>
+          <value name="Sunset" value="0x0d"/>
         </attribute>
         <attribute id="0x0012" name="Gradient Unknown 12" type="bmp32" mfcode="0x100b" access="r" required="o">
           <value name="Unknown 00" value="0x00"/>

--- a/hue.cpp
+++ b/hue.cpp
@@ -21,7 +21,7 @@ code effects[] = {
     { 0x09, QLatin1String("sunrise") },
     { 0x0a, QLatin1String("sparkle") },
     { 0x0b, QLatin1String("opal") },
-    { 0x0c, QLatin1String("glisten") }
+    { 0x0c, QLatin1String("glisten") },
     { 0x0d, QLatin1String("sunset") }
 };
 

--- a/hue.cpp
+++ b/hue.cpp
@@ -122,12 +122,14 @@ bool DeRestPluginPrivate::addTaskHueEffect(TaskItem &task, QString &effectName)
         QDataStream stream(&task.zclFrame.payload(), QIODevice::WriteOnly);
         stream.setByteOrder(QDataStream::LittleEndian);
 
-        if (effectName == "none") {
-            stream << (quint16) 0x0020; // clear effect
-            stream << (quint8) 0; // off
-        } else {
-            stream << (quint16) 0x0021; // set effect (with on/off)
-            stream << (quint8) 1; // on
+        stream << (quint16) 0x0021; // set effect (with on/off)
+        stream << (quint8) 1; // on
+        if (effectName == "none")
+        {
+            stream << (quint8) 0; // none
+        }
+        else
+        {
             stream << effectNameToValue(effectName);
         }
     }

--- a/hue.cpp
+++ b/hue.cpp
@@ -22,6 +22,7 @@ code effects[] = {
     { 0x0a, QLatin1String("sparkle") },
     { 0x0b, QLatin1String("opal") },
     { 0x0c, QLatin1String("glisten") }
+    { 0x0d, QLatin1String("sunset") }
 };
 
 quint8 effectNameToValue(QString &effectName)

--- a/hue.cpp
+++ b/hue.cpp
@@ -42,11 +42,13 @@ quint8 effectNameToValue(QString &effectName)
    \param effectBitmap - the bitmap with supported effects (from 0x0011)
    \return QStringList of effect names
  */
-QStringList DeRestPluginPrivate::getHueEffectNames(quint64 effectBitmap)
+QStringList DeRestPluginPrivate::getHueEffectNames(quint64 effectBitmap, bool colorloop)
 {
-    QStringList names = {
-        "none", "colorloop"
-    };
+    QStringList names = { QLatin1String("none") };
+    if (colorloop)
+    {
+        names.append(QLatin1String("colorloop"));
+    }
     for (auto &e: effects) {
         if (effectBitmap & (0x01 << e.value))
         {

--- a/light_node.cpp
+++ b/light_node.cpp
@@ -431,7 +431,7 @@ void LightNode::setHaEndpoint(const deCONZ::SimpleDescriptor &endpoint)
                             }
                             else
                             {
-                                addItem(DataTypeString, RStateEffect)->setValue(RStateEffectValues[R_EFFECT_NONE]);
+                                addItem(DataTypeString, RStateEffect)->setValue(QVariant("none"));
                                 addItem(DataTypeUInt16, RStateHue);
                                 addItem(DataTypeUInt8, RStateSat);
                             }

--- a/resource.h
+++ b/resource.h
@@ -379,8 +379,6 @@ extern const QStringList RStateAlertValues;
 extern const QStringList RStateAlertValuesTriggerEffect;
 
 extern const QStringList RStateEffectValues;
-#define R_EFFECT_NONE               0
-#define R_EFFECT_COLORLOOP          1
 extern const QStringList RStateEffectValuesMueller;
 extern const QStringList RStateEffectValuesXmasLightStrip;
 

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -400,7 +400,7 @@ bool DeRestPluginPrivate::lightToMap(const ApiRequest &req, const LightNode *lig
                 capabilitiesColor["effects"] = RStateEffectValues;
             }
         }
-        else if (iccs && lightNode->manufacturerCode() == VENDOR_PHILIPS) // no colorloop, but Hue special effects
+        else if (icce && lightNode->manufacturerCode() == VENDOR_PHILIPS) // no colorloop, but Hue special effects
         {
             colorModes.push_back(QLatin1String("effect"));
             capabilitiesColor["effects"] = getHueEffectNames(icce->toNumber(), false);
@@ -753,7 +753,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
     if (taskRef.lightNode->item(RCapColorEffects))
     {
         ResourceItem *icc = taskRef.lightNode->item(RCapColorCapabilities);
-        int cc = icc ? 0 ? icc->toNumber();
+        int cc = icc ? 0 : icc->toNumber();
         bool colorloop = (cc & 0x04) != 0;
         effectList = getHueEffectNames(taskRef.lightNode->item(RCapColorEffects)->toNumber(), colorloop);
     }
@@ -1463,7 +1463,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         }
         else if (taskRef.lightNode->manufacturerCode() == VENDOR_MUELLER)
         {
-            const quint64 value = effect - 1;
+            const quint64 value = effectList.indexOf(effect) - 1;
             deCONZ::ZclAttribute attr(0x4005, deCONZ::Zcl8BitUint, "scene", deCONZ::ZclReadWrite, true);
             attr.setValue(value);
             ok = writeAttribute(taskRef.lightNode, taskRef.lightNode->haEndpoint().endpoint(), BASIC_CLUSTER_ID, attr, VENDOR_MUELLER);

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -750,10 +750,10 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
 
     const QStringList *alertList = &RStateAlertValuesTriggerEffect; // TODO: check RCapAlertTriggerEffect
     QStringList effectList = RStateEffectValues;
-    bool colorloop;
+    bool colorloop = false;
     {
         ResourceItem *icc = taskRef.lightNode->item(RCapColorCapabilities);
-        int cc = icc ? 0 : icc->toNumber();
+        int cc = icc ? icc->toNumber() : 0;
         colorloop = (cc & 0x04) != 0;
     }
     if (taskRef.lightNode->item(RCapColorEffects) && taskRef.lightNode->manufacturerCode() == VENDOR_PHILIPS)
@@ -1229,19 +1229,17 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
         }
         else 
         {
-            bool ok = true;
-            
             if (colorloop)
             {
                 ok = addTaskSetColorLoop(task, false, colorloopSpeed);
             }
-            if (ok && taskRef.lightNode->item(RCapColorEffects)  && taskRef.lightNode->manufacturerCode() == VENDOR_PHILIPS)
+            if (ok && taskRef.lightNode->item(RCapColorEffects) && taskRef.lightNode->manufacturerCode() == VENDOR_PHILIPS)
             {
                 ok = addTaskHueEffect(taskRef, effect);
             }
             else if (ok && taskRef.lightNode->manufacturerCode() == VENDOR_MUELLER)
             {
-                quint64 value = 0;
+                const quint64 value = 0;
                 deCONZ::ZclAttribute attr(0x4005, deCONZ::Zcl8BitUint, "scene", deCONZ::ZclReadWrite, true);
                 attr.setValue(value);
                 ok = writeAttribute(taskRef.lightNode, taskRef.lightNode->haEndpoint().endpoint(), BASIC_CLUSTER_ID, attr, VENDOR_MUELLER);
@@ -1470,7 +1468,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
             rsp.list.append(errorToMap(ERR_INTERNAL_ERROR, QString("/lights/%1/state/effect").arg(id), QString("Internal error, %1").arg(ERR_BRIDGE_BUSY)));
         }
     }
-    else if (effect > 0)
+    else if (effect != "none")
     {
         if (!isOn && !taskRef.lightNode->toBool(RConfigColorExecuteIfOff))
         {
@@ -4056,7 +4054,7 @@ void DeRestPluginPrivate::handleLightEvent(const Event &e)
                     item->clearNeedPush();
                 }
             }
-// @@@
+            
             if (icc) // colormode
             {
                 if (gwWebSocketNotifyAll || icc->needPushChange())

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -1468,7 +1468,7 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
             rsp.list.append(errorToMap(ERR_INTERNAL_ERROR, QString("/lights/%1/state/effect").arg(id), QString("Internal error, %1").arg(ERR_BRIDGE_BUSY)));
         }
     }
-    else if (effect != "none")
+    else if (effect != nullptr && effect != "none")
     {
         if (!isOn && !taskRef.lightNode->toBool(RConfigColorExecuteIfOff))
         {

--- a/xmas.cpp
+++ b/xmas.cpp
@@ -33,6 +33,7 @@ const QStringList RStateEffectValuesXmasLightStrip({
     "updown", "vintage", "fading", "collide",
     "strobe", "sparkles", "carnival", "glow"
 });
+#define R_EFFECT_NONE               0
 
 static void initTask(TaskItem &task, quint8 seq)
 {


### PR DESCRIPTION
With the 1.116.3 / 67.116.3 firmware upgrade from May 2024, most Hue lights get additional special effects (see https://www.philips-hue.com/en-us/support/release-notes/lamps).  There's also a new (undocumented) "sunset" effect, which basically is the reverse of the "sunrise" effect.

Most of these changes should be reflected by the API automatically when, the attributes from the _Hue Effects_ cluster are re-read after the firmware update.

This PR adds support for the new "sunset" effect.  It also brings the GUI up to date with the API ("opal" and "glisten" were missing and "prism" was still called "loop").  It enables the Hue-specific _Startup Current X_ and _Startup Current Y_ attributes, now that the GUI bug handling attributes with the same ID but different manufacturer codes has been fixed.
Finally, it removes the `values` for `state/effect` from the DDFs for the Hue lights, as these are exposed through `capabilities/color/effects`, and as they depend on the firmware revision.

While changing the C++ code, I also fixed the handling of special effects for (white and/or white ambiance) lights that don't support `colorloop`, see #7451. 