### PR TITLE
DDF clone for SONOFF SNZB-02LD variant

### DIFF
--- a/devices/sonoff/snzb-02-multisensor.json
+++ b/devices/sonoff/snzb-02-multisensor.json
@@ -5,11 +5,13 @@
     "eWeLink",
     "SONOFF",
     "SONOFF",
+    "SONOFF",
     "eWeLink"
   ],
   "modelid": [
     "TH01",
     "SNZB-02D",
+    "SNZB-02LD",
     "SNZB-02P",
     "SNZB-02P"
   ],


### PR DESCRIPTION
Added modelid for SONOF SNZB-02LD (variant with external probe https://help.sonoff.tech/docs/snzb-02ld/)