### PR TITLE
DDF clone for Scimagic Soil Moisture Sensor (_TZE284_oitavov2)

### DIFF
--- a/devices/tuya/_TZE200_myd45weu_soil_sensor.json
+++ b/devices/tuya/_TZE200_myd45weu_soil_sensor.json
@@ -5,9 +5,11 @@
     "_TZE200_myd45weu",
     "_TZE200_9cqcpkgb",
     "_TZE200_ga1maeof",
-    "_TZE204_myd45weu"
+    "_TZE204_myd45weu",
+    "_TZE284_oitavov2"
   ],
   "modelid": [
+    "TS0601",
     "TS0601",
     "TS0601",
     "TS0601",


### PR DESCRIPTION
**Purchased at:** https://www.aliexpress.com/item/1005009047166414.html
**Vendor:** [Scimagic](https://scimagic.com.cn/)

## Product

![IMG_6188](https://github.com/user-attachments/assets/b755b9ce-1c53-47e0-ab01-5cb408700365)

## Device info

![telegram-cloud-photo-size-2-5411114341886980153-x](https://github.com/user-attachments/assets/b91dc5a9-253e-4856-b55e-e1f928d1e9a5)
