### PR TITLE
Removal of `config/temperature` from more Xiaomi devices (part 2)

### DIFF
--- a/devices/xiaomi/lumi_curtain_acn002.json
+++ b/devices/xiaomi/lumi_curtain_acn002.json
@@ -223,20 +223,6 @@
           "name": "config/reachable"
         },
         {
-          "name": "config/temperature",
-          "awake": true,
-          "parse": {
-            "fn": "xiaomi:special",
-            "ep": 1,
-            "at": "0x00f7",
-            "idx": "0x03",
-            "eval": "Item.val = Attr.val * 100"
-          },
-          "read": {
-            "fn": "none"
-          }
-        },
-        {
           "name": "state/battery",
           "parse": {
             "fn": "zcl:attr",

--- a/devices/xiaomi/xiaomi_lumi.relay.c2acn01.json
+++ b/devices/xiaomi/xiaomi_lumi.relay.c2acn01.json
@@ -4,7 +4,7 @@
   "manufacturername": "$MF_LUMI",
   "modelid": "lumi.relay.c2acn01",
   "vendor": "Xiaomi Aqara",
-  "product": "2 way control module wireless relay",
+  "product": "2 way control module wireless relay (LLKZMK11LM)",
   "sleeper": false,
   "status": "Silver",
   "subdevices": [

--- a/devices/xiaomi/xiaomi_lumi.relay.c2acn01.json
+++ b/devices/xiaomi/xiaomi_lumi.relay.c2acn01.json
@@ -178,9 +178,6 @@
           "name": "config/reachable"
         },
         {
-          "name": "config/temperature"
-        },
-        {
           "name": "state/current",
           "parse": {
             "at": "0x00F7",
@@ -277,9 +274,6 @@
         },
         {
           "name": "config/reachable"
-        },
-        {
-          "name": "config/temperature"
         },
         {
           "name": "state/consumption",

--- a/devices/xiaomi/xiaomi_qbkg03lm_switch.json
+++ b/devices/xiaomi/xiaomi_qbkg03lm_switch.json
@@ -151,9 +151,6 @@
           "name": "config/reachable"
         },
         {
-          "name": "config/temperature"
-        },
-        {
           "name": "state/buttonevent"
         },
         {

--- a/devices/xiaomi/xiaomi_qbkg04lm_switch.json
+++ b/devices/xiaomi/xiaomi_qbkg04lm_switch.json
@@ -144,9 +144,6 @@
           "name": "config/reachable"
         },
         {
-          "name": "config/temperature"
-        },
-        {
           "name": "state/buttonevent"
         },
         {

--- a/devices/xiaomi/xiaomi_sp-euc01_smart_plug.json
+++ b/devices/xiaomi/xiaomi_sp-euc01_smart_plug.json
@@ -128,9 +128,6 @@
           "name": "config/reachable"
         },
         {
-          "name": "config/temperature"
-        },
-        {
           "name": "state/current",
           "parse": {
             "at": "0x00F7",
@@ -234,9 +231,6 @@
         },
         {
           "name": "config/reachable"
-        },
-        {
-          "name": "config/temperature"
         },
         {
           "name": "state/consumption",

--- a/devices/xiaomi/xiaomi_wsdcgq01lm_temp_hum_sensor.json
+++ b/devices/xiaomi/xiaomi_wsdcgq01lm_temp_hum_sensor.json
@@ -88,10 +88,6 @@
           "name": "config/reachable"
         },
         {
-          "name": "config/temperature",
-          "public": false
-        },
-        {
           "name": "state/lastupdated"
         },
         {
@@ -178,10 +174,6 @@
         },
         {
           "name": "config/reachable"
-        },
-        {
-          "name": "config/temperature",
-          "public": false
         },
         {
           "name": "state/humidity",

--- a/devices/xiaomi/xiaomi_zncz04lm_smart_plug.json
+++ b/devices/xiaomi/xiaomi_zncz04lm_smart_plug.json
@@ -132,9 +132,6 @@
           "name": "config/reachable"
         },
         {
-          "name": "config/temperature"
-        },
-        {
           "name": "state/current",
           "parse": {
             "at": "0x00F7",
@@ -238,9 +235,6 @@
         },
         {
           "name": "config/reachable"
-        },
-        {
-          "name": "config/temperature"
         },
         {
           "name": "state/consumption",

--- a/devices/xiaomi/xiaomi_zncz04lm_smart_plug_v24.json
+++ b/devices/xiaomi/xiaomi_zncz04lm_smart_plug_v24.json
@@ -133,9 +133,6 @@
           "name": "config/reachable"
         },
         {
-          "name": "config/temperature"
-        },
-        {
           "name": "state/current",
           "parse": {
             "at": "0x00F7",
@@ -239,9 +236,6 @@
         },
         {
           "name": "config/reachable"
-        },
-        {
-          "name": "config/temperature"
         },
         {
           "name": "state/consumption",

--- a/devices/xiaomi/xiaomi_zncz12lm_smart_plug.json
+++ b/devices/xiaomi/xiaomi_zncz12lm_smart_plug.json
@@ -123,9 +123,6 @@
           "name": "config/reachable"
         },
         {
-          "name": "config/temperature"
-        },
-        {
           "name": "state/current",
           "parse": {
             "at": "0x00F7",
@@ -229,9 +226,6 @@
         },
         {
           "name": "config/reachable"
-        },
-        {
-          "name": "config/temperature"
         },
         {
           "name": "state/consumption",


### PR DESCRIPTION
This PR is a continuation of #7827 and now `config/temperature` should be removed from all Xiaomi devices.