### PR TITLE
Fix strings without data being null, return empty string instead

### DIFF
--- a/json.cpp
+++ b/json.cpp
@@ -136,7 +136,14 @@ QByteArray Json::serialize(const QVariant &data, bool &success)
 	}
 	else if (data.isNull())
 	{
-		str = "null";
+        if (data.type() == QVariant::String)
+        {
+            str = "\"\"";
+        }
+        else
+        {
+            str = "null";
+        }
 	}
 	else if((data.type() == QVariant::String) || (data.type() == QVariant::ByteArray)) // a string or a byte array?
 	{

--- a/resource.cpp
+++ b/resource.cpp
@@ -1478,12 +1478,16 @@ void ResourceItem::setTimeStamps(const QDateTime &t)
 
 QVariant ResourceItem::toVariant() const
 {
+    const ResourceItemDescriptor *rid = &descriptor();
+
     if (!m_lastSet.isValid())
     {
+        if (rid->type == DataTypeString || rid->type == DataTypeTimePattern)
+        {
+            return QString(""); // otherwise the API would return null for strings
+        }
         return QVariant();
     }
-
-    const ResourceItemDescriptor *rid = &descriptor();
 
     if (rid->type == DataTypeString ||
         rid->type == DataTypeTimePattern)


### PR DESCRIPTION
This fixes the remaining cases where strings could be `null` in my setup only `swversion` and `productid` where affected, since the others are handled by previous PRs.