### PR TITLE
Add support for C401N user interface configuration

### DIFF
--- a/general.xml
+++ b/general.xml
@@ -2982,7 +2982,9 @@ Displayed setpoint is not affected, but regulated setpoint will change. Can be u
             <value name="Display on" value="0x00"></value>
             <value name="Display off" value="0x01"></value>
           </attribute>
-          <attribute id="0x0107" name="Measurement interval, range: 3..255 seconds" type="u8" access="rw" range="0x03,0xFF" default="0x0A" required="o" mfcode="0x1141"></attribute>
+          <attribute id="0x0107" name="Measurement interval, range: 3..255 seconds" type="u8" access="rw" range="0x03,0xFF" default="0x0A" required="o" mfcode="0x1141">
+            <description>Beware: While increasing the measurement interval should save power, it also increases the reaction time for reading/writing values in deCONZ up to the set value (the C401N only connects every n seconds to the Zigbee network). About 60s seems like a sweet spot between power saving and reaction time.</description>
+	  </attribute>
         </attribute-set>
 
         <!-- Bosch manufacturer specific -->

--- a/general.xml
+++ b/general.xml
@@ -2969,6 +2969,21 @@ Displayed setpoint is not affected, but regulated setpoint will change. Can be u
           <value name="Viewing direction 1" value="0x00"></value>
           <value name="Viewing direction 2" value="0x01"></value>
         </attribute>
+        
+        <!-- ZigbeeTLc (C401N) specific -->
+        <attribute-set id="0x0100" description="ZigbeeTLc (C401N) specific" mfcode="0x1141">
+          <attribute id="0x0100" name="Temperature offset in 0.01° steps" type="s16" access="rw" default="0x0000" required="o" mfcode="0x1141"></attribute>
+          <attribute id="0x0101" name="Humidity offset, in 0.01% steps" type="s16" access="rw" default="0x0000" required="o" mfcode="0x1141"></attribute>
+          <attribute id="0x0102" name="Comfort temperature minimum, in 0.01° steps" type="s16" access="rw" default="0x07D0" required="o" mfcode="0x1141"></attribute>
+          <attribute id="0x0103" name="Comfort temperature maximum, in 0.01° steps" type="s16" access="rw" default="0x09C4" required="o" mfcode="0x1141"></attribute>
+          <attribute id="0x0104" name="Comfort humidity minimum, in 1% steps" type="u16" access="rw" range="0x0000,0x270F" default="0x0FA0" required="o" mfcode="0x1141"></attribute>
+          <attribute id="0x0105" name="Comfort humidity maximum, in 1% steps" type="u16" access="rw" range="0x0000,0x270F" default="0x1770" required="o" mfcode="0x1141"></attribute>
+          <attribute id="0x0106" name="Display off" type="enum8" access="rw" range="0x00,0x01" default="0x00" required="o" mfcode="0x1141">
+            <value name="Display on" value="0x00"></value>
+            <value name="Display off" value="0x01"></value>
+          </attribute>
+          <attribute id="0x0107" name="Measurement interval, range: 3..255 seconds" type="u8" access="rw" range="0x03,0xFF" default="0x0A" required="o" mfcode="0x1141"></attribute>
+        </attribute-set>
 
         <!-- Bosch manufacturer specific -->
         <attribute-set id="0x4000" description="Bosch specific" mfcode="0x1209">


### PR DESCRIPTION
Add user interface configuration for temperature/humidity sensor MHO-C401-Z, as mentioned in issue #8069 

```
Attr: 0x0100, INT16 (id:0x29), Temperature offset, in 0.01° steps, range: -32767 (-327.67°)..32767(+327.67°). Default 0.
Attr: 0x0101, INT16 (id:0x29), Humidity offset, in 0.01% steps, range: -32767 (-327.67%)..32767(+327.67%). Default 0.
Attr: 0x0102, INT16 (id:0x29), Comfort temperature minimum, in 0.01° steps, range -32767..+32767 (-327.67° ..+327.67°). Default 2000 (20.00°C).
Attr: 0x0103, INT16 (id:0x29), Comfort temperature maximum, in 0.01° steps, range -32767..+32767 (-327.67° ..+327.67°). Default 2500 (25.00°C).
Attr: 0x0104, UINT16 (id:0x21), Comfort humidity minimum, in 1% steps, range 0..9999 (0..99.99%). Default 4000 (40.00%).
Attr: 0x0105, UINT16 (id:0x21), Comfort humidity maximum, in 1% steps, range 0..9999 (0..99.99%). Default 6000 (60.00%).
Attr: 0x0106, ENUM8 (id:0x30), Turn off the display. 1 - Display Off. Default 0 - Display On.
Attr: 0x0107, UINT8 (id:0x20), Measurement interval, range: 3..255 seconds. Default 10 seconds.
```

Attributes 0x0000 and 0x0002 can already be controlled.

<img width="1030" alt="grafik" src="https://github.com/user-attachments/assets/bc52331f-d005-4253-b3b5-4f84145c2c90" />