### PR TITLE
DDF clone for Tuya Range extender (_TZ3210_amleyeej)

### DIFF
--- a/devices/tuya/_TZ3000__TS0207_range_extender.json
+++ b/devices/tuya/_TZ3000__TS0207_range_extender.json
@@ -5,13 +5,15 @@
     "_TZ3000_m0vaazab",
     "_TZ3000_ufttklsz",
     "_TZ3000_5k5vh43t",
-    "_TZ3000_gszjt2xx"
+    "_TZ3000_gszjt2xx",
+    "_TZ3210_amleyeej"
   ],
   "modelid": [
     "TS0207",
     "TS0207",
     "TS0207",
-    "TS0207"
+    "TS0207",
+    "TS0501B"
   ],
   "vendor": "Tuya",
   "product": "Range Extender (TS0207)",


### PR DESCRIPTION
Product name: ZigBee Range Extender
Manufacturer: _TZ3210_amleyeej
Model identifier: TS0501B

See product : https://www.aliexpress.com/item/1005009792693789.html