### PR TITLE
Give DDF content precedence over legacy sensor load

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -3505,17 +3505,13 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     return 0;
                 }
 
-                const int itemCount = DB_GetSubDeviceItemCount(sensor.item(RAttrUniqueId)->toLatin1String());
-
-                if (itemCount == 0)
-                {
-                    DBG_Printf(DBG_INFO, "DB legacy loading sensor %s %s, later handled by DDF %s\n", qPrintable(sensor.name()), qPrintable(sensor.id()), qPrintable(ddf.product));
-                }
-                else if (DEV_TestManaged() || DDF_IsStatusEnabled(ddf.status))
+                if (DEV_TestManaged() || DDF_IsStatusEnabled(ddf.status))
                 {
                     DBG_Printf(DBG_INFO, "DB skip loading sensor %s %s, handled by DDF %s\n", qPrintable(sensor.name()), qPrintable(sensor.id()), qPrintable(ddf.product));
                     return 0;
                 }
+                
+                DBG_Printf(DBG_INFO, "DB legacy loading sensor %s %s, should be added into DDF %s\n", qPrintable(sensor.name()), qPrintable(sensor.id()), qPrintable(ddf.product));
             }
         }
 


### PR DESCRIPTION
The title already say is. Imho, the DDF should fully define the device exposure and not blindly revive what has been used/saved as sensor in pre DDF-era.

The current state check would have let the blow to be loaded, which is incorrect, non-existent or non-functional (because of the item count being 0, 2nd last line) and also not part of the respective DDF. This has good potental to confuse end users and is very hard to explain. I wouldn't consider just an item count greater 0 to be enough justification for a legacy sensor to be loaded.

I acknowledge that it eventually could get a bit bumpy with the change, however, DDFs should be correctly defined anyway. It corrects the course a bit going forward and supports in creation of better quality DDFs.

```20:48:50:941 Sqlite sensors: sid = 220
20:48:50:941 Sqlite sensors: name = Power 220
20:48:50:941 Sqlite sensors: type = ZHAPower
20:48:50:941 Sqlite sensors: modelid = lumi.plug.aeu001
20:48:50:941 Sqlite sensors: manufacturername = Aqara
20:48:50:941 Sqlite sensors: uniqueid = 54:ef:44:10:00:aa:bb:cc-01-0b04
20:48:50:941 Sqlite sensors: swversion = 0.0.0_029
20:48:50:941 Sqlite sensors: state = {"current":0,"lastupdated":"2024-10-03T14:17:34.987","power":29,"voltage":236}
20:48:50:941 Sqlite sensors: config = {"on":true,"reachable":true}
20:48:50:941 Sqlite sensors: fingerprint = {"d":0,"ep":1,"in":[2820,0],"p":260}
20:48:50:941 Sqlite sensors: deletedState = normal
20:48:50:941 Sqlite sensors: mode = 1
20:48:50:941 Sqlite sensors: lastseen = 2024-10-03T14:06Z
20:48:50:941 Sqlite sensors: lastannounced = 2024-10-03T14:06:57Z
20:48:50:941 DB found sensor Power 220 220
20:48:50:942 DB Power 220 is managed: 0, is enabled: 1, item count: 0
20:48:50:942 DB legacy loading sensor Power 220 220, later handled by DDF Aqara wall outlet H2 EU (WP-P01D)
```

Implementation should maybe wait until the next stable release, assuming that is very soon?!