### PR TITLE
Remove Eurotronic Spirit legacy code

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -7399,15 +7399,7 @@ void DeRestPluginPrivate::addSensorNode(const deCONZ::Node *node, const SensorFi
                 sensorNode.addItem(DataTypeBool, RConfigWindowOpen)->setValue(false);
             }
 
-            if (modelId.startsWith(QLatin1String("SPZB"))) // Eurotronic Spirit
-            {
-                sensorNode.addItem(DataTypeUInt8, RStateValve);
-                sensorNode.addItem(DataTypeUInt32, RConfigHostFlags)->setIsPublic(false);
-                sensorNode.addItem(DataTypeBool, RConfigDisplayFlipped)->setValue(false);
-                sensorNode.addItem(DataTypeBool, RConfigLocked)->setValue(false);
-                sensorNode.addItem(DataTypeString, RConfigMode);
-            }
-            else if (sensorNode.modelId() == QLatin1String("902010/32"))  // Bitron
+            if (sensorNode.modelId() == QLatin1String("902010/32"))  // Bitron
             {
                 sensorNode.addItem(DataTypeString, RConfigMode);
                 sensorNode.addItem(DataTypeUInt8, RConfigControlSequence)->setValue(4);
@@ -15348,8 +15340,7 @@ void DeRestPlugin::idleTimerFired()
                                 val = sensorNode->getZclValue(*ci, 0x0029); // heating operation state
                             }
 
-                            if (sensorNode->modelId().startsWith(QLatin1String("SPZB")) ||      // Eurotronic Spirit
-                                sensorNode->modelId().startsWith(QLatin1String("SLT2")) ||      // Hive Active Heating Thermostat
+                            if (sensorNode->modelId().startsWith(QLatin1String("SLT2")) ||      // Hive Active Heating Thermostat
                                 sensorNode->modelId().startsWith(QLatin1String("SLT3")) ||      // Hive Active Heating Thermostat
                                 sensorNode->modelId().startsWith(QLatin1String("SLR2")) ||      // Hive Active Heating Receiver 2 channel
                                 sensorNode->modelId().startsWith(QLatin1String("SLR1b")) ||     // Hive Active Heating Receiver 1 channel

--- a/rest_sensors.cpp
+++ b/rest_sensors.cpp
@@ -810,23 +810,17 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                         }
                     }
                 }
-
-                if (sensor->modelId().startsWith(QLatin1String("SPZB")) && hostFlags == 0) // Eurotronic Spirit
+				
+				if (rid.suffix == RConfigHostFlags) // Eurotronic Spirit
                 {
-                    ResourceItem *item = sensor->item(RConfigHostFlags);
-                    if (item)
+                    if (devManaged && rsub)
                     {
-                        hostFlags = item->toNumber();
-                    }
-                    else
-                    {
-                        rsp.list.append(errorToMap(ERR_ACTION_ERROR, QString("/sensors/%1/config/%2").arg(id).arg(pi.key()),
-                                                   QLatin1String("Could not set attribute")));
-                        continue;
+                        change.addTargetValue(rid.suffix, data.uinteger);
+                        rsub->addStateChange(change);
+                        updated = true;
                     }
                 }
-
-                if (rid.suffix == RConfigDeviceMode) // String
+                else if (rid.suffix == RConfigDeviceMode) // String
                 {
                     if (devManaged && rsub)
                     {
@@ -1423,7 +1417,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                             }
                         }
                     }
-                    else if (sensor->modelId().startsWith(QLatin1String("SPZB"))) // Eurotronic Spirit
+/*                     else if (sensor->modelId().startsWith(QLatin1String("SPZB"))) // Eurotronic Spirit
                     {
                         const auto match = matchKeyValue(data.string, RConfigModeValuesEurotronic);
 
@@ -1449,7 +1443,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                                 updated = true;
                             }
                         }
-                    }
+                    } */
                     else
                     {
                         const auto match = matchKeyValue(data.string, RConfigModeValues);
@@ -1667,16 +1661,6 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                             updated = true;
                         }
                     }
