### PR TITLE
DDF add a clone for a Tuya door sensor

### DIFF
--- a/devices/tuya/_TZ3000_TS0203_door_sensor.json
+++ b/devices/tuya/_TZ3000_TS0203_door_sensor.json
@@ -3,6 +3,7 @@
   "uuid": "1076594e-6f2f-42eb-bade-e1b41c7dbe78",
   "manufacturername": [
     "_TZ3000_n2egfsli",
+    "_TZ3000_n2egfsli"
     "_TZ3000_oxslv1c9",
     "_TZ3000_7tbsruql",
     "_TZ3000_7d8yme6f",
@@ -22,6 +23,7 @@
   ],
   "modelid": [
     "TS0203",
+    "SNZB-04",
     "TS0203",
     "TS0203",
     "TS0203",

--- a/devices/tuya/_TZ3000_TS0203_door_sensor.json
+++ b/devices/tuya/_TZ3000_TS0203_door_sensor.json
@@ -3,7 +3,7 @@
   "uuid": "1076594e-6f2f-42eb-bade-e1b41c7dbe78",
   "manufacturername": [
     "_TZ3000_n2egfsli",
-    "_TZ3000_n2egfsli"
+    "_TZ3000_n2egfsli",
     "_TZ3000_oxslv1c9",
     "_TZ3000_7tbsruql",
     "_TZ3000_7d8yme6f",


### PR DESCRIPTION
- Product name: Tuya Door Window Sensor
- Manufacturer: _TZ3000_n2egfsli
- Model identifier: SNZB-04

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/6598#issuecomment-2646363347

Remark:
It's not a typo, this device realy use an existing manufacture name from tuya but the "SNZB-04" model Id.
And from the link from Ali Express, it have nothing to see with sonoff, it's a pure Tuya device.