### PR TITLE
Fix database not storing / fresh values of strings

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -7162,14 +7162,14 @@ bool DB_StoreSubDeviceItem(const Resource *sub, ResourceItem *item)
             uint64_t storeDelay = 600;
 #endif
 
+            const DeviceDescription::Item &ddfItem = DeviceDescriptions::instance()->getItem(item);
+            if (ddfItem.isValid() && 0 < ddfItem.refreshInterval && (int)storeDelay < ddfItem.refreshInterval)
+            {
+                storeDelay = (unsigned)ddfItem.refreshInterval * 3 / 4;
+            }
+
             if (isEqual)
             {
-                if (item->descriptor().type == DataTypeString)
-                {
-                    item->clearNeedStore();
-                    return true; // don't check timestamp for strings
-                }
-
                 if (suffix[0] == 'a' && dt < storeDelay) // attr/*  but not a string
                 {
                     return true; // only update timestamp every 10 minutes
@@ -7215,10 +7215,7 @@ bool DB_StoreSubDeviceItem(const Resource *sub, ResourceItem *item)
     {
 //        DBG_Printf(DBG_INFO_L2, "%s\n", &sqlBuf[0]);
 
-        if (DBG_IsEnabled(DBG_MEASURE))
-        {
-            DBG_Printf(DBG_MEASURE, "DB store %s%s/%s ## %s\n", uniqueId->toCString(), sub->prefix(), item->descriptor().suffix, sqlBuf);
-        }
+        DBG_Printf(DBG_DEV, "DB store %s%s/%s ## %s\n", uniqueId->toCString(), sub->prefix(), item->descriptor().suffix, sqlBuf);
 
         char *errmsg = nullptr;
 

--- a/device_ddf_init.cpp
+++ b/device_ddf_init.cpp
@@ -247,8 +247,6 @@ bool DEV_InitDeviceFromDescription(Device *device, const DeviceDescription &ddf)
 
         // TODO storing should be done else where, since this is init code
         DB_StoreSubDevice(rsub->item(RAttrUniqueId)->toCString());
-        DB_StoreSubDeviceItem(rsub, rsub->item(RAttrManufacturerName));
-        DB_StoreSubDeviceItem(rsub, rsub->item(RAttrModelId));
 
         const auto dbItems = DB_LoadSubDeviceItems(rsub->item(RAttrUniqueId)->toLatin1String());
 
@@ -337,6 +335,9 @@ bool DEV_InitDeviceFromDescription(Device *device, const DeviceDescription &ddf)
                 }
             }
         }
+
+        DB_StoreSubDeviceItem(rsub, rsub->item(RAttrManufacturerName));
+        DB_StoreSubDeviceItem(rsub, rsub->item(RAttrModelId));
     }
 
     if (ddf.sleeper >= 0)
@@ -469,6 +470,7 @@ bool DEV_InitDeviceBasic(Device *device)
                     {
                         ddfPolicy->setValue(dbItem.value, (int)dbItem.valueSize);
                         ddfPolicy->setTimeStamps(QDateTime::fromMSecsSinceEpoch(dbItem.timestampMs));
+                        ddfPolicy->clearNeedStore();
                     }
                     else if (dbItem.name == RAttrDdfHash)
                     {
@@ -478,6 +480,7 @@ bool DEV_InitDeviceBasic(Device *device)
                             ResourceItem *ddfHash = device->item(RAttrDdfHash);
                             ddfHash->setValue(dbItem.value, (int)dbItem.valueSize);
                             ddfHash->setTimeStamps(QDateTime::fromMSecsSinceEpoch(dbItem.timestampMs));
+                            ddfHash->clearNeedStore();
                         }
                     }
                 }
@@ -525,6 +528,7 @@ bool DEV_InitDeviceBasic(Device *device)
 
                 reachable->setValue(dbItem.value.toBool());
                 reachable->setTimeStamps(QDateTime::fromMSecsSinceEpoch(dbItem.timestampMs));
+                reachable->clearNeedStore();
             }
             continue;
         }
@@ -542,6 +546,7 @@ bool DEV_InitDeviceBasic(Device *device)
             {
                 item->setValue(dbItem.value);
                 item->setTimeStamps(QDateTime::fromMSecsSinceEpoch(dbItem.timestampMs));
+                item->clearNeedStore();
                 found++;
             }
 


### PR DESCRIPTION
Not the best approach but right now it's better to have fresh timestamps on startup. Add various `item->clearNeedStore()` to items that were loaded from database too.