### PR TITLE
DDF clone for eWeLink SNZB-02P temperature and humidity sensor

### DIFF
--- a/devices/sonoff/snzb-02-multisensor.json
+++ b/devices/sonoff/snzb-02-multisensor.json
@@ -1,8 +1,8 @@
 {
   "schema": "devcap1.schema.json",
   "uuid": "52815a37-6180-4ab8-83ef-021d75496a7b",
-  "manufacturername": ["eWeLink","SONOFF","SONOFF"],
-  "modelid": ["TH01","SNZB-02D","SNZB-02P"],
+  "manufacturername": ["eWeLink","SONOFF","SONOFF","eWeLink"],
+  "modelid": ["TH01","SNZB-02D","SNZB-02P","SNZB-02P"],
   "vendor": "Sonoff",
   "product": "Temperature And Humidity Sensor (SNZB-02)",
   "sleeper": true,


### PR DESCRIPTION
I came across an eWeLink branded model with model number SNZB-02P in a batch of Sonoff branded sensors - this was not catered for in the DDF and was not recognized when added. This DDF fixes it to include the (peculiar) combination of brand and model number.