### PR TITLE
Add basic support for Hue Dynamic Scenes

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -16066,6 +16066,10 @@ int DeRestPlugin::handleHttpRequest(const QHttpRequestHeader &hdr, QTcpSocket *s
                 {
                     ret = d->handleScenesApi(req, rsp);
                 }
+                else if (apiModule == QLatin1String("hue-scenes"))
+                {
+                    ret = d->handleHueScenesApi(req, rsp);
+                }
                 else if (apiModule == QLatin1String("sensors"))
                 {
                     ret = d->handleSensorsApi(req, rsp);

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1075,6 +1075,9 @@ public:
     int modifyScene(const ApiRequest &req, ApiResponse &rsp);
     int deleteScene(const ApiRequest &req, ApiResponse &rsp);
 
+    // REST API hue-scenes
+    int handleHueScenesApi(const ApiRequest &req, ApiResponse &rsp);
+
     bool groupToMap(const ApiRequest &req, const Group *group, QVariantMap &map);
 
     // REST API schedules

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1444,6 +1444,7 @@ public:
     bool validateHueGradient(const ApiRequest &req, ApiResponse &rsp, QVariantMap &gradient, quint16 styleBitmap);
     bool addTaskHueGradient(TaskItem &task, QVariantMap &gradient);
     bool validateHueLightState(ApiResponse &rsp, const LightNode *lightNode, QVariantMap &map, QList<QString> &validatedParameters);
+    bool validateHueDynamicScenePalette(ApiResponse &rsp, const Scene *scene, QVariantMap &map, QList<QString> &validatedParameters);
     bool addTaskHueManufacturerSpecificSetState(TaskItem &task, const QVariantMap &items);
     bool addTaskHueManufacturerSpecificAddScene(TaskItem &task, const quint16 groupId, const quint8 sceneId, const QVariantMap &items);
     bool addTaskHueDynamicSceneRecall(TaskItem &task, const quint16 groupId, const quint8 sceneId, const QVariantMap &palette);

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1433,9 +1433,11 @@ public:
     QStringList getHueEffectNames(quint64 effectBitmap, bool colorloop);
     QStringList getHueGradientStyleNames(quint16 styleBitmap);
     bool isHueEffectLight(const LightNode *lightNode);
+    bool isMappableToManufacturerSpecific(const QVariantMap &map);
     bool addTaskHueEffect(TaskItem &task, QString &effect);
     bool validateHueGradient(const ApiRequest &req, ApiResponse &rsp, QVariantMap &gradient, quint16 styleBitmap);
     bool addTaskHueGradient(TaskItem &task, QVariantMap &gradient);
+    int setHueLightState(const ApiRequest &req, ApiResponse &rsp, TaskItem &taskRef, QVariantMap &map);
 
     // Merry Christmas!
     bool isXmasLightStrip(const LightNode *lightNode);

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -808,7 +808,8 @@ enum TaskType
     TaskTuyaRequest = 41,
     TaskXmasLightStrip = 42,
     TaskSimpleMetering = 43,
-    TaskHueEffect = 44
+    TaskHueEffect = 44,
+    TaskHueManufacturerSpecific = 45
 };
 
 enum XmasLightStripMode
@@ -1437,6 +1438,7 @@ public:
     bool addTaskHueEffect(TaskItem &task, QString &effect);
     bool validateHueGradient(const ApiRequest &req, ApiResponse &rsp, QVariantMap &gradient, quint16 styleBitmap);
     bool addTaskHueGradient(TaskItem &task, QVariantMap &gradient);
+    bool addTaskHueManufacturerSpecific(TaskItem &task, QVariantMap &items);
     int setHueLightState(const ApiRequest &req, ApiResponse &rsp, TaskItem &taskRef, QVariantMap &map);
 
     // Merry Christmas!

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -812,6 +812,22 @@ enum TaskType
     TaskHueManufacturerSpecific = 45
 };
 
+// Option set to represent the payload items in a '0xfc03' cluster's '0x00' command.
+enum HueManufacturerSpecificPayload : quint16
+{
+    None = 0x0,                // 0x0000
+    On = 1 << 0,               // 0x0001
+    Brightness = 1 << 1,       // 0x0002
+    ColorTemperature = 1 << 2, // 0x0004
+    Color = 1 << 3,            // 0x0008
+    TransitionTime = 1 << 4,   // 0x0010
+    Effect = 1 << 5,           // 0x0020
+    UNKNOWN = 1 << 6,          // 0x0040
+    EffectDuration = 1 << 7    // 0x0080
+};
+Q_DECLARE_FLAGS(HueManufacturerSpecificPayloads, HueManufacturerSpecificPayload)
+Q_DECLARE_OPERATORS_FOR_FLAGS(HueManufacturerSpecificPayloads)
+
 enum XmasLightStripMode
 {
     ModeWhite = 0,
@@ -1438,7 +1454,7 @@ public:
     bool addTaskHueEffect(TaskItem &task, QString &effect);
     bool validateHueGradient(const ApiRequest &req, ApiResponse &rsp, QVariantMap &gradient, quint16 styleBitmap);
     bool addTaskHueGradient(TaskItem &task, QVariantMap &gradient);
-    bool addTaskHueManufacturerSpecific(TaskItem &task, QVariantMap &items);
+    bool addTaskHueManufacturerSpecific(TaskItem &task, HueManufacturerSpecificPayloads &payloadItems, QVariantMap &items);
     int setHueLightState(const ApiRequest &req, ApiResponse &rsp, TaskItem &taskRef, QVariantMap &map);
 
     // Merry Christmas!

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1432,6 +1432,7 @@ public:
     // Advanced features of Hue lights.
     QStringList getHueEffectNames(quint64 effectBitmap, bool colorloop);
     QStringList getHueGradientStyleNames(quint16 styleBitmap);
+    bool isHueEffectLight(const LightNode *lightNode);
     bool addTaskHueEffect(TaskItem &task, QString &effect);
     bool validateHueGradient(const ApiRequest &req, ApiResponse &rsp, QVariantMap &gradient, quint16 styleBitmap);
     bool addTaskHueGradient(TaskItem &task, QVariantMap &gradient);

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1458,7 +1458,7 @@ public:
     bool addTaskHueEffect(TaskItem &task, QString &effect);
     bool validateHueGradient(const ApiRequest &req, ApiResponse &rsp, QVariantMap &gradient, quint16 styleBitmap);
     bool addTaskHueGradient(TaskItem &task, QVariantMap &gradient);
-    bool addTaskHueManufacturerSpecific(TaskItem &task, HueManufacturerSpecificPayloads &payloadItems, QVariantMap &items);
+    bool addTaskHueManufacturerSpecificSetState(TaskItem &task, HueManufacturerSpecificPayloads &payloadItems, QVariantMap &items);
     int setHueLightState(const ApiRequest &req, ApiResponse &rsp, TaskItem &taskRef, QVariantMap &map);
     bool addTaskPlayHueDynamicScene(TaskItem &task, quint16 groupId, quint8 sceneId, QVariantMap &palette);
 

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -812,22 +812,6 @@ enum TaskType
     TaskHueManufacturerSpecific = 45
 };
 
