### PR TITLE
DDF, add support for a tuya covering Yoolex _TZE200_9caxna4s

### DIFF
--- a/devices/tuya/_TZB000_42ha4rsc_window_blinds.json
+++ b/devices/tuya/_TZB000_42ha4rsc_window_blinds.json
@@ -3,14 +3,16 @@
   "uuid": "165aea49-d5c1-4418-a479-cdad4dfe1600",
   "manufacturername": [
     "_TZB000_42ha4rsc",
-    "_TZB000_yqjaollc"
+    "_TZB000_yqjaollc",
+    "_TZE200_9caxna4s"
   ],
   "modelid": [
     "TS030F",
-    "TS030F"
+    "TS030F",
+    "TS0301"
   ],
-  "vendor": "Livarno",
-  "product": "Window blinds (TS030F)",
+  "vendor": "Tuya",
+  "product": "Window blinds (not reversed)",
   "sleeper": true,
   "status": "Gold",
   "subdevices": [


### PR DESCRIPTION
  "manufacturername":  "_TZE200_9caxna4s"
  "modelid": "TS0301"

See https://forum.phoscon.de/t/add-support-for-yoolex-tze200-9caxna4s/6340


