### PR TITLE
DDF for Philips Hue smart plug LOM006

### DIFF
--- a/devices/philips/lom007_smart_plug.json
+++ b/devices/philips/lom007_smart_plug.json
@@ -4,13 +4,17 @@
   "manufacturername": [
     "$MF_PHILIPS",
     "$MF_PHILIPS",
+    "$MF_PHILIPS",
+    "$MF_SIGNIFY",
     "$MF_SIGNIFY",
     "$MF_SIGNIFY"
   ],
   "modelid": [
     "LOM001",
+    "LOM006",
     "LOM007",
-    "LOM001",
+    "LOM001",   
+    "LOM006",
     "LOM007"
   ],
   "vendor": "Philips",


### PR DESCRIPTION
Adding the modelid: **LOM006** in the DDF file