### PR TITLE
Fix missing default/init values for DDF items

### DIFF
--- a/device_ddf_init.cpp
+++ b/device_ddf_init.cpp
@@ -148,6 +148,7 @@ static ResourceItem *DEV_InitDeviceDescriptionItem(const DeviceDescription::Item
         if (ddfItem.isStatic || !item->lastSet().isValid())
         {
             item->setValue(ddfItem.defaultValue);
+            item->setTimeStamps(item->lastSet().addSecs(-86400));
             item->clearNeedStore(); // already in DB
         }
     }

--- a/devices/generic/items/attr_appversion_item.json
+++ b/devices/generic/items/attr_appversion_item.json
@@ -5,6 +5,7 @@
   "access": "R",
   "public": true,
   "implicit": false,
+  "default": 0,
   "description": "ZCL Basic cluster application version.",
   "parse": {
     "fn": "zcl:attr",

--- a/devices/generic/items/attr_otaversion_item.json
+++ b/devices/generic/items/attr_otaversion_item.json
@@ -5,6 +5,7 @@
   "access": "R",
   "public": false,
   "implicit": false,
+  "default": 0,
   "description": "OTA cluster file version.",
   "parse": {
     "fn": "zcl:attr",

--- a/devices/generic/items/attr_poweronct_item.json
+++ b/devices/generic/items/attr_poweronct_item.json
@@ -4,5 +4,6 @@
   "datatype": "UInt16",
   "access": "RW",
   "public": true,
+  "default": 370,
   "description": "Ct value set when powered on."
 }

--- a/devices/generic/items/attr_poweronlevel_item.json
+++ b/devices/generic/items/attr_poweronlevel_item.json
@@ -4,5 +4,6 @@
   "datatype": "UInt8",
   "access": "RW",
   "public": true,
+  "default": 254,
   "description": "Brightness set when powered on."
 }

--- a/devices/generic/items/attr_powerup_item.json
+++ b/devices/generic/items/attr_powerup_item.json
@@ -4,5 +4,6 @@
   "datatype": "UInt32",
   "access": "RW",
   "public": true,
+  "default": 0,
   "description": "Powerup mode of a device."
 }

--- a/devices/generic/items/attr_zonetype_item.json
+++ b/devices/generic/items/attr_zonetype_item.json
@@ -5,6 +5,7 @@
   "access": "R",
   "public": true,
   "implicit": false,
