### PR TITLE
DDF for frient Smart Siren (SIRZB-111)

### DIFF
--- a/devices/frient/sirzb-111_siren.json
+++ b/devices/frient/sirzb-111_siren.json
@@ -1,0 +1,225 @@
+{
+  "schema": "devcap1.schema.json",
+  "uuid": "cb65ebbd-876d-4f46-9167-3a6cb183ede4",
+  "manufacturername": [
+    "Develco Products A/S",
+    "frient A/S"
+  ],
+  "modelid": [
+    "SIRZB-111",
+    "SIRZB-111"
+  ],
+  "vendor": "frient",
+  "product": "Smart Siren (SIRZB-111)",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_WARNING_DEVICE",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x2b"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0403",
+        "endpoint": "0x2B",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x0500",
+          "0x0502"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": "0x2B",
+            "cl": "0x0000",
+            "at": "0x8000",
+            "mf": "0x1015",
+            "script": "develco_firmware.js"
+          },
+          "read": {
+            "fn": "zcl:attr",
+            "ep": "0x2B",
+            "cl": "0x0000",
+            "at": "0x8000",
+            "mf": "0x1015"
+          },
+          "refresh.interval": 84000
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "cap/groups/not_supported"
+        },
+        {
+          "name": "cap/otau/file_version"
+        },
+        {
+          "name": "cap/otau/image_type"
+        },
+        {
+          "name": "cap/otau/manufacturer_code"
+        },
+        {
+          "name": "state/alert",
+          "description": "Start warning command payload has 5 Bytes. Byte 1: Options. 0x17 = Warning mode 1 (burglar), Strobe, Very high sound. Byte 2-3: Duration, Byte 4: Strobe duty cycle, Byte 5: Strobe level",
+          "read": {
+            "fn": "none"
+          },
+          "write": {
+            "fn": "zcl:cmd",
+            "ep": "0x2B",
+            "cl": "0x0502",
+            "cmd": "0x00",
+            "eval": "if (Item.val=='select') { '1701000000' } else if (Item.val=='none') { '0000000000' }"
+          }
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_ALARM_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x2b",
+        "0x0500"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0401",
+        "endpoint": "0x2B",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x0500",
+          "0x0502"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": "0x2B",
+            "cl": "0x0000",
+            "at": "0x8000",
+            "mf": "0x1015",
+            "script": "develco_firmware.js"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "cap/otau/file_version"
+        },
+        {
+          "name": "cap/otau/image_type"
+        },
+        {
+          "name": "cap/otau/manufacturer_code"
+        },
+        {
+          "name": "config/battery",
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": "0x2B",
+            "cl": "0x0001",
+            "at": "0x0021",
+            "eval": "Item.val = Attr.val / 2"
+          }
+        },
+        {
+          "name": "config/enrolled",
+          "public": false
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/alarm"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/lowbattery"
+        },
+        {
+          "name": "state/tampered"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": "0x2B",
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 1,
+          "max": 300,
+          "change": "0x01"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Another mains-powered _IAS WD_ device with battery backup.  It doesn't have a strobe light, but the siren is pretty loud.

```json
{
  "capabilities": {
    "alerts": [
      "none",
      "select",
      "lselect"
    ],
    "otau": {
      "file_version": 131076,
      "image_type": 914,
      "manufacturer_code": 4117
    },
    "sleeper": false
  },
  "ddf_hash": null,
  "ddf_policy": "latest_prefer_stable",
  "etag": "46911ba4cb0e3be3ea46bf557973762c",
  "hascolor": false,
  "lastannounced": null,
  "lastseen": "2025-03-31T08:48Z",
  "manufacturername": "frient A/S",
  "modelid": "SIRZB-111",
  "name": "Siren",
  "nwkaddress": 60998,
  "state": {
    "alert": "none",
    "reachable": true
  },
  "swversion": "2.0.4",
  "type": "Warning device",
  "uniqueid": "00:15:bc:00:41:00:79:72-2b",
  "zonetype": 549
}
```
```json
{
  "capabilities": {
    "otau": {
      "file_version": 131076,
      "image_type": 914,
      "manufacturer_code": 4117
    },
    "sleeper": false
  },
  "config": {
    "battery": 90,
    "on": true,
    "reachable": true
  },
  "ddf_hash": null,
  "ddf_policy": "latest_prefer_stable",
  "ep": 43,
  "etag": "9d99c13290612f92ab210514764b40d4",
  "lastannounced": null,
  "lastseen": "2025-03-31T08:48Z",
  "manufacturername": "frient A/S",
  "modelid": "SIRZB-111",
  "name": "Siren",
  "nwkaddress": 60998,
  "state": {
    "alarm": false,
    "lastupdated": "2025-03-31T08:48:20.703",
    "lowbattery": false,
    "tampered": false
  },
  "swversion": "2.0.4",
  "type": "ZHAAlarm",
  "uniqueid": "00:15:bc:00:41:00:79:72-2b-0500",
  "zonetype": 549
}
```