### PR TITLE
Fix for Namron 4512770 4in1 multi sensor

### DIFF
--- a/devices/namron/4512770-4in1-MultiSensor.json
+++ b/devices/namron/4512770-4in1-MultiSensor.json
@@ -66,6 +66,7 @@
         {
           "name": "config/battery",
           "refresh.interval": 86400,
+          "awake": true,
           "read": {
             "at": "0x0021",
             "cl": "0x0001",
@@ -180,6 +181,7 @@
         {
           "name": "config/battery",
           "refresh.interval": 86400,
+          "awake": true,
           "read": {
             "at": "0x0021",
             "cl": "0x0001",
@@ -273,6 +275,7 @@
         {
           "name": "config/battery",
           "refresh.interval": 86400,
+          "awake": true,
           "read": {
             "at": "0x0021",
             "cl": "0x0001",
@@ -366,6 +369,7 @@
         {
           "name": "config/battery",
           "refresh.interval": 86400,
+          "awake": true,
           "read": {
             "at": "0x0021",
             "cl": "0x0001",


### PR DESCRIPTION
Product name: Namron Zigbee Multisensor
Manufacturer: Namron AS
Model identifier: 4512770

See #7290 and #8076

- I believe that "$TYPE_BATTERY_SENSOR" is not needed here.
- For "state/lightlevel" we needed a script.
- Add "config/delay" for presence sensor

@Smanar I'm not entirely sure about the EPs yet.