### PR TITLE
Update xiaomi_ssm-u01_t1_switch.json

### DIFF
--- a/devices/xiaomi/xiaomi_ssm-u01_t1_switch.json
+++ b/devices/xiaomi/xiaomi_ssm-u01_t1_switch.json
@@ -35,13 +35,22 @@
           "name": "attr/name"
         },
         {
+          "name": "cap/otau/file_version"
+        },
+        {
+          "name": "cap/otau/image_type"
+        },
+        {
+          "name": "cap/otau/manufacturer_code"
+        },
+        {
           "name": "attr/swversion",
           "parse": {
-            "at": "0x00f7",
-            "ep": 1,
             "fn": "xiaomi:special",
+            "mf": "0x115F",
+            "at": "0x00F7",
             "idx": "0x08",
-            "script": "xiaomi_swversion.js"
+            "eval": "Item.val = '0.0.0_' + ('0000' + (Attr.val & 0x00FF).toString()).slice(-4)"
           },
           "read": {
             "fn": "none"
@@ -52,6 +61,9 @@
         },
         {
           "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on/startup"
         },
         {
           "name": "state/alert"
@@ -62,111 +74,6 @@
         },
         {
           "name": "state/reachable"
-        }
-      ]
-    },
-    {
-      "type": "$TYPE_POWER_SENSOR",
-      "restapi": "/sensors",
-      "uuid": [
-        "$address.ext",
-        "0x15",
-        "0x000C"
-      ],
-      "fingerprint": {
-        "profile": "0x0104",
-        "device": "0x0100",
-        "endpoint": "0x15",
-        "in": [
-          "0x000C"
-        ]
-      },
-      "items": [
-        {
-          "name": "attr/id"
-        },
-        {
-          "name": "attr/lastannounced"
-        },
-        {
-          "name": "attr/lastseen"
-        },
-        {
-          "name": "attr/manufacturername"
-        },
-        {
-          "name": "attr/modelid"
-        },
-        {
-          "name": "attr/name"
-        },
-        {
-          "name": "attr/swversion",
-          "parse": {
-            "at": "0x00f7",
-            "ep": 1,
-            "fn": "xiaomi:special",
-            "idx": "0x08",
-            "script": "xiaomi_swversion.js"
-          },
-          "read": {
-            "fn": "none"
-          }
-        },
-        {
-          "name": "attr/type"
-        },
-        {
-          "name": "attr/uniqueid"
-        },
-        {
-          "name": "config/on"
-        },
-        {
-          "name": "config/reachable"
-        },
-        {
-          "name": "state/current",
-          "parse": {
-            "at": "0x00F7",
-            "eval": "Item.val = Math.round(Attr.val);",
-            "fn": "xiaomi:special",
-            "idx": "0x97"
-          },
-          "read": {
-            "fn": "none"
-          }
-        },
-        {
-          "name": "state/lastupdated"
-        },
-        {
-          "name": "state/power",
-          "refresh.interval": 10,
-          "read": {
-            "at": "0x0055",
-            "cl": "0x000C",
-            "ep": 21,
-            "fn": "zcl:attr"
-          },
-          "parse": {
-            "at": "0x0055",
-            "cl": "0x000C",
-            "ep": 21,
-            "eval": "Item.val = Math.round(Attr.val);"
-          }
-        },
-        {
-          "name": "state/voltage",
-          "parse": {
-            "at": "0x00F7",
-            "eval": "Item.val = Math.round(Attr.val / 10);",
-            "fn": "xiaomi:special",
-            "idx": "0x96"
-          },
-          "read": {
-            "fn": "none"
-          }
         }
       ]
     },
