### PR TITLE
DDF, update for the tuya 2 gangs battery sensor

### DIFF
--- a/devices/tuya/_TZ3000_TS0042_2gang_remote.json
+++ b/devices/tuya/_TZ3000_TS0042_2gang_remote.json
@@ -80,6 +80,12 @@
             "ep": 1,
             "eval": "Item.val = Attr.val / 2;",
             "fn": "zcl:attr"
+          },
+          "read": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "fn": "zcl:attr"
           }
         },
         {


### PR DESCRIPTION
See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/8211#issuecomment-2918828947

We can't enable reporting on thoses devices (it provoque a battery drain) but need to enable the poll to have data.
Can concert too others devices but haven't someone to test it yet.