### PR TITLE
Remove `state/lowbattery` from ZG-204ZV

### DIFF
--- a/devices/hobeian/hobeian_presence_temperature_humidity_lightlevel_sensor.json
+++ b/devices/hobeian/hobeian_presence_temperature_humidity_lightlevel_sensor.json
@@ -370,9 +370,6 @@
           "name": "state/lastupdated"
         },
         {
-          "name": "state/lowbattery"
-        },
-        {
           "name": "state/presence",
           "awake": true,
           "parse": {


### PR DESCRIPTION
Remove `state/lowbattery` as this device does not support it.