### PR TITLE
Fix bogus reading of binding table for sleeping devices with no bindings

### DIFF
--- a/device.cpp
+++ b/device.cpp
@@ -972,7 +972,11 @@ void DEV_BindingHandler(Device *device, const Event &event)
     }
     else if (event.what() == REventPoll || event.what() == REventAwake || event.what() == REventBindingTick)
     {
-        if (DA_ApsUnconfirmedRequests() > 4)
+        if (device->item(RCapSleeper)->toBool() && d->binding.bindings.empty())
+        {
+            // nothing todo
+        }
+        else if (DA_ApsUnconfirmedRequests() > 4)
         {
             // wait
         }


### PR DESCRIPTION
It doesn't make sense to read the binding table of sleeping devices if they don't have bindings / ZCL reporting specified in the DDF.

As observed in the sniffer for various Xiaomi devices, this puts pressure in the queue and occupies time and APS slots for no reason.