### PR TITLE
DDF clone of Tuya door sensor (_TZ3000_wut53hfm)

### DIFF
--- a/devices/tuya/_TZ3000_TS0203_door_sensor.json
+++ b/devices/tuya/_TZ3000_TS0203_door_sensor.json
@@ -17,9 +17,11 @@
     "_TZ3000_yxqnffam",
     "_TZ3000_zgrffiwg",
     "_TZ3000_1bwpjvlz",
-    "_TZ3000_0hkmcrza"
+    "_TZ3000_0hkmcrza",
+    "_TZ3000_wut53hfm"
   ],
   "modelid": [
+    "TS0203",
     "TS0203",
     "TS0203",
     "TS0203",


### PR DESCRIPTION
Product name : Door Contact Avatto?
Manufacturer : _TZ3000_wut53hfm
Model identifier : TS0203
Device type to add: Sensor

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/8103
