### PR TITLE
DDF clone for Tuya seat pressure sensor (_TZ3000_pjb1ua0m)

### DIFF
--- a/devices/tuya/_TZ3000_TS0203_door_sensor.json
+++ b/devices/tuya/_TZ3000_TS0203_door_sensor.json
@@ -20,11 +20,13 @@
     "_TZ3000_1bwpjvlz",
     "_TZ3000_0hkmcrza",
     "_TZ3000_wut53hfm",
-    "_TZ3000_bpkijo14"
+    "_TZ3000_bpkijo14",
+    "_TZ3000_pjb1ua0m"
   ],
   "modelid": [
     "TS0203",
     "SNZB-04",
+    "TS0203",
     "TS0203",
     "TS0203",
     "TS0203",


### PR DESCRIPTION
Added Tuya Zigbee Seat Pressure Sensor _TZ3000_pjb1ua0m

https://de.aliexpress.com/item/1005008801869408.html?spm=a2g0o.order_list.order_list_main.41.36a25c5fn82gPh&gatewayAdapt=glo2deu