### PR TITLE
Update ZY-M100_human_breathing_presence.json

### DIFF
--- a/devices/tuya/ZY-M100_human_breathing_presence.json
+++ b/devices/tuya/ZY-M100_human_breathing_presence.json
@@ -6,6 +6,7 @@
     "_TZE204_ztc6ggyl",
     "_TZE200_ar0slwnd",
     "_TZE200_sfiy5tfs",
+    "_TZE200_2aaelwxk",
     "_TZE200_mrf6vtua"
   ],
   "modelid": [
@@ -13,6 +14,7 @@
     "TS0601",
     "TS0601",
     "TS0601",
+    "TS0225",
     "TS0601"
   ],
   "vendor": "Tuya",


### PR DESCRIPTION
Added TS0225  (ZG-205Z/A) from manufacturer _TZE200_2aaelwxk. Still several datapoints missing, like light level ("illuminance_raw").