+  "default": 0,
   "description": "IAS Zone zone type.",
   "parse": {
     "fn": "zcl:attr",

--- a/devices/generic/items/cap_bri_min_dim_level_item.json
+++ b/devices/generic/items/cap_bri_min_dim_level_item.json
@@ -4,6 +4,7 @@
   "datatype": "UInt16",
   "access": "R",
   "public": true,
+  "default": 1,
   "description": "Minimum dim level of the device.",
   "parse": {
     "fn": "zcl:attr",

--- a/devices/generic/items/cap_color_capabilities_item.json
+++ b/devices/generic/items/cap_color_capabilities_item.json
@@ -4,6 +4,7 @@
   "datatype": "UInt16",
   "access": "R",
   "public": true,
+  "default": 0,
   "description": "The supported color modes as bitmap.",
   "parse": {
     "fn": "zcl:attr",

--- a/devices/generic/items/cap_color_effects_item.json
+++ b/devices/generic/items/cap_color_effects_item.json
@@ -4,6 +4,7 @@
   "datatype": "UInt8",
   "access": "R",
   "public": true,
+  "default": 0,
   "description": "Supported effects for Hue lights.",
   "parse": {
     "fn": "zcl:attr",

--- a/devices/generic/items/cap_color_gradient_max_segments_item.json
+++ b/devices/generic/items/cap_color_gradient_max_segments_item.json
@@ -4,6 +4,7 @@
   "datatype": "UInt8",
   "access": "R",
   "public": true,
+  "default": 0,
   "description": "Number of segments on Hue gradient light.",
   "parse": {
     "fn": "zcl:attr",

--- a/devices/generic/items/cap_color_gradient_pixel_count_item.json
+++ b/devices/generic/items/cap_color_gradient_pixel_count_item.json
@@ -4,6 +4,7 @@
   "datatype": "UInt8",
   "access": "R",
   "public": true,
+  "default": 0,
   "description": "Number of pixels on Hue gradient light.",
   "parse": {
     "fn": "zcl:attr",

--- a/devices/generic/items/cap_color_gradient_pixel_length_item.json
+++ b/devices/generic/items/cap_color_gradient_pixel_length_item.json
@@ -4,6 +4,7 @@
   "datatype": "UInt16",
   "access": "R",
   "public": true,
+  "default": 0,
   "description": "Length (in 0.1 mm) of a pixel on Hue gradient light.",
   "parse": {
     "fn": "zcl:attr",

--- a/devices/generic/items/cap_otau_file_version_item.json
+++ b/devices/generic/items/cap_otau_file_version_item.json
@@ -5,6 +5,7 @@
   "access": "R",
   "public": true,
   "implicit": false,
+  "default": 0,
   "description": "Firmware file version.",
   "parse": {
     "fn": "zcl:cmd",

--- a/devices/generic/items/cap_otau_image_type_item.json
+++ b/devices/generic/items/cap_otau_image_type_item.json
@@ -5,6 +5,7 @@
   "access": "R",
   "public": true,
   "implicit": false,
+  "default": 0,
   "description": "Firmware image type.",
   "parse": {
     "fn": "zcl:cmd",

--- a/devices/generic/items/cap_otau_manufacturer_code_item.json
+++ b/devices/generic/items/cap_otau_manufacturer_code_item.json
@@ -5,6 +5,7 @@
   "access": "R",
   "public": true,
   "implicit": false,
+  "default": 0,
   "description": "Firmware manufacturer code.",
   "parse": {
     "fn": "zcl:cmd",

--- a/devices/generic/items/config_allowtouchlink_item.json
+++ b/devices/generic/items/config_allowtouchlink_item.json
@@ -4,5 +4,6 @@
   "datatype": "Bool",
   "access": "RW",
   "public": false,
+  "default": false,
   "description": "When true the device can initiate touchlink."
 }

--- a/devices/generic/items/config_battery_bis_item.json
+++ b/devices/generic/items/config_battery_bis_item.json
@@ -8,5 +8,6 @@
     0,
     100
   ],
+  "default": 0,
   "description": "The current device battery level in 0&ndash;100&thinsp;%."
 }

--- a/devices/generic/items/config_color_gradient_pixel_count_item.json
+++ b/devices/generic/items/config_color_gradient_pixel_count_item.json
@@ -4,5 +4,6 @@
   "datatype": "UInt8",
   "access": "RW",
   "public": true,
+  "default": 0,
   "description": "Number of pixels on Aqara LED Strip T1."
 }

--- a/devices/generic/items/config_colorcapabilities_item.json
+++ b/devices/generic/items/config_colorcapabilities_item.json
@@ -6,6 +6,7 @@
   "public": true,
   "description": "Deprecated. The supported color capabilities as bitmap.",
   "deprecated": "2022-11-11",
+  "default": 0,
   "parse": {
     "fn": "zcl:attr",
     "ep": 0,

--- a/devices/generic/items/config_configured_item.json
+++ b/devices/generic/items/config_configured_item.json
@@ -4,5 +4,6 @@
   "datatype": "Bool",
   "access": "R",
   "public": true,
+  "default": false,
   "description": "Determines that a resource is configured."
 }

--- a/devices/generic/items/config_controlsequence_item.json
+++ b/devices/generic/items/config_controlsequence_item.json
@@ -8,5 +8,6 @@
     0,
     5
   ],
+  "default": 0,
   "description": "Specifies the overall operating environment of the thermostat, and thus the possible system modes that the thermostat can operate in."
 }

--- a/devices/generic/items/config_displayflipped_item.json
+++ b/devices/generic/items/config_displayflipped_item.json
@@ -4,5 +4,6 @@
   "datatype": "Bool",
   "access": "RW",
   "public": true,
+  "default": false,
   "description": "Displayed content is normal or upside down."
 }

--- a/devices/generic/items/config_duration_item.json
+++ b/devices/generic/items/config_duration_item.json
@@ -8,5 +8,6 @@
     0,
     65535
   ],
+  "default": 60,
   "description": "The duration until presence is automatically turned back to false."
 }

--- a/devices/generic/items/config_enrolled_item.json
+++ b/devices/generic/items/config_enrolled_item.json
@@ -5,5 +5,6 @@
   "access": "RW",
   "public": false,
   "managed": true,
+  "default": 0,
   "description": "State of IAS enrollment process."
 }

