### PR TITLE
DDF for SMLight router SLZB-06U

### DIFF
--- a/devices/smlight/slzb-06u_router.json
+++ b/devices/smlight/slzb-06u_router.json
@@ -1,0 +1,51 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "TexasInstruments",
+  "modelid": "ti.router",
+  "vendor": "SMLight",
+  "product": "Router (SLZB-06U)",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_RANGE_EXTENDER",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Product name: SLZB-06U
Manufacturer: TexasInstruments
Model identifier: ti.router

See #8504