### PR TITLE
Make Device creation time available

### DIFF
--- a/database.h
+++ b/database.h
@@ -113,7 +113,15 @@ struct DB_IdentifierPair
     unsigned mfnameAtomIndex;
 };
 
-int DB_StoreDevice(const deCONZ::Address &addr);
+struct DB_Device
+{
+    int deviceId;
+    uint16_t nwk;
+    uint64_t mac;
+    int64_t creationTime;
+};
+
+int DB_StoreDevice(DB_Device &dev);
 
 int DB_GetSubDeviceItemCount(QLatin1String uniqueId);
 bool DB_LoadZclValue(DB_ZclValue *val);

--- a/device.cpp
+++ b/device.cpp
@@ -139,6 +139,7 @@ public:
     std::vector<Resource*> subResources;
     const deCONZ::Node *node = nullptr; //! a reference to the deCONZ core node
     int deviceId = DEV_INVALID_DEVICE_ID;
+    int64_t creationTime = -1; //! time when the device was created in database
     DeviceKey deviceKey = 0; //! for physical devices this is the MAC address
 
     /*! The currently active state handler function(s).
@@ -2208,6 +2209,19 @@ void Device::setDeviceId(int id)
     {
         d->deviceId = id;
     }
+}
+
+void Device::setCreationTime(int64_t creationTime)
+{
+    if (0 < creationTime)
+    {
+        d->creationTime = creationTime;
+    }
+}
+
+int64_t Device::creationTime() const
+{
+    return d->creationTime;
 }
 
 int Device::deviceId() const

--- a/device.h
+++ b/device.h
@@ -100,6 +100,8 @@ public:
     explicit Device(DeviceKey key, deCONZ::ApsController*apsCtrl, QObject *parent = nullptr);
     ~Device();
     void setDeviceId(int id);
+    void setCreationTime(int64_t creationTime); //! device creation time in msecs
+    int64_t creationTime() const;
     int deviceId() const;
     void addSubDevice(Resource *sub);
     DeviceKey key() const;


### PR DESCRIPTION
The database already contains the timestamp when a device was created for DDF and legacy devices. This PR loads the timestamp from the database when the Device instance is created.

Will be used in a further PR.