### PR TITLE
DDF clone for newer variant of Heiman HS1SA-E

### DIFF
--- a/devices/heiman/hs1sa_smoke_sensor.json
+++ b/devices/heiman/hs1sa_smoke_sensor.json
@@ -1,8 +1,14 @@
 {
   "schema": "devcap1.schema.json",
   "uuid": "2787627b-76fe-43d4-97d4-9e93236ef963",
-  "manufacturername": "Heiman",
-  "modelid": "SmokeSensor-EF-3.0",
+  "manufacturername": [
+    "Heiman",
+    "HEIMAN"
+  ],
+  "modelid": [
+    "SmokeSensor-EF-3.0",
+    "SmokeSensor-EF-3.0"
+  ],
   "vendor": "Heiman",
   "product": "Smoke sensor (HS1SA)",
   "sleeper": true,


### PR DESCRIPTION
The manufacturer name of the current model is reported in upper case. Contrary to the closing reason of #7862 the matching is still case-sensitive (see #7965).

Please consider merging this change so that the smoke detector is recognised properly.