### PR TITLE
DDF rollback for PR Tuya 2-gangs switch poll battery status

### DIFF
--- a/devices/tuya/_TZ3000_TS0042_2gang_remote.json
+++ b/devices/tuya/_TZ3000_TS0042_2gang_remote.json
@@ -80,12 +80,6 @@
             "ep": 1,
             "eval": "Item.val = Attr.val / 2;",
             "fn": "zcl:attr"
-          },
-          "read": {
-            "at": "0x0021",
-            "cl": "0x0001",
-            "ep": 1,
-            "fn": "zcl:attr"
           }
         },
         {


### PR DESCRIPTION
Rollback for this PR https://github.com/dresden-elektronik/deconz-rest-plugin/pull/8243
No explanation, but it seem there is a battery drain with it.

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/8211#issuecomment-2996810135