### PR TITLE
Disable legacy /gateways endpoint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.13)
 
 project(de_rest_plugin VERSION 2.32.02 LANGUAGES C;CXX)
 
+option(USE_GATEWAY_API  "Enable legacy gateway api code" OFF)
+
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 set(CMAKE_AUTOUIC ON)
@@ -79,8 +81,6 @@ set(PLUGIN_INCLUDE_FILES
     event.h
     event_emitter.h
     fan_control.h
-    gateway.h
-    gateway_scanner.h
     green_power.h
     group.h
     group_info.h
@@ -126,6 +126,10 @@ set(PLUGIN_INCLUDE_FILES
     zdp/zdp.h
     zdp/zdp_handlers.h
     )
+
+if (USE_GATEWAY_API)
+    list(APPEND PLUGIN_INCLUDE_FILES gateway.h gateway_scanner.h)
+endif()
 
 add_library(${PROJECT_NAME} SHARED
     ${PLUGIN_INCLUDE_FILES}
@@ -173,8 +177,6 @@ add_library(${PROJECT_NAME} SHARED
     event_queue.cpp
     fan_control.cpp
     firmware_update.cpp
-    gateway.cpp
-    gateway_scanner.cpp
     green_power.cpp
     group.cpp
     group_info.cpp
@@ -202,7 +204,6 @@ add_library(${PROJECT_NAME} SHARED
     rest_configuration.cpp
     rest_ddf.cpp
     rest_devices.cpp
-    rest_gateways.cpp
     rest_groups.cpp
     rest_info.cpp
     rest_lights.cpp
@@ -283,6 +284,11 @@ target_compile_definitions(${PROJECT_NAME}
     GW_MIN_DERFUSB23E0X_FW_VERSION=0x22030300
     GW_DEFAULT_NAME="\"\"Phoscon-GW\"\""
 )
+
+if (USE_GATEWAY_API)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE USE_GATEWAY_API)
+    target_sources(${PROJECT_NAME} PRIVATE  gateway.cpp  gateway_scanner.cpp rest_gateways.cpp)
+endif()
 
 target_include_directories(${PROJECT_NAME} PRIVATE cj)
 

--- a/database.cpp
+++ b/database.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2016-2025 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -22,7 +22,9 @@
 #include "deconz/u_sstream_ex.h"
 #include "deconz/u_memory.h"
 #include "device_descriptions.h"
+#ifdef USE_GATEWAY_API
 #include "gateway.h"
+#endif
 #include "json.h"
 #include "product_match.h"
 #include "utils/ArduinoJson.h"
@@ -73,7 +75,9 @@ static int sqliteLoadAllRulesCallback(void *user, int ncols, char **colval , cha
 static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , char **colname);
 static int sqliteGetAllLightIdsCallback(void *user, int ncols, char **colval , char **colname);
 static int sqliteGetAllSensorIdsCallback(void *user, int ncols, char **colval , char **colname);
+#ifdef USE_GATEWAY_API
 static int sqliteLoadAllGatewaysCallback(void *user, int ncols, char **colval , char **colname);
+#endif
 
 /******************************************************************************
                     Implementation
@@ -1432,7 +1436,9 @@ void DeRestPluginPrivate::readDb()
     loadAllRulesFromDb();
     loadAllSchedulesFromDb();
     loadAllSensorsFromDb();
+#ifdef USE_GATEWAY_API
     loadAllGatewaysFromDb();
+#endif
 }
 
 /*! Sqlite callback to load authorisation data.
@@ -4576,6 +4582,7 @@ void DeRestPluginPrivate::loadAllSensorsFromDb()
     }
 }
 
+#ifdef USE_GATEWAY_API
 /*! Loads all gateways from database
  */
 void DeRestPluginPrivate::loadAllGatewaysFromDb()
@@ -4604,6 +4611,7 @@ void DeRestPluginPrivate::loadAllGatewaysFromDb()
         }
     }
 }
+#endif // USE_GATEWAY_API
 
 /*! Sqlite callback to load all light ids into temporary array.
  */
@@ -4725,7 +4733,7 @@ static int sqliteGetAllSensorIdsCallback(void *user, int ncols, char **colval , 
     return 0;
 }
 
