### PR TITLE
Fix loading Device reachable = true, set to false if older than 24h

### DIFF
--- a/device_ddf_init.cpp
+++ b/device_ddf_init.cpp
@@ -513,6 +513,16 @@ bool DEV_InitDeviceBasic(Device *device)
             DBG_Assert(reachable);
             if (reachable)
             {
+                if (dbItem.value.toBool())
+                {
+                    auto dt = QDateTime::fromMSecsSinceEpoch(dbItem.timestampMs);
+                    if (86400 < dt.secsTo(QDateTime::currentDateTime()))
+                    {
+                        reachable->setValue(false);
+                        continue;
+                    }
+                }
+
                 reachable->setValue(dbItem.value.toBool());
                 reachable->setTimeStamps(QDateTime::fromMSecsSinceEpoch(dbItem.timestampMs));
             }


### PR DESCRIPTION
The database can contain reachable = true entries but for older timestamps. Fix this on load to prevent early requests to these devices.

TODO: The core should also now about this to adapt Zombie state.