### PR TITLE
DDF for Moes CO sensor (ZC-HM)

### DIFF
--- a/devices/moes/Moes_ZC-HM_co_sensor.json
+++ b/devices/moes/Moes_ZC-HM_co_sensor.json
@@ -91,8 +91,9 @@
         {
           "name": "state/alert",
           "write": {
-            "dpid": 16,
             "fn": "tuya",
+            "dpid": 16,
+            "dt": "0x10",
             "eval": "if (Item.val=='none') { true }"
           },
           "read": {
@@ -204,9 +205,9 @@
         {
           "name": "state/measured_value",
           "parse": {
+            "fn": "tuya",
             "dpid": 2,
-            "eval": "Item.val = Attr.val",
-            "fn": "tuya"
+            "eval": "Item.val = Attr.val"
           },
           "read": {
             "fn": "none"


### PR DESCRIPTION
Product name: Moes CO sensor
Manufacturer: _TZE284_rjxqso4a
Model identifier: TS0601

See #8469