### PR TITLE
Update DDF for OTH4000-ZB thermostat

### DIFF
--- a/devices/ouellet/oth4000-zb_thermostat.json
+++ b/devices/ouellet/oth4000-zb_thermostat.json
@@ -27,6 +27,14 @@
           "0x0B05"
         ]
       },
+      "meta": {
+        "values": {
+          "config/mode": {
+            "off": 0,
+            "heat": 4
+          }
+        }
+      },
       "items": [
         {
           "name": "attr/id"
@@ -65,20 +73,20 @@
             "fn": "zcl:attr",
             "mf": "0x119c"
           },
+          "parse": {
+            "at": "0x0010",
+            "cl": "0xff01",
+            "ep": 1,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl:attr",
+            "mf": "0x119c"
+          },
           "write": {
             "at": "0x0010",
             "cl": "0xff01",
             "dt": "0x29",
             "ep": 1,
             "eval": "Item.val",
-            "fn": "zcl:attr",
-            "mf": "0x119c"
-          },
-          "parse": {
-            "at": "0x0010",
-            "cl": "0xff01",
-            "ep": 1,
-            "eval": "Item.val = Attr.val",
             "fn": "zcl:attr",
             "mf": "0x119c"
           },
@@ -98,6 +106,14 @@
             "fn": "zcl:attr",
             "mf": "0x119c"
           },
+          "parse": {
+            "at": "0x0402",
+            "cl": "0x0201",
+            "ep": 1,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl:attr",
+            "mf": "0x119c"
+          },
           "write": {
             "at": "0x0402",
             "cl": "0x0201",
@@ -107,22 +123,62 @@
             "fn": "zcl:attr",
             "mf": "0x119c"
           },
-          "parse": {
-            "at": "0x0402",
-            "cl": "0x0201",
-            "ep": 1,
-            "eval": "Item.val = Attr.val",
-            "fn": "zcl:attr",
-            "mf": "0x119c"
-          },
           "default": 1
         },
         {
-          "name": "config/mode"
+          "name": "config/locked",
+          "refresh.interval": 3660
+        },
+        {
+          "name": "config/mode",
+          "refresh.interval": 3600,
+          "read": {
+            "at": "0x001C",
+            "cl": "0x0201",
+            "ep": 1,
+            "fn": "zcl:attr"
+          },
+          "parse": {
+            "at": "0x001C",
+            "cl": "0x0201",
+            "ep": 1,
+            "eval": "if (Attr.val == 0) { Item.val = 'off' } else if (Attr.val == 4) { Item.val = 'heat' };",
+            "fn": "zcl:attr"
+          },
+          "write": {
+            "at": "0x001C",
+            "cl": "0x0201",
+            "dt": "0x30",
+            "ep": 1,
+            "eval": "if (Item.val == 'off') { 0 } else if (Item.val == 'heat') { 4 };",
+            "fn": "zcl:attr"
+          },
+          "default": "heat"
         },
         {
           "name": "config/offset",
-          "default": 0
+          "refresh.interval": 3660,
+          "read": {
+            "at": "0x0010",
+            "cl": "0x0201",
+            "ep": 1,
+            "fn": "zcl:attr"
+          },
+          "parse": {
+            "at": "0x0010",
+            "cl": "0x0201",
+            "ep": 1,
+            "eval": "Item.val = Attr.val * 10;",
+            "fn": "zcl:attr"
+          },
+          "write": {
+            "at": "0x0010",
+            "cl": "0x0201",
+            "dt": "0x28",
+            "ep": 1,
+            "eval": "Item.val / 10;",
+            "fn": "zcl:attr"
+          }
         },
         {
           "name": "config/on"
@@ -143,8 +199,14 @@
             "at": "0x0014",
             "cl": "0x0201",
             "ep": 1,
-            "fn": "zcl:attr",
-            "mf": "0x119c"
+            "fn": "zcl:attr"
+          },
+          "parse": {
+            "at": "0x0014",
+            "cl": "0x0201",
+            "ep": 1,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl:attr"
           },
           "write": {
             "at": "0x0014",
@@ -152,16 +214,7 @@
             "dt": "0x29",
             "ep": 1,
             "eval": "Item.val",
-            "fn": "zcl:attr",
-            "mf": "0x119c"
-          },
-          "parse": {
-            "at": "0x0014",
-            "cl": "0x0201",
-            "ep": 1,
-            "eval": "Item.val = Attr.val",
-            "fn": "zcl:attr",
-            "mf": "0x119c"
+            "fn": "zcl:attr"
           },
           "default": 1800
         },
@@ -172,7 +225,17 @@
           "name": "state/lastupdated"
         },
         {
-          "name": "state/on"
+          "name": "state/on",
+          "parse": {
+            "at": "0x0008",
+            "cl": "0x0201",
+            "ep": 1,
+            "eval": "Item.val = Attr.val > 3;",
+            "fn": "zcl:attr"
+          },
+          "read": {
+            "fn": "none"
+          }
         },
         {
           "name": "state/temperature",
@@ -187,7 +250,7 @@
             "at": "0x0000",
             "cl": "0x0201",
             "ep": 1,
-            "eval": "Item.val = Attr.val + R.item('config/offset').val",
+            "eval": "Item.val = Attr.val",
             "fn": "zcl:attr"
           },
           "default": 0
@@ -199,16 +262,14 @@
             "at": "0x0008",
             "cl": "0x0201",
             "ep": 1,
-            "fn": "zcl:attr",
-            "mf": "0x119c"
+            "fn": "zcl:attr"
           },
           "parse": {
             "at": "0x0008",
             "cl": "0x0201",
             "ep": 1,
             "eval": "Item.val = Attr.val",
-            "fn": "zcl:attr",
-            "mf": "0x119c"
+            "fn": "zcl:attr"
           },
           "default": 0
         }
@@ -477,6 +538,48 @@
       "bind": "unicast",
       "src.ep": 1,
       "dst.ep": 1,
+      "cl": "0x0201",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x29",
+          "min": 60,
+          "max": 300,
+          "change": "0x00000032"
+        },
+        {
+          "at": "0x0008",
+          "dt": "0x20",
+          "min": 60,
+          "max": 300,
+          "change": "0x00000001"
+        },
+        {
+          "at": "0x0012",
+          "dt": "0x29",
+          "min": 1,
+          "max": 300,
+          "change": "0x00000001"
+        },
+        {
+          "at": "0x0014",
+          "dt": "0x29",
+          "min": 1,
+          "max": 300,
+          "change": "0x00000001"
+        },
+        {
+          "at": "0x001C",
+          "dt": "0x30",
+          "min": 1,
+          "max": 300
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
       "cl": "0x0204",
       "report": [
         {
@@ -513,20 +616,6 @@
           "min": 1,
           "max": 300,
           "change": "0x00000001"
-        }
-      ]
-    },
-    {
-      "bind": "unicast",
-      "src.ep": 1,
-      "cl": "0x0201",
-      "report": [
-        {
-          "at": "0x0000",
-          "dt": "0x29",
-          "min": 30,
-          "max": 300,
-          "change": "0x0000000A"
         }
       ]
     },


### PR DESCRIPTION
The DDF could be further extended using  [Z2M](https://www.zigbee2mqtt.io/devices/TH1124ZB.html).
- Change `config/mode` => `off` and `heat` 
- Change `config/offset`
- Add `config/locked`
- Change `state/temperature`
- Change `state/on`
- Add bindings