--- a/devices/generic/items/config_externalsensortemp_item.json
+++ b/devices/generic/items/config_externalsensortemp_item.json
@@ -4,5 +4,6 @@
   "datatype": "Int16",
   "access": "RW",
   "public": true,
+  "default": 0,
   "description": "The temperature measured by an external sensor, can be used for regulation or displayed on screen."
 }

--- a/devices/generic/items/config_externalwindowopen_item.json
+++ b/devices/generic/items/config_externalwindowopen_item.json
@@ -4,5 +4,6 @@
   "datatype": "Bool",
   "access": "RW",
   "public": true,
+  "default": false,
   "description": "The window state detected by an external sensor."
 }

--- a/devices/generic/items/config_lock_item.json
+++ b/devices/generic/items/config_lock_item.json
@@ -4,5 +4,6 @@
   "datatype": "Bool",
   "access": "RW",
   "public": true,
+  "default": false,
   "description": "Locks or unlocks the door lock."
 }

--- a/devices/generic/items/config_mountingmode_item.json
+++ b/devices/generic/items/config_mountingmode_item.json
@@ -4,5 +4,6 @@
   "datatype": "Bool",
   "access": "RW",
   "public": true,
+  "default": false,
   "description": "Determines if the device has entered the mounting state."
 }

--- a/devices/generic/items/config_reachable_item.json
+++ b/devices/generic/items/config_reachable_item.json
@@ -6,5 +6,6 @@
   "public": true,
   "implicit": true,
   "managed": true,
+  "default": false,
   "description": "When true the device is assumed to be operational."
 }

--- a/devices/generic/items/config_sensitivity_bis_item.json
+++ b/devices/generic/items/config_sensitivity_bis_item.json
@@ -4,5 +4,6 @@
   "datatype": "UInt8",
   "access": "R",
   "public": false,
+  "default": 0,
   "description": "The sensor sensitivity."
 }

--- a/devices/generic/items/config_sensitivitymax_item.json
+++ b/devices/generic/items/config_sensitivitymax_item.json
@@ -8,5 +8,6 @@
     0,
     255
   ],
+  "default": 0,
   "description": "The maximum sensor sensitivity."
 }

--- a/devices/generic/items/config_speed_item.json
+++ b/devices/generic/items/config_speed_item.json
@@ -4,5 +4,6 @@
   "datatype": "UInt8",
   "access": "RW",
   "public": true,
+  "default": 0,
   "description": "Motor speed for window covering devices."
 }

--- a/devices/generic/items/config_temperature_item.json
+++ b/devices/generic/items/config_temperature_item.json
@@ -8,5 +8,6 @@
     0,
     255
   ],
+  "default": 0,
   "description": "The current device temperature in °C."
 }

--- a/devices/generic/items/config_usertest_item.json
+++ b/devices/generic/items/config_usertest_item.json
@@ -4,5 +4,6 @@
   "datatype": "Bool",
   "access": "RW",
   "public": true,
+  "default": false,
   "description": "Activates the user test mode."
 }

--- a/devices/generic/items/state_airqualityppb_bis_item.json
+++ b/devices/generic/items/state_airqualityppb_bis_item.json
@@ -4,5 +4,6 @@
   "datatype": "UInt16",
   "access": "R",
   "public": false,
+  "default": 0,
   "description": "Measured tVOC level in ppb."
 }

--- a/devices/generic/items/state_airqualityppb_item.json
+++ b/devices/generic/items/state_airqualityppb_item.json
@@ -4,5 +4,6 @@
   "datatype": "UInt16",
   "access": "R",
   "public": true,
+  "default": 0,
   "description": "Measured tVOC level in ppb."
 }

--- a/devices/generic/items/state_alarm_item.json
+++ b/devices/generic/items/state_alarm_item.json
@@ -5,6 +5,7 @@
   "access": "R",
   "public": true,
   "description": "True when an alarm is detected.",
+  "default": false,
   "parse": {
     "fn": "ias:zonestatus",
     "mask": "alarm1,alarm2"

--- a/devices/generic/items/state_angle_item.json
+++ b/devices/generic/items/state_angle_item.json
@@ -4,5 +4,6 @@
   "datatype": "Int16",
   "access": "R",
   "public": true,
+  "default": 0,
   "description": "The angle of an action in degrees."
 }

