### PR TITLE
Reduce Websocket event pressure due attr/lastseen

### DIFF
--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -3985,6 +3985,23 @@ void DeRestPluginPrivate::handleLightEvent(const Event &e)
         return; // already pushed
     }
 
+    if (e.what() == RAttrLastSeen)
+    {
+        QVariantMap map;
+        map[QLatin1String("t")] = QLatin1String("event");
+        map[QLatin1String("e")] = QLatin1String("changed");
+        map[QLatin1String("r")] = QLatin1String("lights");
+        map[QLatin1String("id")] = e.id();
+        map[QLatin1String("uniqueid")] = lightNode->uniqueId();
+        QVariantMap map1;
+        map1[QLatin1String("lastseen")] = item->toString();
+        map[QLatin1String("attr")] = map1;
+
+        item->clearNeedPush();
+        webSocketServer->broadcastTextMessage(Json::serialize(map));
+        return;
+    }
+
     QVariantMap lmap;
     QHttpRequestHeader hdr;  // dummy
     QStringList path;  // dummy

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -3030,6 +3030,23 @@ void DeRestPluginPrivate::handleSensorEvent(const Event &e)
         return; // already pushed
     }
 
+    if (e.what() == RAttrLastSeen)
+    {
+        QVariantMap map;
+        map[QLatin1String("t")] = QLatin1String("event");
+        map[QLatin1String("e")] = QLatin1String("changed");
+        map[QLatin1String("r")] = QLatin1String("sensors");
+        map[QLatin1String("id")] = e.id();
+        map[QLatin1String("uniqueid")] = sensor->uniqueId();
+        QVariantMap map1;
+        map1[QLatin1String("lastseen")] = item->toString();
+        map[QLatin1String("attr")] = map1;
+
+        item->clearNeedPush();
+        webSocketServer->broadcastTextMessage(Json::serialize(map));
+        return;
+    }
+
     QVariantMap smap;
     QHttpRequestHeader hdr;  // dummy
     QStringList path;  // dummy


### PR DESCRIPTION
This PR changes Websocket events caused by `attr/lastseen` updates to only contain that value but not the full `attr` object.

This reduces traffic load on Websockets and also prevents the plugin to cycle through all ResourceItems and build the whole response.

The `attr/lastseen` might be emitted at most once per minute per device, which in a larger network causes quite some traffic.