-                    else if (sensor->modelId().startsWith(QLatin1String("SPZB"))) // Eurotronic Spirit
-                    {
-                        if (data.boolean) { hostFlags |= 0x000080; } // set locked
-                        else              { hostFlags &= 0xffff6f; } // clear locked, clear disable off
-
-                        if (addTaskThermostatReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, VENDOR_JENNIC, THERM_ATTRID_HOST_FLAGS, deCONZ::Zcl24BitUint, hostFlags))
-                        {
-                            updated = true;
-                        }
-                    }
                     else if (devManaged && rsub) // Managed by DDF ? why integer ?
                     {
                         data.uinteger = data.boolean; // Use integer representation
@@ -1696,17 +1680,7 @@ int DeRestPluginPrivate::changeSensorConfig(const ApiRequest &req, ApiResponse &
                 }
                 else if (rid.suffix == RConfigDisplayFlipped) // Boolean
                 {
-                    if (sensor->modelId().startsWith(QLatin1String("SPZB"))) // Eurotronic Spirit
-                    {
-                        if (data.boolean) { hostFlags |= 0x000002; } // set flipped
-                        else              { hostFlags &= 0xffffed; } // clear flipped, clear disable off
-
-                        if (addTaskThermostatReadWriteAttribute(task, deCONZ::ZclWriteAttributesId, VENDOR_JENNIC, THERM_ATTRID_HOST_FLAGS, deCONZ::Zcl24BitUint, hostFlags))
-                        {
-                            updated = true;
-                        }
-                    }
-                    else if (devManaged && rsub)
+                    if (devManaged && rsub)
                     {
                         data.uinteger = data.boolean; // Use integer representation
                         change.addTargetValue(rid.suffix, data.uinteger);

--- a/thermostat.cpp
+++ b/thermostat.cpp
@@ -428,8 +428,7 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
 
             case 0x0008:  // Pi Heating Demand
             {
-                if (sensor->modelId().startsWith(QLatin1String("SPZB")) || // Eurotronic Spirit
-                    sensor->modelId() == QLatin1String("Thermostat"))      // eCozy
+                if (sensor->modelId() == QLatin1String("Thermostat"))      // eCozy
                 {
                     quint8 valve = attr.numericValue().u8;
                     bool on = valve > 3;
@@ -497,21 +496,15 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
 
             case 0x0012: // Occupied Heating Setpoint
             {
-                if (sensor->modelId().startsWith(QLatin1String("SPZB"))) // Eurotronic Spirit
-                {
-                    // Use 0x4003 instead.
-                }
-                else
-                {
-                    qint16 heatSetpoint = attr.numericValue().s16;
-                    item = sensor->item(RConfigHeatSetpoint);
-                    if (item && item->toNumber() != heatSetpoint)
-                    {
-                        item->setValue(heatSetpoint);
-                        enqueueEvent(Event(RSensors, RConfigHeatSetpoint, sensor->id(), item));
-                        configUpdated = true;
-                    }
-                }
+				qint16 heatSetpoint = attr.numericValue().s16;
+				item = sensor->item(RConfigHeatSetpoint);
+				if (item && item->toNumber() != heatSetpoint)
+				{
+					item->setValue(heatSetpoint);
+					enqueueEvent(Event(RSensors, RConfigHeatSetpoint, sensor->id(), item));
+					configUpdated = true;
+				}
+                
                 sensor->setZclValue(updateType, ind.srcEndpoint(), THERMOSTAT_CLUSTER_ID, attrId, attr.numericValue());
             }
                 break;
@@ -810,54 +803,7 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
             }
                 break;
 
-            // manufacturerspecific reported by Eurotronic SPZB0001
-            // https://eurotronic.org/wp-content/uploads/2019/01/Spirit_ZigBee_BAL_web_DE_view_V9.pdf
-            case 0x4000: // enum8 (0x30): value 0x02, TRV mode
-            {
-                if (zclFrame.manufacturerCode() == VENDOR_JENNIC)
-                {
-                }
-                sensor->setZclValue(updateType, ind.srcEndpoint(), THERMOSTAT_CLUSTER_ID, attrId, attr.numericValue());
-            }
-                break;
-
-            case 0x4001: // U8 (0x20): value 0x00, valve position
-            case 0x4002: // U8 (0x20): value 0x00, errors
-            {
-                if (zclFrame.manufacturerCode() == VENDOR_JENNIC)
-                {
-                }
-            }
-                sensor->setZclValue(updateType, ind.srcEndpoint(), THERMOSTAT_CLUSTER_ID, attrId, attr.numericValue());
-                break;
-
-            case 0x4003:
-            {   // Current temperature set point - this will be reported when manually changing the temperature
-                if (zclFrame.manufacturerCode() == VENDOR_JENNIC && sensor->modelId().startsWith(QLatin1String("SPZB"))) // Eurotronic Spirit
-                {
-                    qint16 heatSetpoint = attr.numericValue().s16;
-                    item = sensor->item(RConfigHeatSetpoint);
-                    
-                    if (item)
-                    {
-                        if (updateType == NodeValue::UpdateByZclReport)
-                        {
-                            stateUpdated = true;
-                        }
-                        if (item->toNumber() != heatSetpoint)
-                        {
-                            item->setValue(heatSetpoint);
-                            enqueueEvent(Event(RSensors, RConfigHeatSetpoint, sensor->id(), item));
-                            stateUpdated = true;
-                        }
-                    }
-                }
-                
-                sensor->setZclValue(updateType, ind.srcEndpoint(), THERMOSTAT_CLUSTER_ID, attrId, attr.numericValue());
-            }
-                break;
-
-            case 0x4008: // U24 (0x22): 0x000001, host flags
+/*             case 0x4008: // U24 (0x22): 0x000001, host flags
             {
                 if (zclFrame.manufacturerCode() == VENDOR_JENNIC && sensor->modelId().startsWith(QLatin1String("SPZB"))) // Eurotronic Spirit
                 {
@@ -896,7 +842,7 @@ void DeRestPluginPrivate::handleThermostatClusterIndication(const deCONZ::ApsDat
                 }
                 sensor->setZclValue(updateType, ind.srcEndpoint(), THERMOSTAT_CLUSTER_ID, attrId, attr.numericValue());
             }
-                break;
+                break; */
 
             // Manufacturer Specific for Danfoss Icon Floor Heating Controller
             case 0x4110:  // Danfoss Output Status


### PR DESCRIPTION
This PR removes most of the Eurotronic Spirit legacy code. Some passages have "just" been commented out, as this is not 100% covered by DDF but also unclear, if that is needed or not.
Setting `heatsetpoint` in `rest_sensors.cpp` must remain due to the screwed device firmware.

Must be merged with #8361