### PR TITLE
DDF solve battery issue for a tuya sensor (_TZE200_9yapgbuv)

### DIFF
--- a/devices/tuya/_TZE200_TS0601_humidity_temperature.json
+++ b/devices/tuya/_TZE200_TS0601_humidity_temperature.json
@@ -1,8 +1,8 @@
 {
   "schema": "devcap1.schema.json",
   "uuid": "2a639a12-22c6-4a1c-b2a3-90ae3a68a837",
-  "manufacturername": ["_TZE200_nnrfa68v","_TZE200_znbl8dj5", "_TZE200_qoy0ekbd", "_TZE200_a8sdabtg", "_TZE200_whkgqxse","_TZE200_yjjdcqsq", "_TZE200_utkemkbs", "_TZE200_locansqn", "_TZE204_yjjdcqsq"],
-  "modelid": ["TS0601","TS0601", "TS0601", "TS0601", "TS0601", "TS0601", "TS0601", "TS0601", "TS0601"],
+  "manufacturername": "_TZE200_9yapgbuv",
+  "modelid": "TS0601",
   "vendor": "Tuya",
   "product": "Temperature humidity sensor (TS0601)",
   "sleeper": true,
@@ -64,7 +64,7 @@
         },
         {
           "name": "config/battery",
-          "parse": {"fn": "tuya", "dpid": 4, "eval": "Item.val = Attr.val;" },
+          "parse": {"fn": "tuya", "dpid": 3, "eval": "if (Attr.val == 0) { Item.val=25 } else if (Attr.val == 1) { Item.val=50 } else { Item.val=100 }" },
           "read": {"fn": "none"},
           "default": 0
         },
@@ -117,7 +117,7 @@
         },
         {
           "name": "config/battery",
-          "parse": {"fn": "tuya", "dpid": 4, "eval": "Item.val = Attr.val;" },
+          "parse": {"fn": "tuya", "dpid": 3, "eval": "if (Attr.val == 0) { Item.val=25 } else if (Attr.val == 1) { Item.val=50 } else { Item.val=100 }" },
           "read": {"fn": "none"},
           "default": 0
         },


### PR DESCRIPTION
This model don't use the same DPID for the battery
See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7999