### PR TITLE
DDF for Bosch RADION TriTech ZB Wireless Motion Detector RFDL-ZB-MS

### DIFF
--- a/devices/bosch/bosch_battery.js
+++ b/devices/bosch/bosch_battery.js
@@ -1,0 +1,13 @@
+const vmin = 26;
+const vmax = 30;
+let bat = Attr.val;
+
+if      (bat > vmax) { bat = vmax; }
+else if (bat < vmin) { bat = vmin; }
+
+bat = ((bat - vmin) /(vmax - vmin)) * 100;
+
+if      (bat > 100) { bat = 100; }
+else if (bat <= 0)  { bat = 1; } // ?
+
+Item.val = bat;

--- a/devices/bosch/rfdl-zb-ms_motion_sensor.json
+++ b/devices/bosch/rfdl-zb-ms_motion_sensor.json
@@ -45,7 +45,11 @@
           "name": "attr/name"
         },
         {
-          "name": "attr/swversion"
+          "name": "attr/swversion",
+          "read": {
+            "fn": "none"
+          },
+          "static": "none"
         },
         {
           "name": "attr/type"
@@ -129,7 +133,11 @@
           "name": "attr/name"
         },
         {
-          "name": "attr/swversion"
+          "name": "attr/swversion",
+          "read": {
+            "fn": "none"
+          },
+          "static": "none"
         },
         {
           "name": "attr/type"
@@ -221,7 +229,11 @@
           "name": "attr/name"
         },
         {
-          "name": "attr/swversion"
+          "name": "attr/swversion",
+          "read": {
+            "fn": "none"
+          },
+          "static": "none"
         },
         {
           "name": "attr/type"

--- a/devices/bosch/rfdl-zb-ms_motion_sensor.json
+++ b/devices/bosch/rfdl-zb-ms_motion_sensor.json
@@ -1,0 +1,310 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "BOSCH",
+  "modelid": "RFDL-ZB-MS",
+  "product": "RADION TriTech ZB Wireless Motion Detector",
+  "vendor": "Bosch",
+  "status": "Gold",
+  "sleeper": true,
+  "subdevices": [
+    {
+      "type": "$TYPE_PRESENCE_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0500"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0402",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x0500"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "awake": true,
+          "parse": {
+            "at": "0x0020",
+            "cl": "0x0001",
+            "ep": 1,
+            "script": "bosch_battery.js"
+          }
+        },
+        {
+          "name": "config/enrolled"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/pending"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/lowbattery"
+        },
+        {
+          "name": "state/presence",
+          "awake": true
+        },
+        {
+          "name": "state/tampered",
+          "awake": true
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_LIGHT_LEVEL_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0400"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0402",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x0400"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "awake": true,
+          "parse": {
+            "at": "0x0020",
+            "cl": "0x0001",
+            "ep": 1,
+            "script": "bosch_battery.js"
+          }
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "config/tholddark"
+        },
+        {
+          "name": "config/tholdoffset"
+        },
+        {
+          "name": "state/dark"
+        },
+        {
+          "name": "state/daylight"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/lightlevel",
+          "awake": true,
+          "parse": {
+            "at": "0x0000",
+            "cl": "0x0400",
+            "ep": 1,
+            "script": "../generic/illuminance_cluster/sml_light_level.js"
+          }
+        },
+        {
+          "name": "state/lux"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_TEMPERATURE_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0402"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0402",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x0402"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "awake": true,
+          "parse": {
+            "at": "0x0020",
+            "cl": "0x0001",
+            "ep": 1,
+            "script": "bosch_battery.js"
+          }
+        },
+        {
+          "name": "config/offset"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/temperature",
+          "awake": true
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0500"
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0020",
+          "dt": "0x20",
+          "min": 1,
+          "max": 43200,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0402",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x29",
+          "min": 1,
+          "max": 300,
+          "change": "0x00000014"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0400",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x21",
+          "min": 5,
+          "max": 300,
+          "change": "0x07d0"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Assumption is here that batteries are depleted with 2.6V and that all attribute reports wake up the device.