### PR TITLE
Remove `state/power_divisor` from Sonoff smart Plug (S60ZBTPF)

### DIFF
--- a/devices/sonoff/s60zbtpf_smart_plug.json
+++ b/devices/sonoff/s60zbtpf_smart_plug.json
@@ -4,7 +4,7 @@
   "manufacturername": "SONOFF",
   "modelid": "S60ZBTPF",
   "vendor": "Sonoff",
-  "product": "Zigbee smart plug",
+  "product": "Smart plug (S60ZBTPF)",
   "sleeper": false,
   "status": "Gold",
   "subdevices": [


### PR DESCRIPTION
`state/power_divisor` is not necessary for this device and has therefore been removed. It was a mistake, sorry