### PR TITLE
Fix Ledvance PLUG (COMPACT) EU EM T binding table query loop

### DIFF
--- a/devices/ledvance/ledvance_plug_eu_em_t.json
+++ b/devices/ledvance/ledvance_plug_eu_em_t.json
@@ -13,6 +13,7 @@
   "product": "PLUG (COMPACT) EU EM T",
   "sleeper": false,
   "status": "Gold",
+  "supportsMgmtBind": false,
   "subdevices": [
     {
       "type": "$TYPE_SMART_PLUG",


### PR DESCRIPTION
For some reason the plug reports extra unicast bindings in the binding table. The `Device` state machine tries to clean them up via ZDP Unbind but while the device responds with status Success the bindings aren't removed.

This loops forever. Therefore the PR just says don't use the binding table. Note: creation of the DDF bindings is still done.