### PR TITLE
Add cooling mode to Bosch room thermostat II (BTH-RM)

### DIFF
--- a/devices/bosch/room_thermostat2.json
+++ b/devices/bosch/room_thermostat2.json
@@ -1,7 +1,6 @@
 {
   "schema": "devcap1.schema.json",
-  "uuid": "dc42c5ce-5f0e-42aa-9937-e05e08f23b57",
-  "manufacturername": "BOSCH",
+  "manufacturername": "Bosch",
   "modelid": "RBSH-RTH0-BAT-ZB-EU",
   "vendor": "Bosch",
   "product": "Room thermostat II (BTH-RM)",
@@ -30,9 +29,9 @@
       "meta": {
         "values": {
           "config/mode": {
-            "auto": 0,
-            "heat": 1,
-            "off": 5
+            "off": 0,
+            "heat": 3,
+            "cool": 4
           }
         }
       },
@@ -96,6 +95,10 @@
           }
         },
         {
+          "name": "config/coolsetpoint",
+          "refresh.interval": 360
+        },
+        {
           "name": "config/checkin",
           "public": false,
           "refresh.interval": 3600,
@@ -142,28 +145,25 @@
           "name": "config/mode",
           "refresh.interval": 3600,
           "read": {
-            "at": "0x4007",
+            "at": "0x001C",
             "cl": "0x0201",
             "ep": 1,
-            "fn": "zcl:attr",
-            "mf": "0x1209"
+            "fn": "zcl:attr"
           },
           "write": {
-            "at": "0x4007",
+            "at": "0x001C",
             "cl": "0x0201",
             "dt": "0x30",
             "ep": 1,
-            "eval": "if (Item.val == 'auto') { 0 } else if (Item.val == 'heat') { 1 } else if (Item.val == 'off') { 5 };",
-            "fn": "zcl:attr",
-            "mf": "0x1209"
+            "eval": "if (Item.val == 'off') { 0 } else if (Item.val == 'cool') { 3 } else if (Item.val == 'heat') { 4 }",
+            "fn": "zcl:attr"
           },
           "parse": {
-            "at": "0x4007",
+            "at": "0x001C",
             "cl": "0x0201",
             "ep": 1,
-            "eval": "if (Attr.val == 0) { Item.val = 'auto' } else if (Attr.val == 1) { Item.val = 'heat' } else if (Attr.val == 5) { Item.val = 'off' };",
-            "fn": "zcl:attr",
-            "mf": "0x1209"
+            "eval": "if (Attr.val == 0) { Item.val = 'off' } else if (Attr.val == 3) { Item.val = 'cool' } else if (Attr.val == 4) { Item.val = 'heat' }",
+            "fn": "zcl:attr"
           },
           "default": "heat"
         },
@@ -181,19 +181,48 @@
             "cl": "0x0201",
             "dt": "0x28",
             "ep": 1,
-            "eval": "Item.val / 10",
+            "eval": "Item.val / 10;",
             "fn": "zcl:attr"
           },
           "parse": {
             "at": "0x0010",
             "cl": "0x0201",
             "ep": 1,
-            "eval": "Item.val = Attr.val * 10",
+            "eval": "Item.val = Attr.val * 10;",
             "fn": "zcl:attr"
           }
         },
         {
           "name": "config/on"
+        },
+        {
+          "name": "config/preset",
+          "refresh.interval": 3600,
+          "read": {
+            "at": "0x4007",
+            "cl": "0x0201",
+            "ep": 1,
+            "fn": "zcl:attr",
+            "mf": "0x1209"
+          },
+          "write": {
+            "at": "0x4007",
+            "cl": "0x0201",
+            "dt": "0x30",
+            "ep": 1,
+            "eval": "if (Item.val == 'auto') { 0 } else if (Item.val == 'manual') { 1 }",
+            "fn": "zcl:attr",
+            "mf": "0x1209"
+          },
+          "parse": {
+            "at": "0x4007",
+            "cl": "0x0201",
+            "ep": 1,
+            "eval": "if (Attr.val == 0) { Item.val = 'auto' } else if (Attr.val == 1) { Item.val = 'manual' }",
+            "fn": "zcl:attr",
+            "mf": "0x1209"
+          },
+          "default": "manual"
         },
         {
           "name": "config/reachable"
@@ -258,6 +287,23 @@
         },
         {
           "name": "state/lastupdated"
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 3660,
+          "parse": {
+            "at": "0x0029",
+            "cl": "0x0201",
+            "ep": 1,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl:attr"
+          },
+          "read": {
+            "at": "0x0029",
+            "cl": "0x0201",
+            "ep": 1,
+            "fn": "zcl:attr"
+          }
         },
         {
           "name": "state/temperature",
@@ -376,7 +422,7 @@
             "at": "0x0000",
             "cl": "0x0405",
             "ep": 1,
-            "eval": "Item.val = Attr.val + R.item('config/offset').val",
+            "eval": "Item.val = Attr.val + R.item('config/offset').val;",
             "fn": "zcl:attr"
           }
         },
@@ -414,11 +460,24 @@
           "change": "0x00000032"
         },
         {
+          "at": "0x0011",
+          "dt": "0x29",
+          "min": 1,
+          "max": 300,
+          "change": "0x00000001"
+        },
+        {
           "at": "0x0012",
           "dt": "0x29",
           "min": 1,
           "max": 300,
           "change": "0x00000001"
+        },
+        {
+          "at": "0x001C",
+          "dt": "0x30",
+          "min": 1,
+          "max": 300
         },
         {
           "at": "0x4007",


### PR DESCRIPTION
Try again #7681

It looks like this in Home Assistant:

![BTH-RM](https://github.com/user-attachments/assets/3c960f6e-e0e0-4bf8-94b0-7fdddb0aedd1)

![Cooling](https://github.com/user-attachments/assets/9cd5e997-f3b9-4614-9b67-72829ae5653c)

Changes:

-  Add `config/coolsetpoint`
-  Add `config/preset`
-  Add `state/on` from #8084
-  Change `vendor`
-  Change `config/mode`