### PR TITLE
Fix Ikea scenes with on/off going wild

### DIFF
--- a/resource.cpp
+++ b/resource.cpp
@@ -1880,6 +1880,36 @@ void Resource::cleanupStateChanges()
     }
 }
 
+/*! Removes all StateChange items related to \p suffix.
+ */
+void Resource::removeStateChangesForItem(const char *suffix)
+{
+    bool again = true;
+    while (again)
+    {
+        again = false;
+        auto it = m_stateChanges.cbegin();
+        auto end = m_stateChanges.cend();
+
+        for (; it != end; ++it)
+        {
+            auto it2 = it->items().cbegin();
+            const auto end2 = it->items().cend();
+            for (;it2 != end2; ++it2)
+            {
+                if (it2->suffix == suffix)
+                    break;
+            }
+
+            if (it2 != end2) // found matching item, remove SC and look again
+            {
+                again = true;
+                m_stateChanges.erase(it);
+            }
+        }
+    }
+}
+
 /*! Returns the string presentation of an data type */
 QLatin1String R_DataTypeToString(ApiDataType type)
 {

--- a/resource.h
+++ b/resource.h
@@ -615,6 +615,7 @@ public:
     void addStateChange(const StateChange &stateChange);
     std::vector<StateChange> &stateChanges() { return m_stateChanges; }
     void cleanupStateChanges();
+    void removeStateChangesForItem(const char *suffix);
     Resource *parentResource() { return m_parent; }
     const Resource *parentResource() const { return m_parent; }
     void setParentResource(Resource *parent) { m_parent = parent; }

--- a/rest_groups.cpp
+++ b/rest_groups.cpp
@@ -2764,9 +2764,15 @@ static void recallSceneCheckGroupChanges(DeRestPluginPrivate *d, Group *group, S
         {
             groupOn = true;
         }
-        else if (lightNode->manufacturerCode() == VENDOR_IKEA)
+
+        if (lightNode->manufacturerCode() == VENDOR_IKEA)
         {
-            ikeaTurnLightOffInSceneHack(d, lightNode);
+            lightNode->removeStateChangesForItem(RStateOn);
+
+            if (!ls->on())
+            {
+                ikeaTurnLightOffInSceneHack(d, lightNode);
+            }
         }
 
         {


### PR DESCRIPTION
Issue: https://github.com/dresden-elektronik/deconz-rest-plugin/issues/8187

When a scene with `on=false` is recalled, we send a *Off With Effect Command* to Ikea lights since they otherwise won't turn off physically. There is also a `StateChange` added to ensure this works, which is usually a good thing.

However if a scene is then called with `on=true`, the `StateChange` *might* still be alive and turn the light off again. This can be seen in the issue.

The PR clears the `state/on` `StateChange` for Ikea lights when a scene is recalled preventing old state to be applied on a newer one.