### PR TITLE
DDF for IKEA INSPELNING smart plug

### DIFF
--- a/devices/ikea/inspelning_smart_plug.json
+++ b/devices/ikea/inspelning_smart_plug.json
@@ -44,7 +44,7 @@
         },
         {
           "name": "state/on",
-          "refresh.interval": 300,
+          "refresh.interval": 900,
           "read": {
             "at": "0x0000",
             "cl": "0x0006",
@@ -108,7 +108,7 @@
         },
         {
           "name": "state/consumption",
-          "refresh.interval": 300,
+          "refresh.interval": 10800,
           "read": {
             "at": "0x0000",
             "cl": "0x0702",
@@ -172,7 +172,7 @@
         },
         {
           "name": "state/current",
-          "refresh.interval": 300,
+          "refresh.interval": 600,
           "read": {
             "at": "0x0508",
             "cl": "0x0b04",
@@ -192,7 +192,7 @@
         },
         {
           "name": "state/power",
-          "refresh.interval": 300,
+          "refresh.interval": 600,
           "read": {
             "at": "0x050b",
             "cl": "0x0b04",
@@ -209,7 +209,7 @@
         },
         {
           "name": "state/voltage",
-          "refresh.interval": 300,
+          "refresh.interval": 600,
           "read": {
             "at": "0x0505",
             "cl": "0x0b04",
@@ -223,6 +223,63 @@
             "eval": "if (Attr.val != 65535) { Item.val = Attr.val; }"
           },
           "default": 0
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0006",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 600
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0702",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x25",
+          "min": 60,
+          "max": 3600,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0B04",
+      "report": [
+        {
+          "at": "0x0505",
+          "dt": "0x21",
+          "min": 10,
+          "max": 300,
+          "change": "0x00000005"
+        },
+        {
+          "at": "0x0508",
+          "dt": "0x21",
+          "min": 10,
+          "max": 300,
+          "change": "0x00000064"
+        },
+        {
+          "at": "0x050B",
+          "dt": "0x29",
+          "min": 10,
+          "max": 300,
+          "change": "0x0000000A"
         }
       ]
     }

--- a/devices/ikea/inspelning_smart_plug.json
+++ b/devices/ikea/inspelning_smart_plug.json
@@ -1,0 +1,230 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "$MF_IKEA",
+  "modelid": "INSPELNING Smart plug",
+  "vendor": "IKEA",
+  "product": "INSPELNING smart plug",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_SMART_PLUG",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 300,
+          "read": {
+            "at": "0x0000",
+            "cl": "0x0006",
+            "ep": 0,
+            "fn": "zcl:attr"
+          },
+          "parse": {
+            "at": "0x0000",
+            "cl": "0x0006",
+            "ep": 0,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl:attr"
+          }
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_CONSUMPTION_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0702"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/consumption",
+          "refresh.interval": 300,
+          "read": {
+            "at": "0x0000",
+            "cl": "0x0702",
+            "ep": 0,
+            "fn": "zcl:attr"
+          },
+          "parse": {
+            "at": "0x0000",
+            "cl": "0x0702",
+            "ep": 0,
+            "eval": "Item.val = Attr.val / 1000"
+          },
+          "default": 0
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_POWER_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0b04"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/current",
+          "refresh.interval": 300,
+          "read": {
+            "at": "0x0508",
+            "cl": "0x0b04",
+            "ep": 0,
+            "fn": "zcl:attr"
+          },
+          "parse": {
+            "at": "0x0508",
+            "cl": "0x0b04",
+            "ep": 0,
+            "eval": "if (Attr.val != 65535) { Item.val = Attr.val; }"
+          },
+          "default": 0
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/power",
+          "refresh.interval": 300,
+          "read": {
+            "at": "0x050b",
+            "cl": "0x0b04",
+            "ep": 0,
+            "fn": "zcl:attr"
+          },
+          "parse": {
+            "at": "0x050b",
+            "cl": "0x0b04",
+            "ep": 0,
+            "eval": "if (Attr.val != -32768 && Attr.val != 32768) { Item.val = Attr.val / 10; }"
+          },
+          "default": 0
+        },
+        {
+          "name": "state/voltage",
+          "refresh.interval": 300,
+          "read": {
+            "at": "0x0505",
+            "cl": "0x0b04",
+            "ep": 0,
+            "fn": "zcl:attr"
+          },
+          "parse": {
+            "at": "0x0505",
+            "cl": "0x0b04",
+            "ep": 0,
+            "eval": "if (Attr.val != 65535) { Item.val = Attr.val; }"
+          },
+          "default": 0
+        }
+      ]
+    }
+  ]
+}

--- a/devices/ikea/inspelning_smart_plug.json
+++ b/devices/ikea/inspelning_smart_plug.json
@@ -119,7 +119,7 @@
             "at": "0x0000",
             "cl": "0x0702",
             "ep": 0,
-            "eval": "Item.val = Attr.val / 1000"
+            "eval": "Item.val = Attr.val"
           },
           "default": 0
         },


### PR DESCRIPTION
Solves https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7948

Need verification / double check of Consumption calculation.
Phoscon shows value as `wH`, while comments and docs states value should be in `kWh`.

Anyway, I have already tested and confirmed that the raw value `0x0702 / 0x0000` in deCONZ GUI is in `wH`. Based on the divisor value from `0x0302`, I added a x1000 division.

Maybe @ebaauw can help?