### PR TITLE
DDF for BlitzWolf BW-SHP-13 plug clone

### DIFF
--- a/devices/blitzwolf/bw_shp13_smart_plug.json
+++ b/devices/blitzwolf/bw_shp13_smart_plug.json
@@ -4,11 +4,13 @@
   "manufacturername": [
     "_TZ3000_3ooaz3ng",
     "_TZ3000_g5xawfcq",
-    "_TZ3000_amdymr7l"
+    "_TZ3000_amdymr7l",
+    "_TZ3210_amdymr7l"
   ],
   "modelid": [
     "TS0121",
     "TS0121",
+    "TS011F",
     "TS011F"
   ],
   "vendor": "BlitzWolf",


### PR DESCRIPTION
Product name : BlitzWolf BW-SHP-13
Manufacturer : TZ3210_amdymr7l
Model identifier : TS011F 

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/8166#issuecomment-2816688067