### PR TITLE
DDF for Namron Zigbee Stove Guard 140279X

### DIFF
--- a/devices/namron/140279X_stove_guard.json
+++ b/devices/namron/140279X_stove_guard.json
@@ -144,8 +144,14 @@
                     "default": 0
                 },
                 {
+                    "name": "config/on"
+                },
+                {
+                    "name": "config/reachable"
+                },
+                {
                     "name": "state/alarm",
-                    "refresh.interval": 5,
+                    "refresh.interval": 360,
                     "read": {
                         "at": "0x0000",
                         "cl": "0x0006",
@@ -416,7 +422,7 @@
           "at": "0x0000",
           "dt": "0x10",
           "min": 1,
-          "max": 3600,
+          "max": 3540,
           "change": "0x00000001"
         }
       ]

--- a/devices/namron/140279X_stove_guard.json
+++ b/devices/namron/140279X_stove_guard.json
@@ -1,0 +1,453 @@
+{
+    "schema": "devcap1.schema.json",
+    "manufacturername": [
+        "NAMRON AS",
+        "NAMRON AS",
+        "NAMRON AS",
+        "NAMRON AS",
+        "NAMRON AS",
+        "NAMRON AS"
+    ],
+    "modelid": [
+        "1402790",
+        "1402793",
+        "1402791",
+        "1402795",
+        "1402794",
+        "1402792"
+    ],
+    "vendor": "Namron",
+    "product": "Namron Zigbee Stove Guard (140279X)",
+    "sleeper": false,
+    "status": "Gold",
+    "subdevices": [
+        {
+            "type": "$TYPE_ON_OFF_SWITCH",
+            "restapi": "/lights",
+            "uuid": [
+                "$address.ext",
+                "0x01"
+            ],
+            "items": [
+                {
+                    "name": "attr/id"
+                },
+                {
+                    "name": "attr/lastannounced"
+                },
+                {
+                    "name": "attr/lastseen"
+                },
+                {
+                    "name": "attr/manufacturername"
+                },
+                {
+                    "name": "attr/modelid"
+                },
+                {
+                    "name": "attr/name"
+                },
+                {
+                    "name": "attr/swversion"
+                },
+                {
+                    "name": "attr/type"
+                },
+                {
+                    "name": "attr/uniqueid"
+                },
+                {
+                    "name": "state/alert",
+                    "description": "The currently active alert effect.",
+                    "default": "none"
+                },
+                {
+                    "name": "state/on",
+                    "refresh.interval": 3600,
+                    "read": {
+                        "at": "0x0000",
+                        "cl": "0x0006",
+                        "ep": 1,
+                        "fn": "zcl:attr"
+                    },
+                    "parse": {
+                        "at": "0x0000",
+                        "cl": "0x0006",
+                        "ep": 1,
+                        "eval": "Item.val = Attr.val",
+                        "fn": "zcl:attr"
+                    },
+                    "default": false
+                },
+                {
+                    "name": "state/reachable"
+                }
+            ]
+        },
+        {
+            "type": "$TYPE_ALARM_SENSOR",
+            "restapi": "/sensors",
+            "uuid": [
+                "$address.ext",
+                "0x01",
+                "0x0500"
+            ],
+            "items": [
+                {
+                    "name": "attr/id"
+                },
+                {
+                    "name": "attr/lastannounced"
+                },
+                {
+                    "name": "attr/lastseen"
+                },
+                {
+                    "name": "attr/manufacturername"
+                },
+                {
+                    "name": "attr/mode",
+                    "description": "Operational mode.",
+                    "default": 1
+                },
+                {
+                    "name": "attr/modelid"
+                },
+                {
+                    "name": "attr/name"
+                },
+                {
+                    "name": "attr/swversion"
+                },
+                {
+                    "name": "attr/type"
+                },
+                {
+                    "name": "attr/uniqueid"
+                },
+                {
+                    "name": "config/battery",
+                    "refresh.interval": 3600,
+                    "read": {
+                        "at": "0x0021",
+                        "cl": "0x0001",
+                        "ep": 0,
+                        "fn": "zcl:attr"
+                    },
+                    "parse": {
+                        "at": "0x0021",
+                        "cl": "0x0001",
+                        "ep": 0,
+                        "eval": "Item.val = Attr.val / 2",
+                        "fn": "zcl:attr"
+                    },
+                    "default": 0
+                },
+                {
+                    "name": "state/alarm",
+                    "refresh.interval": 5,
+                    "read": {
+                        "at": "0x0000",
+                        "cl": "0x0006",
+                        "ep": 2,
+                        "fn": "zcl:attr"
+                    },
+                    "parse": {
+                        "at": "0x0000",
+                        "cl": "0x0006",
+                        "ep": 2,
+                        "eval": "Item.val = Attr.val",
+                        "fn": "zcl:attr"
+                    },
+                    "default": false
+                },
+                {
+                    "name": "state/lastupdated"
+                }
+            ]
+        },
+        {
+            "type": "$TYPE_POWER_SENSOR",
+            "restapi": "/sensors",
+            "uuid": [
+                "$address.ext",
+                "0x01",
+                "0x0b04"
+            ],
+            "items": [
+                {
+                    "name": "attr/id"
+                },
+                {
+                    "name": "attr/lastannounced"
+                },
+                {
+                    "name": "attr/lastseen"
+                },
+                {
+                    "name": "attr/manufacturername"
+                },
+                {
+                    "name": "attr/mode",
+                    "description": "Operational mode.",
+                    "default": 1
+                },
+                {
+                    "name": "attr/modelid"
+                },
+                {
+                    "name": "attr/name"
+                },
+                {
+                    "name": "attr/swversion"
+                },
+                {
+                    "name": "attr/type"
+                },
+                {
+                    "name": "attr/uniqueid"
+                },
+                {
+                    "name": "config/on"
+                },
+                {
+                    "name": "config/reachable"
+                },
+                {
+                    "name": "state/lastupdated"
+                },
+                {
+                    "name": "state/power",
+                    "refresh.interval": 300,
+                    "read": {
+                        "at": "0x050b",
+                        "cl": "0x0b04",
+                        "ep": 0,
+                        "fn": "zcl:attr"
+                    },
+                    "parse": {
+                        "at": "0x050b",
+                        "cl": "0x0b04",
+                        "ep": 0,
+                        "eval": "if (Attr.val != -32768 && Attr.val != 32768) { Item.val = Attr.val; }"
+                    },
+                    "default": 0
+                }
+            ]
+        },
+        {
+            "type": "$TYPE_CONSUMPTION_SENSOR",
+            "restapi": "/sensors",
+            "uuid": [
+                "$address.ext",
+                "0x01",
+                "0x0702"
+            ],
+            "items": [
+                {
+                    "name": "attr/id"
+                },
+                {
+                    "name": "attr/lastannounced"
+                },
+                {
+                    "name": "attr/lastseen"
+                },
+                {
+                    "name": "attr/manufacturername"
+                },
+                {
+                    "name": "attr/mode",
+                    "description": "Operational mode.",
+                    "default": 1
+                },
+                {
+                    "name": "attr/modelid"
+                },
+                {
+                    "name": "attr/name"
+                },
+                {
+                    "name": "attr/swversion"
+                },
+                {
+                    "name": "attr/type"
+                },
+                {
+                    "name": "attr/uniqueid"
+                },
+                {
+                    "name": "config/on"
+                },
+                {
+                    "name": "config/reachable"
+                },
+                {
+                    "name": "state/consumption",
+                    "refresh.interval": 300,
+                    "read": {
+                        "at": "0x0000",
+                        "cl": "0x0702",
+                        "ep": 0,
+                        "fn": "zcl:attr"
+                    },
+                    "parse": {
+                        "at": "0x0000",
+                        "cl": "0x0702",
+                        "ep": 0,
+                        "eval": "Item.val = Attr.val * 100"
+                    },
+                    "default": 0
+                },
+                {
+                    "name": "state/lastupdated"
+                }
+            ]
+        },
+        {
+            "type": "$TYPE_TEMPERATURE_SENSOR",
+            "restapi": "/sensors",
+            "uuid": [
+                "$address.ext",
+                "0x01",
+                "0x0402"
+            ],
+            "items": [
+                {
+                    "name": "attr/id"
+                },
+                {
+                    "name": "attr/lastannounced"
+                },
+                {
+                    "name": "attr/lastseen"
+                },
+                {
+                    "name": "attr/manufacturername"
+                },
+                {
+                    "name": "attr/mode",
+                    "default": 1
+                },
+                {
+                    "name": "attr/modelid"
+                },
+                {
+                    "name": "attr/name"
+                },
+                {
+                    "name": "attr/swversion"
+                },
+                {
+                    "name": "attr/type"
+                },
+                {
+                    "name": "attr/uniqueid"
+                },
+                {
+                    "name": "config/offset",
+                    "default": 0
+                },
+                {
+                    "name": "config/on"
+                },
+                {
+                    "name": "config/reachable"
+                },
+                {
+                    "name": "state/lastupdated"
+                },
+                {
+                    "name": "state/temperature",
+                    "refresh.interval": 5,
+                    "read": {
+                        "at": "0x0000",
+                        "cl": "0x0402",
+                        "ep": 0,
+                        "fn": "zcl:attr"
+                    },
+                    "parse": {
+                        "at": "0x0000",
+                        "cl": "0x0402",
+                        "ep": 0,
+                        "eval": "Item.val = Attr.val + R.item('config/offset').val",
+                        "fn": "zcl:attr"
+                    },
+                    "default": 0
+                }
+            ]
+        }
+    ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0B04",
+      "report": [
+        {
+          "at": "0x050B",
+          "dt": "0x29",
+          "min": 1,
+          "max": 300,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0702",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x25",
+          "min": 30,
+          "max": 300,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0006",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 3600,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0402",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x29",
+          "min": 1,
+          "max": 300,
+          "change": "0x00000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 2,
+      "cl": "0x0006",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 300,
+          "change": "0x00000001"
+        }
+      ]
+    }
+  ]
+}

