### PR TITLE
DDF clone for Tuya water leak sensor (_TZ3000_upgcbody / SNZB-05)

### DIFF
--- a/devices/tuya/_TZ3000_TS0207_water_leak_sensor.json
+++ b/devices/tuya/_TZ3000_TS0207_water_leak_sensor.json
@@ -20,7 +20,8 @@
     "_TZ3000_kstbkt6a",
     "_TZ3000_arw23zcs",
     "_TZ3000_amis43tj",
-    "_TZ3000_wuep9zng"
+    "_TZ3000_wuep9zng",
+    "_TZ3000_upgcbody"
   ],
   "modelid": [
     "TS0207",
@@ -41,7 +42,8 @@
     "TS0207",
     "TS0207",
     "TS0207",
-    "TS0207"
+    "TS0207",
+    "SNZB-05"
   ],
   "vendor": "Tuya",
   "product": "Water leak sensor (TS0207)",


### PR DESCRIPTION
https://github.com/dresden-elektronik/deconz-rest-plugin/issues/8194 
Modified standard DDF to add support for clone

<img width="788" height="460" alt="image" src="https://github.com/user-attachments/assets/c5340b9d-d0fd-4c0b-a210-c4cdeb4715c0" />
<img width="684" height="510" alt="image" src="https://github.com/user-attachments/assets/5ae3702b-a47f-46ab-9b15-d203ee944d99" />
<img width="676" height="487" alt="image" src="https://github.com/user-attachments/assets/5f83cd8d-8cf2-4adb-bed6-cc410f4c864e" />
