### PR TITLE
Removing the double `state/power` from Sengled E1C-NB7

### DIFF
--- a/devices/sengled/e1c-nb7.json
+++ b/devices/sengled/e1c-nb7.json
@@ -104,23 +104,6 @@
         },
         {
           "name": "state/lastupdated"
-        },
-        {
-          "name": "state/power",
-          "refresh.interval": 360,
-          "read": {
-            "at": "0x0400",
-            "cl": "0x0702",
-            "ep": 0,
-            "fn": "zcl:attr"
-          },
-          "parse": {
-            "at": "0x0400",
-            "cl": "0x0702",
-            "ep": 0,
-            "eval": "if (Attr.val != -32768) { Item.val = Attr.val / 10; }"
-          },
-          "default": 0
         }
       ]
     },

--- a/devices/sengled/e1c-nb7.json
+++ b/devices/sengled/e1c-nb7.json
@@ -48,7 +48,8 @@
           "default": "none"
         },
         {
-          "name": "state/on"
+          "name": "state/on",
+          "refresh.interval": 360
         },
         {
           "name": "state/reachable"


### PR DESCRIPTION
The power was below consumption and below `TYPE_POWER SENSOR`.