### PR TITLE
DDF improvement for button chords on Illumra Dual Rocker Switch (PTM215ZE Friends of Hue)

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1711,6 +1711,12 @@ void DeRestPluginPrivate::gpProcessButtonEvent(const deCONZ::GpDataIndication &i
     {
         // Map the command to the mapped button and action.
         // PTM215ZE Friends of Hue switch.
+        // Button 1 == A0       Button 3 == B0
+        // Button 2 == A1       Button 4 == B1
+        // Button 5 == A0 + B0 (chord of 1 & 3)
+        // Button 6 == A1 + B0 (chord of 2 & 3)
+        // Button 7 == A0 + B1 (chord of 1 & 4)
+        // Button 8 == A1 + B1 (chord of 2 & 4)
         const quint32 buttonMapPTM215ZE[] = {
             0x12, S_BUTTON_1, S_BUTTON_ACTION_INITIAL_PRESS,
             0x13, S_BUTTON_1, S_BUTTON_ACTION_SHORT_RELEASED,
@@ -1720,6 +1726,14 @@ void DeRestPluginPrivate::gpProcessButtonEvent(const deCONZ::GpDataIndication &i
             0x19, S_BUTTON_3, S_BUTTON_ACTION_SHORT_RELEASED,
             0x22, S_BUTTON_4, S_BUTTON_ACTION_INITIAL_PRESS,
             0x23, S_BUTTON_4, S_BUTTON_ACTION_SHORT_RELEASED,
+            0x1A, S_BUTTON_5, S_BUTTON_ACTION_INITIAL_PRESS,
+            0x1B, S_BUTTON_5, S_BUTTON_ACTION_SHORT_RELEASED,
+            0x1C, S_BUTTON_6, S_BUTTON_ACTION_INITIAL_PRESS,
+            0x1D, S_BUTTON_6, S_BUTTON_ACTION_SHORT_RELEASED,
+            0x1E, S_BUTTON_7, S_BUTTON_ACTION_INITIAL_PRESS,
+            0x1F, S_BUTTON_7, S_BUTTON_ACTION_SHORT_RELEASED,
+            0x62, S_BUTTON_8, S_BUTTON_ACTION_INITIAL_PRESS,
+            0x63, S_BUTTON_8, S_BUTTON_ACTION_SHORT_RELEASED,
             0
         };
 

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -3544,7 +3544,7 @@ void DeRestPluginPrivate::checkSensorStateTimerFired()
                     item = sensor->item(RStateButtonEvent);
                     quint32 btn = item ? static_cast<quint32>(item->toNumber()) : 0;
                     const quint32 action = btn & 0x03;
-                    if (btn >= S_BUTTON_1 && btn <= S_BUTTON_6 && action == S_BUTTON_ACTION_INITIAL_PRESS)
+                    if (btn >= S_BUTTON_1 && btn <= S_BUTTON_8 && action == S_BUTTON_ACTION_INITIAL_PRESS)
                     {
                         btn &= ~0x03;
                         item->setValue(btn + S_BUTTON_ACTION_HOLD);


### PR DESCRIPTION
First of all, huge thanks to everyone (especially @mdolnik) involved in adding the initial support for this switch back in 2020. I've had one sitting in a bin and I finally got it working today thanks to PR #3285 !

I knew from previous experiments with this switch, that in addition to the 4 buttons already implemented, the switch also supports undocumented button "chords", through which additional automations can be assigned. See the stellar research user `rkjnsn` did here: https://www.reddit.com/r/Hue/comments/8s85g7/experience_with_illumra_rocker_switch_and_hue/

Using the additional codes listed there, I added support for 4 additional "virtual" buttons on the Illumra Dual Rocker switch, which are accessed by pushing two of the other buttons simultaneously:
- Button 5 == Button 1 (left top) + Button 3 (right top)
- Button 6 == Button 2 (left bottom) + Button 3 (right top)
- Button 7 == Button 1 (left top) + Button 4 (right bottom)
- Button 8 == Button 2 (left bottom) + Button 4 (right bottom)

It may be kind of arcane, but it could be a cool easter egg. ;-)  It's a very limited change thankfully.