### PR TITLE
Hue smart button v2, model: RDM005.

### DIFF
--- a/devices/philips/rom001_smart_button.json
+++ b/devices/philips/rom001_smart_button.json
@@ -4,14 +4,18 @@
   "manufacturername": [
     "$MF_SIGNIFY",
     "$MF_SIGNIFY",
+    "$MF_SIGNIFY",
+    "$MF_PHILIPS",
     "$MF_PHILIPS",
     "$MF_PHILIPS"
   ],
   "modelid": [
     "ROM001",
     "RDM003",
+    "RDM005",
     "ROM001",
-    "RDM003"
+    "RDM003",
+    "RDM005"
   ],
   "vendor": "Philips",
   "product": "Hue smart button",


### PR DESCRIPTION
Add support for Hue smart button v2, model: RDM005.

It has a different firmware image, 0x012b, than the v1 model, 0x0116.  Apart from the _Basic_ cluster, which now supports some of the newer Hue-specific attributes, it seems identical.