### PR TITLE
OSRAM/Centralite Motion Sensor-A fix wrong presence = false auto reset

### DIFF
--- a/devices/centralite/motion_sensor-a.json
+++ b/devices/centralite/motion_sensor-a.json
@@ -91,10 +91,6 @@
           "refresh.interval": 3600
         },
         {
-          "name": "config/duration",
-          "default": 40
-        },
-        {
           "name": "config/enrolled",
           "default": 1
         },


### PR DESCRIPTION
The sensor does send motion on/off events correctly. The `config/duration` parameter must not be used here since it does reset the motion state to false after 40 seconds, while the sensor still has motion: true and only reports false after the fact.

Forum: https://forum.phoscon.de/t/diff-behaviour-of-osram-smart-motion-sensor-alexa-phoscon/6295/13