### PR TITLE
DDf adds support for Aeotec (Samjin) water leak sensor's

### DIFF
--- a/devices/aeotec/water_sensor.json
+++ b/devices/aeotec/water_sensor.json
@@ -1,0 +1,200 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "Samjin",
+  "modelid": "water",
+  "vendor": "Samjin, Aeotec",
+  "product": "Water alarm with temperature",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_WATER_LEAK_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0500"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0402",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x0500"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "awake": true,
+          "refresh.interval": 86400,
+          "read": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "fn": "zcl:attr"
+          },
+          "parse": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "fn": "zcl:attr",
+            "eval": "Item.val = Attr.val / 2"
+          },
+          "default": 0
+        },
+        {
+          "name": "config/enrolled"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/pending"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/water",
+          "awake": true
+        }
+      ]
+    },
+   {
+      "type": "$TYPE_TEMPERATURE_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0402"
+      ],
+      "items": [
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "awake": true,
+          "refresh.interval": 86400,
+          "read": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "fn": "zcl:attr"
+          },
+          "parse": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "fn": "zcl:attr",
+            "eval": "Item.val = Attr.val / 2"
+          },
+          "default": 0
+        },
+        {
+          "name": "config/offset"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/temperature"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 60,
+          "max": 3600,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0402",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x29",
+          "min": 1,
+          "max": 300,
+          "change": "0x00000014"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0500"
+    }
+  ]
+}

--- a/devices/aeotec/water_sensor.json
+++ b/devices/aeotec/water_sensor.json
@@ -45,7 +45,21 @@
           "name": "attr/name"
         },
         {
-          "name": "attr/swversion"
+          "name": "attr/swversion",
+            "parse": {
+              "fn": "zcl:attr",
+              "ep": 255,
+              "cl": "0x0000",
+              "at": "0x0001",
+              "eval": "Item.val = Attr.val"
+            },
+            "read": {
+              "fn": "zcl:attr",
+              "ep": 1,
+              "cl": "0x0000",
+              "at": "0x0001"
+            },
+            "refresh.interval": 86400
         },
         {
           "name": "attr/type"
@@ -115,7 +129,17 @@
           "name": "attr/name"
         },
         {
-          "name": "attr/swversion"
+          "name": "attr/swversion",
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 255,
+            "cl": "0x0000",
+            "at": "0x0001",
+            "eval": "Item.val = Attr.val"
+          },
+          "read": {
+            "fn": "none"
+          }
         },
         {
           "name": "attr/type"

--- a/devices/bosch/bwa-1_water_sensor.json
+++ b/devices/bosch/bwa-1_water_sensor.json
@@ -55,6 +55,9 @@
           "name": "attr/uniqueid"
         },
         {
+          "name": "attr/zonetype"
+        },
+        {
           "name": "config/battery",
           "awake": true,
           "parse": {


### PR DESCRIPTION
```
  "manufacturername": "Samjin",
  "modelid": "water",
  "vendor": "Samjin, Aeotec",
  "product": "Water alarm with temperature",
```

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/8160#issuecomment-2797824575

This device is managed by legacy core, but recent version have problem.