### PR TITLE
Order corrected in `config/mode` (BTH-RM/BTH-RM230Z)

### DIFF
--- a/devices/bosch/room_thermostat2.json
+++ b/devices/bosch/room_thermostat2.json
@@ -31,8 +31,8 @@
         "values": {
           "config/mode": {
             "off": 0,
-            "heat": 3,
-            "cool": 4
+            "cool": 3,
+            "heat": 4
           }
         }
       },

--- a/devices/bosch/room_thermostat2_230V.json
+++ b/devices/bosch/room_thermostat2_230V.json
@@ -30,8 +30,8 @@
         "values": {
           "config/mode": {
             "off": 0,
-            "heat": 3,
-            "cool": 4
+            "cool": 3,
+            "heat": 4
           }
         }
       },


### PR DESCRIPTION
I don't think anything has changed, but it just didn't fit together.