### PR TITLE
DDF, improve Aqara relay t2 switch

### DIFF
--- a/button_maps.json
+++ b/button_maps.json
@@ -891,6 +891,15 @@
                 [1, "0x01", "DOOR_LOCK", "ATTRIBUTE_REPORT", "3", "S_BUTTON_1", "S_BUTTON_ACTION_DROP", "Drop"]
             ]
         },
+        "xiaomiT2Module": {
+            "vendor": "Xiaomi",
+            "doc": "Xiaomi Aqara T2 Module",
+            "modelids": ["lumi.switch.acn047"],
+            "map": [
+                [1, "0x01", "MULTISTATE_INPUT", "ATTRIBUTE_REPORT", "1", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "B1"],
+                [1, "0x02", "MULTISTATE_INPUT", "ATTRIBUTE_REPORT", "1", "S_BUTTON_2", "S_BUTTON_ACTION_SHORT_RELEASED", "B2"],
+            ]
+        },
         "ubisysS1Map": {
             "vendor": "Ubisys",
             "doc": "Universal power switch S1 (5501)",

--- a/devices/xiaomi/xiaomi_dcm-k01_t2_dual_relay.json
+++ b/devices/xiaomi/xiaomi_dcm-k01_t2_dual_relay.json
@@ -127,6 +127,108 @@
       ]
     },
     {
+      "type": "$TYPE_SWITCH",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0012"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0000",
+        "endpoint": "0x01",
+        "in": [
+          "0x0012"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {
+            "at": "0x00F7",
+            "ep": "0x01",
+            "eval": "Item.val = '0.0.0_' + ('0000' + (Attr.val & 0xFF).toString()).slice(-4)",
+            "fn": "xiaomi:special",
+            "idx": "0x0D",
+            "mf": "0x115F"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "config/clickmode",
+          "refresh.interval": 300,
+          "read": {
+            "at": "0x000a",
+            "cl": "0xfcc0",
+            "ep": 1,
+            "fn": "zcl:attr",
+            "mf": "0x115f"
+          },
+          "parse": {
+            "at": "0x000a",
+            "cl": "0xfcc0",
+            "ep": 1,
+            "eval": "if (Attr.val == 1) { Item.val = 'rocker' } else if (Attr.val == 2) { Item.val = 'momentary' } else { Item.val = 'unknown' }",
+            "fn": "zcl:attr",
+            "mf": "0x115f"
+          },
+          "write": {
+            "at": "0x000a",
+            "cl": "0xfcc0",
+            "dt": "0x20",
+            "ep": 1,
+            "eval": "if (Item.val == 'rocker') { 1 } else if (Item.val == 'momentary') { 2 } else { 'unknown' }",
+            "fn": "zcl:attr",
+            "mf": "0x115f"
+          },
+          "values": [
+            ["\"momentary\"", "Momentary mode"],
+            ["\"rocker\"", "Rocker mode"] 
+          ],
+          "default": "rocker"
+        },
+        {
+          "name": "state/buttonevent"
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    },
+    {
       "type": "$TYPE_POWER_SENSOR",
       "restapi": "/sensors",
       "uuid": [


### PR DESCRIPTION
This change permit the use of input separately from output, if decoupled mode is used.

See https://forum.phoscon.de/t/aqara-relay-t2-switch-type-ddf-modification/5685

