### PR TITLE
Fix creation of invalid Unicast Bindings

### DIFF
--- a/device_descriptions.h
+++ b/device_descriptions.h
@@ -47,14 +47,14 @@ class DDF_Binding
 public:
     union
     {
-        quint16 dstGroup;
-        quint64 dstExtAddress;
+        uint64_t dstExtAddress = 0;
+        uint16_t dstGroup;
     };
 
-    quint16 clusterId;
-    quint8 srcEndpoint;
-    quint8 dstEndpoint;
-    quint8 configGroup;
+    uint16_t clusterId = 0;
+    uint8_t srcEndpoint = 0;
+    uint8_t dstEndpoint = 0;
+    uint8_t configGroup = 0;
     struct
     {
         unsigned int isGroupBinding : 1;


### PR DESCRIPTION
Seen on macOS somehow clang did not init all fields of the binding to zero when creating an object via `DDF_Binding result = {}`. The `u64 dstExtAddress` wasn't initialized only the `u16 dstGroup` in the union. The ext address was some random stuff from memory.

The fix ensures all fields including `dstExtAdress` are zero. And the unicast destination address is filled with the actual coordinator mac address.

Note: Invalid bindings from previous releases are automatically cleaned up and repaired by the `Device` state machine.