### PR TITLE
Fix Websocket setup using proper ports

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -863,7 +863,12 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
             this, SLOT(openClientTimerFired()));
     openClientTimer->start(1000);
 
-    quint16 wsPort = deCONZ::appArgumentNumeric(QLatin1String("--ws-port"), gwConfig["websocketport"].toUInt());
+    uint16_t wsPort = deCONZ::appArgumentNumeric(QLatin1String("--ws-port"), 0);
+    if (wsPort == apsCtrl->getParameter(deCONZ::ParamHttpPort) || wsPort == apsCtrl->getParameter(deCONZ::ParamHttpsPort))
+    {
+        wsPort = 0; // already listening on this port
+    }
+
     webSocketServer = new WebSocketServer(this, wsPort);
     gwConfig["websocketport"] = webSocketServer->port();
 

--- a/websocket_server.h
+++ b/websocket_server.h
@@ -20,7 +20,7 @@ class WebSocketServer : public QObject
 {
     Q_OBJECT
 public:
-    explicit WebSocketServer(QObject *parent, quint16 port);
+    explicit WebSocketServer(QObject *parent, uint16_t wsPort);
     quint16 port() const;
     void handleExternalTcpSocket(const QHttpRequestHeader &hdr, QTcpSocket *sock);
 


### PR DESCRIPTION
- If no `--ws-port=<port>` is given on command line use the default HTTP port indrectly.
- Same if the `--ws-port` parameter is HTTP/HTTPS port. Note that default HTTPS port is 443.