### PR TITLE
DDF extend clones of Tuya Thermostat TRV (TS0601)

### DIFF
--- a/devices/tuya/_TZE200_TS0601_trv.json
+++ b/devices/tuya/_TZE200_TS0601_trv.json
@@ -8,9 +8,13 @@
     "_TZE200_rxntag7i",
     "_TZE200_p3dbf6qs",
     "_TZE284_ogx8u5z6",
-    "_TZE204_o3x45p96"
+    "_TZE204_o3x45p96",
+    "_TZE284_o3x45p96",
+    "_TZE200_9xfjixap"
   ],
   "modelid": [
+    "TS0601",
+    "TS0601",
     "TS0601",
     "TS0601",
     "TS0601",


### PR DESCRIPTION
This pull request updates the device compatibility list for the Tuya TS0601 TRV integration. 

The added identifiers are identifiers found in devices ordered from CN (probably clones)

Device compatibility updates:

* Added support for device identifiers `_TZE284_o3x45p96` and `_TZE200_9xfjixap` to the `devices/tuya/_TZE200_TS0601_trv.json` file.
* Updated the corresponding `modelid` array to include two additional `"TS0601"` entries for the newly added devices.