### PR TITLE
DDF, 1 more clone for tuya door sensor

### DIFF
--- a/devices/tuya/_TZE200_pay2byax_openclose_sensor.json
+++ b/devices/tuya/_TZE200_pay2byax_openclose_sensor.json
@@ -4,9 +4,11 @@
   "manufacturername": [
     "_TZE200_pay2byax",
     "_TZE200_kltffuzl",
-    "_TZE200_fwoorn8y"
+    "_TZE200_fwoorn8y",
+    "_TZE200_n8dljorx"
   ],
   "modelid": [
+    "TS0601",
     "TS0601",
     "TS0601",
     "TS0601"


### PR DESCRIPTION
It's the model without luminosity

Product name : Tuya Door/Window Sensor
Manufacturer : _TZE200_n8dljorx
Model identifier : TS0601

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/8105