### PR TITLE
Fix for new IKEA RODRET model identifier

### DIFF
--- a/button_maps.json
+++ b/button_maps.json
@@ -236,7 +236,7 @@
         "ikeaRodretMap": {
             "vendor": "IKEA",
             "doc": "Rodret dimmer remote",
-            "modelids": ["RODRET Dimmer"],
+            "modelids": ["RODRET Dimmer", "RODRET wireless dimmer"],
             "buttons": [
                 {"S_BUTTON_1": "Dim Up"},
                 {"S_BUTTON_2": "Dim Down"}

--- a/devices/ikea/rodret_dimmer.json
+++ b/devices/ikea/rodret_dimmer.json
@@ -1,8 +1,14 @@
 {
   "schema": "devcap1.schema.json",
   "uuid": "3d671c73-06da-4adc-99f1-076b3dfb3122",
-  "manufacturername": "$MF_IKEA",
-  "modelid": "RODRET Dimmer",
+  "manufacturername": [
+	  "$MF_IKEA", 
+	  "$MF_IKEA"
+  ],
+  "modelid": [
+	  "RODRET Dimmer",
+	  "RODRET wireless dimmer"
+  ],
   "vendor": "IKEA",
   "product": "Rodret Wireless Dimmer (E2201)",
   "sleeper": true,


### PR DESCRIPTION
New IKEA RODRET models have a different model identifier. Added that to the DDF of the RODRET dimmer and to the button map.

The image in phoscon has to be adjusted accordingly.