### PR TITLE
hotfix wrong manufacturer count vs model count

### DIFF
--- a/devices/philips/light_zb3_C.json
+++ b/devices/philips/light_zb3_C.json
@@ -31,6 +31,8 @@
     "$MF_PHILIPS",
     "$MF_PHILIPS",
     "$MF_PHILIPS",
+    "$MF_PHILIPS",
+    "$MF_SIGNIFY",
     "$MF_SIGNIFY",
     "$MF_SIGNIFY",
     "$MF_SIGNIFY",


### PR DESCRIPTION
Master is broken since #7961 , caused by commit [9da501cb1e6b4b2b74248837f29212d7ac55d69e](https://github.com/dresden-elektronik/deconz-rest-plugin/commit/9da501cb1e6b4b2b74248837f29212d7ac55d69e), which was not passing / running DDF checks.