-// Option set to represent the payload items in a '0xfc03' cluster's '0x00' command.
-enum HueManufacturerSpecificPayload : quint16
-{
-    None = 0x0,                // 0x0000
-    On = 1 << 0,               // 0x0001
-    Brightness = 1 << 1,       // 0x0002
-    ColorTemperature = 1 << 2, // 0x0004
-    Color = 1 << 3,            // 0x0008
-    TransitionTime = 1 << 4,   // 0x0010
-    Effect = 1 << 5,           // 0x0020
-    UNKNOWN = 1 << 6,          // 0x0040
-    EffectDuration = 1 << 7    // 0x0080
-};
-Q_DECLARE_FLAGS(HueManufacturerSpecificPayloads, HueManufacturerSpecificPayload)
-Q_DECLARE_OPERATORS_FOR_FLAGS(HueManufacturerSpecificPayloads)
-
 enum XmasLightStripMode
 {
     ModeWhite = 0,
@@ -1078,6 +1062,7 @@ public:
     // REST API hue-scenes
     int handleHueScenesApi(const ApiRequest &req, ApiResponse &rsp);
     int playHueDynamicScene(const ApiRequest &req, ApiResponse &rsp);
+    int modifyHueScene(const ApiRequest &req, ApiResponse &rsp);
 
     bool groupToMap(const ApiRequest &req, const Group *group, QVariantMap &map);
 
@@ -1458,9 +1443,12 @@ public:
     bool addTaskHueEffect(TaskItem &task, QString &effect);
     bool validateHueGradient(const ApiRequest &req, ApiResponse &rsp, QVariantMap &gradient, quint16 styleBitmap);
     bool addTaskHueGradient(TaskItem &task, QVariantMap &gradient);
-    bool addTaskHueManufacturerSpecificSetState(TaskItem &task, HueManufacturerSpecificPayloads &payloadItems, QVariantMap &items);
+    bool validateHueLightState(ApiResponse &rsp, const LightNode *lightNode, QVariantMap &map, QList<QString> &validatedParameters);
+    bool addTaskHueManufacturerSpecificSetState(TaskItem &task, const QVariantMap &items);
+    bool addTaskHueManufacturerSpecificAddScene(TaskItem &task, const quint16 groupId, const quint8 sceneId, const QVariantMap &items);
+    bool addTaskHueDynamicSceneRecall(TaskItem &task, const quint16 groupId, const quint8 sceneId, const QVariantMap &palette);
     int setHueLightState(const ApiRequest &req, ApiResponse &rsp, TaskItem &taskRef, QVariantMap &map);
-    bool addTaskPlayHueDynamicScene(TaskItem &task, quint16 groupId, quint8 sceneId, QVariantMap &palette);
+    int setHueSceneLightState(const ApiRequest &req, ApiResponse &rsp, TaskItem &taskRef, QVariantMap &map);
 
     // Merry Christmas!
     bool isXmasLightStrip(const LightNode *lightNode);

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1077,6 +1077,7 @@ public:
 
     // REST API hue-scenes
     int handleHueScenesApi(const ApiRequest &req, ApiResponse &rsp);
+    int playHueDynamicScene(const ApiRequest &req, ApiResponse &rsp);
 
     bool groupToMap(const ApiRequest &req, const Group *group, QVariantMap &map);
 
@@ -1459,6 +1460,7 @@ public:
     bool addTaskHueGradient(TaskItem &task, QVariantMap &gradient);
     bool addTaskHueManufacturerSpecific(TaskItem &task, HueManufacturerSpecificPayloads &payloadItems, QVariantMap &items);
     int setHueLightState(const ApiRequest &req, ApiResponse &rsp, TaskItem &taskRef, QVariantMap &map);
+    bool addTaskPlayHueDynamicScene(TaskItem &task, quint16 groupId, quint8 sceneId, QVariantMap &palette);
 
     // Merry Christmas!
     bool isXmasLightStrip(const LightNode *lightNode);

--- a/hue.cpp
+++ b/hue.cpp
@@ -406,6 +406,11 @@ bool DeRestPluginPrivate::addTaskHueManufacturerSpecific(TaskItem &task, HueManu
             stream << (quint8)(items["bri"].toUInt());
         }
 
+        if (payloadItems.testFlag(HueManufacturerSpecificPayload::ColorTemperature))
+        {
+            stream << (quint16)(items["ct"].toUInt());
+        }
+
         if (payloadItems.testFlag(HueManufacturerSpecificPayload::TransitionTime))
         {
             stream << (quint16)(items["transitiontime"].toUInt());
@@ -456,6 +461,22 @@ int DeRestPluginPrivate::setHueLightState(const ApiRequest &req, ApiResponse &rs
                     valueOk = true;
                     payloadItems.setFlag(HueManufacturerSpecificPayload::Brightness);
                     itemList["bri"] = QVariant(bri > 0xFE ? 0xFE : bri);
+                }
+            }
+        }
+        else if (param == "ct"  && taskRef.lightNode->item(RStateCt))
+        {
+            paramOk = true;
+            if (map[param].type() == QVariant::Double)
+            {
+                const quint16 ctMin = taskRef.lightNode->toNumber(RCapColorCtMin);
+                const quint16 ctMax = taskRef.lightNode->toNumber(RCapColorCtMax);
+                const uint ct = map[param].toUInt(&ok);
+                if (ok && ct <= 0xFFFF)
+                {
+                    valueOk = true;
+                    payloadItems.setFlag(HueManufacturerSpecificPayload::ColorTemperature);
+                    itemList["ct"] = QVariant((ctMin < 500 && ct < ctMin) ? ctMin : (ctMax > ctMin && ct > ctMax) ? ctMax : ct);
                 }
             }
         }

--- a/hue.cpp
+++ b/hue.cpp
@@ -157,6 +157,161 @@ QStringList DeRestPluginPrivate::getHueGradientStyleNames(quint16 styleBitmap)
 const double maxX = 0.7347;
 const double maxY = 0.8431;
 