-
+#ifdef USE_GATEWAY_API
 static int sqliteLoadAllGatewaysCallback(void *user, int ncols, char **colval , char **colname)
 {
     DBG_Assert(user != 0);
@@ -4801,6 +4809,7 @@ static int sqliteLoadAllGatewaysCallback(void *user, int ncols, char **colval , 
 
     return 0;
 }
+#endif // USE_GATEWAY_API
 
 /*! Determines a unused id for a sensor.
  */
@@ -5191,6 +5200,7 @@ void DeRestPluginPrivate::saveDb()
     // save gateways
     if (saveDatabaseItems & DB_GATEWAYS)
     {
+#ifdef USE_GATEWAY_API
         std::vector<Gateway*>::iterator i = gateways.begin();
         std::vector<Gateway*>::iterator end = gateways.end();
 
@@ -5262,7 +5272,7 @@ void DeRestPluginPrivate::saveDb()
                 }
             }
         }
-
+#endif // USE_GATEWAY_API
         saveDatabaseItems &= ~DB_GATEWAYS;
     }
 

--- a/de_web_plugin.cpp
+++ b/de_web_plugin.cpp
@@ -46,7 +46,9 @@
 #include "de_web_plugin_private.h"
 #include "de_web_widget.h"
 #include "ui/device_widget.h"
+#ifdef USE_GATEWAY_API
 #include "gateway_scanner.h"
+#endif
 #include "ias_ace.h"
 #include "ias_zone.h"
 #include "json.h"
@@ -650,11 +652,12 @@ DeRestPluginPrivate::DeRestPluginPrivate(QObject *parent) :
 
     webSocketServer = 0;
 
+#ifdef USE_GATEWAY_API
     gwScanner = new GatewayScanner(this);
     connect(gwScanner, SIGNAL(foundGateway(QHostAddress,quint16,QString,QString)),
             this, SLOT(foundGateway(QHostAddress,quint16,QString,QString)));
 //    gwScanner->startScan();
-
+#endif
     QString dataPath = deCONZ::getStorageLocation(deCONZ::ApplicationsDataLocation);
 
     saveDatabaseItems = 0;
@@ -1263,7 +1266,9 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
 
         case SCENE_CLUSTER_ID:
             handleSceneClusterIndication(ind, zclFrame);
+#ifdef USE_GATEWAY_API
             handleClusterIndicationGateways(ind, zclFrame);
+#endif
             break;
 
         case OTAU_CLUSTER_ID:
