### PR TITLE
DDF clone for Tuya smoke detector (_TZE284_rccxox8p)

### DIFF
--- a/devices/tuya/_TZE200_TS0601_smoke_detector.json
+++ b/devices/tuya/_TZE200_TS0601_smoke_detector.json
@@ -3,9 +3,13 @@
   "uuid": "0d0e2021-e61c-49fc-8d7c-f54533815996",
   "manufacturername": [
     "_TZE200_m9skfctm",
-    "_TZE200_vzekyi4c"
+    "_TZE200_vzekyi4c",
+    "_TZE200_rccxox8p",
+    "_TZE283_rccxox8p"
   ],
   "modelid": [
+    "TS0601",
+    "TS0601",
     "TS0601",
     "TS0601"
   ],


### PR DESCRIPTION
Product name: Tuya Smoke Fire Alarm Detector
Manufacturer: _TZE283_rccxox8p
Model identifier: TS0601

See #8224