### PR TITLE
Support WebSockets over HTTPS and HTTP port

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -15684,6 +15684,10 @@ bool DeRestPlugin::isHttpTarget(const QHttpRequestHeader &hdr)
             return true;
         }
     }
+    else if (hdr.hasKey(QLatin1String("Upgrade")) && hdr.value(QLatin1String("Upgrade")) == QLatin1String("websocket"))
+    {
+        return true;
+    }
 
     return false;
 }
@@ -15696,6 +15700,12 @@ bool DeRestPlugin::isHttpTarget(const QHttpRequestHeader &hdr)
  */
 int DeRestPlugin::handleHttpRequest(const QHttpRequestHeader &hdr, QTcpSocket *sock)
 {
+    if (hdr.hasKey(QLatin1String("Upgrade")) && hdr.value(QLatin1String("Upgrade")) == QLatin1String("websocket"))
+    {
+        d->webSocketServer->handleExternalTcpSocket(hdr, sock);
+        return 0;
+    }
+
     QString content;
     QTextStream stream(sock);
 

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -102,7 +102,7 @@ void DeRestPluginPrivate::initConfig()
     gwLANBridgeId = (deCONZ::appArgumentNumeric("--lan-bridgeid", 0) == 1) || gwHueMode;
     gwBridgeId = "0000000000000000";
     gwAllowLocal = (deCONZ::appArgumentNumeric("--allow-local", 1) == 1);
-    gwConfig["websocketport"] = 443;
+    gwConfig["websocketport"] = 0;
     fwUpdateState = FW_Idle;
 
     wifiPageActiveTimer = new QTimer(this);
@@ -1124,7 +1124,21 @@ void DeRestPluginPrivate::configToMap(const ApiRequest &req, QVariantMap &map)
     map["lightlastseeninterval"] = gwLightLastSeenInterval;
     map["linkbutton"] = gwLinkButton;
     map["portalservices"] = false;
-    map["websocketport"] = static_cast<double>(gwConfig["websocketport"].toUInt());
+
+    if (webSocketServer && apsCtrl)
+    {
+        auto wsPort = webSocketServer->port();
+        if (wsPort == 0)
+            wsPort = apsCtrl->getParameter(deCONZ::ParamHttpPort);
+        gwConfig["websocketport"] = wsPort;
+        map["websocketport"] = static_cast<double>(gwConfig["websocketport"].toUInt());
+
+#if DECONZ_LIB_VERSION >= 0x011204
+        wsPort = apsCtrl->getParameter(deCONZ::ParamHttpsPort);
+        if (wsPort != 0)
+            map["websocketport_wss"] = (double)wsPort;
+#endif
+    }
     map["websocketnotifyall"] = gwWebSocketNotifyAll;
     map["disablePermitJoinAutoOff"] = gwdisablePermitJoinAutoOff;
 

--- a/websocket_server.cpp
+++ b/websocket_server.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2017-2025 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -22,7 +22,7 @@ WebSocketServer::WebSocketServer(QObject *parent, quint16 port) :
     srv = new QWebSocketServer("deconz", QWebSocketServer::NonSecureMode, this);
 
     quint16 p = 0;
-    quint16 ports[] = { 443, 443, 8080, 8088, 20877, 0 }; // start with proxy frinedly ports first, use random port as fallback
+    quint16 ports[] = { 8087, 20877, 0 }; // start with proxy frinedly ports first, use random port as fallback
     if (port > 0)
     {
         ports[0] = port;
@@ -40,31 +40,53 @@ WebSocketServer::WebSocketServer(QObject *parent, quint16 port) :
         address = QHostAddress(addrArg);
     }
 
-    while (!srv->listen(address, ports[p]))
-    {
-        if (ports[p] == 0)
-        {
-            DBG_Printf(DBG_ERROR, "Giveup starting websocket server on %s, port: %u. error: %s\n", qPrintable(address.toString()), ports[p], qPrintable(srv->errorString()));
-            break;
-        }
+    int wsPort = deCONZ::appArgumentNumeric("--ws-port", 0);
 
-        DBG_Printf(DBG_ERROR, "Failed to start websocket server on %s, port: %u. error: %s\n", qPrintable(address.toString()), ports[p], qPrintable(srv->errorString()));
-        p++;
+    if (wsPort != 0)
+    {
+        while (!srv->listen(address, ports[p]))
+        {
+            if (ports[p] == 0)
+            {
+                DBG_Printf(DBG_ERROR, "Giveup starting websocket server on %s, port: %u. error: %s\n", qPrintable(address.toString()), ports[p], qPrintable(srv->errorString()));
+                break;
+            }
+
+            DBG_Printf(DBG_ERROR, "Failed to start websocket server on %s, port: %u. error: %s\n", qPrintable(address.toString()), ports[p], qPrintable(srv->errorString()));
+            p++;
+        }
     }
 
     if (srv->isListening())
     {
         DBG_Printf(DBG_INFO, "Started websocket server on %s, port: %u\n", qPrintable(address.toString()), srv->serverPort());
-        connect(srv, SIGNAL(newConnection()), this, SLOT(onNewConnection()));
+    }
+
+    connect(srv, &QWebSocketServer::newConnection, this, &WebSocketServer::onNewConnection);
+}
+
+/*! Adds a socket to the internal WebSocket server which handles the handshake.
+
+    The ownership is transferred to \c srv instance.
+ */
+void WebSocketServer::handleExternalTcpSocket(const QHttpRequestHeader &hdr, QTcpSocket *sock)
+{
+    if (srv)
+    {
+        srv->handleConnection(sock);
+    }
+    else
+    {
+        sock->deleteLater(); // shouldn't happen but don't leak anyway
     }
 }
 
 /*! Returns the websocket server port.
-    \return the active server port, or 0 if not active
+    \return the active server port, or 0 if not listening on extra port
  */
 quint16 WebSocketServer::port() const
 {
-    return srv->isListening() ? srv->serverPort() : 0;
+    return srv && srv->isListening() ? srv->serverPort() : 0;
 }
 
 /*! Handler for new client connections.
@@ -74,9 +96,10 @@ void WebSocketServer::onNewConnection()
     while (srv->hasPendingConnections())
     {
         QWebSocket *sock = srv->nextPendingConnection();
-        DBG_Printf(DBG_INFO, "New websocket %s:%u (state: %d) \n", qPrintable(sock->peerAddress().toString()), sock->peerPort(), sock->state());
-        connect(sock, SIGNAL(disconnected()), this, SLOT(onSocketDisconnected()));
+        DBG_Printf(DBG_INFO, "New websocket %s:%u\n", qPrintable(sock->peerAddress().toString()), sock->peerPort());
+        connect(sock, &QWebSocket::disconnected, this, &WebSocketServer::onSocketDisconnected);
         connect(sock, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(onSocketError(QAbstractSocket::SocketError)));
+        connect(sock, &QWebSocket::textMessageReceived, this, &WebSocketServer::onTextMessageReceived);
         clients.push_back(sock);
     }
 }
@@ -120,6 +143,12 @@ void WebSocketServer::onSocketError(QAbstractSocket::SocketError err)
     }
 }
 
+void WebSocketServer::onTextMessageReceived(const QString &message)
+{
+    Q_UNUSED(message);
+    // DBG_Printf(DBG_INFO, "Websocket received: %s\n", qPrintable(message));
+}
+
 /*! Broadcasts a message to all connected clients.
     \param msg the message as JSON string
  */
@@ -128,12 +157,6 @@ void WebSocketServer::broadcastTextMessage(const QString &msg)
     for (size_t i = 0; i < clients.size(); i++)
     {
         QWebSocket *sock = clients[i];
-
-        if (sock->state() != QAbstractSocket::ConnectedState)
-        {
-            DBG_Printf(DBG_INFO, "Websocket %s:%u unexpected state: %d\n", qPrintable(sock->peerAddress().toString()), sock->peerPort(), sock->state());
-        }
-
         qint64 ret = sock->sendTextMessage(msg);
         DBG_Printf(DBG_INFO_L2, "Websocket %s:%u send message: %s (ret = %d)\n", qPrintable(sock->peerAddress().toString()), sock->peerPort(), qPrintable(msg), (int)ret);
         sock->flush();

--- a/websocket_server.h
+++ b/websocket_server.h
@@ -10,6 +10,7 @@
 
 class QWebSocket;
 class QWebSocketServer;
+class QHttpRequestHeader;
 
 /*! \class WebSocketServer
 
@@ -21,6 +22,7 @@ class WebSocketServer : public QObject
 public:
     explicit WebSocketServer(QObject *parent, quint16 port);
     quint16 port() const;
+    void handleExternalTcpSocket(const QHttpRequestHeader &hdr, QTcpSocket *sock);
 
 signals:
 
@@ -32,6 +34,7 @@ private slots:
     void onNewConnection();
     void onSocketDisconnected();
     void onSocketError(QAbstractSocket::SocketError err);
+    void onTextMessageReceived(const QString &message);
 
 private:
     QWebSocketServer *srv;


### PR DESCRIPTION
Together with changes in deCONZ core this allows accepting WebSocket connections directly on the REST-API ports without needing an extra WebSocket server port. Both `ws://` and `wss://` are supported.

- Port 443 isn't any longer tried as default WebSocket server port.
- The extra WebSocket server port is only opened if specified via `--ws-port` and only supports unsecured `ws://` protocol.
- The `/config` object contains an extra key `websocketport_wss` telling the HTTPS port over which `wss://` WebSocket connections can be made, which is also the REST-API HTTPS port.

**Note:** The internal HTTPS entry port is using port 443 which can be reconfigured via `--https-port=<port>`.