### PR TITLE
Fix battery percentage for FireAngel Zigbee module

### DIFF
--- a/devices/fireangel/0001_battery_voltage.js
+++ b/devices/fireangel/0001_battery_voltage.js
@@ -1,3 +1,3 @@
 /* global Attr, Item */
 // Map battery voltage from 1.9V ... 3.0V to 0% ... 100%
-Item.val = Math.max(0, Math.min(Math.round(9.09090909 * (Attr.val - 19), 100)))
+Item.val = Math.max(0, Math.min(Math.round(9.09090909 * (Attr.val - 19)), 100))


### PR DESCRIPTION
Bug fix: values > 3.0V not reported correctly.  Bloody brackets...

See #7941.