### PR TITLE
DDF clone for Tuya door/window sensor (_TZ3000_996rpfy6)

### DIFF
--- a/devices/tuya/_TZ3000_TS0203_door_sensor.json
+++ b/devices/tuya/_TZ3000_TS0203_door_sensor.json
@@ -21,11 +21,13 @@
     "_TZ3000_0hkmcrza",
     "_TZ3000_wut53hfm",
     "_TZ3000_bpkijo14",
-    "_TZ3000_pjb1ua0m"
+    "_TZ3000_pjb1ua0m",
+    "_TZ3000_996rpfy6"
   ],
   "modelid": [
     "TS0203",
     "SNZB-04",
+    "TS0203",
     "TS0203",
     "TS0203",
     "TS0203",


### PR DESCRIPTION
Product name: Zigbee Door Window Sensor Model: ZD06
Manufacturer: _TZ3000_996rpfy6
Model identifier: TS0203

See #8394