### PR TITLE
Disable ZCL Default Response APS ACKs by default

### DIFF
--- a/aps_controller_wrapper.cpp
+++ b/aps_controller_wrapper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2021-2025 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -31,7 +31,6 @@ static bool ZCL_SendDefaultResponse(deCONZ::ApsController *apsCtrl, const deCONZ
     apsReq.setProfileId(ind.profileId());
     apsReq.setRadius(0);
     apsReq.setClusterId(ind.clusterId());
-    apsReq.setTxOptions(deCONZ::ApsTxAcknowledgedTransmission);
 
     deCONZ::ZclFrame outZclFrame;
     outZclFrame.setSequenceNumber(zclFrame.sequenceNumber());


### PR DESCRIPTION
This prevents battery drain and network traffic and helps to reduce queue blocking. The core does enable APS ACKs again if the device is in error state, see: https://github.com/dresden-elektronik/deconz/commit/c92b978ea1008f77ab28c6361a558388759d483f