### PR TITLE
Support relay interlock for Aqara Dual Relay Module T2 (DCM-K01)

### DIFF
--- a/devices/generic/items/config_interlock_item.json
+++ b/devices/generic/items/config_interlock_item.json
@@ -1,0 +1,9 @@
+{
+  "schema": "resourceitem1.schema.json",
+  "id": "config/interlock",
+  "datatype": "Bool",
+  "access": "RW",
+  "public": true,
+  "default": false,
+  "description": "Prevent the use of 2 relays in same time."
+}

--- a/devices/xiaomi/xiaomi_dcm-k01_t2_dual_relay.json
+++ b/devices/xiaomi/xiaomi_dcm-k01_t2_dual_relay.json
@@ -189,7 +189,7 @@
         },
         {
           "name": "config/clickmode",
-          "refresh.interval": 300,
+          "refresh.interval": 86400,
           "read": {
             "at": "0x000a",
             "cl": "0xfcc0",
@@ -219,6 +219,35 @@
             ["\"rocker\"", "Rocker mode"] 
           ],
           "default": "rocker"
+        },
+        {
+          "name": "config/interlock",
+          "refresh.interval": 86400,
+          "read": {
+            "at": "0x02d0",
+            "cl": "0xFCC0",
+            "ep": 1,
+            "fn": "zcl:attr",
+            "mf": "0x115F"
+          },
+          "parse": {
+            "at": "0x02d0",
+            "cl": "0xFCC0",
+            "ep": 1,
+            "eval": "Item.val = Attr.val;",
+            "fn": "zcl:attr",
+            "mf": "0x115F"
+          },
+          "write": {
+            "at": "0x02d0",
+            "cl": "0xFCC0",
+            "dt": "0x10",
+            "ep": 1,
+            "eval": "Item.val",
+            "fn": "zcl:attr",
+            "mf": "0x115F"
+          },
+          "default": false
         },
         {
           "name": "state/buttonevent"

--- a/general.xml
+++ b/general.xml
@@ -6011,6 +6011,7 @@ Contactor > On/off=0003 - HP/HC=0004</description>
           <attribute id="0x020E" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
           <attribute id="0x023B" name="Unknown" type="float" mfcode="0x115f" access="rw" required="m"></attribute>
           <attribute id="0x023E" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
+          <attribute id="0x02d0" name="Interlock" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
         </attribute-set>
         <attribute-set id="0x0270" description="Smart Radiator Thermostat E1">
             <attribute id="0x0270" name="Calibrate" type="u8" mfcode="0x115f" access="rw" required="m"> 


### PR DESCRIPTION
See https://forum.phoscon.de/t/aqara-relay-t2-switch-type-ddf-modification/5685/8

Used on 
```
  "modelid": "lumi.switch.acn047",
  "vendor": "Xiaomi",
  "product": "Aqara Dual Relay Module T2 (DCM-K01)",
```