--- a/devices/generic/items/state_bri_item.json
+++ b/devices/generic/items/state_bri_item.json
@@ -3,6 +3,7 @@
   "id": "state/bri",
   "datatype": "UInt8",
   "access": "RW",
+  "default": 0,
   "public": true,
   "range": [
     0,

--- a/devices/generic/items/state_buttonevent_item.json
+++ b/devices/generic/items/state_buttonevent_item.json
@@ -4,5 +4,6 @@
   "datatype": "UInt32",
   "access": "R",
   "public": true,
+  "default": 0,
   "description": "The last received button event."
 }

--- a/devices/generic/items/state_consumption_2_item.json
+++ b/devices/generic/items/state_consumption_2_item.json
@@ -4,6 +4,7 @@
   "datatype": "UInt64",
   "access": "RW",
   "public": true,
+  "default": 0,
   "description": "The measured consumption (in Wh).",
   "read": {
     "at": "0x0000",

--- a/devices/generic/items/state_ct_item.json
+++ b/devices/generic/items/state_ct_item.json
@@ -4,6 +4,7 @@
   "datatype": "UInt16",
   "access": "RW",
   "public": true,
+  "default": 0,
   "description": "The current Mired color temperature of the light. Where Mired is 1000000 / color temperature (in kelvins).",
   "parse": {
     "fn": "zcl:attr",

--- a/devices/generic/items/state_current_p1_item.json
+++ b/devices/generic/items/state_current_p1_item.json
@@ -4,6 +4,7 @@
   "datatype": "UInt16",
   "access": "RW",
   "public": true,
+  "default": 0,
   "description": "The measured current on phase 1.",
   "read": {
     "at": "0x0508",

--- a/devices/generic/items/state_current_p2_item.json
+++ b/devices/generic/items/state_current_p2_item.json
@@ -4,6 +4,7 @@
   "datatype": "UInt16",
   "access": "RW",
   "public": true,
+  "default": 0,
   "description": "The measured current on phase 2.",
   "read": {
     "at": "0x0908",

--- a/devices/generic/items/state_current_p3_item.json
+++ b/devices/generic/items/state_current_p3_item.json
@@ -4,6 +4,7 @@
   "datatype": "UInt16",
   "access": "RW",
   "public": true,
+  "default": 0,
   "description": "The measured current on phase 3.",
   "read": {
     "at": "0x0a08",

--- a/devices/generic/items/state_distance_item.json
+++ b/devices/generic/items/state_distance_item.json
@@ -4,5 +4,6 @@
   "datatype": "UInt32",
   "access": "R",
   "public": true,
+  "default": 0,
   "description": "Distance at which occupancy was detected."
 }

--- a/devices/generic/items/state_eventduration_item.json
+++ b/devices/generic/items/state_eventduration_item.json
@@ -4,5 +4,6 @@
   "datatype": "UInt32",
   "access": "R",
   "public": true,
+  "default": 0,
   "description": "Determines how long an event lasted."
 }

--- a/devices/generic/items/state_expectedeventduration_item.json
+++ b/devices/generic/items/state_expectedeventduration_item.json
@@ -4,5 +4,6 @@
   "datatype": "UInt16",
   "access": "R",
   "public": true,
+  "default": 0,
   "description": "The expected duration of the last received rotary event."
 }

--- a/devices/generic/items/state_expectedrotation_item.json
+++ b/devices/generic/items/state_expectedrotation_item.json
@@ -4,5 +4,6 @@
   "datatype": "Int16",
   "access": "R",
   "public": true,
+  "default": 0,
   "description": "The expected rotation of the last received rotary event."
 }

--- a/devices/generic/items/state_fire_item.json
+++ b/devices/generic/items/state_fire_item.json
@@ -4,6 +4,7 @@
   "datatype": "Bool",
   "access": "R",
   "public": true,
+  "default": false,
   "description": "True when fire is detected.",
   "parse": {
     "fn": "ias:zonestatus",

--- a/devices/generic/items/state_gesture_item.json
+++ b/devices/generic/items/state_gesture_item.json
@@ -4,5 +4,6 @@
   "datatype": "UInt32",
   "access": "R",
   "public": true,
+  "default": 0,
   "description": "The last received gesture."
 }

--- a/devices/generic/items/state_heating_item.json
+++ b/devices/generic/items/state_heating_item.json
@@ -4,5 +4,6 @@
   "datatype": "Bool",
   "access": "R",
   "public": true,
+  "default": false,
   "description": "Determines heating state for ELKO Super TR thermostat."
 }

