### PR TITLE
Fix don't expose null values from Device for sensors and lights

### DIFF
--- a/rest_lights.cpp
+++ b/rest_lights.cpp
@@ -252,6 +252,11 @@ bool DeRestPluginPrivate::lightToMap(const ApiRequest &req, LightNode *lightNode
                 continue;
             }
 
+            if (!item->lastSet().isValid())
+            {
+                continue;
+            }
+
             const ResourceItemDescriptor &rid = item->descriptor();
 
             // filter for same object parent: attr, state, config ..

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -2683,6 +2683,12 @@ bool DeRestPluginPrivate::sensorToMap(Sensor *sensor, QVariantMap &map, const Ap
             {
                 continue;
             }
+
+            if (!item->lastSet().isValid())
+            {
+                continue;
+            }
+
             const ResourceItemDescriptor &rid = item->descriptor();
 
             // filter for same object parent: attr, state, config ..


### PR DESCRIPTION
For legacy devices this affected items like `cap/sleeper`.