### PR TITLE
DDF for Third Reality Motion Sensor R1 (3RSMR01067Z)

### DIFF
--- a/devices/third_reality/3RSMR01067Z_R1_motion_sensor
+++ b/devices/third_reality/3RSMR01067Z_R1_motion_sensor
@@ -1,0 +1,112 @@
+{
+  "schema": "devcap1.schema.json",
+  "uuid": "240fb1b8-8965-4549-a7eb-df13c38678e1",
+  "manufacturername": "Third Reality, Inc",
+  "modelid": "3RSMR01067Z",
+  "vendor": "Third Reality",
+  "product": "Motion Sensor R1 (3RSMR01067Z)",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_PRESENCE_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0500"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0402",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0001",
+          "0x0500"
+        ],
+        "out": [
+          "0x0019"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/alert"
+        },
+        {
+          "name": "config/battery",
+          "parse": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "eval": "Item.val = Attr.val"
+          }
+        },
+        {
+          "name": "config/duration"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/pending"
+        },
+        {
+          "name": "config/enrolled"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/presence"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 300,
+          "max": 7200,
+          "change": "0x01"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I added the DDF to support the R1 Motion Sensor, copying the DDF for 3RMS16BZ and adjusting the device id.