### PR TITLE
Fix Aqara vibration sensor sensitivity configuration

### DIFF
--- a/devices/xiaomi/lumi_vibration_aq1.json
+++ b/devices/xiaomi/lumi_vibration_aq1.json
@@ -7,6 +7,7 @@
   "product": "Vibration sensor (DJT11LM)",
   "sleeper": true,
   "status": "Gold",
+  "supportsMgmtBind": false,
   "subdevices": [
     {
       "type": "$TYPE_VIBRATION_SENSOR",
@@ -93,7 +94,7 @@
             "cl": "0x0000",
             "mf": "0x115F",
             "at": "0xFF0D",
-            "eval": "Item.val = Attr.val < 3 ? 3 - Attr.val : 2"
+            "eval": "Item.val = Attr.val <= 3 ? 3 - (Attr.val == 0 ? 1 : Attr.val) : 0"
           },
           "read": {
             "fn": "zcl:attr",
@@ -110,7 +111,7 @@
             "mf": "0x115F",
             "at": "0xFF0D",
             "dt": "0x20",
-            "eval": "3 - Item.val",
+            "eval": "(Item.val <= 2 ? 3 - Item.val : 3 - 2)",
             "state.timeout": 2,
             "change.timeout": 3600
           },

--- a/general.xml
+++ b/general.xml
@@ -188,14 +188,6 @@
     <attribute id="0x000d" name="Serial Number" type="cstring" access="r" required="o"></attribute>
     <attribute id="0x000e" name="Product Label" type="cstring" access="r" required="o"></attribute>
           <attribute id="0x4000" name="SW Build ID" type="cstring" access="r" required="o" range="0,16"></attribute>
-          <attribute id="0xff0d" name="Xiaomi Sensitivity" type="u8" access="rw" required="o" mfcode="0x115f"></attribute>
-          <attribute id="0xff22" name="Xiaomi Disconnect 1" type="u8" showas="hex" access="rw" required="o" mfcode="0x115f">
-            <description>Set to 0x12 (0xFE) to connect (disconnect) the left button to (from) the relay.</description>
-          </attribute>
-          <attribute id="0xff23" name="Xiaomi Disconnect 2" type="u8" showas="hex" access="rw" required="o" mfcode="0x115f">
-            <description>Set to 0x22 (0xFE) to connect (disconnect) the left button to (from) the relay.</description>
-          </attribute>
-          <!-- <attribute id="0xff0d" name="Xiaomi Sensitivity" type="u8" access="rw" required="o" mfcode="0x1037"></attribute> -->
           <attribute id="0xfffd" name="Cluster Revision" type="u16" default="0" access="rw" required="o"></attribute>
     <attribute id="0xfffe" name="Tuya magic spell final attribute" type="enum8" default="0" access="rw" required="o">
     <description>Read attributes in this order Manufacturer name,ZCL version,Application version,Model Identifier,Power source and finally this one"</description>


### PR DESCRIPTION

**Part I** Remove duplicate for Basic cluster Xiaomi manufacturer specific attributes in `general.xml`
The duplicate in `general.xml`  caused the GUI never updating the attributes listed in the proper attribute set. But only the attributes which were placed wrongly in the "Basic Device Information" attribute set.

**Part II** Aqara vibration sensor sensitivity fix.

The REST-API values (0: low, 1: medium, 2: high) map to on device values (3, 2, 1). By default the DDF sets high sensitivity (API value: 2) which will be configured automatically.

When setting low sensitivity `{"sensitivity": 0}` via API the correct value 3 was written to the device. However the bug was: reading back value 3 wasn't parsed right and reverted to default value 2 (high). The fix ensures that only correct on devices values (high:1, med: 2, low: 3) will be written. Any out of bound values are corrected. Further it fixes that on device values > 3 won't be turned into API values for high sensitivity (2) but low sensitivity (0).
