### PR TITLE
DDF clone for funeng youpin humidity temperature sensor (TS0201)

### DIFF
--- a/devices/tuya/_TZ3000_TS0201_temp_hum_sensor.json
+++ b/devices/tuya/_TZ3000_TS0201_temp_hum_sensor.json
@@ -14,6 +14,8 @@
     "_TZ3000_utwgoauk",
     "_TZ3000_bjawzodf",
     "_TZ3000_bjawzodf",
+    "_TZ3000_rdhukkmi",
+    "Zbeacon",
     "Zbeacon"
   ],
   "modelid": [
@@ -29,7 +31,9 @@
     "TS0201",
     "TS0201",
     "TY0201",
-    "TS0201"
+    "TS0201",
+    "TS0201",
+    "TH01"
   ],
   "vendor": "Tuya",
   "product": "Temperature and humidity sensor (TS0201)",


### PR DESCRIPTION
Product name:funeng youpin humidity temperature sensor
Manufacturer: Zbeacon / _TZ3000_rdhukkmi
Model identifier: TS0201 / TH01

See #8357

It's funny what Tuya is doing here. Three identical devices with different data.