### PR TITLE
Add DDF support for Hive Thermostatic Radiator Valve variant TRV003

### DIFF
--- a/devices/danfoss/etrv0100_thermostat.json
+++ b/devices/danfoss/etrv0100_thermostat.json
@@ -1,8 +1,8 @@
 {
   "schema": "devcap1.schema.json",
   "uuid": "76d8605f-9699-439f-bed0-52757d62cff1",
-  "manufacturername": ["Danfoss", "Danfoss", "D5X84YU", "D5X84YU", "Danfoss"],
-  "modelid": ["eTRV0100", "eTRV0103", "eT093WRO", "eT093WRG", "TRV001"],
+  "manufacturername": ["Danfoss", "Danfoss", "D5X84YU", "D5X84YU", "Danfoss", "Danfoss"],
+  "modelid": ["eTRV0100", "eTRV0103", "eT093WRO", "eT093WRG", "TRV001", "TRV003"],
   "vendor": "Danfoss",
   "product": "Ally radiator thermostat (014G2461)",
   "sleeper": false,


### PR DESCRIPTION
Simple manufacturername/modelID addition.