### PR TITLE
DDF add tuya door sensor clone

### DIFF
--- a/devices/tuya/_TZ3000_TS0203_door_sensor.json
+++ b/devices/tuya/_TZ3000_TS0203_door_sensor.json
@@ -16,9 +16,11 @@
     "_TZ3000_v7chgqso",
     "_TZ3000_yxqnffam",
     "_TZ3000_zgrffiwg",
-    "_TZ3000_1bwpjvlz"
+    "_TZ3000_1bwpjvlz",
+    "_TZ3000_0hkmcrza"
   ],
   "modelid": [
+    "TS0203",
     "TS0203",
     "TS0203",
     "TS0203",


### PR DESCRIPTION
Product name : Tuya Zigbee Door Window Sensor ZD06
Manufacturer : _TZ3000_0hkmcrza
Model identifier : TS0203

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/8085