### PR TITLE
Fix attr/lastannounced and attr/lastseen sometimes being null

### DIFF
--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -322,6 +322,16 @@ bool DeRestPluginPrivate::lightToMap(const ApiRequest &req, LightNode *lightNode
                 continue;
             }
 
+            // quirk to ensure attr/lastseen and attr/lastannounced aren't null
+            if (rid.suffix == RAttrLastAnnounced || rid.suffix == RAttrLastSeen)
+            {
+                if (device && item->toNumber() <= 0 && 0 < device->creationTime())
+                {
+                    item->setValue(device->creationTime(), ResourceItem::SourceDevice);
+                    lightNode->setNeedSaveDatabase(true);
+                }
+            }
+
             const ApiAttribute a = rid.toApi(map, event);
             QVariantMap *p = a.map;
             QString key = a.key;

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -2748,6 +2748,16 @@ bool DeRestPluginPrivate::sensorToMap(Sensor *sensor, QVariantMap &map, const Ap
                 continue;
             }
 
+            // quirk to ensure attr/lastseen and attr/lastannounced aren't null
+            if (rid.suffix == RAttrLastAnnounced || rid.suffix == RAttrLastSeen)
+            {
+                if (device && item->toNumber() <= 0 && 0 < device->creationTime())
+                {
+                    item->setValue(device->creationTime(), ResourceItem::SourceDevice);
+                    sensor->setNeedSaveDatabase(true);
+                }
+            }
+
             const ApiAttribute a = rid.toApi(map, event);
             QVariantMap *p = a.map;
             QString key = a.key;


### PR DESCRIPTION
PR https://github.com/dresden-elektronik/deconz-rest-plugin/pull/8213 already fixes many instances when the problem occurs, but there are valid timestamps for DDF devices in 'resource_items' table.

However that's not always the case. To cleanup old invalid null entries, this PR takes the device creation time as initial value.