### PR TITLE
Fix CMake FetchContent_Populate() deprecated warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,21 +32,16 @@ if (NOT DECONZ_FULL_BUILD)
 
 include(FetchContent)
 
-FetchContent_Declare(
-  deconzlib
-  GIT_REPOSITORY https://github.com/dresden-elektronik/deconz-lib.git
-  GIT_TAG        main
-)
-# FetchContent_MakeAvailable(deconzlib)
-# FetchContent_MakeAvailable requires CMake 3.14, but Debian Buster has only 3.13
 FetchContent_GetProperties(deconzlib)
 if (NOT deconzlib_POPULATED)
-    FetchContent_Populate(deconzlib)
+    FetchContent_Populate(deconzlib
+        GIT_REPOSITORY https://github.com/dresden-elektronik/deconz-lib.git
+        GIT_TAG        main
+    )
     add_subdirectory(${deconzlib_SOURCE_DIR} ${deconzlib_BINARY_DIR})
 endif()
 
-endif()
-
+endif() # NOT DECONZ_FULL_BUILD
 #----------------------------------------------------------------------
 
 set(PLUGIN_INCLUDE_FILES

--- a/sqlite3/CMakeLists.txt
+++ b/sqlite3/CMakeLists.txt
@@ -2,14 +2,18 @@ cmake_minimum_required(VERSION 3.13)
 
 include(FetchContent)
 
-FetchContent_Declare(sqlite3 URL "https://www.sqlite.org/2023/sqlite-amalgamation-3420000.zip")
+if(${CMAKE_VERSION} VERSION_GREATER "3.23.0")
+    cmake_policy(SET CMP0135 NEW)
+endif()
+
+FetchContent_GetProperties(sqlite3)
 if (NOT sqlite3_POPULATED)
-    FetchContent_Populate(sqlite3)
+    FetchContent_Populate(sqlite3
+        URL "https://www.sqlite.org/2023/sqlite-amalgamation-3420000.zip"
+        URL_HASH MD5=eb9a6e56044bc518e6705521a1a929ed)
 endif()
 
 add_library(sqlite3 SHARED ${sqlite3_SOURCE_DIR}/sqlite3.c)
 add_library(SQLite::SQLite3 ALIAS sqlite3)
 
 target_include_directories(sqlite3 PUBLIC ${sqlite3_SOURCE_DIR})
-
-


### PR DESCRIPTION
FetchContent_Populate() with single argument is deprecated.