### PR TITLE
Fix battery reading of Sonoff water valve SWV-BSP

### DIFF
--- a/devices/sonoff/swv_smart_water_valve.json
+++ b/devices/sonoff/swv_smart_water_valve.json
@@ -1,6 +1,6 @@
+
 {
   "schema": "devcap1.schema.json",
-  "uuid": "8fdcf8cf-0d7e-43ae-b070-0382483a4ac3",
   "manufacturername": "SONOFF",
   "modelid": "SWV",
   "vendor": "Sonoff",
@@ -24,23 +24,6 @@
         },
         {
           "name": "attr/lastseen"
-        },
-        {
-          "name": "config/battery",
-          "parse": {
-            "at": "0x0021",
-            "cl": "0x0001",
-            "ep": 1,
-            "eval": "Item.val = Attr.val"
-          },
-          "read": {
-            "fn": "zcl:attr",
-            "ep": 1,
-            "cl": "0x0001",
-            "at": "0x0021"
-          },
-          "refresh.interval": 4000,
-          "awake": true
         },
         {
           "name": "attr/manufacturername"
@@ -107,16 +90,16 @@
         {
           "name": "config/battery",
           "parse": {
-            "at": "0x0021",
+            "at": "0x0020",
             "cl": "0x0001",
             "ep": 1,
-            "eval": "Item.val = Attr.val"
+           "eval": "const vmin = 20; const vmax = 30; var bat = Attr.val; if (bat > vmax) { bat = vmax; } else if (bat < vmin) { bat = vmin; } bat = ((bat - vmin) / (vmax - vmin)) * 100; if (bat > 100) { bat = 100; } else if (bat <= 0)  { bat = 1; } Item.val = bat;"
           },
           "read": {
             "fn": "zcl:attr",
             "ep": 1,
             "cl": "0x0001",
-            "at": "0x0021"
+            "at": "0x0020"
           },
           "refresh.interval": 4000,
           "awake": true
@@ -157,7 +140,7 @@
       "cl": "0x0001",
       "report": [
         {
-          "at": "0x0021",
+          "at": "0x0020",
           "dt": "0x20",
           "min": 60,
           "max": 3600,

--- a/devices/sonoff/swv_smart_water_valve.json
+++ b/devices/sonoff/swv_smart_water_valve.json
@@ -1,6 +1,7 @@
 
 {
   "schema": "devcap1.schema.json",
+  "uuid": "8fdcf8cf-0d7e-43ae-b070-0382483a4ac3",
   "manufacturername": "SONOFF",
   "modelid": "SWV",
   "vendor": "Sonoff",


### PR DESCRIPTION
It seem this device don't use attribute 0x0021 but 0x0020 for battery report.
See [Sonoff SWV-BSP](https://github.com/dresden-elektronik/deconz-rest-plugin/issues/8229#issuecomment-2967952385)