--- a/devices/generic/items/state_hue_item.json
+++ b/devices/generic/items/state_hue_item.json
@@ -4,6 +4,7 @@
   "datatype": "UInt16",
   "access": "RW",
   "public": true,
+  "default": 0,
   "description": "The current color hue.",
   "parse": {
     "fn": "zcl:attr",

--- a/devices/generic/items/state_humidity_bis_item.json
+++ b/devices/generic/items/state_humidity_bis_item.json
@@ -4,5 +4,6 @@
   "datatype": "UInt16",
   "access": "R",
   "public": false,
+  "default": 0,
   "description": "The current relative humidity in percent."
 }

--- a/devices/generic/items/state_lowbattery_item.json
+++ b/devices/generic/items/state_lowbattery_item.json
@@ -5,6 +5,7 @@
   "access": "R",
   "public": true,
   "managed": true,
+  "default": false,
   "description": "True when the device battery runs low.",
   "parse": {
     "fn": "ias:zonestatus"

--- a/devices/generic/items/state_mountingmodeactive_item.json
+++ b/devices/generic/items/state_mountingmodeactive_item.json
@@ -4,5 +4,6 @@
   "datatype": "Bool",
   "access": "R",
   "public": true,
+  "default": false,
   "description": "The current mounting mode state."
 }

--- a/devices/generic/items/state_music_sync_item.json
+++ b/devices/generic/items/state_music_sync_item.json
@@ -4,5 +4,6 @@
   "datatype": "Bool",
   "access": "RW",
   "public": true,
+  "default": false,
   "description": "Music sync on or off."
 }

--- a/devices/generic/items/state_on_item.json
+++ b/devices/generic/items/state_on_item.json
@@ -4,6 +4,7 @@
   "datatype": "Bool",
   "access": "RW",
   "public": true,
+  "default": false,
   "description": "True when device is on; false when off.",
   "parse": {
     "fn": "zcl:attr",

--- a/devices/generic/items/state_open_bis_item.json
+++ b/devices/generic/items/state_open_bis_item.json
@@ -4,5 +4,6 @@
   "datatype": "Bool",
   "access": "R",
   "public": false,
+  "default": false,
   "description": "True when open is detected."
 }

--- a/devices/generic/items/state_open_item.json
+++ b/devices/generic/items/state_open_item.json
@@ -4,6 +4,7 @@
   "datatype": "Bool",
   "access": "R",
   "public": true,
+  "default": false,
   "description": "True when open is detected.",
   "parse": {
     "fn": "ias:zonestatus",

--- a/devices/generic/items/state_orientation_x_item.json
+++ b/devices/generic/items/state_orientation_x_item.json
@@ -4,5 +4,6 @@
   "datatype": "Int16",
   "access": "R",
   "public": true,
+  "default": 0,
   "description": "The X orientation of a gyro."
 }

--- a/devices/generic/items/state_orientation_y_item.json
+++ b/devices/generic/items/state_orientation_y_item.json
@@ -4,5 +4,6 @@
   "datatype": "Int16",
   "access": "R",
   "public": true,
+  "default": 0,
   "description": "The Y orientation of a gyro."
 }

--- a/devices/generic/items/state_orientation_z_item.json
+++ b/devices/generic/items/state_orientation_z_item.json
@@ -4,5 +4,6 @@
   "datatype": "Int16",
   "access": "R",
   "public": true,
+  "default": 0,
   "description": "The Z orientation of a gyro."
 }

--- a/devices/generic/items/state_pressure_bis_item.json
+++ b/devices/generic/items/state_pressure_bis_item.json
@@ -4,5 +4,6 @@
   "datatype": "Int16",
   "access": "R",
   "public": false,
+  "default": 0,
   "description": "The current air pressure (hPa)."
 }

--- a/devices/generic/items/state_production_item.json
+++ b/devices/generic/items/state_production_item.json
@@ -4,6 +4,7 @@
   "datatype": "UInt64",
   "access": "RW",
   "public": true,
