### PR TITLE
Fix ghost events for sensors

### DIFF
--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -1093,7 +1093,7 @@ public:
     int createSensor(const ApiRequest &req, ApiResponse &rsp);
     int getGroupIdentifiers(const ApiRequest &req, ApiResponse &rsp);
     int recoverSensor(const ApiRequest &req, ApiResponse &rsp);
-    bool sensorToMap(Sensor *sensor, QVariantMap &map, const ApiRequest &req, bool event = false);
+    bool sensorToMap(Sensor *sensor, QVariantMap &map, const ApiRequest &req, const char *event = nullptr);
     void handleSensorEvent(const Event &e);
 
     // REST API resourcelinks

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -2658,7 +2658,7 @@ int DeRestPluginPrivate::getNewSensors(const ApiRequest &req, ApiResponse &rsp)
     \return true - on success
             false - on error
  */
-bool DeRestPluginPrivate::sensorToMap(Sensor *sensor, QVariantMap &map, const ApiRequest &re, bool event)
+bool DeRestPluginPrivate::sensorToMap(Sensor *sensor, QVariantMap &map, const ApiRequest &re, const char *event)
 {
     if (!sensor)
     {
@@ -2684,6 +2684,12 @@ bool DeRestPluginPrivate::sensorToMap(Sensor *sensor, QVariantMap &map, const Ap
                 continue;
             }
             const ResourceItemDescriptor &rid = item->descriptor();
+
+            // filter for same object parent: attr, state, config ..
+            if (event && (event[0] != rid.suffix[0] || event[1] != rid.suffix[1]))
+            {
+                continue;
+            }
 
             const ApiAttribute a = rid.toApi(map, event);
             QVariantMap *p = a.map;
@@ -2713,6 +2719,12 @@ bool DeRestPluginPrivate::sensorToMap(Sensor *sensor, QVariantMap &map, const Ap
             continue;
         }
         const ResourceItemDescriptor &rid = item->descriptor();
+
+        // filter for same object parent: attr, state, config ..
+        if (event && (event[0] != rid.suffix[0] || event[1] != rid.suffix[1]))
+        {
+            continue;
+        }
 
         if (rid.suffix == RConfigReachable && sensor->type().startsWith(QLatin1String("ZGP")))
         {
@@ -3023,7 +3035,7 @@ void DeRestPluginPrivate::handleSensorEvent(const Event &e)
     QStringList path;  // dummy
     ApiRequest req(hdr, path, nullptr, QLatin1String("")); // dummy
     req.mode = ApiModeNormal;
-    sensorToMap(sensor, smap, req, true);
+    sensorToMap(sensor, smap, req, e.what());
 
     bool pushed = false;
     QVariantMap needPush = smap[QLatin1String("_push")].toMap();


### PR DESCRIPTION
After the refactor of `sensorToMap()` when an event arrived in `handleSensorEvent()` not only the respective parent object like `attr/`, `state/`, `config/`, etc. was emitted on Websocket but sometimes other event objects too.

The PR prevents this to filter out any item that doesn't match the events item suffix.

Related forum posts:

https://forum.phoscon.de/t/ghost-button-events-with-deconz-2-29-5-and-aqara-smart-button/6300/14

https://forum.phoscon.de/t/lumi-vibration-aq1-sensor-with-phantom-triggers-since-deconz-2-29-5/6305/6