### PR TITLE
Fix Shelly 1PM/1PM mini consumption value exposure

### DIFF
--- a/devices/shelly/shelly_1pm_gen4.json
+++ b/devices/shelly/shelly_1pm_gen4.json
@@ -271,7 +271,14 @@
         },
         {
           "name": "state/consumption",
-          "refresh.interval": 60
+          "refresh.interval": 60,
+          "parse": {
+            "at": "0x0000",
+            "cl": "0x0702",
+            "ep": 1,
+            "eval": "Item.val = Attr.val / 1000;",
+            "fn": "zcl:attr"
+          }
         },
         {
           "name": "state/lastupdated"

--- a/devices/shelly/shelly_1pm_mini_gen4.json
+++ b/devices/shelly/shelly_1pm_mini_gen4.json
@@ -271,7 +271,14 @@
         },
         {
           "name": "state/consumption",
-          "refresh.interval": 60
+          "refresh.interval": 60,
+          "parse": {
+            "at": "0x0000",
+            "cl": "0x0702",
+            "ep": 1,
+            "eval": "Item.val = Attr.val / 1000;",
+            "fn": "zcl:attr"
+          }
         },
         {
           "name": "state/lastupdated"


### PR DESCRIPTION
Mea culpa, the consumption values need to be divided by 1000.