### PR TITLE
Improve ZGP device representation

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -3620,6 +3620,11 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
             sensor.addItem(DataTypeUInt64, RStateGPDLastPair)->setIsPublic(false);
         }
 
+        if (sensor.type() == QLatin1String("ZGPSwitch"))
+        {
+            sensor.removeItem(RAttrLastAnnounced);
+        }
+
         if (sensor.type().endsWith(QLatin1String("Switch")))
         {
             if (sensor.fingerPrint().hasInCluster(COMMISSIONING_CLUSTER_ID))


### PR DESCRIPTION
- Device class introduce `DEV_ZgpStateHandler()` which hides `attr/nwkaddress` and sets `capabilitiess/sleeper` to `true`.
- Remove `attr/lastannounced` because ZGP devices don't do this and hence attribute was always `null`.
- Always set `attr/lastseen` when ZGP button event is received.
- When pairing a ZGP device make sure its parent is set to respective Device.