### PR TITLE
DDF add some tuya clones for the Air sensor.

### DIFF
--- a/devices/tuya/_TZE200_dwcarsat_air_sensor.json
+++ b/devices/tuya/_TZE200_dwcarsat_air_sensor.json
@@ -1,8 +1,8 @@
 {
   "schema": "devcap1.schema.json",
   "uuid": "85009be3-61c1-4c97-a12b-ca646f7952bb",
-  "manufacturername": "_TZE200_dwcarsat",
-  "modelid": "TS0601",
+  "manufacturername": ["_TZE200_dwcarsat", "_TZE204_dwcarsat", "TZE204_c2fmom5z", "_TZE200_8ygsuhe1", "_TZE200_yvx5lh6k", "_TZE200_ryfmq5rl", "_TZE200_c2fmom5z", "_TZE200_mja3fuja", "_TZE204_c2fmom5z", "_TZE204_yvx5lh6k"],
+  "modelid": ["TS0601", "TS0601", "TS0601", "TS0601", "TS0601", "TS0601", "TS0601", "TS0601", "TS0601", "TS0601"],
   "vendor": "Tuya",
   "product": "Smart Air House keeper (TS0601)",
   "sleeper": true,


### PR DESCRIPTION
See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/8239#issuecomment-2950520245

Have added some more clones, there is some variation on models, sames of them don't have all value or are buggy, but the DDF will work.

```
  "manufacturername": ["_TZE200_dwcarsat", "_TZE204_dwcarsat", "TZE204_c2fmom5z", "_TZE200_8ygsuhe1", "_TZE200_yvx5lh6k", "_TZE200_ryfmq5rl", "_TZE200_c2fmom5z", "_TZE200_mja3fuja", "_TZE204_c2fmom5z", "_TZE204_yvx5lh6k"],
  "modelid": ["TS0601", "TS0601", "TS0601", "TS0601", "TS0601", "TS0601", "TS0601", "TS0601", "TS0601", "TS0601"],
```