### PR TITLE
Add Tuya  _TZE204_o3x45p96 to the list of TRV (TS0601) devices

### DIFF
--- a/devices/tuya/_TZE200_TS0601_trv.json
+++ b/devices/tuya/_TZE200_TS0601_trv.json
@@ -7,9 +7,11 @@
     "_TZE200_gd4rvykv",
     "_TZE200_rxntag7i",
     "_TZE200_p3dbf6qs",
-    "_TZE284_ogx8u5z6"
+    "_TZE284_ogx8u5z6",
+    "_TZE204_o3x45p96"
   ],
   "modelid": [
+    "TS0601",
     "TS0601",
     "TS0601",
     "TS0601",


### PR DESCRIPTION
Tuya _TZE204_o3x45p96 works the same as the other thermostats in _TZE200_TS0601_trv. Add it to the list of supported devices.