### PR TITLE
DDF for Signify LCX015 (Philips Hue Festavia)

### DIFF
--- a/devices/philips/light_zb3_C_festavia.json
+++ b/devices/philips/light_zb3_C_festavia.json
@@ -3,11 +3,13 @@
   "uuid": "e7de8f0e-bf48-4ea0-b655-7e04fb6bdfa9",
   "manufacturername": [
     "$MF_SIGNIFY",
+    "$MF_SIGNIFY",
     "$MF_PHILIPS",
-    "$MF_SIGNIFY"
+    "$MF_PHILIPS"
   ],
   "modelid": [
     "LCX012",
+    "LCX015",
     "LCX012",
     "LCX015"
   ],

--- a/devices/philips/light_zb3_C_festavia.json
+++ b/devices/philips/light_zb3_C_festavia.json
@@ -3,11 +3,13 @@
   "uuid": "e7de8f0e-bf48-4ea0-b655-7e04fb6bdfa9",
   "manufacturername": [
     "$MF_SIGNIFY",
-    "$MF_PHILIPS"
+    "$MF_PHILIPS",
+    "$MF_SIGNIFY"
   ],
   "modelid": [
     "LCX012",
-    "LCX012"
+    "LCX012",
+    "LCX015"
   ],
   "vendor": "Philips",
   "product": "Hue festavia string lights",


### PR DESCRIPTION
I just bought a new set of philips hue festavia lights. They reported a modelid of lcx015 instead of lcx012 which seems to be expected by deconz.
After adding lcx015 to the file, effects like "candle" start working.
