### PR TITLE
DDF clone for eWelink Contact Sensor CK-TLSR8656-SS5-01(7003)

### DIFF
--- a/devices/sonoff/snzb-04_open_close_sensor.json
+++ b/devices/sonoff/snzb-04_open_close_sensor.json
@@ -3,17 +3,19 @@
   "uuid": "cd25fbd8-9b9b-4051-9c01-1c08a9d65203",
   "manufacturername": [
     "eWeLink",
+    "eWeLink",
     "zbeacon",
     "eWeLink",
     "eWeLink"
   ],
   "modelid": [
+    "CK-TLSR8656-SS5-01(7003)",
     "DS01",
     "DS01",
     "SNZB-04P",
     "SNZB-04"
   ],
-  "vendor": "eWeLink",
+  "vendor": "Sonoff/eWeLink",
   "product": "Open/close sensor (DS01)",
   "sleeper": true,
   "status": "Gold",
@@ -72,7 +74,7 @@
             "at": "0x0021",
             "cl": "0x0001",
             "ep": 1,
-            "eval": "Item.val = Attr.val / 2;",
+            "eval": "Item.val = Attr.val / 2",
             "fn": "zcl:attr"
           },
           "read": {


### PR DESCRIPTION
Product name: eWeLink Magnetic Door Sensor
Manufacturer: eWeLink
Model identifier: CK-TLSR8656-SS5-01(7003)

See #8351