### PR TITLE
DDF clone for Paulmann 501.34 light

### DIFF
--- a/devices/paulmann/501_34_battery_switch.json
+++ b/devices/paulmann/501_34_battery_switch.json
@@ -4,7 +4,7 @@
   "manufacturername": ["Paulmann LichtGmbH", "Paulmann Licht GmbH"],
   "modelid": ["501.34", "501.34"],
   "vendor": "Paulmann",
-  "product": "Wall switch on/off/dimm (501.35)",
+  "product": "Wall switch on/off/dimm (501.34)",
   "sleeper": true,
   "status": "Gold",
   "subdevices": [

--- a/devices/paulmann/501_34_battery_switch.json
+++ b/devices/paulmann/501_34_battery_switch.json
@@ -1,8 +1,8 @@
 {
   "schema": "devcap1.schema.json",
   "uuid": "e8f0ae5b-e1c5-4a7b-bebc-2e91becb6f81",
-  "manufacturername": "Paulmann LichtGmbH",
-  "modelid": "501.34",
+  "manufacturername": ["Paulmann LichtGmbH", "Paulmann Licht GmbH"],
+  "modelid": ["501.34", "501.34"],
   "vendor": "Paulmann",
   "product": "Wall switch on/off/dimm (501.35)",
   "sleeper": true,


### PR DESCRIPTION
Nothing special, just a new model with a space in the Manufacture Name
see https://github.com/dresden-elektronik/deconz-rest-plugin/issues/6102#issuecomment-2382377532