### PR TITLE
Deprecate product_match.cpp

### DIFF
--- a/product_match.cpp
+++ b/product_match.cpp
@@ -8,6 +8,17 @@
  *
  */
 
+//
+// !!!!!! DEPRECATED !!!!!!
+//
+// This file is deprecated in favor of DDF files, and will be eventually removed in future versions.
+// Changes in this file are no longer required to add new devices support.
+// Instead, modify the JSON files in the `devices/` directory.
+//
+// For more information, see:
+// https://dresden-elektronik.github.io/deconz-rest-doc/endpoints/ddf/
+//
+
 #include <regex>
 #include <deconz/dbg_trace.h>
 


### PR DESCRIPTION
I've tried to add an alias for a device clone and edited `product_match.cpp` because I found similar vendor IDs in it.

@Smanar [pointed out](https://github.com/dresden-elektronik/deconz-rest-plugin/pull/8261#issuecomment-3024667211), that this file is no longer in use.

A deprecation notice may be useful if this file is indeed deprecated.