### PR TITLE
DDF add support for the PO-BOCO-ELEC (pilot wire heater) from Powernity

### DIFF
--- a/devices/tuya/_TZE204_d6i25bwg_pilote_wire_heating_module.json
+++ b/devices/tuya/_TZE204_d6i25bwg_pilote_wire_heating_module.json
@@ -30,6 +30,22 @@
             },
             "items": [
                 {
+                    "name": "attr/swversion",
+                    "parse": {
+                        "fn": "zcl:attr",
+                        "ep": 1,
+                        "cl": "0x0000",
+                        "at": "0x0001",
+                        "script": "../tuya/tuya_swversion.js"
+                    },
+                    "read": {
+                        "fn": "zcl:attr",
+                        "ep": 1,
+                        "cl": "0x0000",
+                        "at": "0x0001"
+                    }
+                },
+                {
                     "name": "attr/id"
                 },
                 {
@@ -56,7 +72,6 @@
                 },
                 {
                     "name": "config/locked",
-                    "refresh.interval": 3600,
                     "read": {
                         "fn": "none"
                     },
@@ -75,7 +90,6 @@
                 },
                 {
                     "name": "config/mode",
-                    "refresh.interval": 3600,
                     "read": {
                         "fn": "tuya"
                     },
@@ -130,6 +144,22 @@
                 ]
             },
             "items": [
+                {
+                    "name": "attr/swversion",
+                    "parse": {
+                        "fn": "zcl:attr",
+                        "ep": 1,
+                        "cl": "0x0000",
+                        "at": "0x0001",
+                        "script": "../tuya/tuya_swversion.js"
+                    },
+                    "read": {
+                        "fn": "zcl:attr",
+                        "ep": 1,
+                        "cl": "0x0000",
+                        "at": "0x0001"
+                    }
+                },
                 {
                     "name": "attr/id"
                 },


### PR DESCRIPTION
Pilot wire heating module

Manufacturer : Powernity
Model: PO-BOCO-ELEC