### PR TITLE
Remove `state/lowbattery` from ZG-204Z

### DIFF
--- a/devices/hobeian/hobeian_presence_sensor.json
+++ b/devices/hobeian/hobeian_presence_sensor.json
@@ -115,9 +115,6 @@
           "name": "state/lastupdated"
         },
         {
-          "name": "state/lowbattery"
-        },
-        {
           "name": "state/presence",
           "awake": true,
           "parse": {


### PR DESCRIPTION
Remove `state/lowbattery` as this device does not support it.