### PR TITLE
Ensure lights and sensors always have valid Etag

### DIFF
--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -583,6 +583,11 @@ bool DeRestPluginPrivate::lightToMap(const ApiRequest &req, LightNode *lightNode
         map[QLatin1String("hascolor")] = lightNode->hasColor();
     }
 
+    if (lightNode->etag.size() == 0)
+    {
+        updateLightEtag(lightNode);
+    }
+
     QString etag = lightNode->etag;
     map[QLatin1String("etag")] = etag.remove('"');
 

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -2851,6 +2851,11 @@ bool DeRestPluginPrivate::sensorToMap(Sensor *sensor, QVariantMap &map, const Ap
         map[QLatin1String("ep")] = sensor->fingerPrint().endpoint;
     }
 
+    if (sensor->etag.size() == 0)
+    {
+        updateSensorEtag(sensor);
+    }
+
     QString etag = sensor->etag;
     map[QLatin1String("etag")] = etag.remove('"');
 


### PR DESCRIPTION
This could have been empty / null after startup and a device not having received events yet.