### PR TITLE
Fix siren of Frient Intelligent smoke alarm (SMSZB-120) #8040

### DIFF
--- a/devices/frient/smszb-120_smoke_detector.json
+++ b/devices/frient/smszb-120_smoke_detector.json
@@ -253,7 +253,7 @@
           "write": {
             "cl": "0x0502",
             "cmd": "0x00",
-            "ep": "0x01",
+            "ep": 35,
             "eval": "if (Item.val=='select') { '1701000000' } else if (Item.val=='none') { '0000000000' }",
             "fn": "zcl:cmd"
           }


### PR DESCRIPTION
Fix https://github.com/dresden-elektronik/deconz-rest-plugin/issues/8040