### PR TITLE
Fix don't expose internal attr/zonetype to REST-API

### DIFF
--- a/device.cpp
+++ b/device.cpp
@@ -839,7 +839,9 @@ void DEV_GetDeviceDescriptionHandler(Device *device, const Event &event)
         // if there is a IAS Zone Cluster add the RAttrZoneType
         if (DEV_GetSimpleDescriptorForServerCluster(device, 0x0500_clid))
         {
-            device->addItem(DataTypeUInt16, RAttrZoneType);
+            ResourceItem *item = device->addItem(DataTypeUInt16, RAttrZoneType);
+            if (item)
+                item->setIsPublic(false);
         }
         DEV_EnqueueEvent(device, REventDDFInitRequest);
     }


### PR DESCRIPTION
The item is usefull internally to setup the IAS cluster. It is automatically added by the Device class if a IAS cluster is detected. Since `sensorToMap()` also exports Device items it should be non public.

Also prevents showing this attribute as `null` if no data is available for it.