### PR TITLE
DDF for Aqara E1 single rocker wireless switch WXKG16LM

### DIFF
--- a/button_maps.json
+++ b/button_maps.json
@@ -810,6 +810,16 @@
                 [1, "0x07", "MULTISTATE_INPUT", "ATTRIBUTE_REPORT", "255", "S_BUTTON_3", "S_BUTTON_ACTION_LONG_RELEASED", "Long released"]
             ]
         },
+        "xiaomiSwitchE1Acn003Map": {
+            "vendor": "Xiaomi",
+            "doc": "Xiaomi Aqara E1 single rocker wireless switch WXKG16LM",
+            "modelids": ["lumi.remote.acn003"],
+            "map": [
+                [1, "0x01", "MULTISTATE_INPUT", "ATTRIBUTE_REPORT", "1", "S_BUTTON_1", "S_BUTTON_ACTION_SHORT_RELEASED", "Normal press"],
+                [1, "0x01", "MULTISTATE_INPUT", "ATTRIBUTE_REPORT", "2", "S_BUTTON_1", "S_BUTTON_ACTION_DOUBLE_PRESS", "Double press"],
+                [1, "0x01", "MULTISTATE_INPUT", "ATTRIBUTE_REPORT", "0", "S_BUTTON_1", "S_BUTTON_ACTION_HOLD", "Hold"]            
+            ]
+        },
         "xiaomiSwitchE1Acn004Map": {
             "vendor": "Xiaomi",
             "doc": "Xiaomi Aqara E1 dual rocker wireless switch WXKG17LM",

--- a/devices/xiaomi/xiaomi_wxkg16lm_e1_switch.json
+++ b/devices/xiaomi/xiaomi_wxkg16lm_e1_switch.json
@@ -1,0 +1,159 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "$MF_LUMI",
+  "modelid": "lumi.remote.acn003",
+  "matchexpr": "R.endpoints.length === 1",
+  "vendor": "Xiaomi",
+  "product": "Aqara E1 single rocker wireless switch WXKG16LM",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_SWITCH",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0006"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0000",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x0012",
+          "0xFCC0"
+        ],
+        "out": [
+          "0x0006"
+        ]
+      },
+      "meta": {"group.endpoints": [1] },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid",
+          "awake": true
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "awake": true,
+          "parse": {
+            "at": "0x00f7",
+            "ep": 1,
+            "fn": "xiaomi:special",
+            "idx": "0x01",
+            "script": "xiaomi_battery.js"
+          }
+        },
+        {
+          "name": "config/clickmode",
+          "refresh.interval": 3000,
+          "parse": {
+            "at": "0x0125",
+            "cl": "0xfcc0",
+            "ep": 1,
+            "eval": "if (Attr.val == 1) { Item.val = 'highspeed' } else if (Attr.val == 2) { Item.val = 'multiclick' } else { Item.val = 'unknown' }",
+            "fn": "zcl",
+            "mf": "0x115f"
+          },
+          "read": {
+            "at": "0x0125",
+            "cl": "0xfcc0",
+            "ep": 1,
+            "fn": "zcl",
+            "mf": "0x115f"
+          },
+          "write": {
+            "at": "0x0125",
+            "cl": "0xfcc0",
+            "dt": "0x20",
+            "ep": 1,
+            "eval": "if (Item.val == 'highspeed') { 1 } else if (Item.val == 'multiclick') { 2 }",
+            "fn": "zcl",
+            "mf": "0x115f"
+          },
+          "values": [
+            ["\"highspeed\"", "Buttons emit only single click events, but fast"],
+            ["\"multiclick\"", "Emits single, double and treble presses"] 
+          ],
+          "default": "multiclick"
+        },
+        {
+          "name": "config/devicemode",
+          "refresh.interval": 3000,
+          "parse": {
+            "at": "0x0009",
+            "cl": "0xfcc0",
+            "ep": 1,
+            "eval": "if (Attr.val == 1) { Item.val = 'compatibility' } else if (Attr.val == 2) { Item.val = 'zigbee' } else { Item.val = 'unknown' }",
+            "fn": "zcl",
+            "mf": "0x115f"
+          },
+          "read": {
+            "at": "0x0009",
+            "cl": "0xfcc0",
+            "ep": 1,
+            "fn": "zcl",
+            "mf": "0x115f"
+          },
+          "write": {
+            "at": "0x0009",
+            "cl": "0xfcc0",
+            "dt": "0x20",
+            "ep": 1,
+            "eval": "if (Item.val == 'compatibility') { 1 } else if (Item.val == 'zigbee') { 2 }",
+            "fn": "zcl",
+            "mf": "0x115f"
+          },
+          "values": [
+            ["\"compatibility\"", "Default mode for Xiaomi devices"],
+            ["\"zigbee\"", "Closer to zigbee standard"] 
+          ],
+          "default": "compatibility"
+        },
+        {
+          "name": "config/group",
+          "default": "auto"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/buttonevent"
+        },
+        {
+          "name": "state/lastupdated"
+        }
+      ]
+    }
+  ]
+}

--- a/devices/xiaomi/xiaomi_wxkg16lm_e1_switch.json
+++ b/devices/xiaomi/xiaomi_wxkg16lm_e1_switch.json
@@ -79,14 +79,14 @@
             "cl": "0xfcc0",
             "ep": 1,
             "eval": "if (Attr.val == 1) { Item.val = 'highspeed' } else if (Attr.val == 2) { Item.val = 'multiclick' } else { Item.val = 'unknown' }",
-            "fn": "zcl",
+            "fn": "zcl:attr",
             "mf": "0x115f"
           },
           "read": {
             "at": "0x0125",
             "cl": "0xfcc0",
             "ep": 1,
-            "fn": "zcl",
+            "fn": "zcl:attr",
             "mf": "0x115f"
           },
           "write": {
@@ -95,7 +95,7 @@
             "dt": "0x20",
             "ep": 1,
             "eval": "if (Item.val == 'highspeed') { 1 } else if (Item.val == 'multiclick') { 2 }",
-            "fn": "zcl",
+            "fn": "zcl:attr",
             "mf": "0x115f"
           },
           "values": [
@@ -112,14 +112,14 @@
             "cl": "0xfcc0",
             "ep": 1,
             "eval": "if (Attr.val == 1) { Item.val = 'compatibility' } else if (Attr.val == 2) { Item.val = 'zigbee' } else { Item.val = 'unknown' }",
-            "fn": "zcl",
+            "fn": "zcl:attr",
             "mf": "0x115f"
           },
           "read": {
             "at": "0x0009",
             "cl": "0xfcc0",
             "ep": 1,
-            "fn": "zcl",
+            "fn": "zcl:attr",
             "mf": "0x115f"
           },
           "write": {
@@ -128,7 +128,7 @@
             "dt": "0x20",
             "ep": 1,
             "eval": "if (Item.val == 'compatibility') { 1 } else if (Item.val == 'zigbee') { 2 }",
-            "fn": "zcl",
+            "fn": "zcl:attr",
             "mf": "0x115f"
           },
           "values": [


### PR DESCRIPTION
Support for Aqara E1 single rocker wireless switch WXKG16LM

"manufacturername": "LUMI"
"modelid": "lumi.remote.acn003"
"product": "Aqara E1 single rocker wireless switch WXKG16LM"