### PR TITLE
Announce HTTPS port if active (Discovery and UPnP)

### DIFF
--- a/discovery.cpp
+++ b/discovery.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2016-2025 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -192,6 +192,11 @@ void DeRestPluginPrivate::internetDiscoveryTimerFired()
     map["mac"] = gwBridgeId;
     map["internal_ip"] = gwConfig["ipaddress"].toString();
     map["internal_port"] = gwConfig["port"].toDouble();
+    uint16_t httpsPort = ctrl->getParameter(deCONZ::ParamHttpsPort);
+    if (httpsPort > 0)
+    {
+        map["https_port"] = (double)httpsPort;
+    }
     map["interval"] = gwAnnounceInterval;
     map["swversion"] = gwConfig["swversion"].toString();
     map["fwversion"] = gwConfig["fwversion"].toString();


### PR DESCRIPTION
The `description.xml` got and extra element `deconz:info` and within there if HTTPS is active a sub element `httpsPort`.

**Example description.xml:**

``` 
<?xml version="1.0" encoding="UTF-8" ?>
<root xmlns="urn:schemas-upnp-org:device-1-0">
  <specVersion>
    <major>1</major>
    <minor>0</minor>
  </specVersion>
  <URLBase>http://192.168.178.4:8090/</URLBase>
  <device>
    <deviceType>urn:schemas-upnp-org:device:Basic:1</deviceType>
    <friendlyName>Skull (192.168.178.4)</friendlyName>
    <manufacturer>Royal Philips Electronics</manufacturer>
    <manufacturerURL>http://www.dresden-elektronik.de</manufacturerURL>
    <modelDescription>Philips hue compatible Personal Wireless Lighting</modelDescription>
    <modelName>Philips hue bridge 2015</modelName>
    <modelNumber>BSB002</modelNumber>
    <modelURL>http://www.dresden-elektronik.de</modelURL>
    <serialNumber>00212E00C5FB</serialNumber>
    <UDN>uuid:4238efb5-566d-481b-a0db-a9e972c9f4c3</UDN>
    <presentationURL>index.html</presentationURL>
    <iconList>
      <icon>
        <mimetype>image/png</mimetype>
        <height>48</height>
        <width>48</width>
        <depth>24</depth>
        <url>hue_logo_0.png</url>
      </icon>
    </iconList>
    <deconz:info>
      <httpsPort>8443</httpsPort>
    </deconz:info>
  </device>
</root>

``` 

The UPnP UDP broadcast got the extra field `HTTPS.phoscon.de: <https-port>`.

**Example NOTIFY message:**

```
NOTIFY * HTTP/1.1
HOST: 239.255.255.250:1900
CACHE-CONTROL: max-age=100
LOCATION: http://192.168.178.4:8090/description.xml
SERVER: Linux/3.14.0 UPnP/1.0 IpBridge/1.26.0
GWID.phoscon.de: 00212EFFFF00C5FB
hue-bridgeid: 00212EFFFF00C5FB
NTS: ssdp:alive
HTTPS.phoscon.de: 8443
NT: upnp:rootdevice
USN: uuid:4238efb5-566d-481b-a0db-a9e972c9f4c3::upnp:rootdevice
``` 

The HTTPS port gets also announced to the discovery server. Note this currently not visible as processing needs to be added on server side (soon).

Note this is a ad hoc solution, MDNS is better suited to expose extra services like HTTPS and will be added later on.