### PR TITLE
DDF clone for Tuya 24G Radar Motion Sensor (_TZE204_ztqnh5cg)

### DIFF
--- a/devices/tuya/ZY-M100_human_breathing_presence.json
+++ b/devices/tuya/ZY-M100_human_breathing_presence.json
@@ -6,9 +6,11 @@
     "_TZE204_ztc6ggyl",
     "_TZE200_ar0slwnd",
     "_TZE200_sfiy5tfs",
-    "_TZE200_mrf6vtua"
+    "_TZE200_mrf6vtua",
+    "_TZE204_ztqnh5cg"
   ],
   "modelid": [
+    "TS0601",
     "TS0601",
     "TS0601",
     "TS0601",


### PR DESCRIPTION
```
  "manufacturername": "_TZE204_ztqnh5cg",
  "modelid": "TS0601",
```

See https://forum.phoscon.de/t/ddf-for-tuya-24g-radar-motion-sensor-tze204-ztqnh5cg/6095