### PR TITLE
Fix Xiaomi TH-S02D sensor pressure value calculation

### DIFF
--- a/devices/xiaomi/xiaomi_th-s02d_t1_temp_hum_sensor.json
+++ b/devices/xiaomi/xiaomi_th-s02d_t1_temp_hum_sensor.json
@@ -300,7 +300,7 @@
           "parse": {
             "at": "0x00F7",
             "ep": 1,
-            "eval": "R.item('state/pressure').val = Math.round(Attr.val / 100) + R.item('config/offset').val",
+            "eval": "R.item('state/pressure').val = Attr.val + R.item('config/offset').val",
             "fn": "xiaomi:special",
             "idx": "0x66",
             "mf": "0x115F"


### PR DESCRIPTION
The sensor sometimes indicates a value of 10 while the atmospheric pressure is always around 1000 hPa. The calculation is not correct. I corrected it and it works in my tests.