### PR TITLE
Aqara Smart Curtain Controller (ZNCLDJ11LM)

### DIFF
--- a/devices/xiaomi/lumi_curtain.json
+++ b/devices/xiaomi/lumi_curtain.json
@@ -71,25 +71,25 @@
           "parse": {
             "fn": "zcl:attr",
             "ep": 1,
-            "cl": "0x0102",
-            "at": "0x0008",
+            "cl": "0x000D",
+            "at": "0x0055",
             "eval": "Item.val = 100 - Attr.val"
           },
           "read": {
             "fn": "zcl:attr",
             "ep": 1,
-            "cl": "0x0102",
-            "at": "0x0008"
+            "cl": "0x000D",
+            "at": "0x0055"
           },
-          "refresh.interval": 30
+          "refresh.interval": 300
         },
         {
           "name": "state/open",
           "parse": {
             "fn": "zcl:attr",
             "ep": 1,
-            "cl": "0x0102",
-            "at": "0x0008",
+            "cl": "0x000D",
+            "at": "0x0055",
             "eval": "Item.val = Attr.val > 0"
           },
           "read": {


### PR DESCRIPTION
This PR updates the DDF for the Aqara Smart Curtain Controller (ZNCLDJ11LM), `lumi.curtain`:
- Add `otau` items.
- Base `state/lift` and `state/open` on the _Analog Output (Basic)_ cluster (instead of on _Windows Covering_.

Note that this is the original mains-powered curtain controller.  It carries both the _Windows Covering_ and the _Analog Output (Basic)_ cluster.  Controlling the curtains is through _Windows Covering_, but only _Analog Output_ sends reports.  The legacy code used both _Windows Covering_ and _Analog Output_ to update `state/lift` (and `state/open`), but the old DDF only uses _Windows Covering_.  As this cluster sends no reports, the REST API plugin should fallback to polling, but it doesn't.  Hence the improvement to use _Analog Output_ in the DDF.