### PR TITLE
DDF clone for Tuya temperature/humidity sensor (_TZE284_wtikaxzs)

### DIFF
--- a/devices/tuya/_TZE200_TS0601_humidity_temp.json
+++ b/devices/tuya/_TZE200_TS0601_humidity_temp.json
@@ -11,9 +11,11 @@
     "_TZE200_utkemkbs",
     "_TZE200_locansqn",
     "_TZE204_yjjdcqsq",
-    "_TZE200_vs0skpuc"
+    "_TZE200_vs0skpuc",
+    "_TZE284_wtikaxzs"
   ],
   "modelid": [
+    "TS0601",
     "TS0601",
     "TS0601",
     "TS0601",


### PR DESCRIPTION
Product name: Nous E6
Manufacturer: _TZE284_wtikaxzs
Model identifier: TS0601

See #8225