@@ -1275,14 +1280,18 @@ void DeRestPluginPrivate::apsdeDataIndication(const deCONZ::ApsDataIndication &i
             break;
 
         case LEVEL_CLUSTER_ID:
+#ifdef USE_GATEWAY_API
             handleClusterIndicationGateways(ind, zclFrame);
+#endif
             break;
 
         case ONOFF_CLUSTER_ID:
             if (!DEV_TestStrict())
             {
                 handleOnOffClusterIndication(ind, zclFrame);
+#ifdef USE_GATEWAY_API
                 handleClusterIndicationGateways(ind, zclFrame);
+#endif
             }
             break;
 
@@ -15935,10 +15944,12 @@ int DeRestPlugin::handleHttpRequest(const QHttpRequestHeader &hdr, QTcpSocket *s
                 {
                     ret = d->handleUserparameterApi(req, rsp);
                 }
+#ifdef USE_GATEWAY_API
                 else if (apiModule == QLatin1String("gateways"))
                 {
                     ret = d->handleGatewaysApi(req, rsp);
                 }
+#endif // USE_GATEWAY_API
                 else if (apiModule == QLatin1String("alarmsystems") && d->alarmSystems)
                 {
                     ret = AS_handleAlarmSystemsApi(req, rsp, *d->alarmSystems, d->eventEmitter);

--- a/de_web_plugin_private.h
+++ b/de_web_plugin_private.h
@@ -667,8 +667,10 @@ const deCONZ::Node *getCoreNode(uint64_t extAddress);
 class DeviceDescriptions;
 class DeviceWidget;
 class DeviceJs;
+#ifdef USE_GATEWAY_API
 class Gateway;
 class GatewayScanner;
+#endif
 class QUdpSocket;
 class QTcpSocket;
 class DeRestPlugin;
@@ -964,6 +966,7 @@ public:
     bool allowedToCreateApikey(const ApiRequest &req, ApiResponse &rsp, QVariantMap &map);
     void authorise(ApiRequest &req, ApiResponse &rsp);
 
+#ifdef USE_GATEWAY_API
     // REST API gateways
     int handleGatewaysApi(const ApiRequest &req, ApiResponse &rsp);
     int getAllGateways(const ApiRequest &req, ApiResponse &rsp);
@@ -972,6 +975,7 @@ public:
     int addCascadeGroup(const ApiRequest &req, ApiResponse &rsp);
     int deleteCascadeGroup(const ApiRequest &req, ApiResponse &rsp);
     void gatewayToMap(const ApiRequest &req, const Gateway *gw, QVariantMap &map);
+#endif
 
     // REST API configuration
     void initConfig();
@@ -1303,8 +1307,10 @@ public Q_SLOTS:
     void timeManagerTimerFired();
     void ntpqFinished();
 
+#ifdef USE_GATEWAY_API
     // gateways
     void foundGateway(const QHostAddress &host, quint16 port, const QString &uuid, const QString &name);
+#endif // USE_GATEWAY_API
 
     // window covering
     void calibrateWindowCoveringNextStep();
@@ -1447,7 +1453,9 @@ public:
     void handleGroupClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleSceneClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     void handleOnOffClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
+#ifdef USE_GATEWAY_API
     void handleClusterIndicationGateways(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
+#endif // USE_GATEWAY_API
     void handleIasZoneClusterIndication(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
     bool sendIasZoneEnrollResponse(Sensor *sensor);
     bool sendIasZoneEnrollResponse(const deCONZ::ApsDataIndication &ind, deCONZ::ZclFrame &zclFrame);
@@ -1538,7 +1546,9 @@ public:
     void loadAllSensorsFromDb();
     void loadSensorDataFromDb(Sensor *sensor, QVariantList &ls, qint64 fromTime, int max);
     void loadLightDataFromDb(LightNode *lightNode, QVariantList &ls, qint64 fromTime, int max);
+#ifdef USE_GATEWAY_API
     void loadAllGatewaysFromDb();
+#endif // USE_GATEWAY_API
     void saveDb();
     void saveApiKey(QString apikey);
     void closeDb();
@@ -1567,8 +1577,10 @@ public:
     std::vector<ButtonProduct> buttonProductMap;
 
     // gateways
+#ifdef USE_GATEWAY_API
     std::vector<Gateway*> gateways;
     GatewayScanner *gwScanner;
+#endif
 
     // authorisation
     QElapsedTimer apiAuthSaveDatabaseTime;

--- a/rest_configuration.cpp
+++ b/rest_configuration.cpp
@@ -1408,6 +1408,7 @@ int DeRestPluginPrivate::getBasicConfig(const ApiRequest &req, ApiResponse &rsp)
         }
     }
 
+#ifdef USE_GATEWAY_API
     // add more details if this was requested from discover page
     // this should speedup multi-gateway discovery
     if (!gateways.empty())
@@ -1435,6 +1436,7 @@ int DeRestPluginPrivate::getBasicConfig(const ApiRequest &req, ApiResponse &rsp)
             }
         }
     }
+#endif // USE_GATEWAY_API
 
     rsp.httpStatus = HttpStatusOk;
     rsp.etag = gwConfigEtag;

--- a/upnp.cpp
+++ b/upnp.cpp
@@ -16,7 +16,9 @@
 #include <QUdpSocket>
 #include <QVariantMap>
 #include "de_web_plugin_private.h"
+#ifdef USE_GATEWAY_API
 #include "gateway_scanner.h"
+#endif
 
 /*! Inits the UPnP discorvery. */
 void DeRestPluginPrivate::initUpnpDiscovery()
@@ -341,11 +343,12 @@ void DeRestPluginPrivate::upnpReadyRead()
                     continue;
                 }
 
+#ifdef USE_GATEWAY_API
                 // http://192.168.14.103:80/description.xml
-
                 QUrl url(ls[1]);
                 location = QString("http://%1:%2/api/config").arg(url.host()).arg(url.port(80));
                 gwScanner->queryGateway(location);
+#endif // USE_GATEWAY_API
             }
         }
     }


### PR DESCRIPTION
This is an old unofficial and undocumented API. It was used in a customer project to cascade multiple gateways to forward group commands between them.

However this hasn't been used or maintained in years and the networking code shows errors. Therefore disable it by default for now (compile time option).

It is a breaking change but the number of users should be zero ;)