### PR TITLE
DDF for Tuya soil sensor (_TZE284_aao3yzhs)

### DIFF
--- a/devices/tuya/_TZE284_aao3yzhs_soil_sensor.json
+++ b/devices/tuya/_TZE284_aao3yzhs_soil_sensor.json
@@ -1,0 +1,219 @@
+{
+  "schema": "devcap1.schema.json",
+  "uuid": "2e93cde2-7329-4c70-bf90-59af162796ff",
+  "manufacturername": [
+    "_TZE284_aao3yzhs"
+  ],
+  "modelid": [
+    "TS0601"
+  ],
+  "vendor": "Tuya",
+  "product": "Tuya Soil Sensor (TS0601)",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_TEMPERATURE_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0402"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "config/tuya_unlock"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x0001",
+            "script": "tuya_swversion.js"
+          },
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x0001"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "read": {
+            "fn": "none"
+          },
+          "parse": {
+            "dpid": 15,
+            "eval": "Item.val = Attr.val;",
+            "fn": "tuya"
+          },
+          "default": 0
+        },
+        {
+          "name": "state/lowbattery",
+          "read": {
+            "fn": "none"
+          },
+          "parse": {
+            "dpid": 14,
+            "eval": "Item.val = (Attr.val == 0 ? true : false);",
+            "fn": "tuya"
+          },
+          "default": false
+        },
+        {
+          "name": "config/offset"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/temperature",
+          "read": {
+            "fn": "none"
+          },
+          "parse": {
+            "dpid": 5,
+            "eval": "Item.val = Attr.val * 10;",
+            "fn": "tuya"
+          },
+          "default": 0,
+          "awake": true
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_MOISTURE_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0408"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x0001",
+            "script": "tuya_swversion.js"
+          },
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x0001"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "read": {
+            "fn": "none"
+          },
+          "parse": {
+            "dpid": 15,
+            "eval": "Item.val = Attr.val;",
+            "fn": "tuya"
+          },
+          "default": 0
+        },
+        {
+          "name": "state/lowbattery",
+          "read": {
+            "fn": "none"
+          },
+          "parse": {
+            "dpid": 14,
+            "eval": "Item.val = (Attr.val == 0 ? true : false);",
+            "fn": "tuya"
+          },
+          "default": false
+        },
+        {
+          "name": "config/offset"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/moisture",
+          "read": {
+            "fn": "none"
+          },
+          "parse": {
+            "dpid": 3,
+            "eval": "Item.val = Attr.val * 100;",
+            "fn": "tuya"
+          },
+          "default": 0,
+          "awake": true
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Based on https://github.com/dresden-elektronik/deconz-rest-plugin/issues/7902

Add support for additional tuya soil sensor.
Similar to https://github.com/dresden-elektronik/deconz-rest-plugin/blob/master/devices/tuya/_TZE200_myd45weu_soil_sensor.json but needs different temperature handling, therefore additional DDF created.

Other references: https://github.com/Koenkk/zigbee2mqtt/issues/23455