### PR TITLE
Fix state/reachable and config/reachable not stored in database

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -966,6 +966,7 @@ void DeRestPluginPrivate::apsdeDataIndicationDevice(const deCONZ::ApsDataIndicat
         if (!item->toBool())
         {
             item->setValue(true);
+            item->setNeedStore();
             enqueueEvent(Event(device->prefix(), item->descriptor().suffix, 0, device->key()));
         }
     }

--- a/device.cpp
+++ b/device.cpp
@@ -890,6 +890,7 @@ void DEV_CheckReachable(Device *device)
         if (item && ((item->toBool() != devReachable) || !item->lastSet().isValid()))
         {
             r->setValue(item->descriptor().suffix, devReachable);
+            item->setNeedStore();
         }
     }
 }

--- a/zdp/zdp_handlers.cpp
+++ b/zdp/zdp_handlers.cpp
@@ -123,6 +123,7 @@ void DeRestPluginPrivate::handleDeviceAnnceIndication(const deCONZ::ApsDataIndic
                 item->setValue(true); // refresh timestamp after device announce
                 if (i->state() == LightNode::StateNormal)
                 {
+                    item->setNeedStore();
                     Event e(i->prefix(), RStateReachable, i->id(), item);
                     enqueueEvent(e);
                 }


### PR DESCRIPTION
After deCONZ startup it takes a while until the actual state is propagated. The PR helps to restore the state quicker.