+  "default": 0,
   "description": "The measured production (in Wh).",
   "read": {
     "at": "0x0001",

--- a/devices/generic/items/state_reachable_item.json
+++ b/devices/generic/items/state_reachable_item.json
@@ -6,5 +6,6 @@
   "public": true,
   "implicit": true,
   "managed": true,
+  "default": false,
   "description": "When true the device is assumed to be operational."
 }

--- a/devices/generic/items/state_rotaryevent_item.json
+++ b/devices/generic/items/state_rotaryevent_item.json
@@ -4,5 +4,6 @@
   "datatype": "UInt8",
   "access": "R",
   "public": true,
+  "default": 0,
   "description": "The last received rotary event."
 }

--- a/devices/generic/items/state_sat_item.json
+++ b/devices/generic/items/state_sat_item.json
@@ -4,6 +4,7 @@
   "datatype": "UInt8",
   "access": "RW",
   "public": true,
+  "default": 0,
   "description": "The current color saturation.",
   "parse": {
     "fn": "zcl:attr",

--- a/devices/generic/items/state_speed_item.json
+++ b/devices/generic/items/state_speed_item.json
@@ -4,5 +4,6 @@
   "datatype": "UInt8",
   "access": "RW",
   "public": true,
+  "default": 0,
   "description": "The fan speed for mains powered devices."
 }

--- a/devices/generic/items/state_tampered_item.json
+++ b/devices/generic/items/state_tampered_item.json
@@ -4,6 +4,7 @@
   "datatype": "Bool",
   "access": "R",
   "public": true,
+  "default": false,
   "description": "True when the device tampered alarm was triggered.",
   "parse": {
     "fn": "ias:zonestatus"

--- a/devices/generic/items/state_temperature_bis_item.json
+++ b/devices/generic/items/state_temperature_bis_item.json
@@ -4,5 +4,6 @@
   "datatype": "Int16",
   "access": "R",
   "public": false,
+  "default": 0,
   "description": "The current temperature in °C &times; 100."
 }

--- a/devices/generic/items/state_tiltangle_item.json
+++ b/devices/generic/items/state_tiltangle_item.json
@@ -8,5 +8,6 @@
     0,
     360
   ],
+  "default": 0,
   "description": "The current tilt angle."
 }

--- a/devices/generic/items/state_vibration_item.json
+++ b/devices/generic/items/state_vibration_item.json
@@ -4,6 +4,7 @@
   "datatype": "Bool",
   "access": "R",
   "public": true,
+  "default": false,
   "description": "True when vibration is detected.",
   "parse": {
     "fn": "ias:zonestatus",

--- a/devices/generic/items/state_vibrationstrength_item.json
+++ b/devices/generic/items/state_vibrationstrength_item.json
@@ -8,5 +8,6 @@
     0,
     65535
   ],
+  "default": 0,
   "description": "The strength of the detected vibration."
 }

--- a/devices/generic/items/state_water_bis_item.json
+++ b/devices/generic/items/state_water_bis_item.json
@@ -4,5 +4,6 @@
   "datatype": "Bool",
   "access": "R",
   "public": false,
+  "default": false,
   "description": "True when water is detected."
 }

--- a/devices/generic/items/state_water_item.json
+++ b/devices/generic/items/state_water_item.json
@@ -4,6 +4,7 @@
   "datatype": "Bool",
   "access": "R",
   "public": true,
+  "default": false,
   "description": "True when water is detected.",
   "parse": {
     "fn": "ias:zonestatus",

--- a/devices/generic/items/state_x_item.json
+++ b/devices/generic/items/state_x_item.json
@@ -4,6 +4,7 @@
   "datatype": "UInt16",
   "access": "RW",
   "public": true,
+  "default": 0,
   "description": "The current color x coordinate.",
   "parse": {
     "fn": "zcl:attr",

--- a/devices/generic/items/state_y_item.json
+++ b/devices/generic/items/state_y_item.json
@@ -4,6 +4,7 @@
   "datatype": "UInt16",
   "access": "RW",
   "public": true,
+  "default": 0,
   "description": "The current color y coordinate.",
   "parse": {
     "fn": "zcl:attr",


### PR DESCRIPTION
Without these the REST-API would return `null` for items that don't have a value yet. For strings that's ok but numbers and bool values may cause trouble for API clients.

https://forum.phoscon.de/t/decon-v2-29-5-hue-essential-regression/6312/6