### PR TITLE
DDF for BlitzWolf BW-SHP-13/15 - intervals extended

### DIFF
--- a/devices/blitzwolf/bw_shp13_smart_plug.json
+++ b/devices/blitzwolf/bw_shp13_smart_plug.json
@@ -5,13 +5,11 @@
     "_TZ3000_3ooaz3ng",
     "_TZ3000_g5xawfcq",
     "_TZ3000_amdymr7l",
-    "_TZ3210_amdymr7l",
-    "_TZ3210_5ct6e7ye"
+    "_TZ3210_amdymr7l"
   ],
   "modelid": [
     "TS0121",
     "TS0121",
-    "TS011F",
     "TS011F",
     "TS011F"
   ],

--- a/devices/blitzwolf/bw_shp13_smart_plug.json
+++ b/devices/blitzwolf/bw_shp13_smart_plug.json
@@ -5,11 +5,13 @@
     "_TZ3000_3ooaz3ng",
     "_TZ3000_g5xawfcq",
     "_TZ3000_amdymr7l",
-    "_TZ3210_amdymr7l"
+    "_TZ3210_amdymr7l",
+    "_TZ3210_5ct6e7ye"
   ],
   "modelid": [
     "TS0121",
     "TS0121",
+    "TS011F",
     "TS011F",
     "TS011F"
   ],
@@ -72,7 +74,7 @@
         },
         {
           "name": "state/on",
-          "refresh.interval": 5
+          "refresh.interval": 360
         },
         {
           "name": "state/reachable"
@@ -139,18 +141,18 @@
         },
         {
           "name": "state/current",
-          "refresh.interval": 300
+          "refresh.interval": 360
         },
         {
           "name": "state/lastupdated"
         },
         {
           "name": "state/power",
-          "refresh.interval": 300
+          "refresh.interval": 360
         },
         {
           "name": "state/voltage",
-          "refresh.interval": 300
+          "refresh.interval": 360
         }
       ]
     },
@@ -226,7 +228,7 @@
             "ep": 0,
             "eval": "Item.val = Attr.val * 10"
           },
-          "refresh.interval": 300
+          "refresh.interval": 360
         },
         {
           "name": "state/lastupdated"

--- a/devices/blitzwolf/bw_shp15_smart_plug.json
+++ b/devices/blitzwolf/bw_shp15_smart_plug.json
@@ -68,7 +68,7 @@
         },
         {
           "name": "state/on",
-          "refresh.interval": 5
+          "refresh.interval": 360
         },
         {
           "name": "state/reachable"
@@ -135,18 +135,18 @@
         },
         {
           "name": "state/current",
-          "refresh.interval": 300
+          "refresh.interval": 360
         },
         {
           "name": "state/lastupdated"
         },
         {
           "name": "state/power",
-          "refresh.interval": 300
+          "refresh.interval": 360
         },
         {
           "name": "state/voltage",
-          "refresh.interval": 300
+          "refresh.interval": 360
         }
       ]
     },
@@ -222,7 +222,7 @@
             "ep": 0,
             "eval": "Item.val = Attr.val * 10"
           },
-          "refresh.interval": 300
+          "refresh.interval": 360
         },
         {
           "name": "state/lastupdated"


### PR DESCRIPTION
I have inserted the BSEED wall socket into `_TZ3000_TS011F_smart_plug` and this PR is only for the intervals.