### PR TITLE
Prevent initial setup crash in debug build

### DIFF
--- a/device_descriptions.cpp
+++ b/device_descriptions.cpp
@@ -4295,7 +4295,10 @@ uint8_t DDF_GetSubDeviceOrder(const QString &type)
 Resource::Handle R_CreateResourceHandle(const Resource *r, size_t containerIndex)
 {
     Q_ASSERT(r->prefix() != nullptr);
-    Q_ASSERT(!r->item(RAttrUniqueId)->toString().isEmpty());
+    if (r->item(RAttrUniqueId)->toString().isEmpty())
+    {
+        return {};
+    }
 
     Resource::Handle result;
     result.hash = qHash(r->item(RAttrUniqueId)->toString());


### PR DESCRIPTION
When Daylight sensor doesn't have a uniqueid yet, and is loaded from database the assert would trigger.