### PR TITLE
DDF clone for Tuya smoke detector (_TZE284_rccxox8p)

### DIFF
--- a/devices/tuya/_TZE200_TS0601_smoke_detector.json
+++ b/devices/tuya/_TZE200_TS0601_smoke_detector.json
@@ -5,9 +5,11 @@
     "_TZE200_m9skfctm",
     "_TZE200_vzekyi4c",
     "_TZE200_rccxox8p",
-    "_TZE283_rccxox8p"
+    "_TZE283_rccxox8p",
+    "_TZE284_rccxox8p"
   ],
   "modelid": [
+    "TS0601",
     "TS0601",
     "TS0601",
     "TS0601",


### PR DESCRIPTION
Product name: HZ-Smart-Device
Manufacturer: HaiHao Shenzhen Electronic
Model identifier: _TZE284_rccxox8p

See #8335