### PR TITLE
Temporary solution for _TZ3000_qeuvnohg

### DIFF
--- a/devices/tuya/_TZ3000_qeuvnohg_fuse_w_power_meter.json
+++ b/devices/tuya/_TZ3000_qeuvnohg_fuse_w_power_meter.json
@@ -10,64 +10,11 @@
 		"TS011F",
 		"TS011F"
 	],
-	"product": "TO-Q-SY1-JZT Mains/DIN Rail power switch/meter, Note the deleted 'lights:state/on' because of MAINS debate at: https://github.com/dresden-elektronik/deconz-rest-plugin/pull/7012",
+	"product": "TO-Q-SY1-JZT Mains/DIN Rail power switch/meter, Note the omitted /lights section",
 	"vendor": "TONGOU",
 	"sleeper": false,
 	"status": "Gold",
 	"subdevices": [
-		{
-			"type": "$TYPE_SMART_PLUG",
-			"restapi": "/lights",
-			"uuid": [
-				"$address.ext",
-				"0x01"
-			],
-			"items": [
-				{
-					"name": "attr/id"
-				},
-				{
-					"name": "attr/lastannounced"
-				},
-				{
-					"name": "attr/lastseen"
-				},
-				{
-					"name": "attr/manufacturername"
-				},
-				{
-					"name": "attr/modelid"
-				},
-				{
-					"name": "attr/name"
-				},
-				{
-					"name": "attr/swversion",
-					"parse": {
-						"fn": "zcl:attr",
-						"ep": 1,
-						"cl": "0x0000",
-						"at": "0x0001",
-						"script": "tuya_swversion.js"
-					},
-					"read": {
-						"fn": "zcl:attr",
-						"ep": 1,
-						"cl": "0x0000",
-						"at": "0x0001"
-					}
-				},
-				{
-					"name": "attr/type"
-				},
-				{
-					"name": "attr/uniqueid"
-				},
-				{
-					"name": "state/reachable"
-				}
-			]
-		},
 		{
 			"type": "$TYPE_TEMPERATURE_SENSOR",
 			"restapi": "/sensors",


### PR DESCRIPTION
This PR aims to override the PR at https://github.com/dresden-elektronik/deconz-rest-plugin/pull/7012, to make these MAINS device(s) available, but also to mitigate the danger inherent to the MAINS type in that PR.

This is a temporary solution until Mains switches are handled better in Phoscon GUI.

Note that in above discussion it was argued, that security is the job for the API client. Since Phoscon GUI does not yet handle mains specifically, I suggest to merge this PR in the meantime, having:

- no `lights:state/on` property (disable switch)
- `"type": "$TYPE_SMART_PLUG"`, because it currently fits better with the Phoscon GUI.

The remarks by @BabaIsYou for the similar devices (`"_TZ3000_ky0fq4ho","_TZ3000_8bxrzyxz"`) are in this PR too, though untested by myself.

Please DEVs, review/change the timings to your likings. Thanks.

If this gets merged, then https://github.com/dresden-elektronik/deconz-rest-plugin/pull/7012 is not valid anymore.

cheers


![Tongou_TO-Q-SY1-JZT](https://github.com/user-attachments/assets/34c60207-3e42-4749-b165-4b340a4409e4)
