### PR TITLE
DDF clones for various model of Namrom Panel heater; data conversion correction

### DIFF
--- a/devices/namron/5401395_heater.json
+++ b/devices/namron/5401395_heater.json
@@ -1,10 +1,10 @@
 {
   "schema": "devcap1.schema.json",
   "uuid": "6f36f014-8ed9-40ea-9301-05d55797bd3e",
-  "manufacturername": ["NAMRON AS", "NAMRON AS"],
-  "modelid": ["5401395", "5401399"],
+  "manufacturername": ["NAMRON AS", "NAMRON AS", "NAMRON AS", "NAMRON AS", "NAMRON AS", "NAMRON AS"],
+  "modelid": ["5401395", "5401399", "5401393", "5401397", "5401392", "5401396"],
   "vendor": "Namron",
-  "product": "Panel heater 1000W (5401395/5401399)",
+  "product": "Panel heater",
   "sleeper": false,
   "status": "Gold",
   "subdevices": [
@@ -154,7 +154,20 @@
           "name": "state/lastupdated"
         },
         {
-          "name": "state/power"
+          "name": "state/power",
+          "refresh.interval": 365,
+          "read": {
+            "at": "0x050b",
+            "cl": "0x0b04",
+            "ep": 1,
+            "fn": "zcl:attr"
+          },
+          "parse": {
+            "at": "0x050b",
+            "cl": "0x0b04",
+            "ep": 1,
+            "eval": "Item.val = Attr.val/10"
+          }
         },
         {
           "name": "state/voltage"
@@ -214,14 +227,22 @@
         },
         {
           "name": "state/consumption",
-          "default": 0
+          "read": {
+            "at": "0x0000",
+            "cl": "0x0702",
+            "ep": 1,
+            "fn": "zcl:attr"
+          },
+          "parse": {
+            "at": "0x0000",
+            "cl": "0x0702",
+            "ep": 1,
+            "eval": "Item.val = Attr.val*100"
+          },
+          "refresh.interval": 365
         },
         {
           "name": "state/lastupdated"
-        },
-        {
-          "name": "state/power",
-          "default": 0
         }
       ]
     }

--- a/devices/namron/5401395_heater.json
+++ b/devices/namron/5401395_heater.json
@@ -265,6 +265,20 @@
     {
       "bind": "unicast",
       "src.ep": 1,
+      "cl": "0x0702",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x25",
+          "min": 1,
+          "max": 300,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
       "dst.ep": 1,
       "cl": "0x0B04",
       "report": [


### PR DESCRIPTION
See https://github.com/dresden-elektronik/deconz-rest-plugin/pull/6792

It add other model, and correct some data convertion.