### PR TITLE
Enable status reporting for Parkside Smart Watering Timer (_TZE200_htnnfasr)

### DIFF
--- a/devices/lidl/hg06875.json
+++ b/devices/lidl/hg06875.json
@@ -64,6 +64,32 @@
         },
         {
           "name": "state/reachable"
+        },
+        {
+          "name": "config/configured",
+          "public": false,
+          "refresh.interval": 86400,
+          "read": {
+            "at": [
+              "0x0004",
+              "0x0000",
+              "0x0001",
+              "0x0005",
+              "0x0007",
+              "0xfffe"
+            ],
+            "cl": "0x0000",
+            "ep": 1,
+            "fn": "zcl"
+          },
+          "parse": {
+            "at": "0xfffe",
+            "cl": "0x0000",
+            "ep": 1,
+            "eval": "Item.val = (Attr.val != 0)",
+            "fn": "zcl"
+          },
+          "default": false
         }
       ]
     },

--- a/devices/lidl/hg06875.json
+++ b/devices/lidl/hg06875.json
@@ -66,30 +66,7 @@
           "name": "state/reachable"
         },
         {
-          "name": "config/configured",
-          "public": false,
-          "refresh.interval": 86400,
-          "read": {
-            "at": [
-              "0x0004",
-              "0x0000",
-              "0x0001",
-              "0x0005",
-              "0x0007",
-              "0xfffe"
-            ],
-            "cl": "0x0000",
-            "ep": 1,
-            "fn": "zcl"
-          },
-          "parse": {
-            "at": "0xfffe",
-            "cl": "0x0000",
-            "ep": 1,
-            "eval": "Item.val = (Attr.val != 0)",
-            "fn": "zcl"
-          },
-          "default": false
+         "name": "config/tuya_unlock"
         }
       ]
     },


### PR DESCRIPTION
add support for the Parkside Smart Watering Timer (_TZE200_htnnfasr) by adding the necessary tuya  “magic spell” sequence to enable status updates. 

The device now correctly reports its state when toggled via software or manually.  Tested with deCONZ version 2.30.2 — works reliably after initial pairing.