### PR TITLE
DDF clone for Bosch Radiator thermostat II +M

### DIFF
--- a/devices/bosch/thermostat2.json
+++ b/devices/bosch/thermostat2.json
@@ -1,8 +1,14 @@
 {
   "schema": "devcap1.schema.json",
   "uuid": "a29c3216-a9eb-49ae-a62b-c604c3167b41",
-  "manufacturername": "BOSCH",
-  "modelid": "RBSH-TRV0-ZB-EU",
+  "manufacturername": [
+    "BOSCH",
+    "BOSCH"
+  ],
+  "modelid": [
+    "RBSH-TRV0-ZB-EU",
+    "RBSH-TRV1-ZB-EU"
+  ],
   "vendor": "Bosch",
   "product": "Thermostat II (BTH-RA)",
   "sleeper": false,


### PR DESCRIPTION
Product name: Radiator thermostat II +M
Manufacturer: BOSCH
Model identifier: RBSH-TRV1-ZB-EU

See #8423