### PR TITLE
remove superfluous eval conditions

### DIFF
--- a/devices/Jasco-GE/GE45856_wall_switch.json
+++ b/devices/Jasco-GE/GE45856_wall_switch.json
@@ -127,7 +127,7 @@
             "at": "0x0400",
             "cl": "0x0702",
             "ep": 1,
-            "eval": "if (Attr.val != -32768 && Attr.val != 32768) { Item.val = Attr.val / 10; }"
+            "eval": "if (Attr.val != -32768) { Item.val = Attr.val / 10; }"
           },
           "default": 0
         }

--- a/devices/eva/powermeter.json
+++ b/devices/eva/powermeter.json
@@ -70,7 +70,7 @@
             "at": "0x0304",
             "cl": "0x0b04",
             "ep": 0,
-            "eval": "if (Attr.val != -32768 && Attr.val != 32768) { Item.val = Attr.val; }"
+            "eval": "if (Attr.val != -32768) { Item.val = Attr.val; }"
           }
         },
         {

--- a/devices/generic/items/state_power_item.json
+++ b/devices/generic/items/state_power_item.json
@@ -15,7 +15,7 @@
     "at": "0x050b",
     "cl": "0x0b04",
     "ep": 0,
-    "eval": "if (Attr.val != -32768 && Attr.val != 32768) { Item.val = Attr.val; }"
+    "eval": "if (Attr.val != -32768) { Item.val = Attr.val; }"
   },
   "refresh.interval": 300,
   "default": 0

--- a/devices/ouellet/OTH4000-ZB.json
+++ b/devices/ouellet/OTH4000-ZB.json
@@ -300,7 +300,7 @@
             "at": "0x050b",
             "cl": "0x0b04",
             "ep": 1,
-            "eval": "if (Attr.val != -32768 && Attr.val != 32768) { Item.val = Attr.val; }"
+            "eval": "if (Attr.val != -32768) { Item.val = Attr.val; }"
           },
           "default": 0
         },

--- a/devices/sinope/th1124zb.json
+++ b/devices/sinope/th1124zb.json
@@ -399,7 +399,7 @@
             "at": "0x050B",
             "cl": "0x0B04",
             "ep": 1,
-            "eval": "if (Attr.val != -32768 && Attr.val != 32768) { Item.val = Attr.val; }",
+            "eval": "if (Attr.val != -32768) { Item.val = Attr.val; }",
             "fn": "zcl:attr"
           }
         }


### PR DESCRIPTION
Signed s16 integer supports values from `-32768` to `32767`, so `Attr.val != 32768` is superfluous. Typically the lowest value, `-32768` is used to indicate an invalid value.