### PR TITLE
DDF clone for Tuya multi sensor (_TZ3000_bjawzod); add battery polling

### DIFF
--- a/devices/tuya/_TZ3000_TS0201_temp_hum_sensor.json
+++ b/devices/tuya/_TZ3000_TS0201_temp_hum_sensor.json
@@ -1,8 +1,8 @@
 {
   "schema": "devcap1.schema.json",
   "uuid": "d20fd95e-3343-4898-adc3-59111f4812af",
-  "manufacturername": ["_TZ3000_yd2e749y", "_TZ3000_fllyghyj", "_TZ3000_fie1dpkm", "_TZ3000_lbtpiody", "_TZ3000_5nrcorgu", "_TZ3000_ena8vgqb", "_TZ3000_xr3htd96", "_TZ3000_0s1izerx", "_TZ3000_saiqcn0y", "_TZ3000_utwgoauk", "_TZ3000_bjawzodf"],
-  "modelid": ["TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201"],
+  "manufacturername": ["_TZ3000_yd2e749y", "_TZ3000_fllyghyj", "_TZ3000_fie1dpkm", "_TZ3000_lbtpiody", "_TZ3000_5nrcorgu", "_TZ3000_ena8vgqb", "_TZ3000_xr3htd96", "_TZ3000_0s1izerx", "_TZ3000_saiqcn0y", "_TZ3000_utwgoauk", "_TZ3000_bjawzodf", "_TZ3000_bjawzodf"],
+  "modelid": ["TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TS0201", "TY0201"],
   "vendor": "Tuya",
   "product": "Temperature and humidity sensor (TS0201)",
   "sleeper": true,
@@ -47,15 +47,21 @@
           "name": "attr/uniqueid"
         },
         {
-          "name": "config/battery",
-          "awake": true,
-          "parse": {
-            "at": "0x0021",
-            "cl": "0x0001",
-            "ep": 1,
-            "eval": "Item.val = Attr.val / 2;",
-            "fn": "zcl:attr"
-          }
+            "name":"config/battery",
+            "refresh.interval": 86400,
+            "read":{
+                "at":"0x0021",
+                "cl":"0x0001",
+                "ep":1,
+                "fn":"zcl:attr"
+            },
+            "parse":{
+                "at":"0x0021",
+                "cl":"0x0001",
+                "ep":1,
+                "eval":"Item.val = Attr.val/2"
+            },
+            "default":0
         },
         {
           "name": "config/offset"
@@ -114,15 +120,21 @@
           "name": "attr/uniqueid"
         },
         {
-          "name": "config/battery",
-          "awake": true,
-          "parse": {
-            "at": "0x0021",
-            "cl": "0x0001",
-            "ep": 1,
-            "eval": "Item.val = Attr.val / 2;",
-            "fn": "zcl:attr"
-          }
+            "name":"config/battery",
+            "refresh.interval": 86400,
+            "read":{
+                "at":"0x0021",
+                "cl":"0x0001",
+                "ep":1,
+                "fn":"zcl:attr"
+            },
+            "parse":{
+                "at":"0x0021",
+                "cl":"0x0001",
+                "ep":1,
+                "eval":"Item.val = Attr.val/2"
+            },
+            "default":0
         },
         {
           "name": "config/offset"


### PR DESCRIPTION
Manufacturer : _TZ3000_bjawzodf
Model identifier : TY0201

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7684

It add a clone, and help for battery report that can be missing.