### PR TITLE
DDF clone for Tuya temperature/humidity sensor (_TZ3000_bgsigers)

### DIFF
--- a/devices/tuya/_TYZB01_SM0201_temp_hum_sensor.json
+++ b/devices/tuya/_TYZB01_SM0201_temp_hum_sensor.json
@@ -3,11 +3,13 @@
   "uuid": "08dc1145-5065-4dbd-a0dc-3433984f7088",
   "manufacturername": [
     "_TYZB01_cbiezpds",
-    "_TYZB01_zqvwka4k"
+    "_TYZB01_zqvwka4k",
+    "_TZ3000_bgsigers"
   ],
   "modelid": [
     "SM0201",
-    "SM0201"
+    "SM0201",
+    "TS0201"
   ],
   "vendor": "Tuya",
   "product": "Temperature and humidity sensor with LCD display (SM0201)",


### PR DESCRIPTION
Added 
manufacturer: _TZ3000_bgsigers with modelid: TS0201