### PR TITLE
Update ancillary_control.json

### DIFF
--- a/devices/generic/subdevices/ancillary_control.json
+++ b/devices/generic/subdevices/ancillary_control.json
@@ -11,15 +11,17 @@
   ],
   "items": [
     "config/battery",
-    "config/enrolled",
     "config/on",
-    "config/pending",
     "config/reachable",
     "state/action",
     "state/lastupdated",
-    "state/lowbattery",
     "state/seconds_remaining",
-    "state/panel",
+    "state/panel"
+  ],
+  "items_optional": [
+    "config/enrolled",
+    "config/pending",
+    "state/lowbattery",
     "state/tampered"
   ]
 }


### PR DESCRIPTION
Make _IAS Zone_ attributes optional for `ZHAAncillaryControl`, since they should be exposed on a separate ZHAAlarm resource, see #8141 and #8154.