### PR TITLE
DDF for Third Reality contact sensor (3RDS17BZ)

### DIFF
--- a/devices/third_reality/3RDS17BZ_contact_sensor.json
+++ b/devices/third_reality/3RDS17BZ_contact_sensor.json
@@ -1,0 +1,142 @@
+{
+  "schema": "devcap1.schema.json",
+  "uuid": "91b9c12c-2b50-4efc-a23f-2d3042e60b73",
+  "manufacturername": "Third Reality, Inc",
+  "modelid": "3RDS17BZ",
+  "vendor": "Third Reality",
+  "product": "Contact Sensor (3RDS17BZ)",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_OPEN_CLOSE_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0500"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0001",
+            "at": "0x0021"
+          },
+          "parse": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "eval": "Item.val = Attr.val / 2;",
+            "fn": "zcl:attr"
+          },
+          "awake": true,
+          "refresh.interval": 84600
+        },
+        {
+          "name": "config/delay",
+          "description": "Delay (in seconds) until opening is reported.",
+          "parse": {
+            "fn": "zcl:attr",
+            "mf": "0x1233",
+            "ep": 1,
+            "cl": "0xff01",
+            "at": "0x0000",
+            "eval": "Item.val = Attr.val"
+          },
+          "read": {
+            "fn": "zcl:attr",
+            "mf": "0x1233",
+            "ep": 1,
+            "cl": "0xff01",
+            "at": "0x0000"
+          },
+          "write": {
+            "fn": "zcl:attr",
+            "mf": "0x1233",
+            "ep": 1,
+            "cl": "0xff01",
+            "at": "0x0000",
+            "dt": "0x21",
+            "eval": "Item.val"
+          }
+        },
+        {
+          "name": "config/enrolled"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/pending"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/lowbattery",
+          "awake": true
+        },
+        {
+          "name": "state/open",
+          "parse": {
+            "fn": "ias:zonestatus",
+            "mask": "alarm1"
+          },
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0500",
+            "at": "0x0002"
+          },
+          "awake": true,
+          "refresh.interval": 84600
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0500"
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0001"
+    }
+  ]
+}


### PR DESCRIPTION
Add a DDF for the [Third Reality contact sensor](https://zigbee.blakadder.com/Third_Reality_3RDS17BZ.html). The DDF is based on the Ikea Parasoll DDF, as this device also uses the IAS (alarm system) cluster to report opening/closing events.

The device doesn't seem to support reporting for the Battery Percentage Remaining, giving an Unreportable Attribute error when trying to configure it, so this DDF does not configure reporting.

There is an attribute for `config/delay`, which uses a manufacturer-specific cluster to set the delay before an opening event is reported. The cluster is defined by @3reality-support in [zigbee-herdsman-converters PR #7967](https://github.com/Koenkk/zigbee-herdsman-converters/pull/7967) and the [readme for door sensors in ZHA](https://github.com/3reality-support/homeassistant/blob/main/ZHA/README_DOOR.md).

The firmware version must be updated to v1.00.63 for the `config/delay` attribute (manufacturer-specific) to work. Some of my devices came with v1.00.60 and I used the [OTAU file provided by Third Reality](https://tr-zha.s3.amazonaws.com/z2m_firmware/Door_Sensor_PROD_OTA_V63_v1.00.63.ota) (found via [zigbee-OTA repo](https://github.com/Koenkk/zigbee-OTA/blob/41a42de3c8fa3f09444dc872a8d67380bfc8d8de/index.json#L4042C21-L4042C103) to upgrade them.