@@ -206,13 +113,22 @@
           "name": "attr/name"
         },
         {
+          "name": "cap/otau/file_version"
+        },
+        {
+          "name": "cap/otau/image_type"
+        },
+        {
+          "name": "cap/otau/manufacturer_code"
+        },
+        {
           "name": "attr/swversion",
           "parse": {
-            "at": "0x00f7",
-            "ep": 1,
             "fn": "xiaomi:special",
+            "mf": "0x115F",
+            "at": "0x00F7",
             "idx": "0x08",
-            "script": "xiaomi_swversion.js"
+            "eval": "Item.val = '0.0.0_' + ('0000' + (Attr.val & 0x00FF).toString()).slice(-4)"
           },
           "read": {
             "fn": "none"
@@ -232,22 +148,132 @@
         },
         {
           "name": "state/consumption",
-          "refresh.interval": 300,
-          "read": {
-            "at": "0x0055",
-            "cl": "0x000C",
-            "ep": 31,
-            "fn": "zcl:attr"
-          },
           "parse": {
-            "at": "0x0055",
-            "cl": "0x000C",
-            "ep": 31,
-            "eval": "Item.val = Math.round(Attr.val * 1000);"
+            "fn": "xiaomi:special",
+            "mf": "0x115F",
+            "at": "0x00F7",
+            "idx": "0x95",
+            "eval": "Item.val = Math.round(Attr.val * 1000)"
+          },
+          "read": {
+            "fn": "none"
           }
         },
         {
           "name": "state/lastupdated"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_POWER_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x15",
+        "0x000C"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0100",
+        "endpoint": "0x15",
+        "in": [
+          "0x000C"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "cap/otau/file_version"
+        },
+        {
+          "name": "cap/otau/image_type"
+        },
+        {
+          "name": "cap/otau/manufacturer_code"
+        },
+        {
+          "name": "attr/swversion",
+          "parse": {
+            "fn": "xiaomi:special",
+            "mf": "0x115F",
+            "at": "0x00F7",
+            "idx": "0x08",
+            "eval": "Item.val = '0.0.0_' + ('0000' + (Attr.val & 0x00FF).toString()).slice(-4)"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/current",
+          "parse": {
+            "fn": "xiaomi:special",
+            "mf": "0x115F",
+            "at": "0x00F7",
+            "idx": "0x97",
+            "eval": "Item.val = Math.round(Attr.val)"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/power",
+          "parse": {
+            "fn": "xiaomi:special",
+            "mf": "0x115F",
+            "at": "0x00F7",
+            "idx": "0x98",
+            "eval": "Item.val = Math.round(Attr.val)"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "state/voltage",
+          "parse": {
+            "fn": "xiaomi:special",
+            "mf": "0x115F",
+            "at": "0x00F7",
+            "idx": "0x96",
+            "eval": "Item.val = Math.round(Attr.val / 10)"
+          },
+          "read": {
+            "fn": "none"
+          }
         }
       ]
     },
@@ -287,13 +313,22 @@
           "name": "attr/name"
         },
         {
+          "name": "cap/otau/file_version"
+        },
+        {
+          "name": "cap/otau/image_type"
+        },
+        {
+          "name": "cap/otau/manufacturer_code"
+        },
+        {
           "name": "attr/swversion",
           "parse": {
-            "at": "0x00f7",
-            "ep": 1,
             "fn": "xiaomi:special",
+            "mf": "0x115F",
+            "at": "0x00F7",
             "idx": "0x08",
-            "script": "xiaomi_swversion.js"
+            "eval": "Item.val = '0.0.0_' + ('0000' + (Attr.val & 0x00FF).toString()).slice(-4)"
           },
           "read": {
             "fn": "none"


### PR DESCRIPTION
Update DDF for Aqara Single Switch Module T1 (with Neutral).
- Use Xiaomi special attribute report for `state/consumption` (ZHAConsumption resource), `state/power` (ZHAPower resource), and `attr/swversion` (all resources), eliminating the need for polling the device.  It was already used for `state/current` and `state/voltage` (ZHAPower resource).  Note that the device tends to send the report every 20s or so;
- Add `cap/otau` items (all resources)
- Add `config/on/startup` item (`lights` resource)

NOTES:
- While `state/on` is included in the Xiaomi special attribute, it's lags behind.  So we only use the regular 0x0006/0x0000 for that item.  The device reports this attribute just fine.
 
TODO:
- ZHASwitch resource: `buttonevent` values; currently these aren't reported through the introspect API;
- ZHASwitch resource: check whether `config/devicemode` and `config/clickmode` are reported in the special attribute.
- Remove support in legacy code.

For reference, here's the updated resources:
```json
{
  "capabilities": {
    "alerts": [
      "none",
      "select",
      "lselect"
    ],
    "otau": {
      "file_version": 30,
      "image_type": 6169,
      "manufacturer_code": 4447
    },
    "sleeper": false
  },
  "config": {
    "groups": [
      "0",
      "3"
    ],
    "on": {
      "startup": false
    }
  },
  "etag": "1af74aa2c951a13c10749e97bac501ba",
  "hascolor": false,
  "lastannounced": "2025-07-01T13:58:52Z",
  "lastseen": "2025-07-01T13:59Z",
  "manufacturername": "LUMI",
  "modelid": "lumi.switch.n0agl1",
  "name": "Office Fan",
  "nwkaddress": "0x0688",
  "state": {
    "alert": "none",
    "on": true,
    "reachable": true
  },
  "swversion": "0.0.0_0030",
  "type": "On/Off light",
  "uniqueid": "54:ef:44:10:00:c0:51:8e-01"
}
```
```json
{
  "capabilities": {
    "otau": {
      "file_version": 30,
      "image_type": 6169,
      "manufacturer_code": 4447
    },
    "sleeper": false
  },
  "config": {
    "on": true,
    "reachable": true
  },
  "ep": 31,
  "etag": "d99fd24fd4ddb08cb22860b28fc01408",
  "lastannounced": "2025-07-01T13:58:52Z",
  "lastseen": "2025-07-01T14:00Z",
  "manufacturername": "LUMI",
  "modelid": "lumi.switch.n0agl1",
  "name": "Office Fan",
  "nwkaddress": "0x0688",
  "state": {
    "consumption": 40,
    "lastupdated": "2025-07-01T14:00:31.287"
  },
  "swversion": "0.0.0_0030",
  "type": "ZHAConsumption",
  "uniqueid": "54:ef:44:10:00:c0:51:8e-1f-000c"
}
```
```json
{
  "capabilities": {
    "otau": {
      "file_version": 30,
      "image_type": 6169,
      "manufacturer_code": 4447
    },
    "sleeper": false
  },
  "config": {
    "on": true,
    "reachable": true
  },
  "ep": 21,
  "etag": "3f0bb2badb0b8ac57043d7b04e566660",
  "lastannounced": "2025-07-01T13:58:52Z",
  "lastseen": "2025-07-01T14:00Z",
  "manufacturername": "LUMI",
  "modelid": "lumi.switch.n0agl1",
  "name": "Office Fan",
  "nwkaddress": "0x0688",
  "state": {
    "current": 133,
    "lastupdated": "2025-07-01T14:00:54.813",
    "power": 32,
    "voltage": 238
  },
  "swversion": "0.0.0_0030",
  "type": "ZHAPower",
  "uniqueid": "54:ef:44:10:00:c0:51:8e-15-000c"
}
```
```json
{
  "capabilities": {
    "otau": {
      "file_version": 30,
      "image_type": 6169,
      "manufacturer_code": 4447
    },
    "sleeper": false
  },
  "config": {
    "clickmode": "rocker",
    "devicemode": "compatibility",
    "on": true,
    "reachable": true
  },
  "ep": 41,
  "etag": "b78500ccac6ad41219537c2e03138f7f",
  "lastannounced": "2025-07-01T13:58:52Z",
  "lastseen": "2025-07-01T14:00Z",
  "manufacturername": "LUMI",
  "mode": 1,
  "modelid": "lumi.switch.n0agl1",
  "name": "Office Fan",
  "nwkaddress": "0x0688",
  "state": {
    "buttonevent": 0,
    "lastupdated": "none"
  },
  "swversion": "0.0.0_0030",
  "type": "ZHASwitch",
  "uniqueid": "54:ef:44:10:00:c0:51:8e-29-0012"
}
```
Note to self: don't bother with Copilot reviews in future.  It doesn't seem to understand shit.