### PR TITLE
Fix potential crash when closing deCONZ

### DIFF
--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -946,6 +946,7 @@ DeRestPluginPrivate::~DeRestPluginPrivate()
         inetDiscoveryManager->deleteLater();
         inetDiscoveryManager = 0;
     }
+    upnpTimer->stop();
     delete deviceJs;
     deviceJs = nullptr;
     eventEmitter = nullptr;

--- a/upnp.cpp
+++ b/upnp.cpp
@@ -115,6 +115,11 @@ void DeRestPluginPrivate::initDescriptionXml()
 /*! Sends SSDP broadcast for announcement. */
 void DeRestPluginPrivate::announceUpnp()
 {
+    if (!apsCtrl)
+    {
+        return;
+    }
+
     if (udpSock->state() != QAbstractSocket::BoundState)
     {
         joinedMulticastGroup = false;


### PR DESCRIPTION
If the UPNP timer triggers right in that moment there is a nullptr dereference.