### PR TITLE
DDF clone for SONOFF SNZB-02WD variant

### DIFF
--- a/devices/sonoff/snzb-02_multisensor.json
+++ b/devices/sonoff/snzb-02_multisensor.json
@@ -6,14 +6,16 @@
     "eWeLink",
     "SONOFF",
     "SONOFF",
-    "eWeLink"
+    "eWeLink",
+    "SONOFF"
   ],
   "modelid": [
     "CK-TLSR8656-SS5-01(7014)",
     "TH01",
     "SNZB-02D",
     "SNZB-02P",
-    "SNZB-02P"
+    "SNZB-02P",
+    "SNZB-02WD"
   ],
   "vendor": "Sonoff/eWeLink",
   "product": "Temperature and humidity sensor",


### PR DESCRIPTION
Product name: Sonoff SNZB-02WD
Manufacturer: SONOFF
Model identifier: SNZB-02WD

See #8321