+// MARK: - Stream Helpers
+
+void streamPoint(QDataStream &stream, double x, double y)
+{
+    const quint16 rawX = (x >= maxX) ? 4095 : floor(x * 4095 / maxX);
+    const quint16 rawY = (y >= maxY) ? 4095 : floor(y * 4095 / maxY);
+    stream << (quint8) (rawX & 0x0FF);
+    stream << (quint8) (((rawX & 0xF00) >> 8) | ((rawY & 0x00F) << 4));
+    stream << (quint8) ((rawY & 0xFF0) >> 4);
+}
+
+void streamHueManufacturerSpecificState(QDataStream &stream, const QVariantMap &items)
+{
+    // Set payload contents
+    quint16 payloadBitmask = 0x00;
+    if (items.contains("on")) { payloadBitmask |= (1 << 0); }
+    if (items.contains("bri")) { payloadBitmask |= (1 << 1); }
+    if (items.contains("ct")) { payloadBitmask |= (1 << 2); }
+    if (items.contains("xy")) { payloadBitmask |= (1 << 3); }
+    if (items.contains("transitiontime")) { payloadBitmask |= (1 << 4); }
+    if (items.contains("effect")) { payloadBitmask |= (1 << 5); }
+    if (items.contains("gradient")) { payloadBitmask |= (1 << 6); }
+    // 'effect_duration' and 'effect_speed' share the same bit flag.
+    if (items.contains("effect_duration")) { payloadBitmask |= (1 << 7); }
+    if (items.contains("effect_speed")) { payloadBitmask |= (1 << 7); }
+    stream << (quint16)payloadBitmask;
+
+    // !!!: The order the items are processed in is important
+
+    if (items.contains("on"))
+    {
+        stream << (quint8)(items["on"].toBool() ? 0x01 : 0x00);
+    }
+
+    if (items.contains("bri"))
+    {
+        const quint8 bri = items["bri"].toUInt();
+        stream << (quint8)(bri > 0xFE ? 0xFE : bri);
+    }
+
+    if (items.contains("ct"))
+    {
+        stream << (quint16)(items["ct"].toUInt());
+    }
+
+    if (items.contains("xy"))
+    {
+        const QVariantList xy = items["xy"].toList();
+        quint16 colorX = static_cast<quint16>(xy[0].toDouble() * 65535.0);
+        quint16 colorY = static_cast<quint16>(xy[1].toDouble() * 65535.0);
+
+        if (colorX > 65279) { colorX = 65279; }
+        else if (colorX == 0) { colorX = 1; }
+
+        if (colorY > 65279) { colorY = 65279; }
+        else if (colorY == 0) { colorY = 1; }
+
+        stream << (quint32)((colorY << 16) + colorX);
+    }
+
+    if (items.contains("transitiontime"))
+    {
+        const quint8 tt = items["transitiontime"].toUInt();
+        stream << (quint16)(tt > 0xFFFE ? 0xFFFE : tt);
+    }
+
+    if (items.contains("effect"))
+    {
+        QString e = items["effect"].toString();
+        stream << (quint8)(effectNameToValue(e));
+    }
+
+    if (items.contains("effect_duration"))
+    {
+        const uint ed = items["effect_duration"].toUInt();
+
+        const uint resolutionBase = (ed == 0) ? 0 :
+                                    (ed < RESOLUTION_01s_LIMIT) ? RESOLUTION_01s_BASE :
+                                    (ed < RESOLUTION_05s_LIMIT) ? RESOLUTION_05s_BASE :
+                                    (ed < RESOLUTION_15s_LIMIT) ? RESOLUTION_15s_BASE :
+                                    (ed < RESOLUTION_01m_LIMIT) ? RESOLUTION_01m_BASE :
+                                    (ed < RESOLUTION_05m_LIMIT) ? RESOLUTION_05m_BASE : 0;
+
+        const uint resolution = (ed == 0) ? 1 :
+                                (ed < RESOLUTION_01s_LIMIT) ? RESOLUTION_01s :
+                                (ed < RESOLUTION_05s_LIMIT) ? RESOLUTION_05s :
+                                (ed < RESOLUTION_15s_LIMIT) ? RESOLUTION_15s :
+                                (ed < RESOLUTION_01m_LIMIT) ? RESOLUTION_01m :
+                                (ed < RESOLUTION_05m_LIMIT) ? RESOLUTION_05m : 1;
+
+        const quint8 effectDuration = resolutionBase - (ed / resolution);
+        stream << (quint8)(effectDuration);
+    }
+    else if (items.contains("effect_speed"))
+    {
+        const double es = items["effect_speed"].toDouble();
+        quint8 effectSpeed = static_cast<quint8>(es * 254.0);
+        stream << (quint8)(effectSpeed);
+    }
+}
+
+void streamHueManufacturerSpecificPalette(QDataStream &stream, const QVariantMap &palette)
+{
+    // Set payload contents
+    quint8 payloadBitmask = 0x00;
+    if (palette.contains("transitiontime")) { payloadBitmask |= 0x09; }
+    if (palette.contains("bri")) { payloadBitmask |= 0x0A; }
+    if (palette.contains("xy")) { payloadBitmask |= 0x0C; }
+    stream << (quint8)payloadBitmask;
+
+    // !!!: The order the items are processed in is important
+
+    if (palette.contains("transitiontime"))
+    {
+        const quint8 tt = palette["transitiontime"].toUInt();
+        stream << (quint16)(tt > 0xFFFE ? 0xFFFE : tt);
+    }
+
+    if (palette.contains("bri"))
+    {
+        const quint8 bri = palette["bri"].toUInt();
+        stream << (quint8)(bri > 0xFE ? 0xFE : bri);
+    }
+
+    if (palette.contains("xy"))
+    {
+        QVariantList colors = palette["xy"].toList();
+        QVariantList color;
+
+        const quint8 nColors = colors.length();
+        stream << (quint8) (1 + 3 * (nColors + 1));
+        stream << (quint8) (nColors << 4);
+
+        stream << (quint8) 0x00;
+        stream << (quint8) 0x00;
+        stream << (quint8) 0x00;
+
+        // Palette Colors
+        for (auto &color : colors)
+        {
+            QVariantList xy = color.toList();
+            streamPoint(stream, xy[0].toDouble(), xy[1].toDouble());
+        }
+    }
+
+    if (palette.contains("effect_speed"))
+    {
+        const double es = palette["effect_speed"].toDouble();
+        quint8 effectSpeed = static_cast<quint8>(es * 254.0);
+        stream << (quint8)(effectSpeed);
+    }
+}
+
+// MARK: - Tasks
+
 /*! Add a Hue effect task to the queue.
 
    \param task - the task item
@@ -204,6 +359,203 @@ bool DeRestPluginPrivate::addTaskHueEffect(TaskItem &task, QString &effectName)
 
     return addTask(task);
 }
+
+/*! Add a Hue gradient task to the queue.
+
+   \param task - the task item
+   \param gradient - the gradient
+   \return true - on success
+           false - on error
+ */
+bool DeRestPluginPrivate::addTaskHueGradient(TaskItem &task, QVariantMap &gradient)
+{
+    task.taskType = TaskHueGradient;
+    task.req.setClusterId(HUE_EFFECTS_CLUSTER_ID);
+    task.req.setProfileId(HA_PROFILE_ID);
+
+    task.zclFrame.payload().clear();
+    task.zclFrame.setSequenceNumber(zclSeq++);
+    task.zclFrame.setCommandId(0x00);
+    task.zclFrame.setManufacturerCode(VENDOR_PHILIPS);
+    task.zclFrame.setFrameControl(deCONZ::ZclFCClusterCommand |
+                                  deCONZ::ZclFCManufacturerSpecific |
+                                  deCONZ::ZclFCDirectionClientToServer |
+                                  deCONZ::ZclFCDisableDefaultResponse);
+
+    QVariantList points = gradient["points"].toList();
+    QVariantList point;
+    quint8 style = 0xFF;
+    for (auto &s: styles)
+    {
+        if (gradient["style"] == s.name)
+        {
+            style = s.value;
+            break;
+        }
+    }
+
+    { // payload
+        QDataStream stream(&task.zclFrame.payload(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+
+        stream << (quint16) 0x0150; // set gradient
+        stream << (quint16) 0x0004; // transitiontime
+
+        const quint8 nPoints = points.length();
+        stream << (quint8) (1 + 3 * (nPoints + 1));
+        stream << (quint8) (nPoints << 4);
+        stream << (quint8) style;
+        stream << (quint8) 0;
+        stream << (quint8) 0;
+        for (auto &point : points)
+        {
+            QVariantList xy = point.toList();
+            streamPoint(stream, xy[0].toDouble(), xy[1].toDouble());
+        }
+        stream << (quint8) ((gradient["segments"].toUInt() << 3) | gradient["color_adjustment"].toUInt());
+        stream << (quint8) ((gradient["offset"].toUInt() << 3)| gradient["offset_adjustment"].toUInt());
+    }
+
+    { // ZCL frame
+        task.req.asdu().clear(); // cleanup old request data if there is any
+        QDataStream stream(&task.req.asdu(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+        task.zclFrame.writeToStream(stream);
+    }
+    return addTask(task);
+}
+
+/*! Add a Hue Manufacturer Specific '0xfc03' '0x00' task to the queue.
+
+   \param task - the task item
+   \param items - the list of items in the payload
+   \return true - on success
+           false - on error
+ */
+bool DeRestPluginPrivate::addTaskHueManufacturerSpecificSetState(TaskItem &task, const QVariantMap &items)
+{
+    task.taskType = TaskHueManufacturerSpecific;
+    task.req.setClusterId(HUE_EFFECTS_CLUSTER_ID);
+    task.req.setProfileId(HA_PROFILE_ID);
+
+    task.zclFrame.payload().clear();
+    task.zclFrame.setSequenceNumber(zclSeq++);
+    task.zclFrame.setCommandId(0x00);
+    task.zclFrame.setManufacturerCode(VENDOR_PHILIPS);
+    task.zclFrame.setFrameControl(deCONZ::ZclFCClusterCommand |
+                                  deCONZ::ZclFCManufacturerSpecific |
+                                  deCONZ::ZclFCDirectionClientToServer |
+                                  deCONZ::ZclFCDisableDefaultResponse);
+
+    { // Payload
+        QDataStream stream(&task.zclFrame.payload(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+
+        streamHueManufacturerSpecificState(stream, items);
+    }
+
+    { // ZCL frame
+        task.req.asdu().clear(); // cleanup old request data if there is any
+        QDataStream stream(&task.req.asdu(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+        task.zclFrame.writeToStream(stream);
+    }
+
+    return addTask(task);
+}
+
+/*! Add a Hue Manufacturer Specific '0x0005' '0x02' task to the queue.
+
+   \param task - the task item
+   \param groupId - the id of the scene's parent group
+   \param sceneId - the id of the scene to modify
+   \param payloadItems - the contents in the payload
+   \param items - the list of items in the payload
+   \return true - on success
+           false - on error
+ */
+bool DeRestPluginPrivate::addTaskHueManufacturerSpecificAddScene(TaskItem &task, const quint16 groupId, const quint8 sceneId, const QVariantMap &items)
+{
+    task.taskType = TaskHueManufacturerSpecific;
+    task.req.setClusterId(SCENE_CLUSTER_ID);
+    task.req.setProfileId(HA_PROFILE_ID);
+
+    task.zclFrame.payload().clear();
+    task.zclFrame.setSequenceNumber(zclSeq++);
+    task.zclFrame.setCommandId(0x02);
+    task.zclFrame.setManufacturerCode(VENDOR_PHILIPS);
+    task.zclFrame.setFrameControl(deCONZ::ZclFCClusterCommand |
+                                  deCONZ::ZclFCManufacturerSpecific |
+                                  deCONZ::ZclFCDirectionClientToServer |
+                                  deCONZ::ZclFCDisableDefaultResponse);
+
+    { // Payload
+        QDataStream stream(&task.zclFrame.payload(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+
+        // Group and Scene IDs
+        stream << (quint16) groupId;
+        stream << (quint8) sceneId;
+
+        streamHueManufacturerSpecificState(stream, items);
+    }
+
+    { // ZCL frame
+        task.req.asdu().clear(); // cleanup old request data if there is any
+        QDataStream stream(&task.req.asdu(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+        task.zclFrame.writeToStream(stream);
+    }
+
+    return addTask(task);
+}
+
+/*! Add a Play Hue Dynamic Scene task to the queue.
+
+   \param task - the task item
+   \param groupId - the id of the scene's parent group
+   \param sceneId - the id of the scene to recall
+   \param palette - the list of palette items in the payload
+   \return true - on success
+           false - on error
+ */
+bool DeRestPluginPrivate::addTaskHueDynamicSceneRecall(TaskItem &task, const quint16 groupId, const quint8 sceneId, const QVariantMap &palette)
+{
+    task.taskType = TaskHueManufacturerSpecific;
+    task.req.setClusterId(SCENE_CLUSTER_ID);
+    task.req.setProfileId(HA_PROFILE_ID);
+
+    task.zclFrame.payload().clear();
+    task.zclFrame.setSequenceNumber(zclSeq++);
+    task.zclFrame.setCommandId(0x00);
+    task.zclFrame.setManufacturerCode(VENDOR_PHILIPS);
+    task.zclFrame.setFrameControl(deCONZ::ZclFCClusterCommand |
+                                  deCONZ::ZclFCManufacturerSpecific |
+                                  deCONZ::ZclFCDirectionClientToServer |
+                                  deCONZ::ZclFCDisableDefaultResponse);
+
+    { // Payload
+        QDataStream stream(&task.zclFrame.payload(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+
+        // Group and Scene IDs
+        stream << (quint16) groupId;
+        stream << (quint8) sceneId;
+
+        streamHueManufacturerSpecificPalette(stream, palette);
+    }
+
+    { // ZCL frame
+        task.req.asdu().clear(); // cleanup old request data if there is any
+        QDataStream stream(&task.req.asdu(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+        task.zclFrame.writeToStream(stream);
+    }
+
+    return addTask(task);
+}
+
+// MARK: - Validation Helpers
 
 bool DeRestPluginPrivate::validateHueGradient(const ApiRequest &req, ApiResponse &rsp, QVariantMap &gradient, quint16 styleBitmap = 0x0001)
 {
@@ -317,240 +669,10 @@ bool DeRestPluginPrivate::validateHueGradient(const ApiRequest &req, ApiResponse
     return ok;
 }
 
-void streamPoint(QDataStream &stream, double x, double y)
+bool DeRestPluginPrivate::validateHueLightState(ApiResponse &rsp, const LightNode *lightNode, QVariantMap &map, QList<QString> &validatedParameters)
 {
-    const quint16 rawX = (x >= maxX) ? 4095 : floor(x * 4095 / maxX);
-    const quint16 rawY = (y >= maxY) ? 4095 : floor(y * 4095 / maxY);
-    stream << (quint8) (rawX & 0x0FF);
-    stream << (quint8) (((rawX & 0xF00) >> 8) | ((rawY & 0x00F) << 4));
-    stream << (quint8) ((rawY & 0xFF0) >> 4);
-}
-
-/*! Add a Hue gradient task to the queue.
-
-   \param task - the task item
-   \param gradient - the gradient
-   \return true - on success
-           false - on error
- */
-bool DeRestPluginPrivate::addTaskHueGradient(TaskItem &task, QVariantMap &gradient)
-{
-    task.taskType = TaskHueGradient;
-    task.req.setClusterId(HUE_EFFECTS_CLUSTER_ID);
-    task.req.setProfileId(HA_PROFILE_ID);
-
-    task.zclFrame.payload().clear();
-    task.zclFrame.setSequenceNumber(zclSeq++);
-    task.zclFrame.setCommandId(0x00);
-    task.zclFrame.setManufacturerCode(VENDOR_PHILIPS);
-    task.zclFrame.setFrameControl(deCONZ::ZclFCClusterCommand |
-                                  deCONZ::ZclFCManufacturerSpecific |
-                                  deCONZ::ZclFCDirectionClientToServer |
-                                  deCONZ::ZclFCDisableDefaultResponse);
-
-    QVariantList points = gradient["points"].toList();
-    QVariantList point;
-    quint8 style = 0xFF;
-    for (auto &s: styles)
-    {
-        if (gradient["style"] == s.name)
-        {
-            style = s.value;
-            break;
-        }
-    }
-
-    { // payload
-        QDataStream stream(&task.zclFrame.payload(), QIODevice::WriteOnly);
-        stream.setByteOrder(QDataStream::LittleEndian);
-
-        stream << (quint16) 0x0150; // set gradient
-        stream << (quint16) 0x0004; // transitiontime
-
-        const quint8 nPoints = points.length();
-        stream << (quint8) (1 + 3 * (nPoints + 1));
-        stream << (quint8) (nPoints << 4);
-        stream << (quint8) style;
-        stream << (quint8) 0;
-        stream << (quint8) 0;
-        for (auto &point : points)
-        {
-            QVariantList xy = point.toList();
-            streamPoint(stream, xy[0].toDouble(), xy[1].toDouble());
-        }
-        stream << (quint8) ((gradient["segments"].toUInt() << 3) | gradient["color_adjustment"].toUInt());
-        stream << (quint8) ((gradient["offset"].toUInt() << 3)| gradient["offset_adjustment"].toUInt());
-    }
-
-    { // ZCL frame
-        task.req.asdu().clear(); // cleanup old request data if there is any
-        QDataStream stream(&task.req.asdu(), QIODevice::WriteOnly);
-        stream.setByteOrder(QDataStream::LittleEndian);
-        task.zclFrame.writeToStream(stream);
-    }
-    return addTask(task);
-}
-
-void streamHueManufacturerSpecificState(QDataStream &stream, HueManufacturerSpecificPayloads &payloadItems, QVariantMap &items)
-{
-    // Set payload contents
-    stream << (quint16)payloadItems;
-
-    // !!!: The order the items are processed in is important
-
-    if (payloadItems.testFlag(HueManufacturerSpecificPayload::On))
-    {
-        stream << (quint8)(items["on"].toUInt());
-    }
-
-    if (payloadItems.testFlag(HueManufacturerSpecificPayload::Brightness))
-    {
-        stream << (quint8)(items["bri"].toUInt());
-    }
-
-    if (payloadItems.testFlag(HueManufacturerSpecificPayload::ColorTemperature))
-    {
-        stream << (quint16)(items["ct"].toUInt());
-    }
-
-    if (payloadItems.testFlag(HueManufacturerSpecificPayload::Color))
-    {
-        stream << (quint32)(items["xy"].toUInt());
-    }
-
-    if (payloadItems.testFlag(HueManufacturerSpecificPayload::TransitionTime))
-    {
-        stream << (quint16)(items["transitiontime"].toUInt());
-    }
-
-    if (payloadItems.testFlag(HueManufacturerSpecificPayload::Effect))
-    {
-        stream << (quint8)(items["effect"].toUInt());
-    }
-
-    if (payloadItems.testFlag(HueManufacturerSpecificPayload::EffectDuration))
-    {
-        stream << (quint8)(items["effect_duration"].toUInt());
-    }
-}
-
-/*! Add a Hue Manufacturer Specific '0xfc03' '0x00' task to the queue.
-
-   \param task - the task item
-   \param payloadItems - the contents in the payload
-   \param items - the list of items in the payload
-   \return true - on success
-           false - on error
- */
-bool DeRestPluginPrivate::addTaskHueManufacturerSpecificSetState(TaskItem &task, HueManufacturerSpecificPayloads &payloadItems, QVariantMap &items)
-{
-    task.taskType = TaskHueManufacturerSpecific;
-    task.req.setClusterId(HUE_EFFECTS_CLUSTER_ID);
-    task.req.setProfileId(HA_PROFILE_ID);
-
-    task.zclFrame.payload().clear();
-    task.zclFrame.setSequenceNumber(zclSeq++);
-    task.zclFrame.setCommandId(0x00);
-    task.zclFrame.setManufacturerCode(VENDOR_PHILIPS);
-    task.zclFrame.setFrameControl(deCONZ::ZclFCClusterCommand |
-                                  deCONZ::ZclFCManufacturerSpecific |
-                                  deCONZ::ZclFCDirectionClientToServer |
-                                  deCONZ::ZclFCDisableDefaultResponse);
-
-    { // Payload
-        QDataStream stream(&task.zclFrame.payload(), QIODevice::WriteOnly);
-        stream.setByteOrder(QDataStream::LittleEndian);
-
-        streamHueManufacturerSpecificState(stream, payloadItems, items);
-    }
-
-    { // ZCL frame
-        task.req.asdu().clear(); // cleanup old request data if there is any
-        QDataStream stream(&task.req.asdu(), QIODevice::WriteOnly);
-        stream.setByteOrder(QDataStream::LittleEndian);
-        task.zclFrame.writeToStream(stream);
-    }
-
-    return addTask(task);
-}
-
-/*! Add a Play Hue Dynamic Scene task to the queue.
-
-   \param task - the task item
-   \param items - the list of items in the payload
-   \return true - on success
-           false - on error
- */
-bool DeRestPluginPrivate::addTaskPlayHueDynamicScene(TaskItem &task, quint16 groupId, quint8 sceneId, QVariantMap &palette)
-{
-    // FIXME: Update to TaskPlayHueScene
-    task.taskType = TaskHueManufacturerSpecific;
-    task.req.setClusterId(SCENE_CLUSTER_ID);
-    task.req.setProfileId(HA_PROFILE_ID);
-
-    task.zclFrame.payload().clear();
-    task.zclFrame.setSequenceNumber(zclSeq++);
-    task.zclFrame.setCommandId(0x00);
-    task.zclFrame.setManufacturerCode(VENDOR_PHILIPS);
-    task.zclFrame.setFrameControl(deCONZ::ZclFCClusterCommand |
-                                  deCONZ::ZclFCManufacturerSpecific |
-                                  deCONZ::ZclFCDirectionClientToServer |
-                                  deCONZ::ZclFCDisableDefaultResponse);
-
-    { // Payload
-        QDataStream stream(&task.zclFrame.payload(), QIODevice::WriteOnly);
-        stream.setByteOrder(QDataStream::LittleEndian);
-
-        // Group and Scene IDs
-        stream << (quint16) groupId;
-        stream << (quint8) sceneId;
-
-        // FIXME: Contents flag
-        //        Palette-only for now
-        //        Missing brightness and transitiontime
-        stream << (quint8) 0x0C;
-
-        QVariantList colors = palette["xy"].toList();
-        QVariantList color;
-
-        const quint8 nColors = colors.length();
-        stream << (quint8) (1 + 3 * (nColors + 1));
-        stream << (quint8) (nColors << 4);
-
-        stream << (quint8) 0x00;
-        stream << (quint8) 0x00;
-        stream << (quint8) 0x00;
-
-        // Palette Colors
-        for (auto &color : colors)
-        {
-            QVariantList xy = color.toList();
-            streamPoint(stream, xy[0].toDouble(), xy[1].toDouble());
-        }
-
-        // FIXME: Speed
-        stream << (quint8) 0xBA;
-    }
-
-    { // ZCL frame
-        task.req.asdu().clear(); // cleanup old request data if there is any
-        QDataStream stream(&task.req.asdu(), QIODevice::WriteOnly);
-        stream.setByteOrder(QDataStream::LittleEndian);
-        task.zclFrame.writeToStream(stream);
-    }
-
-    return addTask(task);
-}
-
-int DeRestPluginPrivate::setHueLightState(const ApiRequest &req, ApiResponse &rsp, TaskItem &taskRef, QVariantMap &map)
-{
-    bool ok;
-    QVariantMap itemList;
-    QString id = req.path[3];
-    HueManufacturerSpecificPayloads payloadItems(HueManufacturerSpecificPayload::None);
-
-    QMap<QString, QVariant> rspItemStates;
-    QMap<const char *, QVariant> stateValues;
+    bool ok = false;
+    bool hasErrors = false;
 
     for (QVariantMap::const_iterator p = map.begin(); p != map.end(); p++)
     {
@@ -558,22 +680,16 @@ int DeRestPluginPrivate::setHueLightState(const ApiRequest &req, ApiResponse &rs
         bool valueOk = false;
         QString param = p.key();
 
-        if (param == "on" && taskRef.lightNode->item(RStateOn))
+        if (param == "on" && lightNode->item(RStateOn))
         {
             paramOk = true;
             if (map[param].type() == QVariant::Bool)
             {
                 valueOk = true;
-                payloadItems.setFlag(HueManufacturerSpecificPayload::On);
-                bool targetOn = map[param].toBool();
-
-                itemList["on"] = QVariant(targetOn ? 0x01 : 0x00);
-                rspItemStates[param] = targetOn;
-
-                stateValues[RStateOn] = QVariant(targetOn);
+                validatedParameters.append(param);
             }
         }
-        else if (param == "bri" && taskRef.lightNode->item(RStateBri))
+        else if (param == "bri" && lightNode->item(RStateBri))
         {
             paramOk = true;
             if (map[param].type() == QVariant::Double)
@@ -581,40 +697,31 @@ int DeRestPluginPrivate::setHueLightState(const ApiRequest &req, ApiResponse &rs
                 const uint bri = map[param].toUInt(&ok);
                 if (ok && bri <= 0xFF)
                 {
+                    // Clamp to 254
                     valueOk = true;
-                    payloadItems.setFlag(HueManufacturerSpecificPayload::Brightness);
-                    quint8 targetBri = bri > 0xFE ? 0xFE : bri;
-
-                    itemList["bri"] = QVariant(targetBri);
-                    rspItemStates[param] = targetBri;
-
-                    stateValues[RStateBri] = QVariant(targetBri);
+                    validatedParameters.append(param);
+                    map["bri"] = bri > 0xFE ? 0xFE : bri;
                 }
             }
         }
-        else if (param == "ct"  && taskRef.lightNode->item(RStateCt))
+        else if (param == "ct"  && lightNode->item(RStateCt))
         {
             paramOk = true;
             if (map[param].type() == QVariant::Double)
             {
-                const quint16 ctMin = taskRef.lightNode->toNumber(RCapColorCtMin);
-                const quint16 ctMax = taskRef.lightNode->toNumber(RCapColorCtMax);
+                const quint16 ctMin = lightNode->toNumber(RCapColorCtMin);
+                const quint16 ctMax = lightNode->toNumber(RCapColorCtMax);
                 const uint ct = map[param].toUInt(&ok);
                 if (ok && ct <= 0xFFFF)
                 {
+                    // Clamp between ctMin and ctMax
                     valueOk = true;
-                    payloadItems.setFlag(HueManufacturerSpecificPayload::ColorTemperature);
-                    quint16 targetCt = (ctMin < 500 && ct < ctMin) ? ctMin : (ctMax > ctMin && ct > ctMax) ? ctMax : ct;
-
-                    itemList["ct"] = QVariant(targetCt);
-                    rspItemStates[param] = targetCt;
-
-                    stateValues[RStateCt] = QVariant(targetCt);
-                    stateValues[RStateColorMode] = QVariant(QString("ct"));
+                    validatedParameters.append(param);
+                    map["ct"] = (ctMin < 500 && ct < ctMin) ? ctMin : (ctMax > ctMin && ct > ctMax) ? ctMax : ct;
                 }
             }
         }
-        else if (param == "xy" && taskRef.lightNode->item(RStateX) && taskRef.lightNode->item(RStateY))
+        else if (param == "xy" && lightNode->item(RStateX) && lightNode->item(RStateY))
         {
             paramOk = true;
             if (map[param].type() == QVariant::List)
@@ -626,32 +733,13 @@ int DeRestPluginPrivate::setHueLightState(const ApiRequest &req, ApiResponse &rs
                     const double y = ok ? xy[1].toDouble(&ok) : 0;
                     if (ok && x >= 0.0 && x <= 1.0 && y >= 0.0 && y <= 1.0)
                     {
+                        // Clamp to 0.9961
                         valueOk = true;
-                        quint16 colorX = static_cast<quint16>((x > 0.9961 ? 0.9961 : x) * 65535.0);
-                        quint16 colorY = static_cast<quint16>((y > 0.9961 ? 0.9961 : y) * 65535.0);
-
-                        if (colorX > 65279) { colorX = 65279; }
-                        else if (colorX == 0) { colorX = 1; }
-
-                        if (colorY > 65279) { colorY = 65279; }
-                        else if (colorY == 0) { colorY = 1; }
-
-                        payloadItems.setFlag(HueManufacturerSpecificPayload::Color);
-                        itemList["xy"] = QVariant((colorY << 16) + colorX);
-
+                        validatedParameters.append(param);
                         QVariantList xy;
-                        xy.append(colorX);
-                        xy.append(colorY);
-                        rspItemStates[param] = xy;
-
-                        stateValues[RStateX] = QVariant(colorX);
-                        stateValues[RStateY] = QVariant(colorY);
-                        stateValues[RStateColorMode] = QVariant(QString("xy"));
-                    }
-                    else
-                    {
-                        valueOk = true;
-                        rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/lights/%1/state/xy").arg(id), QString("invalid value, [%1,%2], for parameter, xy").arg(xy[0].toString()).arg(xy[1].toString())));
+                        xy.append(x > 0.9961 ? 0.9961 : x);
+                        xy.append(y > 0.9961 ? 0.9961 : y);
+                        map["xy"] = xy;
                     }
                 }
             }
@@ -665,31 +753,21 @@ int DeRestPluginPrivate::setHueLightState(const ApiRequest &req, ApiResponse &rs
                 if (ok && tt <= 0xFFFF)
                 {
                     valueOk = true;
-                    payloadItems.setFlag(HueManufacturerSpecificPayload::TransitionTime);
-                    quint16 transitionTime = tt > 0xFFFE ? 0xFFFE : tt;
-
-                    itemList["transitiontime"] = QVariant(transitionTime);
-                    rspItemStates[param] = transitionTime;
+                    validatedParameters.append(param);
                 }
             }
         }
-        else if (param == "effect" && taskRef.lightNode->item(RStateEffect))
+        else if (param == "effect" && lightNode->item(RStateEffect))
         {
             paramOk = true;
             if (map[param].type() == QVariant::String)
             {
                 QString e = map[param].toString();
-                QStringList effectList = getHueEffectNames(taskRef.lightNode->item(RCapColorEffects)->toNumber(), false);
+                QStringList effectList = getHueEffectNames(lightNode->item(RCapColorEffects)->toNumber(), false);
                 if (effectList.indexOf(e) >= 0)
                 {
                     valueOk = true;
-                    payloadItems.setFlag(HueManufacturerSpecificPayload::Effect);
-
-                    itemList["effect"] = QVariant(effectNameToValue(e));
-                    rspItemStates[param] = e;
-
-                    stateValues[RStateEffect] = QVariant(e);
-                    stateValues[RStateColorMode] = QVariant(QString("effect"));
+                    validatedParameters.append(param);
                 }
             }
         }
@@ -702,26 +780,7 @@ int DeRestPluginPrivate::setHueLightState(const ApiRequest &req, ApiResponse &rs
                 if (ok && ed <= 216000)
                 {
                     valueOk = true;
-
-                    uint resolutionBase = (ed == 0) ? 0 :
-                                        (ed < RESOLUTION_01s_LIMIT) ? RESOLUTION_01s_BASE :
-                                        (ed < RESOLUTION_05s_LIMIT) ? RESOLUTION_05s_BASE :
-                                        (ed < RESOLUTION_15s_LIMIT) ? RESOLUTION_15s_BASE :
-                                        (ed < RESOLUTION_01m_LIMIT) ? RESOLUTION_01m_BASE :
-                                        (ed < RESOLUTION_05m_LIMIT) ? RESOLUTION_05m_BASE : 0;
-
-                    uint resolution = (ed == 0) ? 1 :
-                                    (ed < RESOLUTION_01s_LIMIT) ? RESOLUTION_01s :
-                                    (ed < RESOLUTION_05s_LIMIT) ? RESOLUTION_05s :
-                                    (ed < RESOLUTION_15s_LIMIT) ? RESOLUTION_15s :
-                                    (ed < RESOLUTION_01m_LIMIT) ? RESOLUTION_01m :
-                                    (ed < RESOLUTION_05m_LIMIT) ? RESOLUTION_05m : 1;
-
-                    payloadItems.setFlag(HueManufacturerSpecificPayload::EffectDuration);
-                    quint8 effectDuration = resolutionBase - (ed / resolution);
-
-                    itemList["effect_duration"] = QVariant(effectDuration);
-                    rspItemStates[param] = effectDuration;
+                    validatedParameters.append(param);
                 }
             }
         }
@@ -734,59 +793,145 @@ int DeRestPluginPrivate::setHueLightState(const ApiRequest &req, ApiResponse &rs
                 if (ok && es >= 0.0 && es <= 1.0)
                 {
                     valueOk = true;
-                    quint8 effectSpeed = static_cast<quint8>(es * 254.0);
-
-                    // 'effect_speed' and 'effect_duration' share the same byte in the
-                    // manufacturer-specific command's payload.
-                    payloadItems.setFlag(HueManufacturerSpecificPayload::EffectDuration);
-
-                    itemList["effect_duration"] = QVariant(effectSpeed);
-                    rspItemStates[param] = effectSpeed;
+                    validatedParameters.append(param);
                 }
             }
         }
 
         if (!paramOk)
         {
-            rsp.list.append(errorToMap(ERR_PARAMETER_NOT_AVAILABLE, QString("/lights/%1/state").arg(id), QString("parameter, %1, not available").arg(param)));
+            hasErrors = true;
+            rsp.list.append(errorToMap(ERR_PARAMETER_NOT_AVAILABLE, QString("/lights/%1/state").arg(lightNode->id()), QString("parameter, %1, not available").arg(param)));
         }
         else if (!valueOk)
         {
-            rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/lights/%1/state").arg(id), QString("invalid value, %1, for parameter, %2").arg(map[param].toString()).arg(param)));
+            hasErrors = true;
+            rsp.list.append(errorToMap(ERR_INVALID_VALUE, QString("/lights/%1/state").arg(lightNode->id()), QString("invalid value, %1, for parameter, %2").arg(map[param].toString()).arg(param)));
         }
     }
 
-    ok = addTaskHueManufacturerSpecificSetState(taskRef, payloadItems, itemList);
+    return !hasErrors;
+}
+
+// MARK: - Light State
+
+int DeRestPluginPrivate::setHueLightState(const ApiRequest &req, ApiResponse &rsp, TaskItem &taskRef, QVariantMap &map)
+{
+    bool ok;
+    QList<QString> validatedParameters;
+
+    bool hasErrors = validateHueLightState(rsp, taskRef.lightNode, map, validatedParameters);
+    ok = addTaskHueManufacturerSpecificSetState(taskRef, map);
 
     if (ok)
     {
-        for (QMap<QString, QVariant>::const_iterator s = rspItemStates.begin(); s != rspItemStates.end(); s++)
+        if ((map.contains("on")) && (validatedParameters.contains("on")))
         {
-            QString param = s.key();
+            const bool targetOn = map["on"].toBool();
+
             QVariantMap rspItem;
             QVariantMap rspItemState;
-            rspItemState[QString("/lights/%1/state/%2").arg(id).arg(param)] = rspItemStates[param];
+            rspItemState[QString("/lights/%1/state/on").arg(taskRef.lightNode->id())] = targetOn;
+            rspItem["success"] = rspItemState;
+            rsp.list.append(rspItem);
+
+            taskRef.lightNode->setValue(RStateOn, targetOn);
+        }
+
+        if ((map.contains("bri")) && (validatedParameters.contains("bri")))
+        {
+            const uint targetBri = map["bri"].toUInt();
+
+            QVariantMap rspItem;
+            QVariantMap rspItemState;
+            rspItemState[QString("/lights/%1/state/bri").arg(taskRef.lightNode->id())] = targetBri;
+            rspItem["success"] = rspItemState;
+            rsp.list.append(rspItem);
+
+            taskRef.lightNode->setValue(RStateBri, targetBri);
+        }
+
+        if ((map.contains("ct")) && (validatedParameters.contains("ct")))
+        {
+            const uint targetCt = map["ct"].toUInt();
+
+            QVariantMap rspItem;
+            QVariantMap rspItemState;
+            rspItemState[QString("/lights/%1/state/ct").arg(taskRef.lightNode->id())] = targetCt;
+            rspItem["success"] = rspItemState;
+            rsp.list.append(rspItem);
+
+            taskRef.lightNode->setValue(RStateCt, targetCt);
+            taskRef.lightNode->setValue(RStateColorMode, QString("ct"));
+        }
+
+        if ((map.contains("xy")) && (validatedParameters.contains("xy")))
+        {
+            QVariantList xy = map["xy"].toList();
+            const double targetX = xy[0].toDouble();
+            const double targetY = xy[1].toDouble();
+
+            QVariantMap rspItem;
+            QVariantMap rspItemState;
+            rspItemState[QString("/lights/%1/state/xy").arg(taskRef.lightNode->id())] = xy;
+            rspItem["success"] = rspItemState;
+            rsp.list.append(rspItem);
+
+            taskRef.lightNode->setValue(RStateX, targetX * 65535);
+            taskRef.lightNode->setValue(RStateY, targetY * 65535);
+            taskRef.lightNode->setValue(RStateColorMode, QString("xy"));
+        }
+
+        if ((map.contains("transitiontime")) && (validatedParameters.contains("transitiontime")))
+        {
+            const uint tt = map["transitiontime"].toUInt();
+
+            QVariantMap rspItem;
+            QVariantMap rspItemState;
+            rspItemState[QString("/lights/%1/state/transitiontime").arg(taskRef.lightNode->id())] = tt;
             rspItem["success"] = rspItemState;
             rsp.list.append(rspItem);
         }
 
-        for (QMap<const char *, QVariant>::const_iterator v = stateValues.begin(); v != stateValues.end(); v++)
+        if ((map.contains("effect")) && (validatedParameters.contains("effect")))
         {
-            const char *resource = v.key();
-            QVariant value = stateValues[resource];
+            QString effect = map["effect"].toString();
 
-            if (value.userType() == QMetaType::QString)
-            {
-                taskRef.lightNode->setValue(resource, value.toString());
-            }
-            else if (value.canConvert<qint64>()) // Treat as qint64
-            {
-                taskRef.lightNode->setValue(resource, value.value<qint64>());
-            }
+            QVariantMap rspItem;
+            QVariantMap rspItemState;
+            rspItemState[QString("/lights/%1/state/effect").arg(taskRef.lightNode->id())] = effect;
+            rspItem["success"] = rspItemState;
+            rsp.list.append(rspItem);
+
+            taskRef.lightNode->setValue(RStateEffect, effect);
+            taskRef.lightNode->setValue(RStateColorMode, QString("effect"));
         }
 
-        rsp.etag = taskRef.lightNode->etag;
+        if ((map.contains("effect_duration")) && (validatedParameters.contains("effect_duration")))
+        {
+            const uint ed = map["effect_duration"].toUInt();
+
+            QVariantMap rspItem;
+            QVariantMap rspItemState;
+            rspItemState[QString("/lights/%1/state/effect_duration").arg(taskRef.lightNode->id())] = ed;
+            rspItem["success"] = rspItemState;
+            rsp.list.append(rspItem);
+        }
+
+        if ((map.contains("effect_speed")) && (validatedParameters.contains("effect_speed")))
+        {
+            const double es = map["effect_speed"].toDouble();
+
+            QVariantMap rspItem;
+            QVariantMap rspItemState;
+            rspItemState[QString("/lights/%1/state/effect_speed").arg(taskRef.lightNode->id())] = es;
+            rspItem["success"] = rspItemState;
+            rsp.list.append(rspItem);
+        }
     }
+
+    rsp.httpStatus = HttpStatusOk;
+    rsp.etag = taskRef.lightNode->etag;
 
     return REQ_READY_SEND;
 }

--- a/hue.cpp
+++ b/hue.cpp
@@ -41,6 +41,16 @@ quint8 effectNameToValue(QString &effectName)
     return 0xFF;
 }
 
+/*! Test if a LightNode is a Philips Hue light that supports effects.
+    \param lightNode - the light node to test
+ */
+bool DeRestPluginPrivate::isHueEffectLight(const LightNode *lightNode)
+{
+    return lightNode != nullptr &&
+           lightNode->manufacturerCode() == VENDOR_PHILIPS &&
+           lightNode->item(RCapColorEffects);
+}
+
 /*! Return a list of effect names corresponding to the bitmap of supported effects.
 
    \param effectBitmap - the bitmap with supported effects (from 0x0011)

--- a/hue.cpp
+++ b/hue.cpp
@@ -401,6 +401,11 @@ bool DeRestPluginPrivate::addTaskHueManufacturerSpecific(TaskItem &task, HueManu
             stream << (quint8)(items["on"].toUInt());
         }
 
+        if (payloadItems.testFlag(HueManufacturerSpecificPayload::Brightness))
+        {
+            stream << (quint8)(items["bri"].toUInt());
+        }
+
         if (payloadItems.testFlag(HueManufacturerSpecificPayload::TransitionTime))
         {
             stream << (quint16)(items["transitiontime"].toUInt());
@@ -438,6 +443,20 @@ int DeRestPluginPrivate::setHueLightState(const ApiRequest &req, ApiResponse &rs
                 valueOk = true;
                 payloadItems.setFlag(HueManufacturerSpecificPayload::On);
                 itemList["on"] = QVariant(map[param].toBool() ? 0x01 : 0x00);
+            }
+        }
+        else if (param == "bri" && taskRef.lightNode->item(RStateBri))
+        {
+            paramOk = true;
+            if (map[param].type() == QVariant::Double)
+            {
+                const uint bri = map[param].toUInt(&ok);
+                if (ok && bri <= 0xFF)
+                {
+                    valueOk = true;
+                    payloadItems.setFlag(HueManufacturerSpecificPayload::Brightness);
+                    itemList["bri"] = QVariant(bri > 0xFE ? 0xFE : bri);
+                }
             }
         }
         else if (param == "transitiontime")

--- a/hue.cpp
+++ b/hue.cpp
@@ -372,7 +372,7 @@ bool DeRestPluginPrivate::addTaskHueGradient(TaskItem &task, QVariantMap &gradie
    \return true - on success
            false - on error
  */
-bool DeRestPluginPrivate::addTaskHueManufacturerSpecific(TaskItem &task, QVariantMap &items)
+bool DeRestPluginPrivate::addTaskHueManufacturerSpecific(TaskItem &task, HueManufacturerSpecificPayloads &payloadItems, QVariantMap &items)
 {
     task.taskType = TaskHueManufacturerSpecific;
     task.req.setClusterId(HUE_EFFECTS_CLUSTER_ID);
@@ -391,7 +391,8 @@ bool DeRestPluginPrivate::addTaskHueManufacturerSpecific(TaskItem &task, QVarian
         QDataStream stream(&task.zclFrame.payload(), QIODevice::WriteOnly);
         stream.setByteOrder(QDataStream::LittleEndian);
 
-        // FIXME: Build payload
+        // Set payload contents
+        stream << (quint16)payloadItems;
     }
 
     { // ZCL frame

--- a/hue.cpp
+++ b/hue.cpp
@@ -365,6 +365,45 @@ bool DeRestPluginPrivate::addTaskHueGradient(TaskItem &task, QVariantMap &gradie
     return addTask(task);
 }
 
+/*! Add a Hue Manufacturer Specific '0xfc03' '0x00' task to the queue.
+
+   \param task - the task item
+   \param items - the list of items in the payload
+   \return true - on success
+           false - on error
+ */
+bool DeRestPluginPrivate::addTaskHueManufacturerSpecific(TaskItem &task, QVariantMap &items)
+{
+    task.taskType = TaskHueManufacturerSpecific;
+    task.req.setClusterId(HUE_EFFECTS_CLUSTER_ID);
+    task.req.setProfileId(HA_PROFILE_ID);
+
+    task.zclFrame.payload().clear();
+    task.zclFrame.setSequenceNumber(zclSeq++);
+    task.zclFrame.setCommandId(0x00);
+    task.zclFrame.setManufacturerCode(VENDOR_PHILIPS);
+    task.zclFrame.setFrameControl(deCONZ::ZclFCClusterCommand |
+                                  deCONZ::ZclFCManufacturerSpecific |
+                                  deCONZ::ZclFCDirectionClientToServer |
+                                  deCONZ::ZclFCDisableDefaultResponse);
+
+    { // Payload
+        QDataStream stream(&task.zclFrame.payload(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+
+        // FIXME: Build payload
+    }
+
+    { // ZCL frame
+        task.req.asdu().clear(); // cleanup old request data if there is any
+        QDataStream stream(&task.req.asdu(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+        task.zclFrame.writeToStream(stream);
+    }
+
+    return addTask(task);
+}
+
 int DeRestPluginPrivate::setHueLightState(const ApiRequest &req, ApiResponse &rsp, TaskItem &taskRef, QVariantMap &map)
 {
     return REQ_NOT_HANDLED;

--- a/hue.cpp
+++ b/hue.cpp
@@ -29,7 +29,7 @@
 #define RESOLUTION_05m_LIMIT (6 * 60 * 60 * 10) // 06hrs.
 
 // List of 'state' keys that can be mapped into the '0xfc03' cluster's '0x00' command.
-QList<QString> supportedStateKeys = {"on", "bri", "ct", "xy", "transitiontime", "effect", "effect_duration"};
+QList<QString> supportedStateKeys = {"on", "bri", "ct", "xy", "transitiontime", "effect", "effect_duration", "effect_speed"};
 
 struct code {
     quint8 value;
@@ -648,6 +648,26 @@ int DeRestPluginPrivate::setHueLightState(const ApiRequest &req, ApiResponse &rs
 
                     itemList["effect_duration"] = QVariant(effectDuration);
                     rspItemStates[param] = effectDuration;
+                }
+            }
+        }
+        else if (param == "effect_speed")
+        {
+            paramOk = true;
+            if (map[param].type() == QVariant::Double)
+            {
+                const double es = map[param].toDouble(&ok);
+                if (ok && es >= 0.0 && es <= 1.0)
+                {
+                    valueOk = true;
+                    quint8 effectSpeed = static_cast<quint8>(es * 254.0);
+
+                    // 'effect_speed' and 'effect_duration' share the same byte in the
+                    // manufacturer-specific command's payload.
+                    payloadItems.setFlag(HueManufacturerSpecificPayload::EffectDuration);
+
+                    itemList["effect_duration"] = QVariant(effectSpeed);
+                    rspItemStates[param] = effectSpeed;
                 }
             }
         }

--- a/hue.cpp
+++ b/hue.cpp
@@ -9,6 +9,9 @@
 
 #define HUE_EFFECTS_CLUSTER_ID 0xFC03
 
+// List of 'state' keys that can be mapped into the '0xfc03' cluster's '0x00' command.
+QList<QString> supportedStateKeys = {"on", "bri", "ct", "xy", "transitiontime", "effect", "effect_duration"};
+
 struct code {
     quint8 value;
     QString name;
@@ -49,6 +52,23 @@ bool DeRestPluginPrivate::isHueEffectLight(const LightNode *lightNode)
     return lightNode != nullptr &&
            lightNode->manufacturerCode() == VENDOR_PHILIPS &&
            lightNode->item(RCapColorEffects);
+}
+
+/*! Test whether all the items in a request can be mapped into an '0xfc03' cluster command.
+    \param map - the map to test
+ */
+bool DeRestPluginPrivate::isMappableToManufacturerSpecific(const QVariantMap &map)
+{
+    const QList<QString> keyList = map.keys();
+    for (const QString &key : keyList)
+    {
+        if (!supportedStateKeys.contains(key))
+        {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 /*! Return a list of effect names corresponding to the bitmap of supported effects.
@@ -343,4 +363,9 @@ bool DeRestPluginPrivate::addTaskHueGradient(TaskItem &task, QVariantMap &gradie
         task.zclFrame.writeToStream(stream);
     }
     return addTask(task);
+}
+
+int DeRestPluginPrivate::setHueLightState(const ApiRequest &req, ApiResponse &rsp, TaskItem &taskRef, QVariantMap &map)
+{
+    return REQ_NOT_HANDLED;
 }

--- a/rest_hue_scenes.cpp
+++ b/rest_hue_scenes.cpp
@@ -13,11 +13,177 @@
  */
 int DeRestPluginPrivate::handleHueScenesApi(const ApiRequest &req, ApiResponse &rsp)
 {
-    Q_UNUSED(req);
-    if (rsp.map.isEmpty())
+    if (req.path[2] != QLatin1String("hue-scenes"))
     {
-        rsp.str = "{}"; // return empty object
+        return REQ_NOT_HANDLED;
     }
+
+    // PUT /api/<apikey>/hue-scenes/groups/<group_id>/scenes/<scene_id>/recall
+    else if ((req.path.size() == 8) && (req.hdr.method() == "PUT")  && (req.path[5] == "scenes") && (req.path[7] == "play"))
+    {
+        return playHueDynamicScene(req, rsp);
+    }
+
+    return REQ_NOT_HANDLED;
+}
+
+/*! PUT /api/<apikey>/groups/<group_id>/scenes/<scene_id>/play
+    \return REQ_READY_SEND
+            REQ_NOT_HANDLED
+ */
+int DeRestPluginPrivate::playHueDynamicScene(const ApiRequest &req, ApiResponse &rsp)
+{
+    bool ok;
+    QVariantMap rspItem;
+    QVariantMap rspItemState;
+    QVariant var = Json::parse(req.content, ok);
+    QVariantMap map = var.toMap();
+    const QString &gid = req.path[4];
+    const QString &sid = req.path[6];
+    Scene *scene = nullptr;
+    Group *group = getGroupForId(gid);
     rsp.httpStatus = HttpStatusOk;
+
+    if (req.sock)
+    {
+        userActivity();
+    }
+
+    if (!isInNetwork())
+    {
+        rsp.list.append(errorToMap(ERR_NOT_CONNECTED, QString("/hue-scenes/groups/%1/scenes/%2").arg(gid).arg(sid), "not connected"));
+        rsp.httpStatus = HttpStatusServiceUnavailable;
+        return REQ_READY_SEND;
+    }
+
+    if (!group || (group->state() != Group::StateNormal))
+    {
+        rsp.httpStatus = HttpStatusNotFound;
+        rsp.list.append(errorToMap(ERR_RESOURCE_NOT_AVAILABLE, QString("/hue-scenes/groups/%1/scenes/%2").arg(gid).arg(sid), QString("resource, /groups/%1/scenes/%2, not available").arg(gid).arg(sid)));
+        return REQ_READY_SEND;
+    }
+
+    // check if scene exists
+    uint8_t sceneId = 0;
+    ok = false;
+    if (sid == QLatin1String("next") || sid == QLatin1String("prev"))
+    {
+        ResourceItem *item = group->item(RActionScene);
+        DBG_Assert(item != 0);
+        uint lastSceneId = 0;
+        if (item && !item->toString().isEmpty())
+        {
+            lastSceneId = item->toString().toUInt(&ok);
+        }
+
+        int idx = -1;
+        std::vector<quint8> scenes; // available scenes
+
+        for (const Scene &s : group->scenes)
+        {
+            if (s.state != Scene::StateNormal)
+            {
+                continue;
+            }
+
+            if (lastSceneId == s.id)
+            {
+                idx = scenes.size(); // remember current index
+            }
+            scenes.emplace_back(s.id);
+        }
+
+        if (scenes.size() == 1)
+        {
+            ok = true;
+            sceneId = scenes[0];
+        }
+        else if (scenes.size() > 1)
+        {
+            ok = true;
+            if (idx == -1) // not found
+            {
+                idx = 0; // use first
+            }
+            else if (sid[0] == 'p') // prev
+            {
+                if (idx > 0)  { idx--; }
+                else          { idx = scenes.size() - 1; } // jump to last scene
+            }
+            else // next
+            {
+                if (idx < int(scenes.size() - 1)) { idx++; }
+                else  { idx = 0; } // jump to first scene
+            }
+            DBG_Assert(idx >= 0 && idx < int(scenes.size()));
+            sceneId = scenes[idx];
+        }
+        // else ok == false
+    }
+    else
+    {
+        sceneId = sid.toUInt(&ok);
+    }
+
+    scene = ok ? group->getScene(sceneId) : nullptr;
+
+    if (!scene || (scene->state != Scene::StateNormal))
+    {
+        rsp.httpStatus = HttpStatusNotFound;
+        rsp.list.append(errorToMap(ERR_RESOURCE_NOT_AVAILABLE, QString("/hue-scenes/groups/%1/scenes/%2").arg(gid).arg(sid), QString("resource, /groups/%1/scenes/%2, not available").arg(gid).arg(sid)));
+        return REQ_READY_SEND;
+    }
+
+    TaskItem taskRef;
+    taskRef.req.setDstEndpoint(0xFF);
+    taskRef.req.setDstAddressMode(deCONZ::ApsGroupAddress);
+    taskRef.req.dstAddress().setGroup(group->address());
+    taskRef.req.setSrcEndpoint(getSrcEndpoint(0, taskRef.req));
+
+    // FIXME: Collapse into 'recallHueDynamicScene'
+    if (!callScene(group, sceneId))
+    {
+        rsp.httpStatus = HttpStatusServiceUnavailable;
+        rsp.list.append(errorToMap(ERR_BRIDGE_BUSY, QString("/hue-scenes/groups/%1/scenes/%2").arg(gid).arg(sid), QString("gateway busy")));
+        return REQ_READY_SEND;
+    }
+
+    // FIXME: Rename into 'recallHueDynamicScene'
+    // FIXME: Validate contents of 'map'
+    if (!addTaskPlayHueDynamicScene(taskRef, group->address(), scene->id, map))
+    {
+        rsp.httpStatus = HttpStatusServiceUnavailable;
+        rsp.list.append(errorToMap(ERR_BRIDGE_BUSY, QString("/hue-scenes/groups/%1/scenes/%2").arg(gid).arg(sid), QString("gateway busy")));
+        return REQ_READY_SEND;
+    }
+
+    {
+        const QString scid = QString::number(sceneId);
+        ResourceItem *item = group->item(RActionScene);
+        if (item && item->toString() != scid)
+        {
+            item->setValue(scid);
+            updateGroupEtag(group);
+            Event e(RGroups, RActionScene, group->id(), item);
+            enqueueEvent(e);
+        }
+    }
+
+    // FIXME: Remove unnecessary check
+    //        This call is meant to check the state of the lights have changed to match the
+    //        recalled scene. Apparently, IKEA lights tend to misbehave. This might not be
+    //        needed with Philips Hue lights that support effects.
+    // TODO: Verify that the group and light's states update after the recall
+    //recallSceneCheckGroupChanges(this, group, scene);
+
+    updateEtag(gwConfigEtag);
+
+    rspItemState["id"] = sid;
+    rspItem["success"] = rspItemState;
+    rsp.list.append(rspItem);
+    rsp.httpStatus = HttpStatusOk;
+
+    processTasks();
+
     return REQ_READY_SEND;
 }

--- a/rest_hue_scenes.cpp
+++ b/rest_hue_scenes.cpp
@@ -1,0 +1,23 @@
+/*
+ * Handle Hue-specific Dynamic Scenes.
+ */
+
+#include "de_web_plugin.h"
+#include "de_web_plugin_private.h"
+
+/*! Scenes REST API broker.
+    \param req - request data
+    \param rsp - response data
+    \return REQ_READY_SEND
+            REQ_NOT_HANDLED
+ */
+int DeRestPluginPrivate::handleHueScenesApi(const ApiRequest &req, ApiResponse &rsp)
+{
+    Q_UNUSED(req);
+    if (rsp.map.isEmpty())
+    {
+        rsp.str = "{}"; // return empty object
+    }
+    rsp.httpStatus = HttpStatusOk;
+    return REQ_READY_SEND;
+}

--- a/rest_hue_scenes.cpp
+++ b/rest_hue_scenes.cpp
@@ -152,7 +152,13 @@ int DeRestPluginPrivate::playHueDynamicScene(const ApiRequest &req, ApiResponse 
         return REQ_READY_SEND;
     }
 
-    // FIXME: Validate contents of 'map'
+    QList<QString> validatedParameters;
+    if (!validateHueDynamicScenePalette(rsp, scene, map, validatedParameters))
+    {
+        rsp.httpStatus = HttpStatusBadRequest;
+        return REQ_READY_SEND;
+    }
+
     if (!addTaskHueDynamicSceneRecall(taskRef, group->address(), scene->id, map))
     {
         rsp.httpStatus = HttpStatusServiceUnavailable;
@@ -285,7 +291,6 @@ int DeRestPluginPrivate::modifyHueScene(const ApiRequest &req, ApiResponse &rsp)
     QList<QString> validatedParameters;
     if (!validateHueLightState(rsp, light, map, validatedParameters))
     {
-        // FIXME: Missing addition to 'rsp.list'
         rsp.httpStatus = HttpStatusBadRequest;
         return REQ_READY_SEND;
     }

--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -720,6 +720,12 @@ int DeRestPluginPrivate::setLightState(const ApiRequest &req, ApiResponse &rsp)
     {
         return setWindowCoveringState(req, rsp, taskRef, map);
     }
+    else if (isHueEffectLight(taskRef.lightNode) && isMappableToManufacturerSpecific(map))
+    {
+        // Philips Hue lights that support the '0xfc03' cluster
+        // can be controlled in a manufacturer-specific way.
+        return setHueLightState(req, rsp, taskRef, map);
+    }
     else if (isXmasLightStrip(taskRef.lightNode))
     {
         return setXmasLightStripState(req, rsp, taskRef, map);

--- a/rest_rules.cpp
+++ b/rest_rules.cpp
@@ -1389,6 +1389,14 @@ void DeRestPluginPrivate::triggerRule(Rule &rule)
             }
             triggered = true;
         }
+        else if (path[2] == QLatin1String("hue-scenes"))
+        {
+            if (handleHueScenesApi(req, rsp) == REQ_NOT_HANDLED)
+            {
+                return;
+            }
+            triggered = true;
+        }
         else if (path[2] == QLatin1String("sensors"))
         {
             if (handleSensorsApi(req, rsp) == REQ_NOT_HANDLED)


### PR DESCRIPTION
Requires:
- #7950

This PR adds rudimentary support for Dynamic Scenes for Philips Hue lights that support them. It leverages manufacturer-specific commands to provide two things:

#### * Defining a light's state in a scene using the manufacturer-specific payload used by the `0xFC03` cluster

To keep this separate from other endpoints while testing, the functionality is tucked away behind the (hopefully only temporary) `hue-scenes` path, the endpoint for this feature being `/api/<apikey>/hue-scenes/groups/<group_id>/scenes/<scene_id>/lights/<light_id>/state`. Currently, it is best to first create an empty scene and use this endpoint only to overwrite the states of lights that are members of the scene. The manufacturer-specific way of setting the state of a light in a scene has some advantages over the standard way of doing it:

* The usual `on`, `bri`, `ct`, `xy`, and `transitiontime` parameters are supported
* `effect` is a valid attribute (as are `effect_duration` and `effect_speed`), allowing scenes where lights are recalled to effects
* `gradient` is a valid attribute, allowing scenes where lights are recalled to gradients (not supported at the time of writing this)
* All parameters are considered optional. The state of the light at the time of recalling the scene is used to fill in the missing parameters. This is particularly nice for scenes which turn some lights off - the brightness or color of those lights does not need to be affected.

**N.B.** because of potential format incompatibilities, modifying a light's state in a scene via this command does not currently persist the value of the light's state for the scene to the API.

#### * Recalling Dynamic Scenes

Like the above, this too sits behind the `hue-scenes` path at `/api/<apikey>/hue-scenes/groups/<group_id>/scenes/<scene_id>/play`. This command will firstly recall `<scene_id>` and then provide that group and scene with the "dynamic palette" that makes up the Dynamic Scene. This palette is provided in the body of the request and is not stored by the API. Currently `bri`, `transitiontime`, `effect_speed`, and `xy` are supported.  `xy` must be a list of colors (up to 9). e.g., the Halloween-themed "Glowing Grins" dynamic scene available in the mobile app would be played by the following request body:

```json
{
  "bri": 120,
  "xy" : [
    [0.657060, 0.295434],
    [0.630906, 0.333872],
    [0.593867, 0.378974],
    [0.535248, 0.403478],
    [0.313381, 0.592306]
  ],
  "transitiontime": 4,
  "effect_speed": 0.75
}
```

The effect looks best if the recalled scene `<scene_id>` puts the scene lights to the same brightness and to one of the colors included in the dynamic palette. The light's firmware sorts out playing the effect from the closest color to the current one.

`ct` and `effect` can also be supported as payload for the dynamic palette, but are currently not supported.

