### PR TITLE
DDF for Tuya light sensor (_TZ3000_9kbbfeho)

### DIFF
--- a/devices/tuya/_TZ3000_8uxxzz4b_light_sensor.json
+++ b/devices/tuya/_TZ3000_8uxxzz4b_light_sensor.json
@@ -1,0 +1,136 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": ["_TZ3000_8uxxzz4b", "_TZ3000_hy6ncvmw", "_TZ3000_9kbbfeho", "_TZ3000_l6rsaipj"],
+  "modelid": ["TS0222", "TS0222", "TS0222", "TS0222"],
+  "vendor": "Tuya",
+  "product": "Tuya Luminance sensor",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_LIGHT_LEVEL_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0400"
+      ],
+      "items": [
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "refresh.interval": 86400,
+          "read": {
+            "at": "0x0001",
+            "cl": "0x0000",
+            "ep": 1,
+            "fn": "zcl:attr"
+          },
+          "parse": {
+            "at": "0x0001",
+            "cl": "0x0000",
+            "ep": 1,
+            "fn": "zcl:attr",
+            "script": "tuya_swversion.js"
+          }
+        },
+        {
+          "name": "config/tuya_unlock"
+        },
+        {
+          "name": "config/battery",
+          "parse": {
+            "at": "0x0021",
+            "cl": "0x0001",
+            "ep": 1,
+            "eval": "Item.val = Attr.val / 2;",
+            "fn": "zcl:attr"
+          },
+          "default": 0
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/dark"
+        },
+        {
+          "name": "config/tholddark"
+        },
+        {
+          "name": "config/tholdoffset"
+        },
+        {
+          "name": "state/daylight"
+        },
+        {
+          "name": "state/lightlevel",
+          "awake": true,
+          "parse": {
+            "at": "0x0000",
+            "cl": "0x0400",
+            "ep": 1,
+            "script": "../generic/illuminance_cluster/sml_light_level.js"
+          }
+        },
+        {
+          "name": "state/lux"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0001",
+      "report": [
+        {
+          "at": "0x0021",
+          "dt": "0x20",
+          "min": 60,
+          "max": 3600,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0400",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x21",
+          "min": 60,
+          "max": 600,
+          "change": "0x0000FFFF"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
  "manufacturername": ["_TZ3000_8uxxzz4b", "_TZ3000_hy6ncvmw", "_TZ3000_9kbbfeho", "_TZ3000_l6rsaipj"],
  "modelid": ["TS0222", "TS0222", "TS0222", "TS0222"],
  "vendor": "Tuya",
  "product": "Tuya Luminance sensor",

See https://forum.phoscon.de/t/light-sensor-zss-qy-ls-c-ts0222-tz3000-8uxxzz4b-unknown/6397