### PR TITLE
Update DDF for Sinope TH1124ZB thermostat

### DIFF
--- a/devices/sinope/th1124zb_thermostat.json
+++ b/devices/sinope/th1124zb_thermostat.json
@@ -134,6 +134,10 @@
           "default": true
         },
         {
+          "name": "config/locked",
+          "refresh.interval": 3660
+        },
+        {
           "name": "config/mode",
           "refresh.interval": 3600,
           "read": {


### PR DESCRIPTION
The DDF could be further extended using  [Z2M](https://www.zigbee2mqtt.io/devices/TH1124ZB.html).
- Change `config/mode` => `off` and `heat` 
- Change `config/offset`
- Add `config/locked`
- Remove double `config/unoccupiedheatsetpoint`
- Change `state/temperature`
- Change `state/on`
- Add bindings