--- a/general.xml
+++ b/general.xml
@@ -3398,6 +3398,15 @@ Displayed setpoint is not affected, but regulated setpoint will change. Can be u
           </attribute>
           <attribute id="0x0035" name="Lamp Burn Hours Trip Point" type="u24" access="rw" range="0x000000,0xfffffe" default="0x000000" required="o"></attribute>
         </attribute-set>
+        <attribute-set id="0xe000" description="Dimmer Mode" mfcode="0x105e">
+          <attribute id="0xE000" name="Dimmer Mode" type="enum8" default="0x00" access="rw" required="o" mfcode="0x105e">
+            <description>Sets dimming mode to autodetect or fixed RC/RL/RL_LED mode (max load is reduced in RL_LED)</description>
+            <value name="Auto" value="0"></value>
+            <value name="RC" value="1"></value>
+            <value name="RL" value="2"></value>
+            <value name="RL_LED" value="3"></value>
+          </attribute>
+        </attribute-set>
       </server>
       <client>
       </client>
@@ -6828,3 +6837,4 @@ Writing 1 to 0x0202 and 0x0302 makes 0x0300 writable. Then writing 1 to 0x0300 s
     </device>
   </devices>
 </zcl>
+


### PR DESCRIPTION
Product name : Namron Zigbee Stove Guard
Manufacturer : NAMRON AS
Model identifier : 140279X
Device type to add : Stove Guard
Product documentation: https://www.elektroimportoren.no/namron-zigbee-komfyrvakt-veggsensor-hvit-for-ettermontering/1402790/Product.html