### PR TITLE
DDF, Create DDF for smoke sensor MIR-SM100-E

### DIFF
--- a/devices/multir/mir-sm100-e_smoke_sensor.json
+++ b/devices/multir/mir-sm100-e_smoke_sensor.json
@@ -1,0 +1,109 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "MultIR",
+  "modelid": "MIR-SM100-E",
+  "product": "Smoke Sensor",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_FIRE_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0500"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0402",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x0500"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "static": 1
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/battery",
+          "parse": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "eval": "Item.val = Attr.val / 2",
+            "fn": "zcl:attr"
+          }
+        },
+        {
+          "name": "config/enrolled"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/pending"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/fire"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/lowbattery"
+        },
+        {
+          "name": "state/test"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 600,
+          "max": 43200,
+          "change": "0x00000001"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Product name : SmartWise Zigbee Smoke Sensor
Manufacturer : MultIR
Model identifier : MIR-SM100-E

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/8233

I m using static swversion because this device don't have
- Application version
- HW version
- SW build ID
- Date code
and ect ....