### PR TITLE
add read-only attributes for power formatting factors

### DIFF
--- a/devices/generic/items/state_power_divisor_item.json
+++ b/devices/generic/items/state_power_divisor_item.json
@@ -1,0 +1,22 @@
+{
+  "schema": "resourceitem1.schema.json",
+  "id": "state/power_multiplier",
+  "datatype": "UInt16",
+  "access": "R",
+  "public": false,
+  "description": "AC Power Divisor to be multiplied against the Instantaneous Power and Active Power attributes.",
+  "read": {
+    "at": "0x0605",
+    "cl": "0x0b04",
+    "ep": 0,
+    "fn": "zcl:attr"
+  },
+  "parse": {
+    "at": "0x0605",
+    "cl": "0x0b04",
+    "ep": 0,
+    "eval": "if (Attr.val > 0) { Item.val = Attr.val; }"
+  },
+  "refresh.interval": 600,
+  "default": 1
+}

--- a/devices/generic/items/state_power_multiplier_item.json
+++ b/devices/generic/items/state_power_multiplier_item.json
@@ -1,0 +1,22 @@
+{
+  "schema": "resourceitem1.schema.json",
+  "id": "state/power_multiplier",
+  "datatype": "UInt16",
+  "access": "R",
+  "public": false,
+  "description": "AC Power Divisor to be divided against the Instantaneous Power and Active Power attributes.",
+  "read": {
+    "at": "0x0604",
+    "cl": "0x0b04",
+    "ep": 0,
+    "fn": "zcl:attr"
+  },
+  "parse": {
+    "at": "0x0604",
+    "cl": "0x0b04",
+    "ep": 0,
+    "eval": "if (Attr.val > 0) { Item.val = Attr.val; }"
+  },
+  "refresh.interval": 600,
+  "default": 1
+}


### PR DESCRIPTION
Since some measurement devices provide calculation factors to format measured values correctly, we need to make them available. These factors may change on each report to adapt to the provided output power range. This prevents spamming the network when the "minimum change" property of the reporting binding is set to a low value.

DDF configs may use these attributes to guarantee API values are always in the same unit (Watts).

### Example

| ActivePower | ACPowerMultiplier | ACPowerDivisor | Result
|:--------:|:--------:|:--------:|:--------:|
| 42 | 1 | 1000 | 42 mW |
| 42 | 1 | 1 | 42 W |
| 42 | 1000 | 1 | 42 kW |

### Screenshot

![image](https://github.com/user-attachments/assets/069888b4-d25e-4882-839a-9445255b14e1)

### Specifications

> 4.9.2.2.6.10 ActivePower
> Represents the single phase or Phase A, current demand of active power delivered or received at the premises, in Watts (W). Positive values indicate power delivered to the premises where negative values indicate power received from the premises

> 4.9.2.2.7.5 ACPowerMultiplier
> Provides a value to be multiplied against the InstantaneousPower and ActivePower attributes. This attribute
must be used in conjunction with the ACPowerDivisor attribute. `0x0000` is an invalid value for this attribute.
> 
> 4.9.2.2.7.6 ACPowerDivisor
> Provides a value to be divided against the InstantaneousPower and ActivePower attributes. This attribute
must be used in conjunction with the ACPowerMultiplier attribute. `0x0000` is an invalid value for this attribute.