### PR TITLE
Handle ZCL attribute octed strings (0x41) in Javascript

### DIFF
--- a/device_js/device_js_duktape.cpp
+++ b/device_js/device_js_duktape.cpp
@@ -450,6 +450,13 @@ static duk_ret_t DJS_GetAttributeValue(duk_context *ctx)
         break;
     }
 
+    case deCONZ::ZclOctedString:
+    {
+        QString str = attr->toString();
+        duk_push_string(ctx, qPrintable(str));
+        break;
+    }
+
     case deCONZ::ZclCharacterString:
     {
         QString str = attr->toString();
@@ -806,6 +813,10 @@ static duk_ret_t DJS_SetItemVal(duk_context *ctx)
             {
                 DBG_Printf(DBG_JS, "%s: %s --> %s\n", __FUNCTION__, item->descriptor().suffix, str);
                 ok = item->setValue(QString(QLatin1String(str, out_len)), ResourceItem::SourceDevice);
+            }
+            else
+            {
+                ok = item->setValue(QString(""), ResourceItem::SourceDevice);
             }
             duk_pop(ctx); /* conversion result*/
         }


### PR DESCRIPTION
These are used by Ikea devices for attr/productid. Also depends on another commit in core to yield correct strings.
The commit also allows setting empty strings via Javascript as some attributes can also be present but empty.