### PR TITLE
Add `externalsensortemp` to Bosch room thermostat II (BTH-RM/BTH-RM230Z)

### DIFF
--- a/devices/bosch/room_thermostat2.json
+++ b/devices/bosch/room_thermostat2.json
@@ -106,6 +106,35 @@
           "default": 14400
         },
         {
+          "name": "config/externalsensortemp",
+          "refresh.interval": 360,
+          "read": {
+            "at": "0x4051",
+            "cl": "0x0201",
+            "ep": 1,
+            "fn": "zcl:attr",
+            "mf": "0x1209"
+          },
+          "parse": {
+            "at": "0x4051",
+            "cl": "0x0201",
+            "ep": 1,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl:attr",
+            "mf": "0x1209"
+          },
+          "write": {
+            "at": "0x4051",
+            "cl": "0x0201",
+            "dt": "0x29",
+            "ep": 1,
+            "eval": "Item.val",
+            "fn": "zcl:attr",
+            "mf": "0x1209"
+          },
+          "default": 0
+        },
+        {
           "name": "config/externalwindowopen",
           "refresh.interval": 3660,
           "read": {

--- a/devices/bosch/room_thermostat2_230V.json
+++ b/devices/bosch/room_thermostat2_230V.json
@@ -82,6 +82,35 @@
           "refresh.interval": 360
         },
         {
+          "name": "config/externalsensortemp",
+          "refresh.interval": 360,
+          "read": {
+            "at": "0x4051",
+            "cl": "0x0201",
+            "ep": 1,
+            "fn": "zcl:attr",
+            "mf": "0x1209"
+          },
+          "parse": {
+            "at": "0x4051",
+            "cl": "0x0201",
+            "ep": 1,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl:attr",
+            "mf": "0x1209"
+          },
+          "write": {
+            "at": "0x4051",
+            "cl": "0x0201",
+            "dt": "0x29",
+            "ep": 1,
+            "eval": "Item.val",
+            "fn": "zcl:attr",
+            "mf": "0x1209"
+          },
+          "default": 0
+        },
+        {
           "name": "config/externalwindowopen",
           "refresh.interval": 3660,
           "read": {
@@ -158,14 +187,14 @@
             "cl": "0x0201",
             "dt": "0x28",
             "ep": 1,
-            "eval": "Item.val / 10",
+            "eval": "Item.val / 10;",
             "fn": "zcl:attr"
           },
           "parse": {
             "at": "0x0010",
             "cl": "0x0201",
             "ep": 1,
-            "eval": "Item.val = Attr.val * 10",
+            "eval": "Item.val = Attr.val * 10;",
             "fn": "zcl:attr"
           }
         },
@@ -306,7 +335,7 @@
             "at": "0x4020",
             "cl": "0x0201",
             "ep": 1,
-            "eval": "Item.val = Attr.val;",
+            "eval": "Item.val = Attr.val",
             "fn": "zcl:attr",
             "mf": "0x1209"
           },
@@ -400,7 +429,7 @@
             "at": "0x0000",
             "cl": "0x0405",
             "ep": 1,
-            "eval": "Item.val = Attr.val + R.item('config/offset').val",
+            "eval": "Item.val = Attr.val + R.item('config/offset').val;",
             "fn": "zcl:attr"
           }
         },

--- a/devices/bosch/thermostat2.json
+++ b/devices/bosch/thermostat2.json
@@ -77,7 +77,7 @@
             "at": "0x0021",
             "cl": "0x0001",
             "ep": 1,
-            "eval": "Item.val = Attr.val / 2;",
+            "eval": "Item.val = Attr.val / 2",
             "fn": "zcl:attr"
           },
           "read": {
@@ -106,7 +106,7 @@
             "at": "0x400B",
             "cl": "0x0204",
             "ep": 1,
-            "eval": "Item.val = Attr.val;",
+            "eval": "Item.val = Attr.val",
             "fn": "zcl:attr",
             "mf": "0x1209"
           },
@@ -135,7 +135,7 @@
             "at": "0x4040",
             "cl": "0x0201",
             "ep": 1,
-            "eval": "Item.val = Attr.val;",
+            "eval": "Item.val = Attr.val",
             "fn": "zcl:attr",
             "mf": "0x1209"
           },
@@ -164,7 +164,7 @@
             "at": "0x4042",
             "cl": "0x0201",
             "ep": 1,
-            "eval": "Item.val = Attr.val;",
+            "eval": "Item.val = Attr.val",
             "fn": "zcl:attr",
             "mf": "0x1209"
           },
@@ -294,7 +294,7 @@
             "at": "0x5000",
             "cl": "0x0201",
             "ep": 1,
-            "eval": "Item.val = Attr.val;",
+            "eval": "Item.val = Attr.val",
             "fn": "zcl:attr",
             "mf": "0x1209"
           },
@@ -330,7 +330,7 @@
             "at": "0x0000",
             "cl": "0x0201",
             "ep": 1,
-            "eval": "Item.val = Attr.val;",
+            "eval": "Item.val = Attr.val",
             "fn": "zcl:attr"
           },
           "read": {
@@ -347,7 +347,7 @@
             "at": "0x4020",
             "cl": "0x0201",
             "ep": 1,
-            "eval": "Item.val = Attr.val;",
+            "eval": "Item.val = Attr.val",
             "fn": "zcl:attr",
             "mf": "0x1209"
           },


### PR DESCRIPTION
I've been searching for the address `0x4051` for quite some time now, and it seems to have been discovered on [zigpy](https://github.com/zigpy/zha-device-handlers/blob/dev/zhaquirks/bosch/rbsh_rth0_zb_eu.py#L424). It can then be used, for example, to display the outside temperature.

Additionally, the DDFs are formatted.