### PR TITLE
DDF clones for Tuya Smart plug 16A with power monitoring (_TZ3000_5f43h46b, _TZ3000_ww6drja5)

### DIFF
--- a/devices/neo/NAS-WR01B_TS011F.json
+++ b/devices/neo/NAS-WR01B_TS011F.json
@@ -8,9 +8,13 @@
     "_TZ3000_rdfh8cfs",
     "_TZ3000_fgwhjm9j",
     "_TZ3000_waho4jtj",
-    "_TZ3000_xzhnra8x"
+    "_TZ3000_xzhnra8x",
+    "_TZ3000_5f43h46b",
+    "_TZ3000_ww6drja5"
   ],
   "modelid": [
+    "TS011F",
+    "TS011F",
     "TS011F",
     "TS011F",
     "TS011F",


### PR DESCRIPTION
Nothing special see https://github.com/dresden-elektronik/deconz-rest-plugin/issues/8070

Manufacturer : _TZ3000_5f43h46b
Model identifier : TS011F

and


Manufacturer : _TZ3000_ww6drja5
Model identifier : TS011F