### PR TITLE
Fix debug format datatype warnings, remove some legacy warnings

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -1355,7 +1355,7 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
             break;
 
         case DOOR_LOCK_CLUSTER_ID:
-            DBG_Printf(DBG_INFO, "Door lock debug 0x%016llX, data 0x%08X \n", ind.srcAddress().ext(), zclFrame.commandId() );
+            DBG_Printf(DBG_INFO, "Door lock debug " FMT_MAC ", data 0x%08X \n", FMT_MAC_CAST(ind.srcAddress().ext()), zclFrame.commandId() );
             break;
 
         case XIAOMI_CLUSTER_ID:
@@ -2712,7 +2712,7 @@ void DeRestPluginPrivate::addLightNode(const deCONZ::Node *node)
                             {
                                 // TODO better filter for lumi. devices (i->deviceId(), modelid?)
                                 // blacklist switch endpoints for lumi.ctrl_neutral1 and lumi.ctrl_neutral2
-                                DBG_Printf(DBG_INFO, "Skip load endpoint 0x%02X for 0x%016llX (expect: lumi.ctrl_neutral1 / lumi.ctrl_neutral2)\n", i->endpoint(), node->address().ext());
+                                DBG_Printf(DBG_INFO, "Skip load endpoint 0x%02X for " FMT_MAC " (expect: lumi.ctrl_neutral1 / lumi.ctrl_neutral2)\n", i->endpoint(), FMT_MAC_CAST(node->address().ext()));
                             }
                             else
                             {
@@ -3713,7 +3713,7 @@ LightNode *DeRestPluginPrivate::updateLightNode(const deCONZ::NodeEvent &event)
                         ResourceItem *item = lightNode->item(RStateOn);
                         if (item && item->toBool() != on)
                         {
-                            DBG_Printf(DBG_INFO, "0x%016llX onOff %u --> %u\n", lightNode->address().ext(), (uint)item->toNumber(), on);
+                            DBG_Printf(DBG_INFO, FMT_MAC " onOff %u --> %u\n", FMT_MAC_CAST(lightNode->address().ext()), (uint)item->toNumber(), on);
                             item->setValue(on);
                             Event e(RLights, RStateOn, lightNode->id(), item);
                             enqueueEvent(e);
@@ -8736,7 +8736,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                     }
                     else if (event.clusterId() == BASIC_CLUSTER_ID)
                     {
-                        DBG_Printf(DBG_INFO_L2, "Update Sensor 0x%016llX Basic Cluster\n", event.node()->address().ext());
+                        DBG_Printf(DBG_INFO_L2, "Update Sensor " FMT_MAC " Basic Cluster\n", FMT_MAC_CAST(event.node()->address().ext()));
 
                         for (;ia != enda; ++ia)
                         {
@@ -9165,7 +9165,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                         pushZclValueDb(event.node()->address().ext(), event.endpoint(), event.clusterId(), ia->id(), ia->numericValue().u16);
                                     }
                                     const quint16 value = ia->numericValue().u16;
-                                    DBG_Printf(DBG_INFO, "0x%016llX: 0x0101/0x0055: event: %d\n", event.node()->address().ext(), value);
+                                    DBG_Printf(DBG_INFO, FMT_MAC ": 0x0101/0x0055: event: %d\n", FMT_MAC_CAST(event.node()->address().ext()), value);
 
                                     if (value == 0x0001) // vibration
                                     {
@@ -9201,7 +9201,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                         pushZclValueDb(event.node()->address().ext(), event.endpoint(), event.clusterId(), ia->id(), ia->numericValue().u16);
                                     }
                                     const quint16 value = ia->numericValue().u16;
-                                    DBG_Printf(DBG_INFO, "0x%016llX: 0x0101/0x0503: tilt angle: %d°\n", event.node()->address().ext(), value);
+                                    DBG_Printf(DBG_INFO, FMT_MAC ": 0x0101/0x0503: tilt angle: %d°\n", FMT_MAC_CAST(event.node()->address().ext()), value);
                                     ResourceItem *item = i->item(RStateTiltAngle);
                                     if (item)
                                     {
@@ -9220,7 +9220,7 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
 
                                     const quint32 value = ia->numericValue().u32;
                                     const quint16 strength = (value >> 16) & 0xffff;
-                                    DBG_Printf(DBG_INFO, "0x%016llX: 0x0101/0x0505: vibration strength: %d\n", event.node()->address().ext(), strength);
+                                    DBG_Printf(DBG_INFO, FMT_MAC ": 0x0101/0x0505: vibration strength: %d\n", FMT_MAC_CAST(event.node()->address().ext()), strength);
                                     ResourceItem *item = i->item(RStateVibrationStrength);
                                     if (item)
                                     {
@@ -9240,14 +9240,14 @@ void DeRestPluginPrivate::updateSensorNode(const deCONZ::NodeEvent &event)
                                     const qint16 x = value & 0xffff;
                                     const qint16 y = (value >> 16) & 0xffff;
                                     const qint16 z = (value >> 32) & 0xffff;
-                                    DBG_Printf(DBG_INFO, "0x%016llX: 0x0101/0x0508: raw orientation: 0x%012llx (%d, %d, %d)\n", event.node()->address().ext(), value, x, y, z);
+                                    DBG_Printf(DBG_INFO, FMT_MAC ": 0x0101/0x0508: raw orientation: 0x%012llx (%d, %d, %d)\n", FMT_MAC_CAST(event.node()->address().ext()), value, x, y, z);
                                     const qreal X = 0.0 + x;
                                     const qreal Y = 0.0 + y;
                                     const qreal Z = 0.0 + z;
                                     const qint16 angleX = round(qAtan(X / qSqrt(Z * Z + Y * Y)) * 180 / M_PI);
                                     const qint16 angleY = round(qAtan(Y / qSqrt(X * X + Z * Z)) * 180 / M_PI);
                                     const qint16 angleZ = round(qAtan(Z / qSqrt(X * X + Y * Y)) * 180 / M_PI);
-                                    DBG_Printf(DBG_INFO, "0x%016llX: 0x0101/0x0508: orientation: (%d°, %d°, %d°)\n", event.node()->address().ext(), angleX, angleY, angleZ);
+                                    DBG_Printf(DBG_INFO, FMT_MAC ": 0x0101/0x0508: orientation: (%d°, %d°, %d°)\n", FMT_MAC_CAST(event.node()->address().ext()), angleX, angleY, angleZ);
                                     ResourceItem *item = i->item(RStateOrientationX);
                                     if (item)
                                     {
@@ -10079,7 +10079,6 @@ bool DeRestPluginPrivate::processZclAttributes(Sensor *sensorNode)
         {
             ResourceItem *item = sensorNode->item(RConfigDelay);
 
-            DBG_Printf(DBG_INFO_L2, "handle pending delay for 0x%016llX\n", sensorNode->address().ext());
             if (item)
             {
                 quint64 delay = item->toNumber();
@@ -10110,7 +10109,6 @@ bool DeRestPluginPrivate::processZclAttributes(Sensor *sensorNode)
         {
             ResourceItem *item = sensorNode->item(RConfigSensitivity);
 
-            DBG_Printf(DBG_INFO_L2, "handle pending sensitivity for 0x%016llX\n", sensorNode->address().ext());
             if (item)
             {
                 quint64 sensitivity = item->toNumber();
@@ -10310,7 +10308,6 @@ bool DeRestPluginPrivate::readAttributes(RestNodeBase *restNode, quint8 endpoint
                                       deCONZ::ZclFCDirectionClientToServer |
                                       deCONZ::ZclFCDisableDefaultResponse);
         task.zclFrame.setManufacturerCode(manufacturerCode);
-        DBG_Printf(DBG_INFO_L2, "read manufacturer specific attributes of 0x%016llX cluster: 0x%04X: [ ", restNode->address().ext(), clusterId);
     }
     else
     {
@@ -10318,7 +10315,6 @@ bool DeRestPluginPrivate::readAttributes(RestNodeBase *restNode, quint8 endpoint
                                       deCONZ::ZclFCDirectionClientToServer |
                                       deCONZ::ZclFCDisableDefaultResponse);
 
-        DBG_Printf(DBG_INFO_L2, "read attributes of 0x%016llX cluster: 0x%04X: [ ", restNode->address().ext(), clusterId);
     }
 
     { // payload
@@ -10348,7 +10344,6 @@ bool DeRestPluginPrivate::readAttributes(RestNodeBase *restNode, quint8 endpoint
 
         if (t0.zclFrame.payload() == task.zclFrame.payload())
         {
-            DBG_Printf(DBG_INFO, "discard read attributes of 0x%016llX cluster: 0x%04X (already in queue)\n", restNode->address().ext(), clusterId);
             return false;
         }
     }
@@ -10458,7 +10453,6 @@ bool DeRestPluginPrivate::writeAttribute(RestNodeBase *restNode, quint8 endpoint
                                       deCONZ::ZclFCDirectionClientToServer |
                                       deCONZ::ZclFCDisableDefaultResponse);
         task.zclFrame.setManufacturerCode(manufacturerCode);
-        DBG_Printf(DBG_INFO_L2, "write manufacturer specific attribute of 0x%016llX ep: 0x%02X cluster: 0x%04X: 0x%04X\n", restNode->address().ext(), endpoint, clusterId, attribute.id());
     }
     else
     {
@@ -10466,7 +10460,7 @@ bool DeRestPluginPrivate::writeAttribute(RestNodeBase *restNode, quint8 endpoint
                                       deCONZ::ZclFCDirectionClientToServer |
                                       deCONZ::ZclFCDisableDefaultResponse);
 
-        DBG_Printf(DBG_INFO, "write attribute of 0x%016llX ep: 0x%02X cluster: 0x%04X: 0x%04X\n", restNode->address().ext(), endpoint, clusterId, attribute.id());
+        DBG_Printf(DBG_INFO, "write attribute of " FMT_MAC " ep: 0x%02X cluster: 0x%04X: 0x%04X\n", FMT_MAC_CAST(restNode->address().ext()), endpoint, clusterId, attribute.id());
     }
 
     { // payload
@@ -10497,7 +10491,6 @@ bool DeRestPluginPrivate::writeAttribute(RestNodeBase *restNode, quint8 endpoint
 
         if (t0.zclFrame.payload() == task.zclFrame.payload())
         {
-            DBG_Printf(DBG_INFO, "discard write attribute of 0x%016llX ep: 0x%02X cluster: 0x%04X: 0x%04X (already in queue)\n", restNode->address().ext(), endpoint, clusterId, attribute.id());
             return false;
         }
     }
@@ -10918,7 +10911,7 @@ void DeRestPluginPrivate::foundScene(LightNode *lightNode, Group *group, uint8_t
         }
     }
 
-    DBG_Printf(DBG_INFO, "0x%016llX found scene 0x%02X for group 0x%04X\n", lightNode->address().ext(), sceneId, group->address());
+    DBG_Printf(DBG_INFO, FMT_MAC " found scene 0x%02X for group 0x%04X\n", FMT_MAC_CAST(lightNode->address().ext()), sceneId, group->address());
 
     Scene scene;
     scene.groupAddress = group->address();
@@ -11077,7 +11070,7 @@ bool DeRestPluginPrivate::modifyScene(Group *group, uint8_t sceneId)
 
             if (std::find(v.begin(), v.end(), sceneId) == v.end())
             {
-                DBG_Printf(DBG_INFO, "Start modify scene for 0x%016llX, groupId 0x%04X, scene 0x%02X\n", i->address().ext(), groupInfo->id, sceneId);
+                DBG_Printf(DBG_INFO, "Start modify scene for " FMT_MAC ", groupId 0x%04X, scene 0x%02X\n", FMT_MAC_CAST(i->address().ext()), groupInfo->id, sceneId);
                 groupInfo->modifyScenes.push_back(sceneId);
             }
         }
@@ -11285,7 +11278,7 @@ void DeRestPluginPrivate::handleZclAttributeReportIndication(const deCONZ::ApsDa
 
     if (DBG_IsEnabled(DBG_INFO))
     {
-        DBG_Printf(DBG_INFO, "ZCL attribute report 0x%016llX for cluster: 0x%04X, ep: 0x%02X, frame control: 0x%02X, mfcode: 0x%04X \n", ind.srcAddress().ext(), ind.clusterId(), ind.srcEndpoint(), zclFrame.frameControl(), zclFrame.manufacturerCode());
+        DBG_Printf(DBG_INFO, "ZCL attribute report " FMT_MAC " for cluster: 0x%04X, ep: 0x%02X, frame control: 0x%02X, mfcode: 0x%04X \n", FMT_MAC_CAST(ind.srcAddress().ext()), ind.clusterId(), ind.srcEndpoint(), zclFrame.frameControl(), zclFrame.manufacturerCode());
     }
 
     if (DBG_IsEnabled(DBG_INFO_L2))
@@ -11415,7 +11408,6 @@ void DeRestPluginPrivate::storeRecoverOnOffBri(LightNode *lightNode)
     }
 
     // create new entry
-    DBG_Printf(DBG_INFO, "New recover onOff entry 0x%016llX\n", lightNode->address().ext());
     RecoverOnOff rc;
     rc.address = lightNode->address();
     rc.onOff = onOff->toBool();
@@ -11478,7 +11470,7 @@ bool DeRestPluginPrivate::addTask(const TaskItem &task)
     {
         if (task.req.dstAddress().hasExt())
         {
-            DBG_Printf(DBG_INFO_L2, "add task %d type %d to 0x%016llX cluster 0x%04X req.id %u\n", task.taskId, task.taskType, task.req.dstAddress().ext(), task.req.clusterId(), task.req.id());
+            DBG_Printf(DBG_INFO_L2, "add task %d type %d to " FMT_MAC " cluster 0x%04X req.id %u\n", task.taskId, task.taskType, FMT_MAC_CAST(task.req.dstAddress().ext()), task.req.clusterId(), task.req.id());
         }
         else if (task.req.dstAddress().hasGroup())
         {
@@ -11647,7 +11639,7 @@ void DeRestPluginPrivate::processTasks()
                     else
                     {
                         //DBG_Printf(DBG_INFO, "request %u send time %d, cluster 0x%04X, onAir %d\n", i->req.id(), j->sendTime, j->req.clusterId(), onAir);
-                        DBG_Printf(DBG_INFO, "delay sending request %u dt %d ms to 0x%016llX, ep: 0x%02X cluster: 0x%04X onAir: %d\n", i->req.id(), dt, i->req.dstAddress().ext(), i->req.dstEndpoint(), i->req.clusterId(), onAir);
+                        DBG_Printf(DBG_INFO, "delay sending request %u dt %d ms to " FMT_MAC ", ep: 0x%02X cluster: 0x%04X onAir: %d\n", i->req.id(), dt, FMT_MAC_CAST(i->req.dstAddress().ext()), i->req.dstEndpoint(), i->req.clusterId(), onAir);
                         ok = false;
                     }
                     break;
@@ -12376,7 +12368,7 @@ void DeRestPluginPrivate::handleSceneClusterIndication(const deCONZ::ApsDataIndi
     {
         if (zclFrame.payload().size() < 4)
         {
-            DBG_Printf(DBG_INFO, "get scene membership response payload size too small %d\n", zclFrame.payload().size());
+            DBG_Printf(DBG_INFO, "get scene membership response payload size too small %d\n", (int)zclFrame.payload().size());
             return;
         }
 
@@ -12396,7 +12388,7 @@ void DeRestPluginPrivate::handleSceneClusterIndication(const deCONZ::ApsDataIndi
             stream >> groupId;
             stream >> count;
 
-            DBG_Printf(DBG_INFO, "0x%016llX get scene membership response capacity %u, groupId 0x%04X, count %u\n", ind.srcAddress().ext(), capacity, groupId, count);
+            DBG_Printf(DBG_INFO, FMT_MAC " get scene membership response capacity %u, groupId 0x%04X, count %u\n", FMT_MAC_CAST(ind.srcAddress().ext()), capacity, groupId, count);
 
             Group *group = getGroupForId(groupId);
             LightNode *lightNode = getLightNodeForAddress(ind.srcAddress(), ind.srcEndpoint());
@@ -12441,13 +12433,13 @@ void DeRestPluginPrivate::handleSceneClusterIndication(const deCONZ::ApsDataIndi
                     {
                         if (st->lid() == lightNode->id())
                         {
-                            DBG_Printf(DBG_INFO, "0x%016llX restore scene 0x%02X in group 0x%04X\n", lightNode->address().ext(), i->id, groupId);
+                            DBG_Printf(DBG_INFO, FMT_MAC " restore scene 0x%02X in group 0x%04X\n", FMT_MAC_CAST(lightNode->address().ext()), i->id, groupId);
 
                             std::vector<uint8_t> &v = groupInfo->modifyScenes;
 
                             if (std::find(v.begin(), v.end(), i->id) == v.end())
                             {
-                                DBG_Printf(DBG_INFO, "0x%016llX start modify scene, groupId 0x%04X, scene 0x%02X\n", lightNode->address().ext(), groupInfo->id, i->id);
+                                DBG_Printf(DBG_INFO, FMT_MAC " start modify scene, groupId 0x%04X, scene 0x%02X\n", FMT_MAC_CAST(lightNode->address().ext()), groupInfo->id, i->id);
                                 groupInfo->modifyScenes.push_back(i->id);
                             }
                         }
@@ -12468,7 +12460,7 @@ void DeRestPluginPrivate::handleSceneClusterIndication(const deCONZ::ApsDataIndi
     {
         if (zclFrame.payload().size() < 4)
         {
-            DBG_Printf(DBG_INFO, "store scene response payload size too small %d\n", zclFrame.payload().size());
+            DBG_Printf(DBG_INFO, "store scene response payload size too small %d\n", (int)zclFrame.payload().size());
             return;
         }
 
@@ -12653,7 +12645,7 @@ void DeRestPluginPrivate::handleSceneClusterIndication(const deCONZ::ApsDataIndi
     {
         if (zclFrame.payload().size() < 4)
         {
-            DBG_Printf(DBG_INFO, "remove scene response payload size too small %d\n", zclFrame.payload().size());
+            DBG_Printf(DBG_INFO, "remove scene response payload size too small %d\n", (int)zclFrame.payload().size());
             return;
         }
 
@@ -12728,7 +12720,7 @@ void DeRestPluginPrivate::handleSceneClusterIndication(const deCONZ::ApsDataIndi
     {
         if (zclFrame.payload().size() < 4)
         {
-            DBG_Printf(DBG_INFO, "add scene response payload size too small %d\n", zclFrame.payload().size());
+            DBG_Printf(DBG_INFO, "add scene response payload size too small %d\n", (int)zclFrame.payload().size());
             return;
         }
 
@@ -12773,7 +12765,7 @@ void DeRestPluginPrivate::handleSceneClusterIndication(const deCONZ::ApsDataIndi
     {
         if (zclFrame.payload().size() < 4)
         {
-            DBG_Printf(DBG_INFO, "view scene response payload size too small %d\n", zclFrame.payload().size());
+            DBG_Printf(DBG_INFO, "view scene response payload size too small %d\n", (int)zclFrame.payload().size());
             return;
         }
 
@@ -12828,7 +12820,7 @@ void DeRestPluginPrivate::handleSceneClusterIndication(const deCONZ::ApsDataIndi
             quint16 ehue = 0;
             quint8 sat = 0;
 
-            DBG_Printf(DBG_INFO_L2, "View scene rsp 0x%016llX group 0x%04X scene 0x%02X\n", lightNode->address().ext(), groupId, sceneId);
+            DBG_Printf(DBG_INFO_L2, "View scene rsp " FMT_MAC " group 0x%04X scene 0x%02X\n", FMT_MAC_CAST(lightNode->address().ext()), groupId, sceneId);
 
             while (!stream.atEnd())
             {
@@ -14517,7 +14509,7 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
             if (item && (item->toNumber() & R_PENDING_MODE))
             {
                 // Some Aqara switches need to be configured to send proper button events, send the magic word
-                DBG_Printf(DBG_INFO, "Write Aqara switch 0x%016llX mode attribute 0x0009 = 1\n", sensor->address().ext());
+                DBG_Printf(DBG_INFO, "Write Aqara switch " FMT_MAC " mode attribute 0x0009 = 1\n", FMT_MAC_CAST(sensor->address().ext()));
                 deCONZ::ZclAttribute attr(0x0009, deCONZ::Zcl8BitUint, QLatin1String("mode"), deCONZ::ZclReadWrite, false);
                 attr.setValue(static_cast<quint64>(1));
                 writeAttribute(sensor, sensor->fingerPrint().endpoint, XIAOMI_CLUSTER_ID, attr, VENDOR_XIAOMI);
@@ -14535,7 +14527,7 @@ void DeRestPluginPrivate::delayedFastEnddeviceProbe(const deCONZ::NodeEvent *eve
 
             if (!attributes.empty() && readAttributes(sensor, sensor->fingerPrint().endpoint, XIAOMI_CLUSTER_ID, attributes, VENDOR_XIAOMI))
             {
-                DBG_Printf(DBG_INFO, "Read 0x%016llX motion sensitivity attribute 0x010C...\n", sensor->address().ext());
+                DBG_Printf(DBG_INFO, "Read " FMT_MAC " motion sensitivity attribute 0x010C...\n", FMT_MAC_CAST(sensor->address().ext()));
                 queryTime = queryTime.addSecs(1);
             }
         }
@@ -15041,7 +15033,6 @@ void DeRestPlugin::idleTimerFired()
         DeRestPluginPrivate::RecoverOnOff &rc = d->recoverOnOff.back();
         if ((d->idleTotalCounter - rc.idleTotalCounterCopy) > MAX_RECOVER_ENTRY_AGE)
         {
-            DBG_Printf(DBG_INFO, "Pop recover info for 0x%016llX\n", rc.address.ext());
             d->recoverOnOff.pop_back();
         }
     }


### PR DESCRIPTION
Depending on the architecture the handling of 64-bit data types is different. The `FMT_MAC` and `FMT_MAC_CAST` macros handle these.

Also removed some legacy noise debug prints.