### PR TITLE
Fix don't expose `ddf_hash` and `ddf_policy` for lights and sensors

### DIFF
--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -260,6 +260,12 @@ bool DeRestPluginPrivate::lightToMap(const ApiRequest &req, LightNode *lightNode
                 continue;
             }
 
+            // following are only exposed on /devices
+            if (rid.suffix == RAttrDdfHash || rid.suffix == RAttrDdfPolicy)
+            {
+                continue;
+            }
+
             const ApiAttribute a = rid.toApi(map, event);
             QVariantMap *p = a.map;
             (*p)[a.key] = item->toVariant();

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -2691,6 +2691,12 @@ bool DeRestPluginPrivate::sensorToMap(Sensor *sensor, QVariantMap &map, const Ap
                 continue;
             }
 
+            // following are only exposed on /devices
+            if (rid.suffix == RAttrDdfHash || rid.suffix == RAttrDdfPolicy)
+            {
+                continue;
+            }
+
             const ApiAttribute a = rid.toApi(map, event);
             QVariantMap *p = a.map;
             (*p)[a.key] = item->toVariant();


### PR DESCRIPTION
These are only part of `/devices` endpoint. Also removes another attribute which can be `null` for lights and sensors.