### PR TITLE
Fix to prevent poll attributes after startup if value timestamp is fresh enough

### DIFF
--- a/device.cpp
+++ b/device.cpp
@@ -1871,7 +1871,7 @@ std::vector<DEV_PollItem> DEV_GetPollItems(Device *device)
                     }
                 }
 
-                if (item->lastSet().isValid() && item->valueSource() == ResourceItem::SourceDevice)
+                if (item->lastSet().isValid() && (item->valueSource() == ResourceItem::SourceDevice || item->valueSource() == ResourceItem::SourceUnknown))
                 {
                     const auto dt2 = item->lastSet().secsTo(now);
                     if (dt2  < item->refreshInterval().val)


### PR DESCRIPTION
E.g before this PR `SwBuildId` and similar attributes would be queried even if they already have been queried during the DDF `refreshInterval`.

This reduces traffic after startup.