### PR TITLE
Add Sonoff specific cluster data to general.xml

### DIFF
--- a/general.xml
+++ b/general.xml
@@ -142,18 +142,18 @@
             <value name="Emergency mains and transfer switch" value="6"></value>
             <value name="Unknown with battery backup" value="0x80"></value>
             <value name="Mains (single phase) with battery backup" value="0x81"></value>
-	          <value name="Mains (3 phase) with battery backup" value="0x82"></value>
-	          <value name="Battery with battery backup" value="0x83"></value>
+            <value name="Mains (3 phase) with battery backup" value="0x82"></value>
+            <value name="Battery with battery backup" value="0x83"></value>
             <value name="DC Source with battery backup" value="0x84"></value>
             <value name="Emergency mains constantly powered with battery backup" value="0x85"></value>
             <value name="Emergency mains and transfer switch with battery backup" value="0x86"></value>
           </attribute>
-          <attribute id="0x0008" name="Generic Device Class" type="enum8" default="0xff" access="r" required="o" >
+          <attribute id="0x0008" name="Generic Device Class" type="enum8" default="0xff" access="r" required="o">
             <description>IKEA control outlet specific.</description>
             <value name="Lighting" value="0"></value>
             <value name="Unspecified" value="0xff"></value>
           </attribute>
-          <attribute id="0x0009" name="Generic Device Type" type="enum8" default="0xff" access="r" required="o" >
+          <attribute id="0x0009" name="Generic Device Type" type="enum8" default="0xff" access="r" required="o">
             <description>IKEA control outlet specific.</description>
             <value name="Incandescent" value="0"></value>
             <value name="Spotlight Halogen" value="1"></value>
@@ -180,18 +180,18 @@
             <value name="Retrofit Actuator" value="0xf4"></value>
             <value name="Unspecified" value="0xff"></value>
           </attribute>
-          <attribute id="0x000a" name="Product code" type="ostring" access="r" required="o" >
+          <attribute id="0x000a" name="Product code" type="ostring" access="r" required="o">
             <description>As printed on the product.</description>
           </attribute>
-    <attribute id="0x000b" name="Product URL" type="cstring" access="r" required="o" range="0,50"></attribute>
-    <attribute id="0x000c" name="Manufacturer Version Details" type="cstring" access="r" required="o"></attribute>
-    <attribute id="0x000d" name="Serial Number" type="cstring" access="r" required="o"></attribute>
-    <attribute id="0x000e" name="Product Label" type="cstring" access="r" required="o"></attribute>
+          <attribute id="0x000b" name="Product URL" type="cstring" access="r" required="o" range="0,50"></attribute>
+          <attribute id="0x000c" name="Manufacturer Version Details" type="cstring" access="r" required="o"></attribute>
+          <attribute id="0x000d" name="Serial Number" type="cstring" access="r" required="o"></attribute>
+          <attribute id="0x000e" name="Product Label" type="cstring" access="r" required="o"></attribute>
           <attribute id="0x4000" name="SW Build ID" type="cstring" access="r" required="o" range="0,16"></attribute>
           <attribute id="0xfffd" name="Cluster Revision" type="u16" default="0" access="rw" required="o"></attribute>
-    <attribute id="0xfffe" name="Tuya magic spell final attribute" type="enum8" default="0" access="rw" required="o">
-    <description>Read attributes in this order Manufacturer name,ZCL version,Application version,Model Identifier,Power source and finally this one"</description>
-    </attribute>
+          <attribute id="0xfffe" name="Tuya magic spell final attribute" type="enum8" default="0" access="rw" required="o">
+            <description>Read attributes in this order Manufacturer name,ZCL version,Application version,Model Identifier,Power source and finally this one"</description>
+          </attribute>
         </attribute-set>
         <attribute-set id="0x0010" description="Basic Device Settings">
           <attribute id="0x0010" name="Location Description" type="cstring" range="0,16" access="rw" required="o"></attribute>
@@ -381,9 +381,9 @@
             <value name="0x02 - Indicate motion detection" value="1"></value>
           </attribute>
         </attribute-set>
-        
-        
-        
+
+
+
         <attribute-set id="0x9000" description="Sunricher specific" mfcode="0x1224">
           <attribute id="0x8806" name="Dimming brightness curve" type="u8" default="0x00" access="rw" required="m" mfcode="0x1224">
             <description>Works after reset power of the device.
@@ -412,13 +412,10 @@
               1: enabled.</description>
           </attribute>
           <attribute id="0x8907" name="Send ON/OFF command to the touchlink devices" type="u8" default="0x01" access="rw" required="m" mfcode="0x1224">
-            <description>Works after reset power of the device. Configuration of whether to send ON/OFF command to the touchlink devices and binding devices.
-              0=do not send,
-              1=send</description>
+            <description>Works after reset power of the device. Configuration of whether to send ON/OFF command to the touchlink devices and binding devices. 0=do not send, 1=send</description>
           </attribute>
           <attribute id="0x890C" name="Brightness module" type="u8" default="0x01" access="rw" required="m" mfcode="0x1224">
-            <description>0=disabled,
-              1=enabled</description>
+            <description>0=disabled, 1=enabled</description>
           </attribute>
           <attribute id="0x8902" name="Light on time" type="u16" default="0x003C" access="rw" required="m" mfcode="0x1224">
             <description>Light on time (the first delay time).
@@ -450,8 +447,7 @@
           </attribute>
           <attribute id="0x890E" name="Fixed deviation of LUX measurement" type="s16" default="0x0000" access="rw" required="m" mfcode="0x1224">
             <description>For instance, if we need to increase the measurement value by 100LUX, then this parameter value will be +100.
-              If we need to decrease the measurement value by 100LUX, then this parameter value will be -100.
-</description>
+              If we need to decrease the measurement value by 100LUX, then this parameter value will be -100.</description>
           </attribute>
         </attribute-set>
         <attribute-set id="0x9000" description="Sunricher specific" mfcode="0x1224">
@@ -544,9 +540,9 @@
             <value name="AAA" value="4"></value>
             <value name="C" value="5"></value>
             <value name="D" value="6"></value>
-      	    <value name="CR2" value="7"></value>
-	          <value name="CR123A" value="8"></value>
-	          <value name="Unknown" value="0xff"></value>
+            <value name="CR2" value="7"></value>
+            <value name="CR123A" value="8"></value>
+            <value name="Unknown" value="0xff"></value>
           </attribute>
           <attribute id="0x0032" name="Battery AHr Rating" type="u16" access="rw" required="o"></attribute>
           <attribute id="0x0033" name="Battery Quantity" type="u8" access="rw" required="o"></attribute>
@@ -660,7 +656,7 @@
           <description>Get the group membership of the device.</description>
           <payload>
             <attribute id="0x0000" type="u8" name="Group count" required="m" default="0x00"></attribute>
-            <attribute id="0x0001" type="u16" name="Group list" showas="hex" listSize="@0x0000" required="m" ></attribute>
+            <attribute id="0x0001" type="u16" name="Group list" showas="hex" listSize="@0x0000" required="m"></attribute>
           </payload>
         </command>
         <command id="03" dir="recv" name="Remove group" required="m" response="0x03">
@@ -698,7 +694,7 @@
           <payload>
             <attribute id="0x0000" type="u8" name="Capacity" required="m" default="0x00"></attribute>
             <attribute id="0x0001" type="u8" name="Group count" required="m" default="0x00"></attribute>
-            <attribute id="0x0002" type="u16" name="Group list" showas="hex" listSize="0x0001" required="o" ></attribute>
+            <attribute id="0x0002" type="u16" name="Group list" showas="hex" listSize="0x0001" required="o"></attribute>
           </payload>
         </command>
         <command id="03" dir="recv" name="Remove group response" required="m">
@@ -892,7 +888,7 @@
             <value name="Mode 1-Off" value="0"></value>
             <value name="Mode 2-Light when On" value="1"></value>
             <value name="Mode 3-Light when Off" value="2"></value>
-            <value name="Mode 4-Actual state" value="3"></value>		  
+            <value name="Mode 4-Actual state" value="3"></value>
           </attribute>
           <attribute id="0x8002" name="Power on state" type="enum8" default="0" required="o" access="rw">
             <value name="Off" value="0"></value>
@@ -900,13 +896,13 @@
             <value name="Last state" value="2"></value>
           </attribute>
           <attribute id="0x8003" name="Over current alarm" type="bool" default="0" required="o" access="r">
-                <value name="Over current OK" value="0"></value>
-                <value name="Over current alarm" value="1"></value>
-            </attribute>
-	          <attribute id="0x8004" name="Switch operation mode" type="enum8" default="0" required="m" access="r">
-                <value name="Command Mode (Light OnOff/Dimmer commands)" value="0"></value>
-                <value name="Event Mode (Tuya Scene commands)" value="1"></value>
-            </attribute>
+            <value name="Over current OK" value="0"></value>
+            <value name="Over current alarm" value="1"></value>
+          </attribute>
+          <attribute id="0x8004" name="Switch operation mode" type="enum8" default="0" required="m" access="r">
+            <value name="Command Mode (Light OnOff/Dimmer commands)" value="0"></value>
+            <value name="Event Mode (Tuya Scene commands)" value="1"></value>
+          </attribute>
         </attribute-set>
         <attribute-set id="0xe000" description="Schneider specific" mfcode="0x105e">
           <attribute id="0xe001" name="On Time Reload" type="u32" access="rw" required="o" mfcode="0x105e">
@@ -1176,7 +1172,7 @@
         <command id="0x40" dir="recv" name="Distance measure" required="m" response="0x40" showas="hex">
           <description></description>
           <payload>
-            <attribute id="0x0000" type="u16" name="Target address" required="m" default="0x0000" ></attribute>
+            <attribute id="0x0000" type="u16" name="Target address" required="m" default="0x0000"></attribute>
             <attribute id="0x0001" type="enum8" name="Resolution" required="m" default="0x00">
               <value name="High" value="0x00"></value>
               <value name="Mid" value="0x01"></value>
@@ -2358,8 +2354,8 @@
           <attribute id="0x0025" name="Thermostat Programming Operation Mode" type="bmp8" default="0" access="rw" required="o">
             <value name="Simple/setpoint mode" value="0">
               <description>0 – This mode means the thermostat setpoint is altered only by manual up/down changes at the thermostat or remotely, not by internal schedule programming.
-1 – Schedule programming mode. This enables or disables any programmed weekly schedule con-figurations.
-Note: It does not clear or delete previous weekly schedule programming configurations.</description>
+                           1 – Schedule programming mode. This enables or disables any programmed weekly schedule con-figurations.
+                           Note: It does not clear or delete previous weekly schedule programming configurations.</description>
             </value>
             <value name="Auto/recovery mode" value="1"></value>
             <value name="Economy/EnergyStar mode" value="2"></value>
@@ -2453,8 +2449,8 @@ Note: It does not clear or delete previous weekly schedule programming configura
           <attribute id="0x001a" name="HeatingDemandLowerBound" type="u8" access="rw" required="o" mfcode="0x10f2"></attribute>
           <attribute id="0x001b" name="HeatingDemandUpperBound" type="u8" access="rw" required="o" mfcode="0x10f2"></attribute>
           <attribute id="0x001c" name="Season" type="enum8" access="rw" required="m" mfcode="0x10f2">
-              <value name="winter" value="0x00"></value>
-              <value name="summer" value="0x01"></value>
+            <value name="winter" value="0x00"></value>
+            <value name="summer" value="0x01"></value>
           </attribute>
           <attribute id="0x001d" name="BackupHeatingDemand" type="u8" access="rw" required="o" mfcode="0x10f2"></attribute>
           <attribute id="0x001e" name="AlternateBackupHeatingDemand" type="u8" access="rw" required="o" mfcode="0x10f2"></attribute>
@@ -2467,19 +2463,19 @@ Note: It does not clear or delete previous weekly schedule programming configura
         <!-- Sinope manufacturer specific -->
         <attribute-set id="0x0400" description="Sinope specific" mfcode="0x119c">
           <attribute id="0x0400" name="Occupancy" type="enum8" access="rw" required="m" mfcode="0x119c">
-              <value name="Unoccupied" value="0x00"></value>
-              <value name="Occupied" value="0x01"></value>
+            <value name="Unoccupied" value="0x00"></value>
+            <value name="Occupied" value="0x01"></value>
           </attribute>
           <attribute id="0x0401" name="Main Cycle Output" type="u16" access="rw" required="m" mfcode="0x119c">
             <description>Number of second</description>
           </attribute>
-            <attribute id="0x0402" name="Backlight" type="enum8" access="rw" required="m" mfcode="0x119c">
-              <value name="On demand" value="0x00"></value>
-              <value name="Always ON" value="0x01"></value>
+          <attribute id="0x0402" name="Backlight" type="enum8" access="rw" required="m" mfcode="0x119c">
+            <value name="On demand" value="0x00"></value>
+            <value name="Always ON" value="0x01"></value>
           </attribute>
-            <attribute id="0x0404" name="Aux Cycle Output" type="u16" access="rw" required="m" mfcode="0x119c">
+          <attribute id="0x0404" name="Aux Cycle Output" type="u16" access="rw" required="m" mfcode="0x119c">
             <description>Number of second</description>
-          </attribute>			
+          </attribute>
         </attribute-set>
         <!-- ELKO specific -->
         <attribute-set id="0x0400" description="ELKO specific" mfcode="0x1002">
@@ -2694,460 +2690,460 @@ Note: It does not clear or delete previous weekly schedule programming configura
           <attribute id="0x4020" name="Valve position" type="enum8" access="rw" required="o" mfcode="0x1209"></attribute>
           <attribute id="0x4021" name="Unknown" type="u16" access="rw" required="o" mfcode="0x1209"></attribute>
           <attribute id="0x4022" name="Valve adaptation status" type="enum8" access="rw" required="o" mfcode="0x1209"></attribute>
-            <value name="Unknown" value="0x00"></value>
-            <value name="Ready to calibrate" value="0x01"></value>
-            <value name="Calibration in progress" value="0x02"></value>
-            <value name="Error" value="0x03"></value>
-            <value name="Success" value="0x04"></value>
-          </attribute>
-          <attribute id="0x4023" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209">
-            <value name="0" value="0x00"></value>
-            <value name="1" value="0x01"></value>
-            <value name="2" value="0x02"></value>
-            <value name="3" value="0x03"></value>
-            <value name="4" value="0x04"></value>
-            <value name="5" value="0x05"></value>
-            <value name="6" value="0x06"></value>
-            <value name="7" value="0x07"></value>
-          </attribute>
-          <attribute id="0x4024" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209">
-            <value name="0" value="0x00"></value>
-            <value name="1" value="0x01"></value>
-            <value name="2" value="0x02"></value>
-            <value name="3" value="0x03"></value>
-            <value name="4" value="0x04"></value>
-            <value name="5" value="0x05"></value>
-            <value name="6" value="0x06"></value>
-            <value name="7" value="0x07"></value>
-            <value name="8" value="0x08"></value>
-            <value name="9" value="0x09"></value>
-            <value name="10" value="0x0A"></value>
-            <value name="11" value="0x0B"></value>
-            <value name="12" value="0x0C"></value>
-            <value name="13" value="0x0D"></value>
-            <value name="14" value="0x0E"></value>
-            <value name="15" value="0x0F"></value>
-            <value name="16" value="0x10"></value>
-            <value name="17" value="0x11"></value>
-            <value name="18" value="0x12"></value>
-            <value name="19" value="0x13"></value>
-            <value name="20" value="0x14"></value>
-            <value name="21" value="0x15"></value>
-            <value name="22" value="0x16"></value>
-            <value name="23" value="0x17"></value>
-          </attribute>
-          <attribute id="0x4025" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209"></attribute>
-          <attribute id="0x4032" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209">
-            <value name="0" value="0x00"></value>
-            <value name="1" value="0x01"></value>
-            <value name="2" value="0x02"></value>
-            <value name="3" value="0x03"></value>
-            <value name="4" value="0x04"></value>
-            <value name="5" value="0x05"></value>
-            <value name="6" value="0x06"></value>
-            <value name="7" value="0x07"></value>
-            <value name="8" value="0x08"></value>
-            <value name="9" value="0x09"></value>
-            <value name="10" value="0x0A"></value>
-            <value name="11" value="0x0B"></value>
-            <value name="12" value="0x0C"></value>
-            <value name="13" value="0x0D"></value>
-            <value name="14" value="0x0E"></value>
-            <value name="15" value="0x0F"></value>
-          </attribute>
-          <attribute id="0x4040" name="External measured sensor" type="s16" access="rw" required="o" mfcode="0x1209"></attribute>
-          <attribute id="0x4041" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209">
-            <value name="0" value="0x00"></value>
-            <value name="1" value="0x01"></value>
-            <value name="2" value="0x02"></value>
-            <value name="3" value="0x03"></value>
-            <value name="4" value="0x04"></value>
-          </attribute>
-          <attribute id="0x4042" name="External window open detection" type="enum8" access="rw" required="o" mfcode="0x1209">
-            <value name="Closed" value="0x00"></value>
-            <value name="Open" value="0x01"></value>
-          </attribute>
-          <attribute id="0x4043" name="Boost" type="enum8" access="rw" required="o" mfcode="0x1209">
-            <value name="Off" value="0x00"></value>
-            <value name="On" value="0x01"></value>
-          </attribute>
-          <attribute id="0x4050" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209">
-            <value name="5" value="0x05"></value>
-            <value name="6" value="0x06"></value>
-            <value name="7" value="0x07"></value>
-            <value name="8" value="0x08"></value>
-            <value name="9" value="0x09"></value>
-            <value name="10" value="0x0A"></value>
-          </attribute>
-          <attribute id="0x4051" name="Outdoor temperature" type="s16" access="rw" required="o" mfcode="0x1209"></attribute>
-          <attribute id="0x4052" name="External sensor" type="s16" access="rw" required="o" mfcode="0x1209"></attribute>
-          <attribute id="0x405b" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209"></attribute>
-          <attribute id="0x4060" name="Actuator type setting" type="enum8" access="rw" required="o" mfcode="0x1209">            
-            <value name="Normally closed" value="0x00"></value>
-            <value name="Normally open" value="0x01"></value>
-          </attribute>
-          <attribute id="0x4061" name="Unknown" type="enum8" access="r" required="o" mfcode="0x1209"></attribute>
-          <attribute id="0x4062" name="External sensor connection config" type="enum8" access="rw" required="o" mfcode="0x1209">
-            <value name="Not used" value="0x00"></value>
-            <value name="Without regulation " value="0xB0"></value>
-            <value name="With regulation" value="0xB1"></value>
-          </attribute>
-          <attribute id="0x4063" name="Heater type" type="enum8" access="rw" required="o" mfcode="0x1209">
-            <value name="Underfloor heating" value="0x00"></value>
-            <value name="Boiler" value="0x01"></value>
-            <value name="Radiator" value="0x02"></value>
-            <value name="Central heating " value="0x03"></value>
-          </attribute>
-          <attribute id="0x5000" name="Error code" type="bmp8" access="rw" required="o" mfcode="0x1209"></attribute>
-          <attribute id="0x5010" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209">
-            <value name="0" value="0x00"></value>
-            <value name="1" value="0x01"></value>
-            <value name="2" value="0x02"></value>
-            <value name="3" value="0x03"></value>
-            <value name="4" value="0x04"></value>
-          </attribute>
-        </attribute-set>
-        <command id="0x00" dir="recv" name="Setpoint Raise/Lower" required="m">
-          <description>This command increases (or decreases) the setpoint(s) by amount, in steps of 0.1°C.</description>
-          <payload>
-            <attribute id="0x0000" type="enum8" name="Mode" required="m">
-              <value name="Heat (adjust Heat Setpoint)" value="0x00"></value>
-              <value name="Cool (adjust Cool Setpoint)" value="0x01"></value>
-              <value name="Both (adjust Heat Setpoint and Cool Setpoint)" value="0x02"></value>
-            </attribute>
-            <attribute id="0x0001" type="s8" name="Amount" required="m">
-              <description>The amount field is a signed 8-bit integer that specifies the amount the setpoint(s) are to be a increased (or decreased) by, in steps of 0.1°C.</description>
-            </attribute>
-          </payload>
-        </command>
-        <command id="0x01" dir="recv" name="Set Weekly Schedule" required="o">
-          <payload>
-            <attribute id="0x0000" type="enum8" name="Number of Transtions for Sequence" required="m">
-              <value name="0" value="0"></value>
-              <value name="1" value="1"></value>
-              <value name="2" value="2"></value>
-              <value name="3" value="3"></value>
-              <value name="4" value="4"></value>
-              <value name="5" value="5"></value>
-              <value name="6" value="6"></value>
-              <value name="7" value="7"></value>
-              <value name="8" value="8"></value>
-              <value name="9" value="9"></value>
-              <value name="10" value="10"></value>
-            </attribute>
-            <attribute id="0x0001" type="bmp8" name="Day of Week for Sequence" required="m">
-              <value name="Sunday" value="0"></value>
-              <value name="Monday" value="1"></value>
-              <value name="Tuesday" value="2"></value>
-              <value name="Wednesday" value="3"></value>
-              <value name="Thursday" value="4"></value>
-              <value name="Friday" value="5"></value>
-              <value name="Saturday" value="6"></value>
-              <value name="Vacation or Away" value="7"></value>
-            </attribute>
-            <attribute id="0x0002" type="bmp8" name="Mode for Sequence" required="m">
-              <value name="Heat Setpoint Field Present in Payload" value="0"></value>
-              <value name="Cool Setpoint Field Present in Payload" value="1"></value>
-            </attribute>
-            <attribute id="0x0003" type="u16" name="Transition Time 1" required="o"/>
-            <attribute id="0x0004" type="s16" name="Heat Set Point 1" required="o"/>
-            <attribute id="0x0005" type="u16" name="Transition Time 2" required="o"/>
-            <attribute id="0x0006" type="s16" name="Heat Set Point 2" required="o"/>
-            <attribute id="0x0007" type="u16" name="Transition Time 3" required="o"/>
-            <attribute id="0x0008" type="s16" name="Heat Set Point 3" required="o"/>
-            <attribute id="0x0009" type="u16" name="Transition Time 4" required="o"/>
-            <attribute id="0x000A" type="s16" name="Heat Set Point 4" required="o"/>
-            <attribute id="0x000B" type="u16" name="Transition Time 5" required="o"/>
-            <attribute id="0x000C" type="s16" name="Heat Set Point 5" required="o"/>
-            <attribute id="0x000D" type="u16" name="Transition Time 6" required="o"/>
-            <attribute id="0x000E" type="s16" name="Heat Set Point 6" required="o"/>
-            <attribute id="0x000F" type="u16" name="Transition Time 7" required="o"/>
-            <attribute id="0x0010" type="s16" name="Heat Set Point 7" required="o"/>
-            <attribute id="0x0011" type="u16" name="Transition Time 8" required="o"/>
-            <attribute id="0x0012" type="s16" name="Heat Set Point 8" required="o"/>
-            <attribute id="0x0013" type="u16" name="Transition Time 9" required="o"/>
-            <attribute id="0x0014" type="s16" name="Heat Set Point 9" required="o"/>
-            <attribute id="0x0015" type="u16" name="Transition Time 10" required="o"/>
-            <attribute id="0x0016" type="s16" name="Heat Set Point 10" required="o"/>
-          </payload>
-        </command>
-        <command id="0x02" dir="recv" name="Get Weekly Schedule" required="o" response="0x00">
-          <payload>
-            <attribute id="0x0000" type="bmp8" name="Days to Return" required="m">
-              <value name="Sunday" value="0"></value>
-              <value name="Monday" value="1"></value>
-              <value name="Tuesday" value="2"></value>
-              <value name="Wednesday" value="3"></value>
-              <value name="Thursday" value="4"></value>
-              <value name="Friday" value="5"></value>
-              <value name="Saturday" value="6"></value>
-              <value name="Vacation or Away" value="7"></value>
-            </attribute>
-            <attribute id="0x0001" type="bmp8" name="Mode to Return" required="m">
-              <value name="Heat Setpoint Field Present in Payload" value="0"></value>
-              <value name="Cool Setpoint Field Present in Payload" value="1"></value>
-            </attribute>
-          </payload>
-        </command>
-        <command id="0x03" dir="recv" name="Clear Weekly Schedule" required="o"></command>
-        <command id="0x04" dir="recv" name="Get Relay Status Log" required="o"></command>
-        <!-- Danfoss manufacturer specific -->
-        <command id="0x40" dir="recv" name="Set Heating Setpoint" required="o" mfcode="0x1246">
-          <description>Set immediately:
-The actuator will make a large movement to minimize reaction time.
-
-Mimic Occupied Heating Setpoint Behavior:
-The behavior will be the same as setting the attribute "Occupied Heating Setpoint" to the same value.
-
-Preserve Displayed Setpoint:
-Displayed setpoint is not affected, but regulated setpoint will change. Can be used for Forecast functionality.</description>
-          <payload>
-            <attribute id="0x0000" type="enum8" name="Setpoint Type" required="m">
-              <value name="Set immediately" value="0"/>
-              <value name="Mimic Occupied Heating Setpoint Behavior" value="1"/>
-              <value name="Preserve Displayed Setpoint" value="2"/>
-            </attribute>
-            <attribute id="0x0001" type="u16" name="Heating Setpoint" required="m"/>
-          </payload>
-        </command>
-        <command id="0x41" dir="recv" name="Danfoss Test Command" required="o" mfcode="0x1246"></command>
-        <command id="0x42" dir="recv" name="Preheat" required="o" mfcode="0x1246">
-          <description>Request eTRV to enter pre-heat if in schedule mode and if other eTRV in same room has triggeed pre-heat.</description>
-          <payload>
-            <attribute id="0x0000" type="enum8" name="Type" required="m">
-              <value name="Force Preheat" value="0"></value>
-            </attribute>
-            <attribute id="0x0001" type="u32" name="Timestamp" required="m">
-              <description>Timestamp received from other eTRV in the same room that went into preheat.</description>
-            </attribute>
-          </payload>
-        </command>
-      </server>
-      <client>
-        <command id="0x00" dir="recv" name="Get Weekly Schedule Response" required="o">
-          <payload>
-            <attribute id="0x0000" type="enum8" name="Number of Transtions for Sequence" required="m">
-              <value name="0" value="0"></value>
-              <value name="1" value="1"></value>
-              <value name="2" value="2"></value>
-              <value name="3" value="3"></value>
-              <value name="4" value="4"></value>
-              <value name="5" value="5"></value>
-              <value name="6" value="6"></value>
-              <value name="7" value="7"></value>
-              <value name="8" value="8"></value>
-              <value name="9" value="9"></value>
-              <value name="10" value="10"></value>
-            </attribute>
-            <attribute id="0x0001" type="bmp8" name="Day of Week for Sequence" required="m">
-              <value name="Sunday" value="0"></value>
-              <value name="Monday" value="1"></value>
-              <value name="Tuesday" value="2"></value>
-              <value name="Wednesday" value="3"></value>
-              <value name="Thursday" value="4"></value>
-              <value name="Friday" value="5"></value>
-              <value name="Saturday" value="6"></value>
-              <value name="Vacation or Away" value="7"></value>
-            </attribute>
-            <attribute id="0x0002" type="bmp8" name="Mode for Sequence" required="m">
-              <value name="Heat Setpoint Field Present in Payload" value="0"></value>
-              <value name="Cool Setpoint Field Present in Payload" value="1"></value>
-            </attribute>
-            <attribute id="0x0003" type="u16" name="Transition Time 1" required="o"/>
-            <attribute id="0x0004" type="s16" name="Heat Set Point 1" required="o"/>
-            <attribute id="0x0005" type="u16" name="Transition Time 2" required="o"/>
-            <attribute id="0x0006" type="s16" name="Heat Set Point 2" required="o"/>
-            <attribute id="0x0007" type="u16" name="Transition Time 3" required="o"/>
-            <attribute id="0x0008" type="s16" name="Heat Set Point 3" required="o"/>
-            <attribute id="0x0009" type="u16" name="Transition Time 4" required="o"/>
-            <attribute id="0x000A" type="s16" name="Heat Set Point 4" required="o"/>
-            <attribute id="0x000B" type="u16" name="Transition Time 5" required="o"/>
-            <attribute id="0x000C" type="s16" name="Heat Set Point 5" required="o"/>
-            <attribute id="0x000D" type="u16" name="Transition Time 6" required="o"/>
-            <attribute id="0x000E" type="s16" name="Heat Set Point 6" required="o"/>
-            <attribute id="0x000F" type="u16" name="Transition Time 7" required="o"/>
-            <attribute id="0x0010" type="s16" name="Heat Set Point 7" required="o"/>
-            <attribute id="0x0011" type="u16" name="Transition Time 8" required="o"/>
-            <attribute id="0x0012" type="s16" name="Heat Set Point 8" required="o"/>
-            <attribute id="0x0013" type="u16" name="Transition Time 9" required="o"/>
-            <attribute id="0x0014" type="s16" name="Heat Set Point 9" required="o"/>
-            <attribute id="0x0015" type="u16" name="Transition Time 10" required="o"/>
-            <attribute id="0x0016" type="s16" name="Heat Set Point 10" required="o"/>
-          </payload>
-        </command>
-      </client>
-    </cluster>
-
-    <cluster id="0x0202" name="Fan Control">
-      <description>This cluster specifies an interface to control the speed of a fan as part of a heating / cooling system.</description>
-      <server>
-        <attribute id="0x0000" name="Fan Mode" type="enum8" access="rw" default="0x05" required="m">
+          <value name="Unknown" value="0x00"></value>
+          <value name="Ready to calibrate" value="0x01"></value>
+          <value name="Calibration in progress" value="0x02"></value>
+          <value name="Error" value="0x03"></value>
+          <value name="Success" value="0x04"></value>
+        </attribute>
+        <attribute id="0x4023" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209">
+          <value name="0" value="0x00"></value>
+          <value name="1" value="0x01"></value>
+          <value name="2" value="0x02"></value>
+          <value name="3" value="0x03"></value>
+          <value name="4" value="0x04"></value>
+          <value name="5" value="0x05"></value>
+          <value name="6" value="0x06"></value>
+          <value name="7" value="0x07"></value>
+        </attribute>
+        <attribute id="0x4024" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209">
+          <value name="0" value="0x00"></value>
+          <value name="1" value="0x01"></value>
+          <value name="2" value="0x02"></value>
+          <value name="3" value="0x03"></value>
+          <value name="4" value="0x04"></value>
+          <value name="5" value="0x05"></value>
+          <value name="6" value="0x06"></value>
+          <value name="7" value="0x07"></value>
+          <value name="8" value="0x08"></value>
+          <value name="9" value="0x09"></value>
+          <value name="10" value="0x0A"></value>
+          <value name="11" value="0x0B"></value>
+          <value name="12" value="0x0C"></value>
+          <value name="13" value="0x0D"></value>
+          <value name="14" value="0x0E"></value>
+          <value name="15" value="0x0F"></value>
+          <value name="16" value="0x10"></value>
+          <value name="17" value="0x11"></value>
+          <value name="18" value="0x12"></value>
+          <value name="19" value="0x13"></value>
+          <value name="20" value="0x14"></value>
+          <value name="21" value="0x15"></value>
+          <value name="22" value="0x16"></value>
+          <value name="23" value="0x17"></value>
+        </attribute>
+        <attribute id="0x4025" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209"></attribute>
+        <attribute id="0x4032" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209">
+          <value name="0" value="0x00"></value>
+          <value name="1" value="0x01"></value>
+          <value name="2" value="0x02"></value>
+          <value name="3" value="0x03"></value>
+          <value name="4" value="0x04"></value>
+          <value name="5" value="0x05"></value>
+          <value name="6" value="0x06"></value>
+          <value name="7" value="0x07"></value>
+          <value name="8" value="0x08"></value>
+          <value name="9" value="0x09"></value>
+          <value name="10" value="0x0A"></value>
+          <value name="11" value="0x0B"></value>
+          <value name="12" value="0x0C"></value>
+          <value name="13" value="0x0D"></value>
+          <value name="14" value="0x0E"></value>
+          <value name="15" value="0x0F"></value>
+        </attribute>
+        <attribute id="0x4040" name="External measured sensor" type="s16" access="rw" required="o" mfcode="0x1209"></attribute>
+        <attribute id="0x4041" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209">
+          <value name="0" value="0x00"></value>
+          <value name="1" value="0x01"></value>
+          <value name="2" value="0x02"></value>
+          <value name="3" value="0x03"></value>
+          <value name="4" value="0x04"></value>
+        </attribute>
+        <attribute id="0x4042" name="External window open detection" type="enum8" access="rw" required="o" mfcode="0x1209">
+          <value name="Closed" value="0x00"></value>
+          <value name="Open" value="0x01"></value>
+        </attribute>
+        <attribute id="0x4043" name="Boost" type="enum8" access="rw" required="o" mfcode="0x1209">
           <value name="Off" value="0x00"></value>
-          <value name="Low" value="0x01"></value>
-          <value name="Medium" value="0x02"></value>
-          <value name="High" value="0x03"></value>
-          <value name="On" value="0x04"></value>
-          <value name="Auto" value="0x05"></value>
-          <value name="Smart" value="0x06"></value>
+          <value name="On" value="0x01"></value>
         </attribute>
-        <attribute id="0x0001" name="Fan Mode Sequence" type="enum8" access="rw" default="0x02" required="m">
-          <value name="Low/Med/High" value="0x00"></value>
-          <value name="Low/High" value="0x01"></value>
-          <value name="Low/Med/High/Auto" value="0x02"></value>
-          <value name="Low/High/Auto" value="0x03"></value>
-          <value name="On/Auto" value="0x04"></value>
+        <attribute id="0x4050" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209">
+          <value name="5" value="0x05"></value>
+          <value name="6" value="0x06"></value>
+          <value name="7" value="0x07"></value>
+          <value name="8" value="0x08"></value>
+          <value name="9" value="0x09"></value>
+          <value name="10" value="0x0A"></value>
         </attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+        <attribute id="0x4051" name="Outdoor temperature" type="s16" access="rw" required="o" mfcode="0x1209"></attribute>
+        <attribute id="0x4052" name="External sensor" type="s16" access="rw" required="o" mfcode="0x1209"></attribute>
+        <attribute id="0x405b" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209"></attribute>
+        <attribute id="0x4060" name="Actuator type setting" type="enum8" access="rw" required="o" mfcode="0x1209">
+          <value name="Normally closed" value="0x00"></value>
+          <value name="Normally open" value="0x01"></value>
+        </attribute>
+        <attribute id="0x4061" name="Unknown" type="enum8" access="r" required="o" mfcode="0x1209"></attribute>
+        <attribute id="0x4062" name="External sensor connection config" type="enum8" access="rw" required="o" mfcode="0x1209">
+          <value name="Not used" value="0x00"></value>
+          <value name="Without regulation " value="0xB0"></value>
+          <value name="With regulation" value="0xB1"></value>
+        </attribute>
+        <attribute id="0x4063" name="Heater type" type="enum8" access="rw" required="o" mfcode="0x1209">
+          <value name="Underfloor heating" value="0x00"></value>
+          <value name="Boiler" value="0x01"></value>
+          <value name="Radiator" value="0x02"></value>
+          <value name="Central heating " value="0x03"></value>
+        </attribute>
+        <attribute id="0x5000" name="Error code" type="bmp8" access="rw" required="o" mfcode="0x1209"></attribute>
+        <attribute id="0x5010" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209">
+          <value name="0" value="0x00"></value>
+          <value name="1" value="0x01"></value>
+          <value name="2" value="0x02"></value>
+          <value name="3" value="0x03"></value>
+          <value name="4" value="0x04"></value>
+        </attribute>
+      </attribute-set>
+      <command id="0x00" dir="recv" name="Setpoint Raise/Lower" required="m">
+        <description>This command increases (or decreases) the setpoint(s) by amount, in steps of 0.1°C.</description>
+        <payload>
+          <attribute id="0x0000" type="enum8" name="Mode" required="m">
+            <value name="Heat (adjust Heat Setpoint)" value="0x00"></value>
+            <value name="Cool (adjust Cool Setpoint)" value="0x01"></value>
+            <value name="Both (adjust Heat Setpoint and Cool Setpoint)" value="0x02"></value>
+          </attribute>
+          <attribute id="0x0001" type="s8" name="Amount" required="m">
+            <description>The amount field is a signed 8-bit integer that specifies the amount the setpoint(s) are to be a increased (or decreased) by, in steps of 0.1°C.</description>
+          </attribute>
+        </payload>
+      </command>
+      <command id="0x01" dir="recv" name="Set Weekly Schedule" required="o">
+        <payload>
+          <attribute id="0x0000" type="enum8" name="Number of Transtions for Sequence" required="m">
+            <value name="0" value="0"></value>
+            <value name="1" value="1"></value>
+            <value name="2" value="2"></value>
+            <value name="3" value="3"></value>
+            <value name="4" value="4"></value>
+            <value name="5" value="5"></value>
+            <value name="6" value="6"></value>
+            <value name="7" value="7"></value>
+            <value name="8" value="8"></value>
+            <value name="9" value="9"></value>
+            <value name="10" value="10"></value>
+          </attribute>
+          <attribute id="0x0001" type="bmp8" name="Day of Week for Sequence" required="m">
+            <value name="Sunday" value="0"></value>
+            <value name="Monday" value="1"></value>
+            <value name="Tuesday" value="2"></value>
+            <value name="Wednesday" value="3"></value>
+            <value name="Thursday" value="4"></value>
+            <value name="Friday" value="5"></value>
+            <value name="Saturday" value="6"></value>
+            <value name="Vacation or Away" value="7"></value>
+          </attribute>
+          <attribute id="0x0002" type="bmp8" name="Mode for Sequence" required="m">
+            <value name="Heat Setpoint Field Present in Payload" value="0"></value>
+            <value name="Cool Setpoint Field Present in Payload" value="1"></value>
+          </attribute>
+          <attribute id="0x0003" type="u16" name="Transition Time 1" required="o"/>
+          <attribute id="0x0004" type="s16" name="Heat Set Point 1" required="o"/>
+          <attribute id="0x0005" type="u16" name="Transition Time 2" required="o"/>
+          <attribute id="0x0006" type="s16" name="Heat Set Point 2" required="o"/>
+          <attribute id="0x0007" type="u16" name="Transition Time 3" required="o"/>
+          <attribute id="0x0008" type="s16" name="Heat Set Point 3" required="o"/>
+          <attribute id="0x0009" type="u16" name="Transition Time 4" required="o"/>
+          <attribute id="0x000A" type="s16" name="Heat Set Point 4" required="o"/>
+          <attribute id="0x000B" type="u16" name="Transition Time 5" required="o"/>
+          <attribute id="0x000C" type="s16" name="Heat Set Point 5" required="o"/>
+          <attribute id="0x000D" type="u16" name="Transition Time 6" required="o"/>
+          <attribute id="0x000E" type="s16" name="Heat Set Point 6" required="o"/>
+          <attribute id="0x000F" type="u16" name="Transition Time 7" required="o"/>
+          <attribute id="0x0010" type="s16" name="Heat Set Point 7" required="o"/>
+          <attribute id="0x0011" type="u16" name="Transition Time 8" required="o"/>
+          <attribute id="0x0012" type="s16" name="Heat Set Point 8" required="o"/>
+          <attribute id="0x0013" type="u16" name="Transition Time 9" required="o"/>
+          <attribute id="0x0014" type="s16" name="Heat Set Point 9" required="o"/>
+          <attribute id="0x0015" type="u16" name="Transition Time 10" required="o"/>
+          <attribute id="0x0016" type="s16" name="Heat Set Point 10" required="o"/>
+        </payload>
+      </command>
+      <command id="0x02" dir="recv" name="Get Weekly Schedule" required="o" response="0x00">
+        <payload>
+          <attribute id="0x0000" type="bmp8" name="Days to Return" required="m">
+            <value name="Sunday" value="0"></value>
+            <value name="Monday" value="1"></value>
+            <value name="Tuesday" value="2"></value>
+            <value name="Wednesday" value="3"></value>
+            <value name="Thursday" value="4"></value>
+            <value name="Friday" value="5"></value>
+            <value name="Saturday" value="6"></value>
+            <value name="Vacation or Away" value="7"></value>
+          </attribute>
+          <attribute id="0x0001" type="bmp8" name="Mode to Return" required="m">
+            <value name="Heat Setpoint Field Present in Payload" value="0"></value>
+            <value name="Cool Setpoint Field Present in Payload" value="1"></value>
+          </attribute>
+        </payload>
+      </command>
+      <command id="0x03" dir="recv" name="Clear Weekly Schedule" required="o"></command>
+      <command id="0x04" dir="recv" name="Get Relay Status Log" required="o"></command>
+      <!-- Danfoss manufacturer specific -->
+      <command id="0x40" dir="recv" name="Set Heating Setpoint" required="o" mfcode="0x1246">
+        <description>Set immediately:
+            The actuator will make a large movement to minimize reaction time.
 
-    <cluster id="0x0203" name="Dehumidification Control">
-      <description>dfdf</description>
+            Mimic Occupied Heating Setpoint Behavior:
+            The behavior will be the same as setting the attribute "Occupied Heating Setpoint" to the same value.
+
+            Preserve Displayed Setpoint:
+            Displayed setpoint is not affected, but regulated setpoint will change. Can be used for Forecast functionality.</description>
+        <payload>
+          <attribute id="0x0000" type="enum8" name="Setpoint Type" required="m">
+            <value name="Set immediately" value="0"/>
+            <value name="Mimic Occupied Heating Setpoint Behavior" value="1"/>
+            <value name="Preserve Displayed Setpoint" value="2"/>
+          </attribute>
+          <attribute id="0x0001" type="u16" name="Heating Setpoint" required="m"/>
+        </payload>
+      </command>
+      <command id="0x41" dir="recv" name="Danfoss Test Command" required="o" mfcode="0x1246"></command>
+      <command id="0x42" dir="recv" name="Preheat" required="o" mfcode="0x1246">
+        <description>Request eTRV to enter pre-heat if in schedule mode and if other eTRV in same room has triggeed pre-heat.</description>
+        <payload>
+          <attribute id="0x0000" type="enum8" name="Type" required="m">
+            <value name="Force Preheat" value="0"></value>
+          </attribute>
+          <attribute id="0x0001" type="u32" name="Timestamp" required="m">
+            <description>Timestamp received from other eTRV in the same room that went into preheat.</description>
+          </attribute>
+        </payload>
+      </command>
+    </server>
+    <client>
+      <command id="0x00" dir="recv" name="Get Weekly Schedule Response" required="o">
+        <payload>
+          <attribute id="0x0000" type="enum8" name="Number of Transtions for Sequence" required="m">
+            <value name="0" value="0"></value>
+            <value name="1" value="1"></value>
+            <value name="2" value="2"></value>
+            <value name="3" value="3"></value>
+            <value name="4" value="4"></value>
+            <value name="5" value="5"></value>
+            <value name="6" value="6"></value>
+            <value name="7" value="7"></value>
+            <value name="8" value="8"></value>
+            <value name="9" value="9"></value>
+            <value name="10" value="10"></value>
+          </attribute>
+          <attribute id="0x0001" type="bmp8" name="Day of Week for Sequence" required="m">
+            <value name="Sunday" value="0"></value>
+            <value name="Monday" value="1"></value>
+            <value name="Tuesday" value="2"></value>
+            <value name="Wednesday" value="3"></value>
+            <value name="Thursday" value="4"></value>
+            <value name="Friday" value="5"></value>
+            <value name="Saturday" value="6"></value>
+            <value name="Vacation or Away" value="7"></value>
+          </attribute>
+          <attribute id="0x0002" type="bmp8" name="Mode for Sequence" required="m">
+            <value name="Heat Setpoint Field Present in Payload" value="0"></value>
+            <value name="Cool Setpoint Field Present in Payload" value="1"></value>
+          </attribute>
+          <attribute id="0x0003" type="u16" name="Transition Time 1" required="o"/>
+          <attribute id="0x0004" type="s16" name="Heat Set Point 1" required="o"/>
+          <attribute id="0x0005" type="u16" name="Transition Time 2" required="o"/>
+          <attribute id="0x0006" type="s16" name="Heat Set Point 2" required="o"/>
+          <attribute id="0x0007" type="u16" name="Transition Time 3" required="o"/>
+          <attribute id="0x0008" type="s16" name="Heat Set Point 3" required="o"/>
+          <attribute id="0x0009" type="u16" name="Transition Time 4" required="o"/>
+          <attribute id="0x000A" type="s16" name="Heat Set Point 4" required="o"/>
+          <attribute id="0x000B" type="u16" name="Transition Time 5" required="o"/>
+          <attribute id="0x000C" type="s16" name="Heat Set Point 5" required="o"/>
+          <attribute id="0x000D" type="u16" name="Transition Time 6" required="o"/>
+          <attribute id="0x000E" type="s16" name="Heat Set Point 6" required="o"/>
+          <attribute id="0x000F" type="u16" name="Transition Time 7" required="o"/>
+          <attribute id="0x0010" type="s16" name="Heat Set Point 7" required="o"/>
+          <attribute id="0x0011" type="u16" name="Transition Time 8" required="o"/>
+          <attribute id="0x0012" type="s16" name="Heat Set Point 8" required="o"/>
+          <attribute id="0x0013" type="u16" name="Transition Time 9" required="o"/>
+          <attribute id="0x0014" type="s16" name="Heat Set Point 9" required="o"/>
+          <attribute id="0x0015" type="u16" name="Transition Time 10" required="o"/>
+          <attribute id="0x0016" type="s16" name="Heat Set Point 10" required="o"/>
+        </payload>
+      </command>
+    </client>
+  </cluster>
+
+  <cluster id="0x0202" name="Fan Control">
+    <description>This cluster specifies an interface to control the speed of a fan as part of a heating / cooling system.</description>
+    <server>
+      <attribute id="0x0000" name="Fan Mode" type="enum8" access="rw" default="0x05" required="m">
+        <value name="Off" value="0x00"></value>
+        <value name="Low" value="0x01"></value>
+        <value name="Medium" value="0x02"></value>
+        <value name="High" value="0x03"></value>
+        <value name="On" value="0x04"></value>
+        <value name="Auto" value="0x05"></value>
+        <value name="Smart" value="0x06"></value>
+      </attribute>
+      <attribute id="0x0001" name="Fan Mode Sequence" type="enum8" access="rw" default="0x02" required="m">
+        <value name="Low/Med/High" value="0x00"></value>
+        <value name="Low/High" value="0x01"></value>
+        <value name="Low/Med/High/Auto" value="0x02"></value>
+        <value name="Low/High/Auto" value="0x03"></value>
+        <value name="On/Auto" value="0x04"></value>
+      </attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0203" name="Dehumidification Control">
+    <description>dfdf</description>
+    <!-- TODO -->
+  </cluster>
+
+  <cluster id="0x0204" name="Thermostat User Interface Configuration">
+    <description>This cluster provides an interface to allow configuration of the user interface for a thermostat, or a thermostat controller device, that supports a keypad and LCD screen.</description>
+    <server>
+      <attribute id="0x0000" name="Temperature Display Mode" type="enum8" access="rw" range="0x00,0x01" default="0x00" required="m">
+        <value name="Temperature in °C" value="0x00"></value>
+        <value name="Temperature in °F" value="0x01"></value>
+      </attribute>
+      <attribute id="0x0001" name="Keypad Lockout" type="enum8" access="rw" range="0x00,0x05" default="0x00" required="m">
+        <value name="No lockout" value="0x00"></value>
+        <value name="Level 1 lockout" value="0x01"></value>
+        <value name="Level 2 lockout" value="0x02"></value>
+        <value name="Level 3 lockout" value="0x03"></value>
+        <value name="Level 4 lockout" value="0x04"></value>
+        <value name="Level 5 lockout" value="0x05"></value>
+      </attribute>
+      <attribute id="0x0002" name="Schedule Programming Visibility" type="enum8" access="rw" range="0x00,0x01" default="0x00" required="o">
+        <value name="Local schedule programming enabled" value="0x00"></value>
+        <value name="Local schedule programming disabled" value="0x01"></value>
+      </attribute>
+      <attribute id="0x4000" name="Viewing Direction" type="enum8" access="rw" range="0x00,0x01" default="0x00" required="o" mfcode="0x1246">
+        <value name="Viewing direction 1" value="0x00"></value>
+        <value name="Viewing direction 2" value="0x01"></value>
+      </attribute>
+
+      <!-- ZigbeeTLc (C401N) specific -->
+      <attribute-set id="0x0100" description="ZigbeeTLc (C401N) specific" mfcode="0x1141">
+        <attribute id="0x0100" name="Temperature offset in 0.01° steps" type="s16" access="rw" default="0x0000" required="o" mfcode="0x1141"></attribute>
+        <attribute id="0x0101" name="Humidity offset, in 0.01% steps" type="s16" access="rw" default="0x0000" required="o" mfcode="0x1141"></attribute>
+        <attribute id="0x0102" name="Comfort temperature minimum, in 0.01° steps" type="s16" access="rw" default="0x07D0" required="o" mfcode="0x1141"></attribute>
+        <attribute id="0x0103" name="Comfort temperature maximum, in 0.01° steps" type="s16" access="rw" default="0x09C4" required="o" mfcode="0x1141"></attribute>
+        <attribute id="0x0104" name="Comfort humidity minimum, in 1% steps" type="u16" access="rw" range="0x0000,0x270F" default="0x0FA0" required="o" mfcode="0x1141"></attribute>
+        <attribute id="0x0105" name="Comfort humidity maximum, in 1% steps" type="u16" access="rw" range="0x0000,0x270F" default="0x1770" required="o" mfcode="0x1141"></attribute>
+        <attribute id="0x0106" name="Display off" type="enum8" access="rw" range="0x00,0x01" default="0x00" required="o" mfcode="0x1141">
+          <value name="Display on" value="0x00"></value>
+          <value name="Display off" value="0x01"></value>
+        </attribute>
+        <attribute id="0x0107" name="Measurement interval, range: 3..255 seconds" type="u8" access="rw" range="0x03,0xFF" default="0x0A" required="o" mfcode="0x1141">
+          <description>Beware: While increasing the measurement interval should save power, it also increases the reaction time for reading/writing values in deCONZ up to the set value (the C401N only connects every n seconds to the Zigbee network). About 60s seems like a sweet spot between power saving and reaction time.</description>
+        </attribute>
+      </attribute-set>
+
+      <!-- Bosch manufacturer specific -->
+      <attribute-set id="0x4000" description="Bosch specific" mfcode="0x1209">
+        <attribute id="0x400B" name="Display orientation" type="enum8" access="rw" required="o" mfcode="0x1209">
+          <value name="Normal" value="0x00"></value>
+          <value name="Flipped" value="0x01"></value>
+        </attribute>
+        <attribute id="0x4031" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209">
+          <value name="0x00" value="0x00"></value>
+          <value name="0x01" value="0x01"></value>
+        </attribute>
+        <attribute id="0x4032" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209">
+          <value name="0" value="0x00"></value>
+          <value name="1" value="0x01"></value>
+          <value name="2" value="0x02"></value>
+          <value name="3" value="0x03"></value>
+          <value name="4" value="0x04"></value>
+          <value name="5" value="0x05"></value>
+          <value name="6" value="0x06"></value>
+          <value name="7" value="0x07"></value>
+          <value name="8" value="0x08"></value>
+          <value name="9" value="0x09"></value>
+          <value name="10" value="0x0A"></value>
+          <value name="11" value="0x0B"></value>
+          <value name="12" value="0x0C"></value>
+          <value name="13" value="0x0D"></value>
+          <value name="14" value="0x0E"></value>
+          <value name="15" value="0x0F"></value>
+        </attribute>
+        <attribute id="0x4033" name="Valve status LED" type="enum8" access="rw" required="o" mfcode="0x1209">
+          <value name="Off" value="0x00"></value>
+          <value name="Normal" value="0x01"></value>
+          <value name="On" value="0x02"></value>
+        </attribute>
+        <attribute id="0x4039" name="Displayed temperature" type="enum8" access="rw" required="o" mfcode="0x1209">
+          <value name="Setpoint" value="0x00"></value>
+          <value name="Measured" value="0x01"></value>
+        </attribute>
+        <attribute id="0x403a" name="Display on-time" type="enum8" access="rw" required="o" mfcode="0x1209">
+          <value name="1" value="0x01"></value>
+          <value name="2" value="0x02"></value>
+          <value name="3" value="0x03"></value>
+          <value name="4" value="0x04"></value>
+          <value name="5" value="0x05"></value>
+          <value name="6" value="0x06"></value>
+          <value name="7" value="0x07"></value>
+          <value name="8" value="0x08"></value>
+          <value name="9" value="0x09"></value>
+          <value name="10" value="0x0A"></value>
+          <value name="15" value="0x0F"></value>
+          <value name="20" value="0x14"></value>
+          <value name="25" value="0x19"></value>
+          <value name="30" value="0x1E"></value>
+        </attribute>
+        <attribute id="0x403b" name="Display brightness" type="enum8" access="rw" required="o" mfcode="0x1209">
+          <value name="0" value="0x00"></value>
+          <value name="1" value="0x01"></value>
+          <value name="2" value="0x02"></value>
+          <value name="3" value="0x03"></value>
+          <value name="4" value="0x04"></value>
+          <value name="5" value="0x05"></value>
+          <value name="6" value="0x06"></value>
+          <value name="7" value="0x07"></value>
+          <value name="8" value="0x08"></value>
+          <value name="9" value="0x09"></value>
+          <value name="10" value="0x0A"></value>
+        </attribute>
+        <attribute id="0x406a" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209"></attribute>
+        <attribute id="0x406b" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209"></attribute>
+        <attribute id="0x406c" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209"></attribute>
+        <attribute id="0x406d" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209"></attribute>
+      </attribute-set>
+
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0xde42" name="DE Debug">
+    <description>Attributes and commands for debugging purposes.</description>
+    <server>
+      <attribute id="0x0000" name="Debug enabled" type="bool" access="rw" default="0x00" required="m"></attribute>
+      <attribute id="0x0001" name="Debug destination" type="u16" access="rw" default="0x0000" showas="hex" required="m"></attribute>
+    </server>
+    <client>
       <!-- TODO -->
-    </cluster>
+    </client>
+  </cluster>
+</domain>
 
-    <cluster id="0x0204" name="Thermostat User Interface Configuration">
-      <description>This cluster provides an interface to allow configuration of the user interface for a thermostat, or a thermostat controller device, that supports a keypad and LCD screen.</description>
-      <server>
-        <attribute id="0x0000" name="Temperature Display Mode" type="enum8" access="rw" range="0x00,0x01" default="0x00" required="m">
-          <value name="Temperature in °C" value="0x00"></value>
-          <value name="Temperature in °F" value="0x01"></value>
-        </attribute>
-        <attribute id="0x0001" name="Keypad Lockout" type="enum8" access="rw" range="0x00,0x05" default="0x00" required="m">
-          <value name="No lockout" value="0x00"></value>
-          <value name="Level 1 lockout" value="0x01"></value>
-          <value name="Level 2 lockout" value="0x02"></value>
-          <value name="Level 3 lockout" value="0x03"></value>
-          <value name="Level 4 lockout" value="0x04"></value>
-          <value name="Level 5 lockout" value="0x05"></value>
-        </attribute>
-        <attribute id="0x0002" name="Schedule Programming Visibility" type="enum8" access="rw"  range="0x00,0x01" default="0x00" required="o">
-          <value name="Local schedule programming enabled" value="0x00"></value>
-          <value name="Local schedule programming disabled" value="0x01"></value>
-        </attribute>
-        <attribute id="0x4000" name="Viewing Direction" type="enum8" access="rw" range="0x00,0x01" default="0x00" required="o" mfcode="0x1246">
-          <value name="Viewing direction 1" value="0x00"></value>
-          <value name="Viewing direction 2" value="0x01"></value>
-        </attribute>
-        
-        <!-- ZigbeeTLc (C401N) specific -->
-        <attribute-set id="0x0100" description="ZigbeeTLc (C401N) specific" mfcode="0x1141">
-          <attribute id="0x0100" name="Temperature offset in 0.01° steps" type="s16" access="rw" default="0x0000" required="o" mfcode="0x1141"></attribute>
-          <attribute id="0x0101" name="Humidity offset, in 0.01% steps" type="s16" access="rw" default="0x0000" required="o" mfcode="0x1141"></attribute>
-          <attribute id="0x0102" name="Comfort temperature minimum, in 0.01° steps" type="s16" access="rw" default="0x07D0" required="o" mfcode="0x1141"></attribute>
-          <attribute id="0x0103" name="Comfort temperature maximum, in 0.01° steps" type="s16" access="rw" default="0x09C4" required="o" mfcode="0x1141"></attribute>
-          <attribute id="0x0104" name="Comfort humidity minimum, in 1% steps" type="u16" access="rw" range="0x0000,0x270F" default="0x0FA0" required="o" mfcode="0x1141"></attribute>
-          <attribute id="0x0105" name="Comfort humidity maximum, in 1% steps" type="u16" access="rw" range="0x0000,0x270F" default="0x1770" required="o" mfcode="0x1141"></attribute>
-          <attribute id="0x0106" name="Display off" type="enum8" access="rw" range="0x00,0x01" default="0x00" required="o" mfcode="0x1141">
-            <value name="Display on" value="0x00"></value>
-            <value name="Display off" value="0x01"></value>
-          </attribute>
-          <attribute id="0x0107" name="Measurement interval, range: 3..255 seconds" type="u8" access="rw" range="0x03,0xFF" default="0x0A" required="o" mfcode="0x1141">
-            <description>Beware: While increasing the measurement interval should save power, it also increases the reaction time for reading/writing values in deCONZ up to the set value (the C401N only connects every n seconds to the Zigbee network). About 60s seems like a sweet spot between power saving and reaction time.</description>
-	  </attribute>
-        </attribute-set>
-
-        <!-- Bosch manufacturer specific -->
-        <attribute-set id="0x4000" description="Bosch specific" mfcode="0x1209">
-          <attribute id="0x400B" name="Display orientation" type="enum8" access="rw" required="o" mfcode="0x1209">
-            <value name="Normal" value="0x00"></value>
-            <value name="Flipped" value="0x01"></value>
-          </attribute>
-          <attribute id="0x4031" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209">
-            <value name="0x00" value="0x00"></value>
-            <value name="0x01" value="0x01"></value>
-          </attribute>
-          <attribute id="0x4032" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209">
-            <value name="0" value="0x00"></value>
-            <value name="1" value="0x01"></value>
-            <value name="2" value="0x02"></value>
-            <value name="3" value="0x03"></value>
-            <value name="4" value="0x04"></value>
-            <value name="5" value="0x05"></value>
-            <value name="6" value="0x06"></value>
-            <value name="7" value="0x07"></value>
-            <value name="8" value="0x08"></value>
-            <value name="9" value="0x09"></value>
-            <value name="10" value="0x0A"></value>
-            <value name="11" value="0x0B"></value>
-            <value name="12" value="0x0C"></value>
-            <value name="13" value="0x0D"></value>
-            <value name="14" value="0x0E"></value>
-            <value name="15" value="0x0F"></value>
-          </attribute>
-          <attribute id="0x4033" name="Valve status LED" type="enum8" access="rw" required="o" mfcode="0x1209">
-            <value name="Off" value="0x00"></value>
-            <value name="Normal" value="0x01"></value>
-            <value name="On" value="0x02"></value>
-          </attribute>
-          <attribute id="0x4039" name="Displayed temperature" type="enum8" access="rw" required="o" mfcode="0x1209">
-            <value name="Setpoint" value="0x00"></value>
-            <value name="Measured" value="0x01"></value>
-          </attribute>
-          <attribute id="0x403a" name="Display on-time" type="enum8" access="rw" required="o" mfcode="0x1209">
-            <value name="1" value="0x01"></value>
-            <value name="2" value="0x02"></value>
-            <value name="3" value="0x03"></value>
-            <value name="4" value="0x04"></value>
-            <value name="5" value="0x05"></value>
-            <value name="6" value="0x06"></value>
-            <value name="7" value="0x07"></value>
-            <value name="8" value="0x08"></value>
-            <value name="9" value="0x09"></value>
-            <value name="10" value="0x0A"></value>
-            <value name="15" value="0x0F"></value>
-            <value name="20" value="0x14"></value>
-            <value name="25" value="0x19"></value>
-            <value name="30" value="0x1E"></value>
-          </attribute>
-          <attribute id="0x403b" name="Display brightness" type="enum8" access="rw" required="o" mfcode="0x1209">
-            <value name="0" value="0x00"></value>
-            <value name="1" value="0x01"></value>
-            <value name="2" value="0x02"></value>
-            <value name="3" value="0x03"></value>
-            <value name="4" value="0x04"></value>
-            <value name="5" value="0x05"></value>
-            <value name="6" value="0x06"></value>
-            <value name="7" value="0x07"></value>
-            <value name="8" value="0x08"></value>
-            <value name="9" value="0x09"></value>
-            <value name="10" value="0x0A"></value>
-          </attribute>
-          <attribute id="0x406a" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209"></attribute>
-          <attribute id="0x406b" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209"></attribute>
-          <attribute id="0x406c" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209"></attribute>
-          <attribute id="0x406d" name="Unknown" type="enum8" access="rw" required="o" mfcode="0x1209"></attribute>
-        </attribute-set>
-
-      </server>
-      <client>
-      </client>
-    </cluster>
-
-    <cluster id="0xde42" name="DE Debug">
-      <description>Attributes and commands for debugging purposes.</description>
-      <server>
-        <attribute id="0x0000" name="Debug enabled" type="bool" access="rw" default="0x00" required="m"></attribute>
-        <attribute id="0x0001" name="Debug destination" type="u16" access="rw" default="0x0000" showas="hex" required="m"></attribute>
-      </server>
-      <client>
-        <!-- TODO -->
-      </client>
-    </cluster>
-  </domain>
-
-  <domain name="Lighting" low_bound="0300" high_bound="03ff" description="The lighting functional domain contains clusters and information to build devices in the lighting domain, e.g. ballast units.">
-    <cluster id="0x0300" name="Color Control">
-      <description>Attributes and commands for controlling the color properties of a color-capable light.</description>
-      <server>
-        <attribute-set id="0x0000" description="Color Information">
-          <attribute id="0x0000" name="Current Hue" type="u8" access="r" range="0x00,0xfe" default="0x00" required="o"></attribute>
-          <attribute id="0x0001" name="Current Saturation" type="u8" access="r" range="0x00,0xfe" default="0x00" required="o"></attribute>
-          <attribute id="0x0002" name="Remaining Time" type="u16" access="r" range="0x0000,0xfffe" default="0x0000" required="o"></attribute>
-          <attribute id="0x0003" name="Current X" type="u16" access="r" range="0x0000,0xfeff" default="0x61eb" required="m"></attribute>
-          <attribute id="0x0004" name="Current Y" type="u16" access="r" range="0x0000,0xfeff" default="0x607b" required="m"></attribute>
-          <!-- Haven't yet seen any lights supporting these
+<domain name="Lighting" low_bound="0300" high_bound="03ff" description="The lighting functional domain contains clusters and information to build devices in the lighting domain, e.g. ballast units.">
+  <cluster id="0x0300" name="Color Control">
+    <description>Attributes and commands for controlling the color properties of a color-capable light.</description>
+    <server>
+      <attribute-set id="0x0000" description="Color Information">
+        <attribute id="0x0000" name="Current Hue" type="u8" access="r" range="0x00,0xfe" default="0x00" required="o"></attribute>
+        <attribute id="0x0001" name="Current Saturation" type="u8" access="r" range="0x00,0xfe" default="0x00" required="o"></attribute>
+        <attribute id="0x0002" name="Remaining Time" type="u16" access="r" range="0x0000,0xfffe" default="0x0000" required="o"></attribute>
+        <attribute id="0x0003" name="Current X" type="u16" access="r" range="0x0000,0xfeff" default="0x61eb" required="m"></attribute>
+        <attribute id="0x0004" name="Current Y" type="u16" access="r" range="0x0000,0xfeff" default="0x607b" required="m"></attribute>
+        <!-- Haven't yet seen any lights supporting these
           <attribute id="0x0005" name="Drift Compensation" type="enum8" access="r" required="o">
             <value name="None" value="0x00"></value>
             <value name="Other / Unknown" value="0x01"></value>
@@ -3156,1354 +3152,1398 @@ Displayed setpoint is not affected, but regulated setpoint will change. Can be u
 	        </attribute>
           <attribute id="0x0006" name="Compensation Text" type="cstring" access="r" required="o"></attribute>
           -->
-          <attribute id="0x0007" name="Color Temperature Mireds" type="u16" access="r" range="0x0000,0xfeff" default="0" required="m"></attribute>
-          <attribute id="0x0008" name="Color Mode" type="enum8" access="r" range="0x00,0x02" default="0x01" required="o">
-            <value name="Current hue and current saturation" value="0x00"></value>
-            <value name="Current x and current y" value="0x01"></value>
-            <value name="Color temperature" value="0x02"></value>
-          </attribute>
-          <attribute id = "0x000f" name="Options" type="bmp8" access="rw" required="o">
-            <value name="Execute If Off" value="0"></value>
-          </attribute>
-          <!-- TODO -->
-          <attribute id="0x4000" name="Enhanced Current Hue" type="u16" access="r" range="0x0000,0xffff" default="0x0000" required="m"></attribute>
-          <attribute id="0x4001" name="Enhanced Color Mode" type="enum8" access="r" range="0x00,0xff" default="0x00" required="m">
-            <value name="Current hue and current saturation" value="0x00"></value>
-            <value name="Current x and current y" value="0x01"></value>
-            <value name="Color temperature" value="0x02"></value>
-            <value name="Enhanced current hue and current saturation" value="0x03"></value>
-          </attribute>
-          <attribute id="0x4002" name="Color Loop Active" type="u8" access="r" range="0x00,0xff" default="0x00" required="m"></attribute>
-          <attribute id="0x4003" name="Color Loop Direction" type="u8" access="r" range="0x00,0xff" default="0x00" required="m"></attribute>
-          <attribute id="0x4004" name="Color Loop Time" type="u16" access="r" range="0x00,0xff" default="0x0019" required="m"></attribute>
-          <attribute id="0x4005" name="Color Loop Start Enhanced Hue" type="u16" access="r" range="0x00,0xff" default="0x2300" required="m"></attribute>
-          <attribute id="0x4006" name="Color Loop Stored Enhanced Hue" type="u16" access="r" range="0x00,0xff" default="0x0000" required="m"></attribute>
-          <attribute id="0x400a" type="bmp16" name="Color Capabilities" access="r" required="m" default="0x0000">
-            <value name="Hue saturation" value="0"></value>
-            <value name="Enhanced Hue saturation" value="1"></value>
-            <value name="Color loop" value="2"></value>
-            <value name="CIE 1931 XY" value="3"></value>
-            <value name="Color temperature" value="4"></value>
-          </attribute>
-          <attribute id="0x400b" name="Color Temperature Min Mireds" type="u16" access="r" range="0x0000,0xfeff" default="0" required="m"></attribute>
-          <attribute id="0x400c" name="Color Temperature Max Mireds" type="u16" access="r" range="0x0000,0xfeff" default="0xfeff" required="m"></attribute>
-          <attribute id="0x400d" name="Couple Color Temp To Min Mireds" type="u16" access="r" range="0x0000,0xfeff" required="m"></attribute>
-          <attribute id="0x4010" name="StartUp Color Temperature Mireds" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
-          <attribute id="0x0003" mfcode="0x100b" name="Hue StartUp Current X" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
-          <attribute id="0x0004" mfcode="0x100b" name="Hue StartUp Current Y" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
-        </attribute-set>
-        <attribute-set id="0x0010" description="Defined Primaries Information">
-          <attribute id="0x0010" name="Number of Primaries" type="u8" access="r" range="0x00,0x06" required="o"></attribute>
-          <attribute id="0x0011" name="Primary1 X" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0012" name="Primary1 Y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0013" name="Primary1 Intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
-          <attribute id="0x0015" name="Primary2 X" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0016" name="Primary2 Y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0017" name="Primary2 Intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
-          <attribute id="0x0019" name="Primary3 X" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x001a" name="Primary3 Y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x001b" name="Primary3 Intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
-        </attribute-set>
-        <attribute-set id="0x0020" description="Additional Defined Primaries Information">
-          <attribute id="0x0020" name="Primary4 X" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0021" name="Primary4 Y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0022" name="Primary4 Intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
-          <attribute id="0x0024" name="Primary5 X" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0025" name="Primary5 Y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0026" name="Primary5 Intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
-          <attribute id="0x0028" name="Primary6 X" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0029" name="Primary6 Y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x002a" name="Primary6 Intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
-        </attribute-set>
-        <attribute-set id="0x0030" description="Defined Color Points Settings">
-          <attribute id="0x0030" name="WhitePoint X" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0031" name="WhitePoint Y" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0032" name="ColorPoint R X" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0033" name="ColorPoint R Y" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0034" name="ColorPoint R Intensity" type="u8" access="rw" range="0x00,0xff" required="o"></attribute>
-          <attribute id="0x0036" name="ColorPoint G X" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0037" name="ColorPoint G Y" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x0038" name="ColorPoint G Intensity" type="u8" access="rw" range="0x00,0xff" required="o"></attribute>
-          <attribute id="0x003a" name="ColorPoint B X" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x003b" name="ColorPoint B Y" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
-          <attribute id="0x003c" name="ColorPoint B Intensity" type="u8" access="rw" range="0x00,0xff" required="o"></attribute>
-        </attribute-set>
-        <attribute-set id="0xde00" description="FLS extensions" mfcode="0x1135">
-          <attribute id="0xde01" name="Active channels" type="u8" access="r" range="0x00,0xff" default="0x00" required="m"></attribute>
-        </attribute-set>
-        <command id="0x00" dir="recv" name="Move to Hue" required="o">
-          <payload>
-            <attribute id="0x0000" type="u8" name="Hue" required="m"></attribute>
-            <attribute id="0x0001" type="enum8" name="Direction" required="m">
-              <value name="Shortest Distance" value="0x00"></value>
-              <value name="Longest Distance" value="0x01"></value>
-              <value name="Up" value="0x02"></value>
-              <value name="Down" value="0x03"></value>
-            </attribute>
-            <attribute id="0x0002" type="u16" name="Transition Time" required="m">
-              <description>The transition time in 1/10ths of a second.</description>
-            </attribute>
-          </payload>
-        </command>
-        <command id="0x01" dir="recv" name="Move Hue" required="o">
-          <payload>
-            <attribute id="0x0001" type="enum8" name="Move Mode" required="m">
-              <value name="Stop" value="0x00"></value>
-              <value name="Up" value="0x01"></value>
-              <value name="Down" value="0x03"></value>
-            </attribute>
-            <attribute id="0x0002" type="u8" name="Rate" required="m"></attribute>
-          </payload>
-        </command>
-        <command id="0x02" dir="recv" name="Step Hue" required="o">
-          <payload>
-            <attribute id="0x0000" type="enum8" name="Step Mode" required="m">
-              <value name="Up" value="0x01"></value>
-              <value name="Down" value="0x03"></value>
-            </attribute>
-            <attribute id="0x0001" type="u8" name="Step Size" required="m"></attribute>
-            <attribute id="0x0002" type="u8" name="Transition Time" required="m">
-              <description>The transition time in 1/10 seconds.</description>
-            </attribute>
-          </payload>
-        </command>
-        <command id="0x03" dir="recv" name="Move to Saturation" required="o">
-          <payload>
-            <attribute id="0x0000" type="u8" name="Saturation" required="m"></attribute>
-            <attribute id="0x0001" type="u16" name="Transition Time" required="m">
-              <description>The transition time in 1/10 seconds.</description>
-            </attribute>
-          </payload>
-        </command>
-        <command id="0x04" dir="recv" name="Move Saturation" required="o">
-          <payload>
-            <attribute id="0x0000" type="enum8" name="Move Mode" required="m">
-              <value name="Stop" value="0x00"></value>
-              <value name="Up" value="0x01"></value>
-              <value name="Down" value="0x03"></value>
-            </attribute>
-            <attribute id="0x0001" type="u8" name="Rate" required="m">
-              <description>The steps per second.</description>
-            </attribute>
-          </payload>
-        </command>
-        <command id="0x05" dir="recv" name="Step Saturation" required="o">
-          <payload>
-            <attribute id="0x0000" type="enum8" name="Step Mode" required="m">
-              <value name="Up" value="0x01"></value>
-              <value name="Down" value="0x03"></value>
-            </attribute>
-            <attribute id="0x0001" type="u8" name="Step Size" required="m"></attribute>
-            <attribute id="0x0002" type="u8" name="Transition Time" required="m">
-              <description>The transition time in 1/10 seconds.</description>
-            </attribute>
-          </payload>
-        </command>
-        <command id="0x06" dir="recv" name="Move to Hue and Saturation" required="o">
-          <payload>
-            <attribute id="0x0000" type="u8" name="Hue" required="m"></attribute>
-            <attribute id="0x0001" type="u8" name="Saturation" required="m"></attribute>
-            <attribute id="0x0002" type="u16" name="Transition Time" required="m">
-              <description>The transition time in 1/10 seconds.</description>
-            </attribute>
-          </payload>
-        </command>
-        <command id="0x07" dir="recv" name="Move to Color" required="m">
-          <payload>
-            <attribute id="0x0000" type="u16" name="Color X" required="m"></attribute>
-            <attribute id="0x0001" type="u16" name="Color Y" required="m"></attribute>
-            <attribute id="0x0002" type="u16" name="Transition Time" required="m">
-              <description>The transition time in 1/10 seconds.</description>
-            </attribute>
-          </payload>
-        </command>
-        <command id="0x08" dir="recv" name="Move Color" required="o">
-          <payload>
-            <attribute id="0x0000" type="s16" name="Rate X" required="m">
-              <description>The steps per second.</description>
-            </attribute>
-            <attribute id="0x0001" type="s16" name="Rate Y" required="m">
-              <description>The steps per second.</description>
-            </attribute>
-          </payload>
-        </command>
-        <command id="0x09" dir="recv" name="Step Color" required="o">
-          <payload>
-            <attribute id="0x0000" type="s16" name="Step X" required="m"></attribute>
-            <attribute id="0x0001" type="s16" name="Step Y" required="m"></attribute>
-            <attribute id="0x0002" type="u16" name="Transition Time" required="m">
-              <description>The transition time in 1/10 seconds.</description>
-            </attribute>
-          </payload>
-        </command>
-        <command id="0x0a" dir="recv" name="Move to Color Temperature" required="o">
-          <payload>
-            <attribute id="0x0000" type="u16" name="Color temperature Mireds" required="m"></attribute>
-            <attribute id="0x0001" type="u16" name="Transition Time" required="m">
-              <description>The transition time in 1/10 seconds.</description>
-            </attribute>
-          </payload>
-        </command>
-        <command id="0x40" dir="recv" name="Enhanced Move to Hue" required="m">
-          <payload>
-            <attribute id="0x0000" type="u16" name="Enhanced Hue" required="m"></attribute>
-            <attribute id="0x0001" type="enum8" name="Direction" required="m">
-              <value name="Shortest Distance" value="0x00"></value>
-              <value name="Longest Distance" value="0x01"></value>
-              <value name="Up" value="0x02"></value>
-              <value name="Down" value="0x03"></value>
-            </attribute>
-            <attribute id="0x0002" type="u16" name="Transition Time" required="m">
-              <description>The transition time in 1/10 seconds.</description>
-            </attribute>
-          </payload>
-        </command>
-        <command id="0x41" dir="recv" name="Enhanced Move Hue" required="m">
-          <payload>
-            <attribute id="0x0000" type="enum8" name="Move Mode" required="m">
-              <value name="Stop" value="0x00"></value>
-              <value name="Up" value="0x01"></value>
-              <value name="Down" value="0x03"></value>
-            </attribute>
-            <attribute id="0x0001" type="u16" name="Rate" required="m">
-              <description>Steps per second.</description>
-            </attribute>
-          </payload>
-        </command>
-        <command id="0x42" dir="recv" name="Enhanced Step Hue" required="m">
-          <payload>
-            <attribute id="0x0000" type="enum8" name="Step Mode" required="m">
-              <value name="Up" value="0x01"></value>
-              <value name="Down" value="0x03"></value>
-            </attribute>
-            <attribute id="0x0001" type="u16" name="Step Size" required="m"></attribute>
-            <attribute id="0x0002" type="u16" name="Transition Time" required="m">
-              <description>The transition time in 1/10 seconds.</description>
-            </attribute>
-          </payload>
-        </command>
-        <command id="0x43" dir="recv" name="Enhanced Move to Hue and Saturation" required="m">
-          <payload>
-            <attribute id="0x0000" type="u16" name="Enhanced Hue" required="m"></attribute>
-            <attribute id="0x0001" type="u8" name="Saturation" required="m"></attribute>
-            <attribute id="0x0002" type="u16" name="Transition Time" required="m">
-              <description>The transition time in 1/10 seconds.</description>
-            </attribute>
-          </payload>
-        </command>
-        <command id="0x44" dir="recv" name="Color Loop Set" required="m">
-          <payload>
-            <attribute id="0x0000" type="bmp8" name="Update Flags" required="m">
-              <value name="Update Action" value="0"></value>
-              <value name="Update Direction" value="1"></value>
-              <value name="Update Time" value="2"></value>
-              <value name="Update Start Hue" value="3"></value>
-            </attribute>
-            <attribute id="0x0001" type="enum8" name="Action" required="m">
-              <value name="De-activate color loop" value="0x00"></value>
-              <value name="Activate from Color Loop Start Enhanced Hue" value="0x01"></value>
-              <value name="Activate from Enhanced Current Hue" value="0x02"></value>
-            </attribute>
-            <attribute id="0x0002" type="enum8" name="Direction" required="m">
-              <value name="Decrement Hue" value="0x00"></value>
-              <value name="Increment Hue" value="0x01"></value>
-            </attribute>
-            <attribute id="0x0003" type="u16" name="Time" required="m">
-              <description>Time in seconds used for a whole color loop.</description>
-            </attribute>
-            <attribute id="0x0004" type="u16" name="Start Enhanced Hue" required="m"></attribute>
-          </payload>
-        </command>
-        <command id="0x47" dir="recv" name="Stop move step" required="m">
-          <description>Stops move to and step commands. It has no effect on a active color loop.</description>
-          <payload></payload>
-        </command>
-        <command id="0x4b" dir="recv" name="Move Color Temperature" required="m">
-          <payload>
-            <attribute id="0x0000" type="enum8" name="Move Mode" required="m">
-              <value name="Stop" value="0x00"></value>
-              <value name="Up" value="0x01"></value>
-              <value name="Down" value="0x03"></value>
-            </attribute>
-            <attribute id="0x0001" type="u16" name="Rate" required="m">
-              <description>Steps per second.</description>
-            </attribute>
-            <attribute id="0x0002" type="u16" name="Color Temperature Min Mireds" required="m">
-              <description>Specifies a lower bound on the color temperature for the current move operation.</description>
-            </attribute>
-            <attribute id="0x0003" type="u16" name="Color Temperature Max Mireds" required="m">
-              <description>Specifies a upper bound on the color temperature for the current move operation.</description>
-            </attribute>
-          </payload>
-        </command>
-        <command id="0x4c" dir="recv" name="Step Color Temperature" required="m">
-          <payload>
-            <attribute id="0x0000" type="enum8" name="Step Mode" required="m">
-              <value name="Up" value="0x01"></value>
-              <value name="Down" value="0x03"></value>
-            </attribute>
-            <attribute id="0x0001" type="u16" name="Step Size" required="m"></attribute>
-            <attribute id="0x0002" type="u16" name="Transition Time" required="m">
-              <description>The transition time in 1/10 seconds.</description>
-            </attribute>
-            <attribute id="0x0003" type="u16" name="Color Temperature Min Mireds" required="m">
-              <description>Specifies a lower bound on the color temperature for the current step operation.</description>
-            </attribute>
-            <attribute id="0x0004" type="u16" name="Color Temperature Max Mireds" required="m">
-              <description>Specifies a upper bound on the color temperature for the current step operation.</description>
-            </attribute>
-          </payload>
-        </command>
-        <command id="0xd0" dir="recv" name="Set Active Channels" required="m">
-          <payload>
-            <attribute id="0x00" type="u8" name="Channels" required="m"></attribute>
-          </payload>
-        </command>
-      </server>
-      <client></client>
-    </cluster>
-
-    <cluster id="0x0301" name="Ballast Configuration">
-      <description>Attributes and commands to configure a ballast.</description>
-      <server>
-        <attribute-set id="0x0000" description="Ballast Information">
-          <attribute id="0x0000" name="Physical Min Level" type="u8" access="r" range="0x01,0xfe" default="0x01" required="o"></attribute>
-          <attribute id="0x0001" name="Physical Max Level" type="u8" access="r" range="0x01,0xfe" default="0xfe" required="o"></attribute>
-          <attribute id="0x0002" name="Ballast Status" type="bmp8" access="r" default="0x00" required="m">
-            <value name="Non-operational" value="0"></value>
-            <value name="Lamp not in socket" value="1"></value>
-          </attribute>
-        </attribute-set>
-        <attribute-set id="0x0010" description="Ballast Settings">
-          <attribute id="0x0010" name="Min Level" type="u8" access="rw" range="0x01,0xfe" default="0x01" required="o"></attribute>
-          <attribute id="0x0011" name="Max Level" type="u8" access="rw" range="0x01,0xfe" default="0xfe" required="o"></attribute>
-          <attribute id="0x0012" name="Power On Level" type="u8" access="rw" range="0x01,0xfe" default="0xfe" required="o"></attribute>
-          <attribute id="0x0013" name="Power On Fade Time" type="u16" access="rw" range="0x0000,0xfffe" default="0x0000" required="o"></attribute>
-          <attribute id="0x0014" name="Intrinsic Ballast Factor" type="u8" access="rw" range="0x00,0xfe" default="0x00" required="o"></attribute>
-          <attribute id="0x0015" name="Ballast Factor Adjustment" type="u8" access="rw" range="0x64,0xff" default="0xff" required="o"></attribute>
-        </attribute-set>
-        <attribute-set id="0x0020" description="Lamp Information">
-          <attribute id="0x0020" name="Lamp Quantity" type="u8" access="r" range="0x00,0xfe" default="0x00" required="o"></attribute>
-        </attribute-set>
-        <attribute-set id="0x0030" description="Lamp Settings">
-          <attribute id="0x0030" name="Lamp Type" type="cstring" access="rw" required="o"></attribute>
-          <attribute id="0x0031" name="Lamp Manufacturer" type="cstring" access="rw" required="o"></attribute>
-          <attribute id="0x0032" name="Lamp Rated Hours" type="u24" access="rw" range="0x000000,0xfffffe" default="0xffffff" required="o"></attribute>
-          <attribute id="0x0033" name="Lamp Burn Hours" type="u24" access="rw" range="0x000000,0xfffffe" default="0x000000" required="o"></attribute>
-          <attribute id="0x0034" name="Lamp Alarm Mode" type="bmp8" access="rw" default="0x00" required="m">
-            <value name="Lamp Burn Hours" value="0"></value>
-          </attribute>
-          <attribute id="0x0035" name="Lamp Burn Hours Trip Point" type="u24" access="rw" range="0x000000,0xfffffe" default="0x000000" required="o"></attribute>
-        </attribute-set>
-        <attribute-set id="0xe000" description="Dimmer Mode" mfcode="0x105e">
-          <attribute id="0xE000" name="Dimmer Mode" type="enum8" default="0x00" access="rw" required="o" mfcode="0x105e">
-            <description>Sets dimming mode to autodetect or fixed RC/RL/RL_LED mode (max load is reduced in RL_LED)</description>
-            <value name="Auto" value="0"></value>
-            <value name="RC" value="1"></value>
-            <value name="RL" value="2"></value>
-            <value name="RL_LED" value="3"></value>
-          </attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-  </domain>
-
-  <domain name="Measurement and sensing" low_bound="0400" high_bound="04ff" description="The measurement and sensing functional domain contains clusters and information to build devices in the measurement and sensing domain, e.g. a temperature sensor or an occupancy sensor.">
-    <cluster id="0x0400" name="Illuminance measurement">
-      <description>The server cluster provides an interface to illuminance measurement functionality, including configuration and provision of notifications of illuminance measurements.</description>
-      <!-- TODO -->
-      <server>
-        <attribute-set id="0x0000" description="Illuminance Measurement Information">
-          <attribute id="0x0000" name="Measured Value" type="u16" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="u16" access="r" required="m" range="0x0002,0xfffd"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="u16" access="r" required="m" range="0x0001,0x7ffe"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o" range="0x0000,0x0800"></attribute>
-          <attribute id="0x0004" name="Light Sensor Type" type="enum8" range="0x00,0xff" access="r" required="o">
-            <value name="Photodiode" value="0x00"></value>
-            <value name="CMOS" value="0x01"></value>
-            <value name="Unknown" value="0xff"></value>
-          </attribute>
-        </attribute-set>
-      </server>
-      <client>
-        <attribute-set id="0xf000" description="Illuminance Adjustement Configuration">
-          <attribute id="0xf000" name="Hysteresis" type="u16" access="rw" required="o"></attribute>
-          <attribute id="0xf001" name="Max Up Speed" type="u16" access="rw" required="o">
-            <description>Maximum up adjustment speed in 1/10 seconds.</description>
-          </attribute>
-          <attribute id="0xf002" name="Max Down Speed" type="u16" access="rw" required="o">
-            <description>Maximum down adjustment speed in 1/10 seconds.</description>
-          </attribute>
-          <attribute id="0xf003" name="Target Value" type="u16" access="rw" required="o">
-            <description>Target value in Lux which should be kept.</description>
-          </attribute>
-          <attribute id="0xf004" name="Startup Type" type="enum8" access="rw" required="o">
-            <description>Brightness control startup type.</description>
-            <value name="Default Level" value="0x00"></value>
-            <value name="Zero Level" value="0x01"></value>
-          </attribute>
-        </attribute-set>
-      </client>
-    </cluster>
-
-    <cluster id="0x0401" name="Illuminance level sensing">
-      <description></description>
-      <!-- TODO -->
-    </cluster>
-
-    <cluster id="0x0402" name="Temperature measurement">
-      <description>The server cluster provides an interface to temperature measurement functionality, including configuration and provision of notifications of temperature measurements.</description>
-      <!-- TODO -->
-      <server>
-        <attribute-set id="0x0000" description="Temperature Measurement Information">
-          <attribute id="0x0000" name="Measured Value" type="s16" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="s16" access="r" required="m" range="0x954d,0x7ffe"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="s16" access="r" required="m" range="0x954e,0x7ffe"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o" range="0x0000,0x0800"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-
-    <cluster id="0x0403" name="Pressure measurement">
-      <description>The server cluster provides an interface to air pressure measurement functionality, including configuration and provision of notifications of air pressure measurements.</description>
-      <server>
-        <attribute-set id="0x0000" description="Pressure Measurement Information">
-          <attribute id="0x0000" name="Measured Value" type="s16" access="r" default="0x8000" required="m"></attribute>
-	  <attribute id="0x0001" name="Min Measured Value" type="u16" access="r" required="m" range="0x8001,0x7ffe"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="u16" access="r" required="m" range="0x8002,0x7fff"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o" range="0x0000,0x0800"></attribute>
-        </attribute-set>
-	<attribute-set id="0x0001" description="Extended Pressure Measurement Information">
-          <attribute id="0x0010" name="Scaled Value" type="s16" access="r" default="0" required="o"></attribute>
-	  <attribute id="0x0011" name="Min Scaled Value" type="u16" access="r" required="m" range="0x8001,0x7ffe"></attribute>
-          <attribute id="0x0012" name="Max Scaled Value" type="u16" access="r" required="m" range="0x8002,0x7fff"></attribute>
-          <attribute id="0x0013" name="Scaled Tolerance" type="u16" access="r" required="o" range="0x0000,0x0800"></attribute>
-          <attribute id="0x0014" name="Scale" type="s8" access="r" required="o" range="0x81,0x7f"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-
-    <cluster id="0x0404" name="Flow measurement">
-      <description>The server cluster provides an interface to flow measurement measurement functionality, including configuration and provision of notifications of flow measurements.</description>
-      <server>
-        <attribute-set id="0x0000" description="Flow Measurement Information">
-          <attribute id="0x0000" name="Measured Value" type="u16" access="r" default="0xFFFF" required="m">
-	  <description>Represents the flow in m3/h times 10 </description></attribute>
-	  <attribute id="0x0001" name="Min Measured Value" type="u16" access="r" required="m" range="0x0000,0xfffd"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="u16" access="r" required="m" range="0x0001,0x7ffe"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o" range="0x0000,0x0800"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-
-    <cluster id="0x0405" name="Relative humidity measurement">
-      <description>Percentage of water in the air</description>
-      <server>
-        <attribute-set id="0x0000" description="Relative Humidity Measurement Information">
-          <attribute id="0x0000" name="Measured Value" type="u16" access="r" default="0xffff" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="u16" access="r" required="m" range="0x0000,0x270f"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="u16" access="r" required="m" range="0x0001,0x2710"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o" range="0x0000,0x0800"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-
-    <cluster id="0x0406" name="Occupancy sensing">
-      <description>
+        <attribute id="0x0007" name="Color Temperature Mireds" type="u16" access="r" range="0x0000,0xfeff" default="0" required="m"></attribute>
+        <attribute id="0x0008" name="Color Mode" type="enum8" access="r" range="0x00,0x02" default="0x01" required="o">
+          <value name="Current hue and current saturation" value="0x00"></value>
+          <value name="Current x and current y" value="0x01"></value>
+          <value name="Color temperature" value="0x02"></value>
+        </attribute>
+        <attribute id = "0x000f" name="Options" type="bmp8" access="rw" required="o">
+          <value name="Execute If Off" value="0"></value>
+        </attribute>
         <!-- TODO -->
-      </description>
-      <server>
-        <attribute-set id="0x0000" description="Occupancy sensor information">
-          <attribute id="0x0000" name="Occupancy" type="bmp8" range="0000000x" access="r" required="m"></attribute>
-          <attribute id="0x0001" name="Occupancy Sensor Type" type="enum8" range="0x00,0xfe" access="r" required="m">
-            <value name="PIR" value="0x00"></value>
-            <value name="Ultrasonic" value="0x01"></value>
-            <value name="PIR and ultrasonic" value="0x02"></value>
-	    <value name="Physical contact" value="0x03"></value>
+        <attribute id="0x4000" name="Enhanced Current Hue" type="u16" access="r" range="0x0000,0xffff" default="0x0000" required="m"></attribute>
+        <attribute id="0x4001" name="Enhanced Color Mode" type="enum8" access="r" range="0x00,0xff" default="0x00" required="m">
+          <value name="Current hue and current saturation" value="0x00"></value>
+          <value name="Current x and current y" value="0x01"></value>
+          <value name="Color temperature" value="0x02"></value>
+          <value name="Enhanced current hue and current saturation" value="0x03"></value>
+        </attribute>
+        <attribute id="0x4002" name="Color Loop Active" type="u8" access="r" range="0x00,0xff" default="0x00" required="m"></attribute>
+        <attribute id="0x4003" name="Color Loop Direction" type="u8" access="r" range="0x00,0xff" default="0x00" required="m"></attribute>
+        <attribute id="0x4004" name="Color Loop Time" type="u16" access="r" range="0x00,0xff" default="0x0019" required="m"></attribute>
+        <attribute id="0x4005" name="Color Loop Start Enhanced Hue" type="u16" access="r" range="0x00,0xff" default="0x2300" required="m"></attribute>
+        <attribute id="0x4006" name="Color Loop Stored Enhanced Hue" type="u16" access="r" range="0x00,0xff" default="0x0000" required="m"></attribute>
+        <attribute id="0x400a" type="bmp16" name="Color Capabilities" access="r" required="m" default="0x0000">
+          <value name="Hue saturation" value="0"></value>
+          <value name="Enhanced Hue saturation" value="1"></value>
+          <value name="Color loop" value="2"></value>
+          <value name="CIE 1931 XY" value="3"></value>
+          <value name="Color temperature" value="4"></value>
+        </attribute>
+        <attribute id="0x400b" name="Color Temperature Min Mireds" type="u16" access="r" range="0x0000,0xfeff" default="0" required="m"></attribute>
+        <attribute id="0x400c" name="Color Temperature Max Mireds" type="u16" access="r" range="0x0000,0xfeff" default="0xfeff" required="m"></attribute>
+        <attribute id="0x400d" name="Couple Color Temp To Min Mireds" type="u16" access="r" range="0x0000,0xfeff" required="m"></attribute>
+        <attribute id="0x4010" name="StartUp Color Temperature Mireds" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
+        <attribute id="0x0003" mfcode="0x100b" name="Hue StartUp Current X" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
+        <attribute id="0x0004" mfcode="0x100b" name="Hue StartUp Current Y" type="u16" access="rw" range="0x0000,0xffff" default="0xffff" required="o"></attribute>
+      </attribute-set>
+      <attribute-set id="0x0010" description="Defined Primaries Information">
+        <attribute id="0x0010" name="Number of Primaries" type="u8" access="r" range="0x00,0x06" required="o"></attribute>
+        <attribute id="0x0011" name="Primary1 X" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+        <attribute id="0x0012" name="Primary1 Y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+        <attribute id="0x0013" name="Primary1 Intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
+        <attribute id="0x0015" name="Primary2 X" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+        <attribute id="0x0016" name="Primary2 Y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+        <attribute id="0x0017" name="Primary2 Intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
+        <attribute id="0x0019" name="Primary3 X" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+        <attribute id="0x001a" name="Primary3 Y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+        <attribute id="0x001b" name="Primary3 Intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
+      </attribute-set>
+      <attribute-set id="0x0020" description="Additional Defined Primaries Information">
+        <attribute id="0x0020" name="Primary4 X" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+        <attribute id="0x0021" name="Primary4 Y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+        <attribute id="0x0022" name="Primary4 Intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
+        <attribute id="0x0024" name="Primary5 X" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+        <attribute id="0x0025" name="Primary5 Y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+        <attribute id="0x0026" name="Primary5 Intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
+        <attribute id="0x0028" name="Primary6 X" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+        <attribute id="0x0029" name="Primary6 Y" type="u16" access="r" range="0x0000,0xfeff" required="o"></attribute>
+        <attribute id="0x002a" name="Primary6 Intensity" type="u8" access="r" range="0x00,0xff" required="o"></attribute>
+      </attribute-set>
+      <attribute-set id="0x0030" description="Defined Color Points Settings">
+        <attribute id="0x0030" name="WhitePoint X" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
+        <attribute id="0x0031" name="WhitePoint Y" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
+        <attribute id="0x0032" name="ColorPoint R X" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
+        <attribute id="0x0033" name="ColorPoint R Y" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
+        <attribute id="0x0034" name="ColorPoint R Intensity" type="u8" access="rw" range="0x00,0xff" required="o"></attribute>
+        <attribute id="0x0036" name="ColorPoint G X" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
+        <attribute id="0x0037" name="ColorPoint G Y" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
+        <attribute id="0x0038" name="ColorPoint G Intensity" type="u8" access="rw" range="0x00,0xff" required="o"></attribute>
+        <attribute id="0x003a" name="ColorPoint B X" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
+        <attribute id="0x003b" name="ColorPoint B Y" type="u16" access="rw" range="0x0000,0xfeff" required="o"></attribute>
+        <attribute id="0x003c" name="ColorPoint B Intensity" type="u8" access="rw" range="0x00,0xff" required="o"></attribute>
+      </attribute-set>
+      <attribute-set id="0xde00" description="FLS extensions" mfcode="0x1135">
+        <attribute id="0xde01" name="Active channels" type="u8" access="r" range="0x00,0xff" default="0x00" required="m"></attribute>
+      </attribute-set>
+      <command id="0x00" dir="recv" name="Move to Hue" required="o">
+        <payload>
+          <attribute id="0x0000" type="u8" name="Hue" required="m"></attribute>
+          <attribute id="0x0001" type="enum8" name="Direction" required="m">
+            <value name="Shortest Distance" value="0x00"></value>
+            <value name="Longest Distance" value="0x01"></value>
+            <value name="Up" value="0x02"></value>
+            <value name="Down" value="0x03"></value>
           </attribute>
-	  <attribute id="0x0002" name="Occupancy Sensor Type Bitmap" type="bmp8" access="r" required="m"></attribute>
-        </attribute-set>
-        <attribute-set id="0x0010" description="PIR configuration">
-          <attribute id="0x0010" name="PIR Occupied To Unoccupied Delay" type="u16" range="0x00,0xfffe" access="rw" required="o" default="0x00">
-            <description>The PIROccupiedToUnoccupiedDelay attribute is 16-bits in length and specifies the time delay, in seconds, before the PIR sensor changes to its occupied state when the sensed area becomes unoccupied. This attribute, along with PIRUnoccupiedToOccupiedTime, may be used to reduce sensor 'chatter' when used in an area where occupation changes frequently.</description>
+          <attribute id="0x0002" type="u16" name="Transition Time" required="m">
+            <description>The transition time in 1/10ths of a second.</description>
           </attribute>
-          <attribute id="0x0011" name="PIR Unoccupied To Occupied Delay" type="u16" range="0x00,0xfffe" access="rw" required="o" default="0x00">
-            <description>The PIRUnoccupiedToOccupiedDelay attribute is 16-bits in length and specifies the time delay, in seconds, before the PIR sensor changes to its unoccupied state when the sensed area becomes occupied.</description>
+        </payload>
+      </command>
+      <command id="0x01" dir="recv" name="Move Hue" required="o">
+        <payload>
+          <attribute id="0x0001" type="enum8" name="Move Mode" required="m">
+            <value name="Stop" value="0x00"></value>
+            <value name="Up" value="0x01"></value>
+            <value name="Down" value="0x03"></value>
           </attribute>
-          <attribute id="0x0012" name="PIR Unoccupied To Occupied Threshold" type="u8" range="0x01,0xfe" access="rw" required="o" default="0x01">
-            <description>The PIRUnoccupiedToOccupiedThreshold attribute is 8 bits in length and specifies the number of movement detection events that must occur in the period PIRUnoccupiedToOccupiedDelay, before the PIR sensor changes to its occupied state.</description>
+          <attribute id="0x0002" type="u8" name="Rate" required="m"></attribute>
+        </payload>
+      </command>
+      <command id="0x02" dir="recv" name="Step Hue" required="o">
+        <payload>
+          <attribute id="0x0000" type="enum8" name="Step Mode" required="m">
+            <value name="Up" value="0x01"></value>
+            <value name="Down" value="0x03"></value>
           </attribute>
-        </attribute-set>
-        <attribute-set id="0x0020" description="Ultrasonic configuration">
-          <attribute id="0x0020" name="Ultrasonic Occupied To Unoccupied Delay" type="u16" range="0x00,0xfe" access="rw" required="o" default="0x00">
-            <description>The UltraSonicOccupiedToUnoccupiedDelay attribute specifies the time delay, in seconds, before the ultrasonic sensor changes to its occupied state when the sensed area becomes unoccupied. This attribute, along with UltraSonicUnoccupiedToOccupiedTime, may be used to reduce sensor 'chatter' when used in an area where occupation changes frequently.</description>
+          <attribute id="0x0001" type="u8" name="Step Size" required="m"></attribute>
+          <attribute id="0x0002" type="u8" name="Transition Time" required="m">
+            <description>The transition time in 1/10 seconds.</description>
           </attribute>
-          <attribute id="0x0021" name="Ultrasonic Unoccupied To Occupied Delay" type="u16" range="0x00,0xfe" access="rw" required="o" default="0x00">
-            <description>The UltraSonicUnoccupiedToOccupiedDelay attribute specifies the time delay, in seconds, before the ultrasonic sensor changes to its unoccupied state when the sensed area becomes occupied.</description>
+        </payload>
+      </command>
+      <command id="0x03" dir="recv" name="Move to Saturation" required="o">
+        <payload>
+          <attribute id="0x0000" type="u8" name="Saturation" required="m"></attribute>
+          <attribute id="0x0001" type="u16" name="Transition Time" required="m">
+            <description>The transition time in 1/10 seconds.</description>
           </attribute>
-	  <attribute id="0x0022" name="Ultrasonic Unoccupied To Occupied Threshold" type="u8" range="0x01,0xfe" access="rw" required="o" default="0x01">
-            <description>The UltrasonicUnoccupiedToOccupiedThreshold attribute is 8 bits in length and specifies the number of movement detection events that must occur in the period PIRUnoccupiedToOccupiedDelay, before the PIR sensor changes to its occupied state.</description>
+        </payload>
+      </command>
+      <command id="0x04" dir="recv" name="Move Saturation" required="o">
+        <payload>
+          <attribute id="0x0000" type="enum8" name="Move Mode" required="m">
+            <value name="Stop" value="0x00"></value>
+            <value name="Up" value="0x01"></value>
+            <value name="Down" value="0x03"></value>
           </attribute>
-        </attribute-set>
-	<attribute-set id="0x0030" description="Physical Contact configuration">
-          <attribute id="0x0030" name="Physical Contact Occupied To Unoccupied Delay" type="u16" range="0x00,0xfe" access="rw" required="o" default="0x00">
-            <description>The PhysicalContactOccupiedToUnoccupiedDelay attribute specifies the time delay, in seconds, before the Physical Contact sensor changes to its occupied state when the sensed area becomes unoccupied. This attribute, along with UltraSonicUnoccupiedToOccupiedTime, may be used to reduce sensor 'chatter' when used in an area where occupation changes frequently.</description>
+          <attribute id="0x0001" type="u8" name="Rate" required="m">
+            <description>The steps per second.</description>
           </attribute>
-          <attribute id="0x0031" name="Physical Contact Unoccupied To Occupied Delay" type="u16" range="0x00,0xfe" access="rw" required="o" default="0x00">
-            <description>The PhysicalContactUnoccupiedToOccupiedDelay attribute specifies the time delay, in seconds, before the Physical Contact sensor changes to its unoccupied state when the sensed area becomes occupied.</description>
+        </payload>
+      </command>
+      <command id="0x05" dir="recv" name="Step Saturation" required="o">
+        <payload>
+          <attribute id="0x0000" type="enum8" name="Step Mode" required="m">
+            <value name="Up" value="0x01"></value>
+            <value name="Down" value="0x03"></value>
           </attribute>
-	  <attribute id="0x0032" name="Physical Contact Unoccupied To Occupied Threshold" type="u8" range="0x01,0xfe" access="rw" required="o" default="0x01">
-            <description>The PhysicalContactUnoccupiedToOccupiedThreshold attribute is 8 bits in length and specifies the number of movement detection events that must occur in the period PIRUnoccupiedToOccupiedDelay, before the PIR sensor changes to its occupied state.</description>
+          <attribute id="0x0001" type="u8" name="Step Size" required="m"></attribute>
+          <attribute id="0x0002" type="u8" name="Transition Time" required="m">
+            <description>The transition time in 1/10 seconds.</description>
           </attribute>
-        </attribute-set>
-        <attribute-set id="0x0030" description="Philips Specific" mfcode="0x100b">
-          <attribute id="0x0030" name="Sensitivity" type="u8" default="0" access="rw" required="o" mfcode="0x100b"></attribute>
-          <attribute id="0x0031" name="Sensitivity max." type="u8" default="0" access="rw" required="o" mfcode="0x100b"></attribute>
-        </attribute-set>
-        <attribute-set id="0x0000" description="Develco Specific" mfcode="0x1015">
-          <attribute id="0x0000" name="ArmThreshold_MinTemperature" type="s16" access="rw" range="0x954d,0x7ffe" required="m" mfcode="0x1015"></attribute>
-          <attribute id="0x0001" name="ArmThreshold_MaxTemperature" type="s16" access="rw" range="0x954d,0x7ffe" required="m" mfcode="0x1015"></attribute>
-          <attribute id="0x0002" name="Target Level" type="u16" access="rw" range="0x0002,0xfffd" required="m" mfcode="0x1015"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-   
-    <cluster id="0x0407" name="Leaf Wetness measurement">
-      <description>Percentage of water on the leaves of plants</description>
-      <server>
-        <attribute-set id="0x0000" description="Leaf Wetness Measurement Information">
-          <attribute id="0x0000" name="Measured Value" type="u16" access="r" default="0xffff" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="u16" access="r" required="m" range="0x0000,0x270f"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="u16" access="r" required="m" range="0x0001,0x2710"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o" range="0x0000,0x0800"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-            
-    <cluster id="0x0408" name="Soil Moisture measurement">
-      <description>Percentage of water in the soil</description>
-      <server>
-        <attribute-set id="0x0000" description="Soil Moisture Measurement Information">
-          <attribute id="0x0000" name="Measured Value" type="u16" access="r" default="0xffff" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="u16" access="r" required="m" range="0x0000,0x270f"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="u16" access="r" required="m" range="0x0001,0x2710"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o" range="0x0000,0x0800"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-    
-    <cluster id="0x0409" name="pH Measurement">
-      <description>Provides an interface to pH measurement functionality</description>
-      <server>
-        <attribute-set id="0x0000" description="pH measurement Information">
-          <attribute id="0x0000" name="Measured Value" type="u16" access="r" default="0xffff" required="m">
-	    <description>"Represents the pH with no units as follows: Measured Value = 100 x pH"</description>
-	  </attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="u16" access="r" default="0xffff" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="u16" access="r" required="m" default="0xffff"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-    
-    <cluster id="0x040A" name="Electrical Conductivity">
-      <description>Provides an interface to Electrical Conductivity measurement functionality</description>
-      <server>
-        <attribute-set id="0x0000" description="Electrical Conductivity Information">
-          <attribute id="0x0000" name="Measured Value" type="u16" access="r" default="0xffff" required="m">
-	    <description>"Electrical Conductivity in mS/m. The maximum resolution this format allows is 0.1"</description>
-	  </attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="u16" access="r" default="0xffff" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="u16" access="r" required="m" default="0xffff"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-    
-    <cluster id="0x040B" name="Wind Speed Measurement">
-      <description>Provides an interface to Wind Speed Measurement functionality</description>
-      <server>
-        <attribute-set id="0x0000" description="Wind Speed Measurement Information">
-          <attribute id="0x0000" name="Measured Value" type="u16" access="r" default="0xffff" required="m">
-	    <description>"100 x Wind Speed in m/s. The maximum resolution this format allows is 0.01"</description>
-	  </attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="u16" access="r" default="0xffff" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="u16" access="r" required="m" default="0xffff"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
+        </payload>
+      </command>
+      <command id="0x06" dir="recv" name="Move to Hue and Saturation" required="o">
+        <payload>
+          <attribute id="0x0000" type="u8" name="Hue" required="m"></attribute>
+          <attribute id="0x0001" type="u8" name="Saturation" required="m"></attribute>
+          <attribute id="0x0002" type="u16" name="Transition Time" required="m">
+            <description>The transition time in 1/10 seconds.</description>
+          </attribute>
+        </payload>
+      </command>
+      <command id="0x07" dir="recv" name="Move to Color" required="m">
+        <payload>
+          <attribute id="0x0000" type="u16" name="Color X" required="m"></attribute>
+          <attribute id="0x0001" type="u16" name="Color Y" required="m"></attribute>
+          <attribute id="0x0002" type="u16" name="Transition Time" required="m">
+            <description>The transition time in 1/10 seconds.</description>
+          </attribute>
+        </payload>
+      </command>
+      <command id="0x08" dir="recv" name="Move Color" required="o">
+        <payload>
+          <attribute id="0x0000" type="s16" name="Rate X" required="m">
+            <description>The steps per second.</description>
+          </attribute>
+          <attribute id="0x0001" type="s16" name="Rate Y" required="m">
+            <description>The steps per second.</description>
+          </attribute>
+        </payload>
+      </command>
+      <command id="0x09" dir="recv" name="Step Color" required="o">
+        <payload>
+          <attribute id="0x0000" type="s16" name="Step X" required="m"></attribute>
+          <attribute id="0x0001" type="s16" name="Step Y" required="m"></attribute>
+          <attribute id="0x0002" type="u16" name="Transition Time" required="m">
+            <description>The transition time in 1/10 seconds.</description>
+          </attribute>
+        </payload>
+      </command>
+      <command id="0x0a" dir="recv" name="Move to Color Temperature" required="o">
+        <payload>
+          <attribute id="0x0000" type="u16" name="Color temperature Mireds" required="m"></attribute>
+          <attribute id="0x0001" type="u16" name="Transition Time" required="m">
+            <description>The transition time in 1/10 seconds.</description>
+          </attribute>
+        </payload>
+      </command>
+      <command id="0x40" dir="recv" name="Enhanced Move to Hue" required="m">
+        <payload>
+          <attribute id="0x0000" type="u16" name="Enhanced Hue" required="m"></attribute>
+          <attribute id="0x0001" type="enum8" name="Direction" required="m">
+            <value name="Shortest Distance" value="0x00"></value>
+            <value name="Longest Distance" value="0x01"></value>
+            <value name="Up" value="0x02"></value>
+            <value name="Down" value="0x03"></value>
+          </attribute>
+          <attribute id="0x0002" type="u16" name="Transition Time" required="m">
+            <description>The transition time in 1/10 seconds.</description>
+          </attribute>
+        </payload>
+      </command>
+      <command id="0x41" dir="recv" name="Enhanced Move Hue" required="m">
+        <payload>
+          <attribute id="0x0000" type="enum8" name="Move Mode" required="m">
+            <value name="Stop" value="0x00"></value>
+            <value name="Up" value="0x01"></value>
+            <value name="Down" value="0x03"></value>
+          </attribute>
+          <attribute id="0x0001" type="u16" name="Rate" required="m">
+            <description>Steps per second.</description>
+          </attribute>
+        </payload>
+      </command>
+      <command id="0x42" dir="recv" name="Enhanced Step Hue" required="m">
+        <payload>
+          <attribute id="0x0000" type="enum8" name="Step Mode" required="m">
+            <value name="Up" value="0x01"></value>
+            <value name="Down" value="0x03"></value>
+          </attribute>
+          <attribute id="0x0001" type="u16" name="Step Size" required="m"></attribute>
+          <attribute id="0x0002" type="u16" name="Transition Time" required="m">
+            <description>The transition time in 1/10 seconds.</description>
+          </attribute>
+        </payload>
+      </command>
+      <command id="0x43" dir="recv" name="Enhanced Move to Hue and Saturation" required="m">
+        <payload>
+          <attribute id="0x0000" type="u16" name="Enhanced Hue" required="m"></attribute>
+          <attribute id="0x0001" type="u8" name="Saturation" required="m"></attribute>
+          <attribute id="0x0002" type="u16" name="Transition Time" required="m">
+            <description>The transition time in 1/10 seconds.</description>
+          </attribute>
+        </payload>
+      </command>
+      <command id="0x44" dir="recv" name="Color Loop Set" required="m">
+        <payload>
+          <attribute id="0x0000" type="bmp8" name="Update Flags" required="m">
+            <value name="Update Action" value="0"></value>
+            <value name="Update Direction" value="1"></value>
+            <value name="Update Time" value="2"></value>
+            <value name="Update Start Hue" value="3"></value>
+          </attribute>
+          <attribute id="0x0001" type="enum8" name="Action" required="m">
+            <value name="De-activate color loop" value="0x00"></value>
+            <value name="Activate from Color Loop Start Enhanced Hue" value="0x01"></value>
+            <value name="Activate from Enhanced Current Hue" value="0x02"></value>
+          </attribute>
+          <attribute id="0x0002" type="enum8" name="Direction" required="m">
+            <value name="Decrement Hue" value="0x00"></value>
+            <value name="Increment Hue" value="0x01"></value>
+          </attribute>
+          <attribute id="0x0003" type="u16" name="Time" required="m">
+            <description>Time in seconds used for a whole color loop.</description>
+          </attribute>
+          <attribute id="0x0004" type="u16" name="Start Enhanced Hue" required="m"></attribute>
+        </payload>
+      </command>
+      <command id="0x47" dir="recv" name="Stop move step" required="m">
+        <description>Stops move to and step commands. It has no effect on a active color loop.</description>
+        <payload></payload>
+      </command>
+      <command id="0x4b" dir="recv" name="Move Color Temperature" required="m">
+        <payload>
+          <attribute id="0x0000" type="enum8" name="Move Mode" required="m">
+            <value name="Stop" value="0x00"></value>
+            <value name="Up" value="0x01"></value>
+            <value name="Down" value="0x03"></value>
+          </attribute>
+          <attribute id="0x0001" type="u16" name="Rate" required="m">
+            <description>Steps per second.</description>
+          </attribute>
+          <attribute id="0x0002" type="u16" name="Color Temperature Min Mireds" required="m">
+            <description>Specifies a lower bound on the color temperature for the current move operation.</description>
+          </attribute>
+          <attribute id="0x0003" type="u16" name="Color Temperature Max Mireds" required="m">
+            <description>Specifies a upper bound on the color temperature for the current move operation.</description>
+          </attribute>
+        </payload>
+      </command>
+      <command id="0x4c" dir="recv" name="Step Color Temperature" required="m">
+        <payload>
+          <attribute id="0x0000" type="enum8" name="Step Mode" required="m">
+            <value name="Up" value="0x01"></value>
+            <value name="Down" value="0x03"></value>
+          </attribute>
+          <attribute id="0x0001" type="u16" name="Step Size" required="m"></attribute>
+          <attribute id="0x0002" type="u16" name="Transition Time" required="m">
+            <description>The transition time in 1/10 seconds.</description>
+          </attribute>
+          <attribute id="0x0003" type="u16" name="Color Temperature Min Mireds" required="m">
+            <description>Specifies a lower bound on the color temperature for the current step operation.</description>
+          </attribute>
+          <attribute id="0x0004" type="u16" name="Color Temperature Max Mireds" required="m">
+            <description>Specifies a upper bound on the color temperature for the current step operation.</description>
+          </attribute>
+        </payload>
+      </command>
+      <command id="0xd0" dir="recv" name="Set Active Channels" required="m">
+        <payload>
+          <attribute id="0x00" type="u8" name="Channels" required="m"></attribute>
+        </payload>
+      </command>
+    </server>
+    <client></client>
+  </cluster>
 
-    <cluster id="0x040C" name="Carbon monoxyde (CO) measurement">
-      <description></description>
-      <server>
-        <attribute-set id="0x0000" description="Carbon monoxyde Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-    
-    <cluster id="0x040D" name="Carbon dioxyde (CO2) measurement">
-      <description></description>
-      <server>
-        <attribute-set id="0x0000" description="Carbon Dioxyde Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-    
-    <cluster id="0x040E" name="Ethylene (CH2) measurement">
-      <description></description>
-      <server>
-        <attribute-set id="0x0000" description="Ethylene Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-    
-   <cluster id="0x040F" name="Ethylene Oxide (C2H4O) measurement">
-      <description></description>
-      <server>
-        <attribute-set id="0x0000" description="Ethylene Oxide Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-    
-   <cluster id="0x0410" name="Hydrogen (H) measurement">
-      <description></description>
-      <server>
-        <attribute-set id="0x0000" description="Hydrogen Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-    
-   <cluster id="0x0411" name="Hydrogen Sulfide (H2S) measurement">
-      <description></description>
-      <server>
-        <attribute-set id="0x0000" description="Hydrogen Sulfide Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-    
-   <cluster id="0x0412" name="Nitric Oxide (NO) measurement">
-      <description></description>
-      <server>
-        <attribute-set id="0x0000" description="Nitric Oxide Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-    
-   <cluster id="0x0413" name="Nitrogen Dioxide (NO2) measurement">
-      <description></description>
-      <server>
-        <attribute-set id="0x0000" description="Nitrogen Dioxide Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-    
-   <cluster id="0x0414" name="Oxygen (O2) measurement">
-      <description></description>
-      <server>
-        <attribute-set id="0x0000" description="Oxygen Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-        
-   <cluster id="0x0415" name="Ozone (O3) measurement">
-      <description></description>
-      <server>
-        <attribute-set id="0x0000" description="Ozone Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-            
-   <cluster id="0x0416" name="Sulfur Dioxide measurement">
-      <description></description>
-      <server>
-        <attribute-set id="0x0000" description="Sulfur Dioxide Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-               
-   <cluster id="0x0417" name="Dissolved Oxygen (DO) measurement">
-      <description></description>
-      <server>
-        <attribute-set id="0x0000" description="Dissolved Oxygen Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-                    
-   <cluster id="0x0418" name="Bromate measurement">
-      <description>Typical range example: not detected to 3.6 PPB. Typical value example:1.79 PPB</description>
-      <server>
-        <attribute-set id="0x0000" description="Bromate Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-                           
-   <cluster id="0x0419" name="Chloramines measurement">
-      <description>Typical range example: 0.9 to 3.8 PPM. typical value example: 2.87 PPM</description>
-      <server>
-        <attribute-set id="0x0000" description="Chloramines Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-                               
-   <cluster id="0x041A" name="Chlorine measurement">
-      <description>Typical range example: 0.1 to 2.4 PPM. Typical value example: 1.28 PPM</description>
-      <server>
-        <attribute-set id="0x0000" description="Chlorine Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-                                
-   <cluster id="0x041B" name="Fecal coliform and E Coli measurement">
-      <description>Percent of positive samples. Typical value example: 0</description>
-      <server>
-        <attribute-set id="0x0000" description="Fecal coliform and E Coli Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-                                    
-   <cluster id="0x041C" name="Fluoride measurement">
-      <description>Typical range example: 0 to 100 PPM.Typical value example: 0.72 PPM</description>
-      <server>
-        <attribute-set id="0x0000" description="Fluoride Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-                                        
-   <cluster id="0x041D" name="Haloacetic Acids measurement">
-      <description>Typical range example: Not Detected to 20 PPB. Ttypical value example: 14 PPB</description>
-      <server>
-        <attribute-set id="0x0000" description="Haloacetic Acids Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-                                           
-   <cluster id="0x041E" name="Total Trihalomethanes measurement">
-      <description>Typical range example: 0 to 100 PPB. Typical value example: 44 PPB</description>
-      <server>
-        <attribute-set id="0x0000" description="Total Trihalomethanes Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster> 
-                                           
-   <cluster id="0x041F" name="Total Coliform Bacteria measurement">
-      <description>Percent of positive samples. Typical range example: 0 to 100%. Typical value example: 1.33%</description>
-      <server>
-        <attribute-set id="0x0000" description="Total Coliform Bacteria Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster> 
-                                           
-   <cluster id="0x0420" name="Turbidity measurement">
-      <description>Cloudiness of particles in water where an average person would notice a 5 or higher. Typical range example: 0 to 10. Typical value example: 0.18</description>
-      <server>
-        <attribute-set id="0x0000" description="Turbidity Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster> 
-                                           
-   <cluster id="0x0421" name="Copper measurement">
-      <description>Typical range example: 0 to 10 PPM. Typical value example: 0.191 PPM</description>
-      <server>
-        <attribute-set id="0x0000" description="Copper Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-                                           
-   <cluster id="0x0422" name="Lead measurement">
-      <description>Typical range example: 0 to 10 PPB. Typical value example: 3.2 PPB</description>
-      <server>
-        <attribute-set id="0x0000" description="Lead Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-                                           
-   <cluster id="0x0423" name="Manganese measurement">
-      <description>Typical range example: 0 to 1000 PPB. Typical value example: 31 PPB</description>
-      <server>
-        <attribute-set id="0x0000" description="Manganese Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-                                           
-   <cluster id="0x0424" name="Sulfate measurement">
-      <description>Typical range example: 0 to 1000 PPB. Typical value example: 36 PPB</description>
-      <server>
-        <attribute-set id="0x0000" description="Sulfate Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-                                           
-   <cluster id="0x0425" name="Bromodichloromethane measurement">
-      <description>Typical range example: 0 to 1000 PPB. Typical value example: 9.6 PPB</description>
-      <server>
-        <attribute-set id="0x0000" description="Bromodichloromethane Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-                                            
-   <cluster id="0x0426" name="Bromoform measurement">
-      <description>Typical range example: 0 to 1000 PPB. Typical value example: 1.1 PPB</description>
-      <server>
-        <attribute-set id="0x0000" description="Bromoform Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-                                             
-   <cluster id="0x0427" name="Chlorodibromomethane measurement">
-      <description>Typical range example: 0 to 1000 PPB. Typical value example: 6.4 PPB</description>
-      <server>
-        <attribute-set id="0x0000" description="Chlorodibromomethane Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-                                             
-   <cluster id="0x0428" name="Chloroform measurement">
-      <description>Typical range example: 0 to 1000 PPB. Typical value example: 8.0 PPB</description>
-      <server>
-        <attribute-set id="0x0000" description="Chloroform Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-                                               
-   <cluster id="0x0429" name="Sodium measurement">
-      <description>Typical range example: 0 to 1000 PPB. Typical value example: 27 PPB</description>
-      <server>
-        <attribute-set id="0x0000" description="Sodium Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-    
-    <cluster id="0x042A" name="PM2.5 Measurement"> 
-      <description>Particulate Matter 2.5 microns or less</description>
-      <server>
-        <attribute-set id="0x0000" description="PM 2.5 Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-            
-    <cluster id="0x042B" name="Formaldehyde Measurement"> 
-      <description></description>
-      <server>
-        <attribute-set id="0x0000" description="Formaldehyde Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-            
-    <cluster id="0x042C" name="PM1 Measurement"> 
-      <description>PM1 concentration measurement</description>
-      <server>
-        <attribute-set id="0x0000" description="PM1 Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-           
-    <cluster id="0x042D" name="PM10 Measurement"> 
-      <description>PM10 concentration measurement</description>
-      <server>
-        <attribute-set id="0x0000" description="PM10 Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-            
-    <cluster id="0x042E" name="VOC Measurement"> 
-      <description>Volatile Organic Compounds concentration measurement.Typical range example: 0 to 10 PPM. Typical value example: 1.11 PPM</description>
-      <server>
-        <attribute-set id="0x0000" description="VOC Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
-          <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-    <cluster id="0x0b04" name="Electrical Measurement">
-      <description>Provides a mechanism for querying data about the electrical properties as measured by the device.</description>
-      <server>
-        <attribute-set id="0x0000" description="Basic Information">
-          <attribute id="0x0000" name="Measurement Type" type="bmp32" access="r" required="m" default="0x00000000">
-            <value name="Active measurement (AC)" value="0"></value>
-            <value name="Reactive measurement (AC)" value="1"></value>
-            <value name="Apparent measurement (AC)" value="2"></value>
-            <value name="Phase A measurement" value="3"></value>
-            <value name="Phase B measurement" value="4"></value>
-            <value name="Phase C measurement" value="5"></value>
-            <value name="DC measurement" value="6"></value>
-            <value name="Harmonics measurement" value="7"></value>
-            <value name="Power quality measurement" value="8"></value>
-          </attribute>
-        </attribute-set>
-	<attribute-set id="0x0100" description="DC Measurement">
-	  <attribute id="0x0100" name="DC Voltage" type="u16" access="r" required="o" default="0x8000"></attribute>
-	  <attribute id="0x0101" name="DC Voltage Min" type="u16" access="r" required="o" default="0x8000"></attribute>
-          <attribute id="0x0102" name="DC Voltage Max" type="u16" access="r" required="o" default="0x8000"></attribute>
-          <attribute id="0x0103" name="DC Current" type="u16" access="r" required="o" default="0x8000"></attribute>
-	  <attribute id="0x0104" name="DC Current Min" type="u16" access="r" required="o" default="0x8000"></attribute>
-	  <attribute id="0x0105" name="DC Current Max" type="u16" access="r" required="o" default="0x8000"></attribute>
-	  <attribute id="0x0106" name="DC Power" type="u16" access="r" required="o" default="0x8000"></attribute>
-	  <attribute id="0x0107" name="DC Power Min" type="u16" access="r" required="o" default="0x8000"></attribute>
-	  <attribute id="0x0108" name="DC Power Max" type="u16" access="r" required="o" default="0x8000"></attribute>
-        </attribute-set>
-	<attribute-set id="0x0200" description="DC Formatting">
-	  <attribute id="0x0200" name="DC Voltage Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
-	  <attribute id="0x0201" name="DC Voltage Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
-          <attribute id="0x0202" name="DC Current Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
-          <attribute id="0x0203" name="DC Current Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
-	  <attribute id="0x0204" name="DC Power Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
-	  <attribute id="0x0205" name="DC Power Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
-        </attribute-set>
-        <attribute-set id="0x0300" description="AC (Non-phase Specific) Measurements">
-          <attribute id="0x0300" name="AC Frequency" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-	  <attribute id="0x0301" name="AC Frequency Min" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-	  <attribute id="0x0302" name="AC Frequency Max" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-	  <attribute id="0x0303" name="Neutral current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-          <attribute id="0x0304" name="Total Active Power" type="s32" access="r" required="o"></attribute>
-          <attribute id="0x0305" name="Total Reactive Power" type="s32" access="r" required="o"></attribute>
-          <attribute id="0x0306" name="Total Apparent Power" type="u32" access="r" required="o"></attribute>
-	  <attribute id="0x0307" name="Measured 1st harmonic Current" type="s16" access="r" required="o"> default="0x8000"</attribute>
-          <attribute id="0x0308" name="Measured 3rd harmonic Current" type="s16" access="r" required="o"> default="0x8000"</attribute>
-	  <attribute id="0x0309" name="Measured 5th harmonic Current" type="s16" access="r" required="o"> default="0x8000"</attribute>
-	  <attribute id="0x030A" name="Measured 7th harmonic Current" type="s16" access="r" required="o"> default="0x8000"</attribute>
-	  <attribute id="0x030B" name="Measured 9th harmonic Current" type="s16" access="r" required="o"> default="0x8000"</attribute>
-	  <attribute id="0x030C" name="Measured 11th harmonic Current" type="s16" access="r" required="o"> default="0x8000"</attribute>
-	  <attribute id="0x030D" name="Measured Phase 1st harmonic Current" type="s16" access="r" required="o"> default="0x8000"</attribute>
-	  <attribute id="0x030E" name="Measured Phase 3rd harmonic Current" type="s16" access="r" required="o"> default="0x8000"</attribute>
-	  <attribute id="0x030F" name="Measured Phase 5th harmonic Current" type="s16" access="r" required="o"> default="0x8000"</attribute>
-	  <attribute id="0x0310" name="Measured Phase 7th harmonic Current" type="s16" access="r" required="o"> default="0x8000"</attribute>
-	  <attribute id="0x0311" name="Measured Phase 9th harmonic Current" type="s16" access="r" required="o"> default="0x8000"</attribute>
-	  <attribute id="0x0312" name="Measured Phase 11th harmonic Current" type="s16" access="r" required="o"> default="0x8000"</attribute>
-        </attribute-set>
-        <attribute-set id="0x0400" description="AC (Non-phase Specific) Formatting">
-	  <attribute id="0x0400" name="AC Frequency Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
-	  <attribute id="0x0401" name="AC Frequency Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
-          <attribute id="0x0402" name="Power Multiplier" type="u32" access="r" required="o" default="0x000001"></attribute>
-          <attribute id="0x0403" name="Power Divisor" type="u32" access="r" required="o" default="0x000001"></attribute>
-	  <attribute id="0x0404" name="Harmonic Current Multiplier" type="s8" access="r" required="o" default="0x00"></attribute>
-	  <attribute id="0x0405" name="Phase Harmonic Current Multiplier" type="s8" access="r" required="o" default="0x00"></attribute>
-        </attribute-set>
-        <attribute-set id="0x0500" description="AC (Single Phase or Phase A) Measurements">
-	  <attribute id="0x0501" name="Line Current" type="u16" access="r" required="o" default="0xffff"></attribute>
-	  <attribute id="0x0502" name="Active Current" type="s16" access="r" required="o" default="0x8000"></attribute>
-	  <attribute id="0x0503" name="Reactive Current" type="s16" access="r" required="o" default="0x8000"></attribute>
-          <attribute id="0x0505" name="RMS Voltage" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-	  <attribute id="0x0506" name="RMS Voltage Min" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-	  <attribute id="0x0507" name="RMS Voltage Max" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-          <attribute id="0x0508" name="RMS Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-	  <attribute id="0x0509" name="RMS Current Min" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-          <attribute id="0x050a" name="RMS Current Max" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-          <attribute id="0x050b" name="Active Power" type="s16" access="r" required="o" default="0x8000">
-            <description>Represents the single phase or Phase A, current demand of active power delivered or received at the premises, in Watts (W). Positive values indicate power delivered to the premises where negative values indicate power received from the premises.</description>
-          </attribute>
-	  <attribute id="0x050c" name="Active Power Min" type="s16" access="r" required="o" default="0x8000"></attribute>
-	  <attribute id="0x050d" name="Active Power Max" type="s16" access="r" required="o" default="0x8000"></attribute>
-          <attribute id="0x050e" name="Reactive Power" type="s16" access="r" required="o" default="0x8000"></attribute>
-          <attribute id="0x050f" name="Apparent Power" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-          <attribute id="0x0510" name="Power Factor" type="s8" access="r" required="o" default="0x00"></attribute>
-	  <attribute id="0x0511" name="Average RMS Voltage Measurement Period" type="u16" access="rw" required="o" default="0x0000"></attribute>
-	  <attribute id="0x0512" name="Average RMS Over Voltage Counter" type="u16" access="rw" required="o" default="0x0000"></attribute>
-	  <attribute id="0x0513" name="Average RMS Under Voltage Counter" type="u16" access="rw" required="o" default="0x0000"></attribute>
-	  <attribute id="0x0514" name="RMS Extreme Over Voltage Period" type="u16" access="rw" required="o" default="0x0000"></attribute>
-	  <attribute id="0x0515" name="RMS Extreme Under Voltage Period" type="u16" access="rw" required="o" default="0x0000"></attribute>
-	  <attribute id="0x0516" name="RMS Voltage Sag Period" type="u16" access="rw" required="o" default="0x0000"></attribute>
-	  <attribute id="0x0517" name="RMS Voltage Swell Period" type="u16" access="rw" required="o" default="0x0000"></attribute>
-        </attribute-set>
-        <attribute-set id="0x0600" description="AC Formatting">
-          <attribute id="0x0600" name="AC Voltage Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
-          <attribute id="0x0601" name="AC Voltage Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
-          <attribute id="0x0602" name="AC Current Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
-          <attribute id="0x0603" name="AC Current Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
-          <attribute id="0x0604" name="AC Power Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
-          <attribute id="0x0605" name="AC Power Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
-        </attribute-set>
-        <attribute-set id="0x0700" description="DC Manufacturer Threshold Alarms">
-          <attribute id="0x0700" name="DC Overload Alarms Mask" type="bmp8" access="rw" required="o" default="00000000">
-	              <value name="Voltage Overload" value="0"></value>
-                      <value name="Current Overload" value="1"></value>
-	  </attribute>
-          <attribute id="0x0701" name="AC Voltage Overload" type="s16" access="r" required="o" default="0xffff"></attribute>
-          <attribute id="0x0702" name="AC Current Overload" type="s16" access="r" required="o" default="0xffff"></attribute>
-        </attribute-set>
-	<attribute-set id="0x0800" description="AC Manufacturer Threshold Alarms">
-          <attribute id="0x0800" name="DC Overload Alarms Mask" type="bmp16" access="rw" required="o" default="0x0">
-	              <value name="Voltage Overload" value="0"></value>
-                      <value name="Current Overload" value="1"></value>
-		      <value name="Active Power Overload" value="2"></value>
-                      <value name="Reactive Power Overload" value="3"></value>
-		      <value name="Average RMS Over Voltage" value="4"></value>
-                      <value name="Average RMS Under Voltage" value="5"></value>
-		      <value name="RMS Extreme Over Voltage" value="6"></value>
-                      <value name="RMS Extreme Under Voltage" value="7"></value>
-		      <value name="RMS Voltage Sag" value="8"></value>
-                      <value name="RMS Voltage Swell" value="9"></value>
-	  </attribute>
-          <attribute id="0x0801" name="AC Voltage Overload" type="s16" access="r" required="o" default="0xffff"></attribute>
-          <attribute id="0x0802" name="AC Current Overload" type="s16" access="r" required="o" default="0xffff"></attribute>
-	  <attribute id="0x0803" name="AC Active Power Overload" type="s16" access="r" required="o" default="0xffff"></attribute>
-          <attribute id="0x0804" name="AC Reactive Power Overload" type="s16" access="r" required="o" default="0xffff"></attribute>
-	  <attribute id="0x0805" name="Average RMS Over Voltage" type="s16" access="r" required="o"></attribute>
-          <attribute id="0x0806" name="Average RMS Under Voltage" type="s16" access="r" required="o"></attribute>
-	  <attribute id="0x0807" name="RMS Extreme Over Voltage" type="s16" access="rw" required="o"></attribute>
-	  <attribute id="0x0808" name="RMS Extreme Under Voltage" type="s16" access="rw" required="o"></attribute>
-	  <attribute id="0x0809" name="RMS Voltage Sag" type="s16" access="rw" required="o"></attribute>
-	  <attribute id="0x080a" name="RMS Voltage Swell" type="s16" access="rw" required="o"></attribute>
-        </attribute-set>
-        <attribute-set id="0x0900" description="AC (Phase B) Measurements">
-          <attribute id="0x0901" name="Line Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-	  <attribute id="0x0902" name="Active Current" type="s16" access="r" required="o" default="0x8000"></attribute>
-	  <attribute id="0x0903" name="Reactive Current" type="s16" access="r" required="o" default="0x8000"></attribute>
-	  <attribute id="0x0905" name="RMS Voltage" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-	  <attribute id="0x0906" name="RMS Voltage Min" type="u16" access="r" required="o" default="0x8000"></attribute>
-	  <attribute id="0x0907" name="RMS Voltage Max" type="u16" access="r" required="o" default="0x8000"></attribute>
-          <attribute id="0x0908" name="RMS Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-	  <attribute id="0x0909" name="RMS Current Min" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-          <attribute id="0x090a" name="RMS Current Max" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-	  <attribute id="0x090b" name="Active Power" type="s16" access="r" required="o" default="0x8000"></attribute>
-	  <attribute id="0x090c" name="Active Power Min" type="s16" access="r" required="o" default="0x8000"></attribute>
-	  <attribute id="0x090d" name="Active Power Max" type="s16" access="r" required="o" default="0x8000"></attribute>
-	  <attribute id="0x090e" name="Reactive Power" type="s16" access="r" required="o" default="0x8000"></attribute>
-          <attribute id="0x090f" name="Apparent Power" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-	  <attribute id="0x0910" name="Power Factor" type="s8" access="r" required="o" default="0x00"></attribute>
-	  <attribute id="0x0911" name="Average RMS Voltage Measurement Period" type="u16" access="r" required="o" default="0x0000"></attribute>
-	  <attribute id="0x0912" name="Average RMS Over Voltage Counter" type="u16" access="r" required="o" default="0x0000"></attribute>
-	  <attribute id="0x0913" name="Average RMS Under Voltage Counter" type="u16" access="r" required="o" default="0x0000"></attribute>
-	  <attribute id="0x0914" name="RMS Extreme Over Voltage Period" type="u16" access="r" required="o" default="0x0000"></attribute>
-	  <attribute id="0x0915" name="RMS Extreme Under Voltage Period" type="u16" access="r" required="o" default="0x0000"></attribute>
-	  <attribute id="0x0916" name="RMS Voltage Sag Period" type="u16" access="rw" required="o" default="0x0000"></attribute>
-	  <attribute id="0x0917" name="RMS Voltage Swell Period" type="u16" access="rw" required="o" default="0x0000"></attribute>
-        </attribute-set>
-        <attribute-set id="0x0a00" description="AC (Phase C) Measurements">
-	  <attribute id="0x0a01" name="Line Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-	  <attribute id="0x0a02" name="Active Current" type="s16" access="r" required="o" default="0x8000"></attribute>
-	  <attribute id="0x0a03" name="Reactive Current" type="s16" access="r" required="o" default="0x8000"></attribute>
-	  <attribute id="0x0a05" name="RMS Voltage" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-	  <attribute id="0x0a06" name="RMS Voltage Min" type="u16" access="r" required="o" default="0x8000"></attribute>
-	  <attribute id="0x0a07" name="RMS Voltage Max" type="u16" access="r" required="o" default="0x8000"></attribute>
-          <attribute id="0x0a08" name="RMS Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-	  <attribute id="0x0a09" name="RMS Current Min" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-          <attribute id="0x0a0a" name="RMS Current Max" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-	  <attribute id="0x0a0b" name="Active Power" type="s16" access="r" required="o" default="0x8000"></attribute>
-	  <attribute id="0x0a0c" name="Active Power Min" type="s16" access="r" required="o" default="0x8000"></attribute>
-	  <attribute id="0x0a0d" name="Active Power Max" type="s16" access="r" required="o" default="0x8000"></attribute>
-	  <attribute id="0x0a0e" name="Reactive Power" type="s16" access="r" required="o" default="0x8000"></attribute>
-          <attribute id="0x0a0f" name="Apparent Power" type="u16" access="r" required="o" default="0xFFFF"></attribute>
-	  <attribute id="0x0a10" name="Power Factor" type="s8" access="r" required="o" default="0x00"></attribute>
-	  <attribute id="0x0a11" name="Average RMS Voltage Measurement Period" type="u16" access="r" required="o" default="0x0000"></attribute>
-	  <attribute id="0x0a12" name="Average RMS Over Voltage Counter" type="u16" access="r" required="o" default="0x0000"></attribute>
-	  <attribute id="0x0a13" name="Average RMS Under Voltage Counter" type="u16" access="r" required="o" default="0x0000"></attribute>
-	  <attribute id="0x0a14" name="RMS Extreme Over Voltage Period" type="u16" access="r" required="o" default="0x0000"></attribute>
-	  <attribute id="0x0a15" name="RMS Extreme Under Voltage Period" type="u16" access="r" required="o" default="0x0000"></attribute>
-	  <attribute id="0x0a16" name="RMS Voltage Sag Period" type="u16" access="rw" required="o" default="0x0000"></attribute>
-	  <attribute id="0x0a17" name="RMS Voltage Swell Period" type="u16" access="rw" required="o" default="0x0000"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <cluster id="0x0301" name="Ballast Configuration">
+    <description>Attributes and commands to configure a ballast.</description>
+    <server>
+      <attribute-set id="0x0000" description="Ballast Information">
+        <attribute id="0x0000" name="Physical Min Level" type="u8" access="r" range="0x01,0xfe" default="0x01" required="o"></attribute>
+        <attribute id="0x0001" name="Physical Max Level" type="u8" access="r" range="0x01,0xfe" default="0xfe" required="o"></attribute>
+        <attribute id="0x0002" name="Ballast Status" type="bmp8" access="r" default="0x00" required="m">
+          <value name="Non-operational" value="0"></value>
+          <value name="Lamp not in socket" value="1"></value>
+        </attribute>
+      </attribute-set>
+      <attribute-set id="0x0010" description="Ballast Settings">
+        <attribute id="0x0010" name="Min Level" type="u8" access="rw" range="0x01,0xfe" default="0x01" required="o"></attribute>
+        <attribute id="0x0011" name="Max Level" type="u8" access="rw" range="0x01,0xfe" default="0xfe" required="o"></attribute>
+        <attribute id="0x0012" name="Power On Level" type="u8" access="rw" range="0x01,0xfe" default="0xfe" required="o"></attribute>
+        <attribute id="0x0013" name="Power On Fade Time" type="u16" access="rw" range="0x0000,0xfffe" default="0x0000" required="o"></attribute>
+        <attribute id="0x0014" name="Intrinsic Ballast Factor" type="u8" access="rw" range="0x00,0xfe" default="0x00" required="o"></attribute>
+        <attribute id="0x0015" name="Ballast Factor Adjustment" type="u8" access="rw" range="0x64,0xff" default="0xff" required="o"></attribute>
+      </attribute-set>
+      <attribute-set id="0x0020" description="Lamp Information">
+        <attribute id="0x0020" name="Lamp Quantity" type="u8" access="r" range="0x00,0xfe" default="0x00" required="o"></attribute>
+      </attribute-set>
+      <attribute-set id="0x0030" description="Lamp Settings">
+        <attribute id="0x0030" name="Lamp Type" type="cstring" access="rw" required="o"></attribute>
+        <attribute id="0x0031" name="Lamp Manufacturer" type="cstring" access="rw" required="o"></attribute>
+        <attribute id="0x0032" name="Lamp Rated Hours" type="u24" access="rw" range="0x000000,0xfffffe" default="0xffffff" required="o"></attribute>
+        <attribute id="0x0033" name="Lamp Burn Hours" type="u24" access="rw" range="0x000000,0xfffffe" default="0x000000" required="o"></attribute>
+        <attribute id="0x0034" name="Lamp Alarm Mode" type="bmp8" access="rw" default="0x00" required="m">
+          <value name="Lamp Burn Hours" value="0"></value>
+        </attribute>
+        <attribute id="0x0035" name="Lamp Burn Hours Trip Point" type="u24" access="rw" range="0x000000,0xfffffe" default="0x000000" required="o"></attribute>
+      </attribute-set>
+      <attribute-set id="0xe000" description="Dimmer Mode" mfcode="0x105e">
+        <attribute id="0xE000" name="Dimmer Mode" type="enum8" default="0x00" access="rw" required="o" mfcode="0x105e">
+          <description>Sets dimming mode to autodetect or fixed RC/RL/RL_LED mode (max load is reduced in RL_LED)</description>
+          <value name="Auto" value="0"></value>
+          <value name="RC" value="1"></value>
+          <value name="RL" value="2"></value>
+          <value name="RL_LED" value="3"></value>
+        </attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+</domain>
 
-    <cluster id="0x0b05" name="Diagnostics">
-      <description>The diagnostics cluster provides access to information regarding the operation of the ZigBee stack over time.</description>
-      <server>
-        <attribute-set id="0x0000" description="Hardware Information">
-          <attribute id="0x0000" name="Number of Resets" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x0001" name="Persistens Memory Writes" type="u16" access="r" required="o" default="0x0000"></attribute>
-        </attribute-set>
-        <attribute-set id="0x0100" description="Stack/Network Information">
-          <attribute id="0x0100" name="Mac Rx Bcast" type="u32" access="r" required="o" default="0x00000000"></attribute>
-          <attribute id="0x0101" name="Mac Tx Bcast" type="u32" access="r" required="o" default="0x00000000"></attribute>
-          <attribute id="0x0102" name="Mac Rx Ucast" type="u32" access="r" required="o" default="0x00000000"></attribute>
-          <attribute id="0x0103" name="Mac Tx Ucast" type="u32" access="r" required="o" default="0x00000000"></attribute>
-          <attribute id="0x0104" name="Mac Tx Ucast Retry" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x0105" name="Mac Tx Ucast Fail" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x0106" name="APS Rx Bcast" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x0107" name="APS Tx Bcast" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x0108" name="APS Rx Ucast" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x0109" name="APS Tx Ucast Success" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x010a" name="APS Tx Ucast Retry" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x010b" name="APS Tx Ucast Fail" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x010c" name="Route Disc Initiated" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x010d" name="Neighbor Added" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x010e" name="Neighbor Removed" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x010f" name="Neighbor Stale" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x0110" name="Join Indication" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x0111" name="Child Moved" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x0112" name="NWK FC Failure" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x0113" name="APS FC Failure" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x0114" name="APS Unauthorized Key" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x0115" name="NWK Decrypt Failures" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x0116" name="APS Decrypt Failures" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x0117" name="Packet Buffer Alloc Failures" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x0118" name="Relayed Ucast" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x0119" name="Phy to MAC queue limit reached" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x011a" name="Packet Validate Dropcount" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x011b" name="Avg MAC Retry per APS Msg Sent" type="u16" access="r" required="o" default="0x0000"></attribute>
-          <attribute id="0x011c" name="Last Message LQI" type="u8" access="r" required="o" default="0x00"></attribute>
-          <attribute id="0x011d" name="Last Message RSSI" type="s8" access="r" required="o" default="0x00"></attribute>
-        </attribute-set>
-        <attribute-set id="0x4000" description="Vendor specific attributes">
-          <attribute id="0x4000" name="SW error code" type="bmp16" access="rw" default="0" required="o" mfcode="0x1246"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
+<domain name="Measurement and sensing" low_bound="0400" high_bound="04ff" description="The measurement and sensing functional domain contains clusters and information to build devices in the measurement and sensing domain, e.g. a temperature sensor or an occupancy sensor.">
+  <cluster id="0x0400" name="Illuminance measurement">
+    <description>The server cluster provides an interface to illuminance measurement functionality, including configuration and provision of notifications of illuminance measurements.</description>
+    <!-- TODO -->
+    <server>
+      <attribute-set id="0x0000" description="Illuminance Measurement Information">
+        <attribute id="0x0000" name="Measured Value" type="u16" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="u16" access="r" required="m" range="0x0002,0xfffd"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="u16" access="r" required="m" range="0x0001,0x7ffe"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o" range="0x0000,0x0800"></attribute>
+        <attribute id="0x0004" name="Light Sensor Type" type="enum8" range="0x00,0xff" access="r" required="o">
+          <value name="Photodiode" value="0x00"></value>
+          <value name="CMOS" value="0x01"></value>
+          <value name="Unknown" value="0xff"></value>
+        </attribute>
+      </attribute-set>
+    </server>
+    <client>
+      <attribute-set id="0xf000" description="Illuminance Adjustement Configuration">
+        <attribute id="0xf000" name="Hysteresis" type="u16" access="rw" required="o"></attribute>
+        <attribute id="0xf001" name="Max Up Speed" type="u16" access="rw" required="o">
+          <description>Maximum up adjustment speed in 1/10 seconds.</description>
+        </attribute>
+        <attribute id="0xf002" name="Max Down Speed" type="u16" access="rw" required="o">
+          <description>Maximum down adjustment speed in 1/10 seconds.</description>
+        </attribute>
+        <attribute id="0xf003" name="Target Value" type="u16" access="rw" required="o">
+          <description>Target value in Lux which should be kept.</description>
+        </attribute>
+        <attribute id="0xf004" name="Startup Type" type="enum8" access="rw" required="o">
+          <description>Brightness control startup type.</description>
+          <value name="Default Level" value="0x00"></value>
+          <value name="Zero Level" value="0x01"></value>
+        </attribute>
+      </attribute-set>
+    </client>
+  </cluster>
 
-    <cluster id="0x0500" name="IAS Zone">
-      <description>The IAS Zone cluster defines an interface to the functionality of an IAS security zone device. IAS Zone supports up to two alarm types per zone, low battery reports and supervision of the IAS network.</description>
-      <server>
-        <attribute-set id="0x0000" description="Zone information">
-          <attribute id="0x0000" name="Zone State" type="enum8" range="0x00,0x01" access="r" required="m">
-            <value name="Not enrolled" value="0x00"></value>
-            <value name="Enrolled" value="0x01">
-              <description>The client will react to Zone State Change Notification commands from the server.</description>
-            </value>
+  <cluster id="0x0401" name="Illuminance level sensing">
+    <description></description>
+    <!-- TODO -->
+  </cluster>
+
+  <cluster id="0x0402" name="Temperature measurement">
+    <description>The server cluster provides an interface to temperature measurement functionality, including configuration and provision of notifications of temperature measurements.</description>
+    <!-- TODO -->
+    <server>
+      <attribute-set id="0x0000" description="Temperature Measurement Information">
+        <attribute id="0x0000" name="Measured Value" type="s16" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="s16" access="r" required="m" range="0x954d,0x7ffe"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="s16" access="r" required="m" range="0x954e,0x7ffe"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o" range="0x0000,0x0800"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0403" name="Pressure measurement">
+    <description>The server cluster provides an interface to air pressure measurement functionality, including configuration and provision of notifications of air pressure measurements.</description>
+    <server>
+      <attribute-set id="0x0000" description="Pressure Measurement Information">
+        <attribute id="0x0000" name="Measured Value" type="s16" access="r" default="0x8000" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="u16" access="r" required="m" range="0x8001,0x7ffe"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="u16" access="r" required="m" range="0x8002,0x7fff"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o" range="0x0000,0x0800"></attribute>
+      </attribute-set>
+      <attribute-set id="0x0001" description="Extended Pressure Measurement Information">
+        <attribute id="0x0010" name="Scaled Value" type="s16" access="r" default="0" required="o"></attribute>
+        <attribute id="0x0011" name="Min Scaled Value" type="u16" access="r" required="m" range="0x8001,0x7ffe"></attribute>
+        <attribute id="0x0012" name="Max Scaled Value" type="u16" access="r" required="m" range="0x8002,0x7fff"></attribute>
+        <attribute id="0x0013" name="Scaled Tolerance" type="u16" access="r" required="o" range="0x0000,0x0800"></attribute>
+        <attribute id="0x0014" name="Scale" type="s8" access="r" required="o" range="0x81,0x7f"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0404" name="Flow measurement">
+    <description>The server cluster provides an interface to flow measurement measurement functionality, including configuration and provision of notifications of flow measurements.</description>
+    <server>
+      <attribute-set id="0x0000" description="Flow Measurement Information">
+        <attribute id="0x0000" name="Measured Value" type="u16" access="r" default="0xFFFF" required="m">
+          <description>Represents the flow in m3/h times 10 </description>
+        </attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="u16" access="r" required="m" range="0x0000,0xfffd"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="u16" access="r" required="m" range="0x0001,0x7ffe"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o" range="0x0000,0x0800"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0405" name="Relative humidity measurement">
+    <description>Percentage of water in the air</description>
+    <server>
+      <attribute-set id="0x0000" description="Relative Humidity Measurement Information">
+        <attribute id="0x0000" name="Measured Value" type="u16" access="r" default="0xffff" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="u16" access="r" required="m" range="0x0000,0x270f"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="u16" access="r" required="m" range="0x0001,0x2710"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o" range="0x0000,0x0800"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0406" name="Occupancy sensing">
+    <description>
+      <!-- TODO -->
+    </description>
+    <server>
+      <attribute-set id="0x0000" description="Occupancy sensor information">
+        <attribute id="0x0000" name="Occupancy" type="bmp8" range="0000000x" access="r" required="m"></attribute>
+        <attribute id="0x0001" name="Occupancy Sensor Type" type="enum8" range="0x00,0xfe" access="r" required="m">
+          <value name="PIR" value="0x00"></value>
+          <value name="Ultrasonic" value="0x01"></value>
+          <value name="PIR and ultrasonic" value="0x02"></value>
+          <value name="Physical contact" value="0x03"></value>
+        </attribute>
+        <attribute id="0x0002" name="Occupancy Sensor Type Bitmap" type="bmp8" access="r" required="m"></attribute>
+      </attribute-set>
+      <attribute-set id="0x0010" description="PIR configuration">
+        <attribute id="0x0010" name="PIR Occupied To Unoccupied Delay" type="u16" range="0x00,0xfffe" access="rw" required="o" default="0x00">
+          <description>The PIROccupiedToUnoccupiedDelay attribute is 16-bits in length and specifies the time delay, in seconds, before the PIR sensor changes to its occupied state when the sensed area becomes unoccupied. This attribute, along with PIRUnoccupiedToOccupiedTime, may be used to reduce sensor 'chatter' when used in an area where occupation changes frequently.</description>
+        </attribute>
+        <attribute id="0x0011" name="PIR Unoccupied To Occupied Delay" type="u16" range="0x00,0xfffe" access="rw" required="o" default="0x00">
+          <description>The PIRUnoccupiedToOccupiedDelay attribute is 16-bits in length and specifies the time delay, in seconds, before the PIR sensor changes to its unoccupied state when the sensed area becomes occupied.</description>
+        </attribute>
+        <attribute id="0x0012" name="PIR Unoccupied To Occupied Threshold" type="u8" range="0x01,0xfe" access="rw" required="o" default="0x01">
+          <description>The PIRUnoccupiedToOccupiedThreshold attribute is 8 bits in length and specifies the number of movement detection events that must occur in the period PIRUnoccupiedToOccupiedDelay, before the PIR sensor changes to its occupied state.</description>
+        </attribute>
+      </attribute-set>
+      <attribute-set id="0x0020" description="Ultrasonic configuration">
+        <attribute id="0x0020" name="Ultrasonic Occupied To Unoccupied Delay" type="u16" range="0x00,0xfe" access="rw" required="o" default="0x00">
+          <description>The UltraSonicOccupiedToUnoccupiedDelay attribute specifies the time delay, in seconds, before the ultrasonic sensor changes to its occupied state when the sensed area becomes unoccupied. This attribute, along with UltraSonicUnoccupiedToOccupiedTime, may be used to reduce sensor 'chatter' when used in an area where occupation changes frequently.</description>
+        </attribute>
+        <attribute id="0x0021" name="Ultrasonic Unoccupied To Occupied Delay" type="u16" range="0x00,0xfe" access="rw" required="o" default="0x00">
+          <description>The UltraSonicUnoccupiedToOccupiedDelay attribute specifies the time delay, in seconds, before the ultrasonic sensor changes to its unoccupied state when the sensed area becomes occupied.</description>
+        </attribute>
+        <attribute id="0x0022" name="Ultrasonic Unoccupied To Occupied Threshold" type="u8" range="0x01,0xfe" access="rw" required="o" default="0x01">
+          <description>The UltrasonicUnoccupiedToOccupiedThreshold attribute is 8 bits in length and specifies the number of movement detection events that must occur in the period PIRUnoccupiedToOccupiedDelay, before the PIR sensor changes to its occupied state.</description>
+        </attribute>
+      </attribute-set>
+      <attribute-set id="0x0030" description="Physical Contact configuration">
+        <attribute id="0x0030" name="Physical Contact Occupied To Unoccupied Delay" type="u16" range="0x00,0xfe" access="rw" required="o" default="0x00">
+          <description>The PhysicalContactOccupiedToUnoccupiedDelay attribute specifies the time delay, in seconds, before the Physical Contact sensor changes to its occupied state when the sensed area becomes unoccupied. This attribute, along with UltraSonicUnoccupiedToOccupiedTime, may be used to reduce sensor 'chatter' when used in an area where occupation changes frequently.</description>
+        </attribute>
+        <attribute id="0x0031" name="Physical Contact Unoccupied To Occupied Delay" type="u16" range="0x00,0xfe" access="rw" required="o" default="0x00">
+          <description>The PhysicalContactUnoccupiedToOccupiedDelay attribute specifies the time delay, in seconds, before the Physical Contact sensor changes to its unoccupied state when the sensed area becomes occupied.</description>
+        </attribute>
+        <attribute id="0x0032" name="Physical Contact Unoccupied To Occupied Threshold" type="u8" range="0x01,0xfe" access="rw" required="o" default="0x01">
+          <description>The PhysicalContactUnoccupiedToOccupiedThreshold attribute is 8 bits in length and specifies the number of movement detection events that must occur in the period PIRUnoccupiedToOccupiedDelay, before the PIR sensor changes to its occupied state.</description>
+        </attribute>
+      </attribute-set>
+      <attribute-set id="0x0030" description="Philips Specific" mfcode="0x100b">
+        <attribute id="0x0030" name="Sensitivity" type="u8" default="0" access="rw" required="o" mfcode="0x100b"></attribute>
+        <attribute id="0x0031" name="Sensitivity max." type="u8" default="0" access="rw" required="o" mfcode="0x100b"></attribute>
+      </attribute-set>
+      <attribute-set id="0x0000" description="Develco Specific" mfcode="0x1015">
+        <attribute id="0x0000" name="ArmThreshold_MinTemperature" type="s16" access="rw" range="0x954d,0x7ffe" required="m" mfcode="0x1015"></attribute>
+        <attribute id="0x0001" name="ArmThreshold_MaxTemperature" type="s16" access="rw" range="0x954d,0x7ffe" required="m" mfcode="0x1015"></attribute>
+        <attribute id="0x0002" name="Target Level" type="u16" access="rw" range="0x0002,0xfffd" required="m" mfcode="0x1015"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0407" name="Leaf Wetness measurement">
+    <description>Percentage of water on the leaves of plants</description>
+    <server>
+      <attribute-set id="0x0000" description="Leaf Wetness Measurement Information">
+        <attribute id="0x0000" name="Measured Value" type="u16" access="r" default="0xffff" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="u16" access="r" required="m" range="0x0000,0x270f"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="u16" access="r" required="m" range="0x0001,0x2710"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o" range="0x0000,0x0800"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0408" name="Soil Moisture measurement">
+    <description>Percentage of water in the soil</description>
+    <server>
+      <attribute-set id="0x0000" description="Soil Moisture Measurement Information">
+        <attribute id="0x0000" name="Measured Value" type="u16" access="r" default="0xffff" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="u16" access="r" required="m" range="0x0000,0x270f"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="u16" access="r" required="m" range="0x0001,0x2710"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o" range="0x0000,0x0800"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0409" name="pH Measurement">
+    <description>Provides an interface to pH measurement functionality</description>
+    <server>
+      <attribute-set id="0x0000" description="pH measurement Information">
+        <attribute id="0x0000" name="Measured Value" type="u16" access="r" default="0xffff" required="m">
+          <description>"Represents the pH with no units as follows: Measured Value = 100 x pH"</description>
+        </attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="u16" access="r" default="0xffff" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="u16" access="r" required="m" default="0xffff"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x040A" name="Electrical Conductivity">
+    <description>Provides an interface to Electrical Conductivity measurement functionality</description>
+    <server>
+      <attribute-set id="0x0000" description="Electrical Conductivity Information">
+        <attribute id="0x0000" name="Measured Value" type="u16" access="r" default="0xffff" required="m">
+          <description>"Electrical Conductivity in mS/m. The maximum resolution this format allows is 0.1"</description>
+        </attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="u16" access="r" default="0xffff" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="u16" access="r" required="m" default="0xffff"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x040B" name="Wind Speed Measurement">
+    <description>Provides an interface to Wind Speed Measurement functionality</description>
+    <server>
+      <attribute-set id="0x0000" description="Wind Speed Measurement Information">
+        <attribute id="0x0000" name="Measured Value" type="u16" access="r" default="0xffff" required="m">
+          <description>"100 x Wind Speed in m/s. The maximum resolution this format allows is 0.01"</description>
+        </attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="u16" access="r" default="0xffff" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="u16" access="r" required="m" default="0xffff"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="u16" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x040C" name="Carbon monoxyde (CO) measurement">
+    <description></description>
+    <server>
+      <attribute-set id="0x0000" description="Carbon monoxyde Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x040D" name="Carbon dioxyde (CO2) measurement">
+    <description></description>
+    <server>
+      <attribute-set id="0x0000" description="Carbon Dioxyde Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x040E" name="Ethylene (CH2) measurement">
+    <description></description>
+    <server>
+      <attribute-set id="0x0000" description="Ethylene Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x040F" name="Ethylene Oxide (C2H4O) measurement">
+    <description></description>
+    <server>
+      <attribute-set id="0x0000" description="Ethylene Oxide Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0410" name="Hydrogen (H) measurement">
+    <description></description>
+    <server>
+      <attribute-set id="0x0000" description="Hydrogen Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0411" name="Hydrogen Sulfide (H2S) measurement">
+    <description></description>
+    <server>
+      <attribute-set id="0x0000" description="Hydrogen Sulfide Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0412" name="Nitric Oxide (NO) measurement">
+    <description></description>
+    <server>
+      <attribute-set id="0x0000" description="Nitric Oxide Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0413" name="Nitrogen Dioxide (NO2) measurement">
+    <description></description>
+    <server>
+      <attribute-set id="0x0000" description="Nitrogen Dioxide Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0414" name="Oxygen (O2) measurement">
+    <description></description>
+    <server>
+      <attribute-set id="0x0000" description="Oxygen Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0415" name="Ozone (O3) measurement">
+    <description></description>
+    <server>
+      <attribute-set id="0x0000" description="Ozone Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0416" name="Sulfur Dioxide measurement">
+    <description></description>
+    <server>
+      <attribute-set id="0x0000" description="Sulfur Dioxide Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0417" name="Dissolved Oxygen (DO) measurement">
+    <description></description>
+    <server>
+      <attribute-set id="0x0000" description="Dissolved Oxygen Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0418" name="Bromate measurement">
+    <description>Typical range example: not detected to 3.6 PPB. Typical value example:1.79 PPB</description>
+    <server>
+      <attribute-set id="0x0000" description="Bromate Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0419" name="Chloramines measurement">
+    <description>Typical range example: 0.9 to 3.8 PPM. typical value example: 2.87 PPM</description>
+    <server>
+      <attribute-set id="0x0000" description="Chloramines Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x041A" name="Chlorine measurement">
+    <description>Typical range example: 0.1 to 2.4 PPM. Typical value example: 1.28 PPM</description>
+    <server>
+      <attribute-set id="0x0000" description="Chlorine Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x041B" name="Fecal coliform and E Coli measurement">
+    <description>Percent of positive samples. Typical value example: 0</description>
+    <server>
+      <attribute-set id="0x0000" description="Fecal coliform and E Coli Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x041C" name="Fluoride measurement">
+    <description>Typical range example: 0 to 100 PPM.Typical value example: 0.72 PPM</description>
+    <server>
+      <attribute-set id="0x0000" description="Fluoride Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x041D" name="Haloacetic Acids measurement">
+    <description>Typical range example: Not Detected to 20 PPB. Ttypical value example: 14 PPB</description>
+    <server>
+      <attribute-set id="0x0000" description="Haloacetic Acids Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x041E" name="Total Trihalomethanes measurement">
+    <description>Typical range example: 0 to 100 PPB. Typical value example: 44 PPB</description>
+    <server>
+      <attribute-set id="0x0000" description="Total Trihalomethanes Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x041F" name="Total Coliform Bacteria measurement">
+    <description>Percent of positive samples. Typical range example: 0 to 100%. Typical value example: 1.33%</description>
+    <server>
+      <attribute-set id="0x0000" description="Total Coliform Bacteria Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0420" name="Turbidity measurement">
+    <description>Cloudiness of particles in water where an average person would notice a 5 or higher. Typical range example: 0 to 10. Typical value example: 0.18</description>
+    <server>
+      <attribute-set id="0x0000" description="Turbidity Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0421" name="Copper measurement">
+    <description>Typical range example: 0 to 10 PPM. Typical value example: 0.191 PPM</description>
+    <server>
+      <attribute-set id="0x0000" description="Copper Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0422" name="Lead measurement">
+    <description>Typical range example: 0 to 10 PPB. Typical value example: 3.2 PPB</description>
+    <server>
+      <attribute-set id="0x0000" description="Lead Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0423" name="Manganese measurement">
+    <description>Typical range example: 0 to 1000 PPB. Typical value example: 31 PPB</description>
+    <server>
+      <attribute-set id="0x0000" description="Manganese Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0424" name="Sulfate measurement">
+    <description>Typical range example: 0 to 1000 PPB. Typical value example: 36 PPB</description>
+    <server>
+      <attribute-set id="0x0000" description="Sulfate Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0425" name="Bromodichloromethane measurement">
+    <description>Typical range example: 0 to 1000 PPB. Typical value example: 9.6 PPB</description>
+    <server>
+      <attribute-set id="0x0000" description="Bromodichloromethane Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0426" name="Bromoform measurement">
+    <description>Typical range example: 0 to 1000 PPB. Typical value example: 1.1 PPB</description>
+    <server>
+      <attribute-set id="0x0000" description="Bromoform Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0427" name="Chlorodibromomethane measurement">
+    <description>Typical range example: 0 to 1000 PPB. Typical value example: 6.4 PPB</description>
+    <server>
+      <attribute-set id="0x0000" description="Chlorodibromomethane Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0428" name="Chloroform measurement">
+    <description>Typical range example: 0 to 1000 PPB. Typical value example: 8.0 PPB</description>
+    <server>
+      <attribute-set id="0x0000" description="Chloroform Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0429" name="Sodium measurement">
+    <description>Typical range example: 0 to 1000 PPB. Typical value example: 27 PPB</description>
+    <server>
+      <attribute-set id="0x0000" description="Sodium Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x042A" name="PM2.5 Measurement">
+    <description>Particulate Matter 2.5 microns or less</description>
+    <server>
+      <attribute-set id="0x0000" description="PM 2.5 Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x042B" name="Formaldehyde Measurement">
+    <description></description>
+    <server>
+      <attribute-set id="0x0000" description="Formaldehyde Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x042C" name="PM1 Measurement">
+    <description>PM1 concentration measurement</description>
+    <server>
+      <attribute-set id="0x0000" description="PM1 Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x042D" name="PM10 Measurement">
+    <description>PM10 concentration measurement</description>
+    <server>
+      <attribute-set id="0x0000" description="PM10 Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x042E" name="VOC Measurement">
+    <description>Volatile Organic Compounds concentration measurement.Typical range example: 0 to 10 PPM. Typical value example: 1.11 PPM</description>
+    <server>
+      <attribute-set id="0x0000" description="VOC Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m"></attribute>
+        <attribute id="0x0003" name="Tolerance" type="float" access="r" required="o"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+  <cluster id="0x0b04" name="Electrical Measurement">
+    <description>Provides a mechanism for querying data about the electrical properties as measured by the device.</description>
+    <server>
+      <attribute-set id="0x0000" description="Basic Information">
+        <attribute id="0x0000" name="Measurement Type" type="bmp32" access="r" required="m" default="0x00000000">
+          <value name="Active measurement (AC)" value="0"></value>
+          <value name="Reactive measurement (AC)" value="1"></value>
+          <value name="Apparent measurement (AC)" value="2"></value>
+          <value name="Phase A measurement" value="3"></value>
+          <value name="Phase B measurement" value="4"></value>
+          <value name="Phase C measurement" value="5"></value>
+          <value name="DC measurement" value="6"></value>
+          <value name="Harmonics measurement" value="7"></value>
+          <value name="Power quality measurement" value="8"></value>
+        </attribute>
+      </attribute-set>
+      <attribute-set id="0x0100" description="DC Measurement">
+        <attribute id="0x0100" name="DC Voltage" type="u16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x0101" name="DC Voltage Min" type="u16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x0102" name="DC Voltage Max" type="u16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x0103" name="DC Current" type="u16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x0104" name="DC Current Min" type="u16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x0105" name="DC Current Max" type="u16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x0106" name="DC Power" type="u16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x0107" name="DC Power Min" type="u16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x0108" name="DC Power Max" type="u16" access="r" required="o" default="0x8000"></attribute>
+      </attribute-set>
+      <attribute-set id="0x0200" description="DC Formatting">
+        <attribute id="0x0200" name="DC Voltage Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
+        <attribute id="0x0201" name="DC Voltage Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
+        <attribute id="0x0202" name="DC Current Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
+        <attribute id="0x0203" name="DC Current Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
+        <attribute id="0x0204" name="DC Power Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
+        <attribute id="0x0205" name="DC Power Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
+      </attribute-set>
+      <attribute-set id="0x0300" description="AC (Non-phase Specific) Measurements">
+        <attribute id="0x0300" name="AC Frequency" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+        <attribute id="0x0301" name="AC Frequency Min" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+        <attribute id="0x0302" name="AC Frequency Max" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+        <attribute id="0x0303" name="Neutral current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+        <attribute id="0x0304" name="Total Active Power" type="s32" access="r" required="o"></attribute>
+        <attribute id="0x0305" name="Total Reactive Power" type="s32" access="r" required="o"></attribute>
+        <attribute id="0x0306" name="Total Apparent Power" type="u32" access="r" required="o"></attribute>
+        <attribute id="0x0307" name="Measured 1st harmonic Current" type="s16" access="r" required="o"> default="0x8000"</attribute>
+        <attribute id="0x0308" name="Measured 3rd harmonic Current" type="s16" access="r" required="o"> default="0x8000"</attribute>
+        <attribute id="0x0309" name="Measured 5th harmonic Current" type="s16" access="r" required="o"> default="0x8000"</attribute>
+        <attribute id="0x030A" name="Measured 7th harmonic Current" type="s16" access="r" required="o"> default="0x8000"</attribute>
+        <attribute id="0x030B" name="Measured 9th harmonic Current" type="s16" access="r" required="o"> default="0x8000"</attribute>
+        <attribute id="0x030C" name="Measured 11th harmonic Current" type="s16" access="r" required="o"> default="0x8000"</attribute>
+        <attribute id="0x030D" name="Measured Phase 1st harmonic Current" type="s16" access="r" required="o"> default="0x8000"</attribute>
+        <attribute id="0x030E" name="Measured Phase 3rd harmonic Current" type="s16" access="r" required="o"> default="0x8000"</attribute>
+        <attribute id="0x030F" name="Measured Phase 5th harmonic Current" type="s16" access="r" required="o"> default="0x8000"</attribute>
+        <attribute id="0x0310" name="Measured Phase 7th harmonic Current" type="s16" access="r" required="o"> default="0x8000"</attribute>
+        <attribute id="0x0311" name="Measured Phase 9th harmonic Current" type="s16" access="r" required="o"> default="0x8000"</attribute>
+        <attribute id="0x0312" name="Measured Phase 11th harmonic Current" type="s16" access="r" required="o"> default="0x8000"</attribute>
+      </attribute-set>
+      <attribute-set id="0x0400" description="AC (Non-phase Specific) Formatting">
+        <attribute id="0x0400" name="AC Frequency Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
+        <attribute id="0x0401" name="AC Frequency Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
+        <attribute id="0x0402" name="Power Multiplier" type="u32" access="r" required="o" default="0x000001"></attribute>
+        <attribute id="0x0403" name="Power Divisor" type="u32" access="r" required="o" default="0x000001"></attribute>
+        <attribute id="0x0404" name="Harmonic Current Multiplier" type="s8" access="r" required="o" default="0x00"></attribute>
+        <attribute id="0x0405" name="Phase Harmonic Current Multiplier" type="s8" access="r" required="o" default="0x00"></attribute>
+      </attribute-set>
+      <attribute-set id="0x0500" description="AC (Single Phase or Phase A) Measurements">
+        <attribute id="0x0501" name="Line Current" type="u16" access="r" required="o" default="0xffff"></attribute>
+        <attribute id="0x0502" name="Active Current" type="s16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x0503" name="Reactive Current" type="s16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x0505" name="RMS Voltage" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+        <attribute id="0x0506" name="RMS Voltage Min" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+        <attribute id="0x0507" name="RMS Voltage Max" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+        <attribute id="0x0508" name="RMS Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+        <attribute id="0x0509" name="RMS Current Min" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+        <attribute id="0x050a" name="RMS Current Max" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+        <attribute id="0x050b" name="Active Power" type="s16" access="r" required="o" default="0x8000">
+          <description>Represents the single phase or Phase A, current demand of active power delivered or received at the premises, in Watts (W). Positive values indicate power delivered to the premises where negative values indicate power received from the premises.</description>
+        </attribute>
+        <attribute id="0x050c" name="Active Power Min" type="s16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x050d" name="Active Power Max" type="s16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x050e" name="Reactive Power" type="s16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x050f" name="Apparent Power" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+        <attribute id="0x0510" name="Power Factor" type="s8" access="r" required="o" default="0x00"></attribute>
+        <attribute id="0x0511" name="Average RMS Voltage Measurement Period" type="u16" access="rw" required="o" default="0x0000"></attribute>
+        <attribute id="0x0512" name="Average RMS Over Voltage Counter" type="u16" access="rw" required="o" default="0x0000"></attribute>
+        <attribute id="0x0513" name="Average RMS Under Voltage Counter" type="u16" access="rw" required="o" default="0x0000"></attribute>
+        <attribute id="0x0514" name="RMS Extreme Over Voltage Period" type="u16" access="rw" required="o" default="0x0000"></attribute>
+        <attribute id="0x0515" name="RMS Extreme Under Voltage Period" type="u16" access="rw" required="o" default="0x0000"></attribute>
+        <attribute id="0x0516" name="RMS Voltage Sag Period" type="u16" access="rw" required="o" default="0x0000"></attribute>
+        <attribute id="0x0517" name="RMS Voltage Swell Period" type="u16" access="rw" required="o" default="0x0000"></attribute>
+      </attribute-set>
+      <attribute-set id="0x0600" description="AC Formatting">
+        <attribute id="0x0600" name="AC Voltage Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
+        <attribute id="0x0601" name="AC Voltage Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
+        <attribute id="0x0602" name="AC Current Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
+        <attribute id="0x0603" name="AC Current Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
+        <attribute id="0x0604" name="AC Power Multiplier" type="u16" access="r" required="o" default="0x0001"></attribute>
+        <attribute id="0x0605" name="AC Power Divisor" type="u16" access="r" required="o" default="0x0001"></attribute>
+      </attribute-set>
+      <attribute-set id="0x0700" description="DC Manufacturer Threshold Alarms">
+        <attribute id="0x0700" name="DC Overload Alarms Mask" type="bmp8" access="rw" required="o" default="00000000">
+          <value name="Voltage Overload" value="0"></value>
+          <value name="Current Overload" value="1"></value>
+        </attribute>
+        <attribute id="0x0701" name="AC Voltage Overload" type="s16" access="r" required="o" default="0xffff"></attribute>
+        <attribute id="0x0702" name="AC Current Overload" type="s16" access="r" required="o" default="0xffff"></attribute>
+      </attribute-set>
+      <attribute-set id="0x0800" description="AC Manufacturer Threshold Alarms">
+        <attribute id="0x0800" name="DC Overload Alarms Mask" type="bmp16" access="rw" required="o" default="0x0">
+          <value name="Voltage Overload" value="0"></value>
+          <value name="Current Overload" value="1"></value>
+          <value name="Active Power Overload" value="2"></value>
+          <value name="Reactive Power Overload" value="3"></value>
+          <value name="Average RMS Over Voltage" value="4"></value>
+          <value name="Average RMS Under Voltage" value="5"></value>
+          <value name="RMS Extreme Over Voltage" value="6"></value>
+          <value name="RMS Extreme Under Voltage" value="7"></value>
+          <value name="RMS Voltage Sag" value="8"></value>
+          <value name="RMS Voltage Swell" value="9"></value>
+        </attribute>
+        <attribute id="0x0801" name="AC Voltage Overload" type="s16" access="r" required="o" default="0xffff"></attribute>
+        <attribute id="0x0802" name="AC Current Overload" type="s16" access="r" required="o" default="0xffff"></attribute>
+        <attribute id="0x0803" name="AC Active Power Overload" type="s16" access="r" required="o" default="0xffff"></attribute>
+        <attribute id="0x0804" name="AC Reactive Power Overload" type="s16" access="r" required="o" default="0xffff"></attribute>
+        <attribute id="0x0805" name="Average RMS Over Voltage" type="s16" access="r" required="o"></attribute>
+        <attribute id="0x0806" name="Average RMS Under Voltage" type="s16" access="r" required="o"></attribute>
+        <attribute id="0x0807" name="RMS Extreme Over Voltage" type="s16" access="rw" required="o"></attribute>
+        <attribute id="0x0808" name="RMS Extreme Under Voltage" type="s16" access="rw" required="o"></attribute>
+        <attribute id="0x0809" name="RMS Voltage Sag" type="s16" access="rw" required="o"></attribute>
+        <attribute id="0x080a" name="RMS Voltage Swell" type="s16" access="rw" required="o"></attribute>
+      </attribute-set>
+      <attribute-set id="0x0900" description="AC (Phase B) Measurements">
+        <attribute id="0x0901" name="Line Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+        <attribute id="0x0902" name="Active Current" type="s16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x0903" name="Reactive Current" type="s16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x0905" name="RMS Voltage" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+        <attribute id="0x0906" name="RMS Voltage Min" type="u16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x0907" name="RMS Voltage Max" type="u16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x0908" name="RMS Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+        <attribute id="0x0909" name="RMS Current Min" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+        <attribute id="0x090a" name="RMS Current Max" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+        <attribute id="0x090b" name="Active Power" type="s16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x090c" name="Active Power Min" type="s16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x090d" name="Active Power Max" type="s16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x090e" name="Reactive Power" type="s16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x090f" name="Apparent Power" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+        <attribute id="0x0910" name="Power Factor" type="s8" access="r" required="o" default="0x00"></attribute>
+        <attribute id="0x0911" name="Average RMS Voltage Measurement Period" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0912" name="Average RMS Over Voltage Counter" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0913" name="Average RMS Under Voltage Counter" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0914" name="RMS Extreme Over Voltage Period" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0915" name="RMS Extreme Under Voltage Period" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0916" name="RMS Voltage Sag Period" type="u16" access="rw" required="o" default="0x0000"></attribute>
+        <attribute id="0x0917" name="RMS Voltage Swell Period" type="u16" access="rw" required="o" default="0x0000"></attribute>
+      </attribute-set>
+      <attribute-set id="0x0a00" description="AC (Phase C) Measurements">
+        <attribute id="0x0a01" name="Line Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+        <attribute id="0x0a02" name="Active Current" type="s16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x0a03" name="Reactive Current" type="s16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x0a05" name="RMS Voltage" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+        <attribute id="0x0a06" name="RMS Voltage Min" type="u16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x0a07" name="RMS Voltage Max" type="u16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x0a08" name="RMS Current" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+        <attribute id="0x0a09" name="RMS Current Min" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+        <attribute id="0x0a0a" name="RMS Current Max" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+        <attribute id="0x0a0b" name="Active Power" type="s16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x0a0c" name="Active Power Min" type="s16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x0a0d" name="Active Power Max" type="s16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x0a0e" name="Reactive Power" type="s16" access="r" required="o" default="0x8000"></attribute>
+        <attribute id="0x0a0f" name="Apparent Power" type="u16" access="r" required="o" default="0xFFFF"></attribute>
+        <attribute id="0x0a10" name="Power Factor" type="s8" access="r" required="o" default="0x00"></attribute>
+        <attribute id="0x0a11" name="Average RMS Voltage Measurement Period" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0a12" name="Average RMS Over Voltage Counter" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0a13" name="Average RMS Under Voltage Counter" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0a14" name="RMS Extreme Over Voltage Period" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0a15" name="RMS Extreme Under Voltage Period" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0a16" name="RMS Voltage Sag Period" type="u16" access="rw" required="o" default="0x0000"></attribute>
+        <attribute id="0x0a17" name="RMS Voltage Swell Period" type="u16" access="rw" required="o" default="0x0000"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0b05" name="Diagnostics">
+    <description>The diagnostics cluster provides access to information regarding the operation of the ZigBee stack over time.</description>
+    <server>
+      <attribute-set id="0x0000" description="Hardware Information">
+        <attribute id="0x0000" name="Number of Resets" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0001" name="Persistens Memory Writes" type="u16" access="r" required="o" default="0x0000"></attribute>
+      </attribute-set>
+      <attribute-set id="0x0100" description="Stack/Network Information">
+        <attribute id="0x0100" name="Mac Rx Bcast" type="u32" access="r" required="o" default="0x00000000"></attribute>
+        <attribute id="0x0101" name="Mac Tx Bcast" type="u32" access="r" required="o" default="0x00000000"></attribute>
+        <attribute id="0x0102" name="Mac Rx Ucast" type="u32" access="r" required="o" default="0x00000000"></attribute>
+        <attribute id="0x0103" name="Mac Tx Ucast" type="u32" access="r" required="o" default="0x00000000"></attribute>
+        <attribute id="0x0104" name="Mac Tx Ucast Retry" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0105" name="Mac Tx Ucast Fail" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0106" name="APS Rx Bcast" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0107" name="APS Tx Bcast" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0108" name="APS Rx Ucast" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0109" name="APS Tx Ucast Success" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x010a" name="APS Tx Ucast Retry" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x010b" name="APS Tx Ucast Fail" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x010c" name="Route Disc Initiated" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x010d" name="Neighbor Added" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x010e" name="Neighbor Removed" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x010f" name="Neighbor Stale" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0110" name="Join Indication" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0111" name="Child Moved" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0112" name="NWK FC Failure" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0113" name="APS FC Failure" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0114" name="APS Unauthorized Key" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0115" name="NWK Decrypt Failures" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0116" name="APS Decrypt Failures" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0117" name="Packet Buffer Alloc Failures" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0118" name="Relayed Ucast" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x0119" name="Phy to MAC queue limit reached" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x011a" name="Packet Validate Dropcount" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x011b" name="Avg MAC Retry per APS Msg Sent" type="u16" access="r" required="o" default="0x0000"></attribute>
+        <attribute id="0x011c" name="Last Message LQI" type="u8" access="r" required="o" default="0x00"></attribute>
+        <attribute id="0x011d" name="Last Message RSSI" type="s8" access="r" required="o" default="0x00"></attribute>
+      </attribute-set>
+      <attribute-set id="0x4000" description="Vendor specific attributes">
+        <attribute id="0x4000" name="SW error code" type="bmp16" access="rw" default="0" required="o" mfcode="0x1246"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <cluster id="0x0500" name="IAS Zone">
+    <description>The IAS Zone cluster defines an interface to the functionality of an IAS security zone device. IAS Zone supports up to two alarm types per zone, low battery reports and supervision of the IAS network.</description>
+    <server>
+      <attribute-set id="0x0000" description="Zone information">
+        <attribute id="0x0000" name="Zone State" type="enum8" range="0x00,0x01" access="r" required="m">
+          <value name="Not enrolled" value="0x00"></value>
+          <value name="Enrolled" value="0x01">
+            <description>The client will react to Zone State Change Notification commands from the server.</description>
+          </value>
+        </attribute>
+        <attribute id="0x0001" name="Zone Type" type="enum16" range="0x0000,0xffff" access="r" required="m">
+          <value name="Standard CIE" value="0x0000"></value>
+          <value name="Motion sensor" value="0x000d"></value>
+          <value name="Contact switch" value="0x0015"></value>
+          <value name="Fire sensor" value="0x0028"></value>
+          <value name="Water sensor" value="0x002a"></value>
+          <value name="Carbon Monoxide (CO) sensor" value="0x002b"></value>
+          <value name="Personal emergency device" value="0x002c"></value>
+          <value name="Vibration / Movement sensor" value="0x002d"></value>
+          <value name="Remote Control" value="0x010f"></value>
+          <value name="Key fob" value="0x0115"></value>
+          <value name="Keypad" value="0x021d"></value>
+          <value name="Standard Warning Device" value="0x0225"></value>
+          <value name="Glass break sensor" value="0x0226"></value>
+          <value name="Security repeater" value="0x0229"></value>
+          <value name="Manufacturer specific" value="0x8000"></value>
+          <value name="Invalid Zone Type" value="0xffff"></value>
+        </attribute>
+        <attribute id="0x0002" type="bmp16" name="Zone Status" access="r" required="m">
+          <value name="Alarm 1" value="0"></value>
+          <value name="Alarm 2" value="1"></value>
+          <value name="Tamper" value="2"></value>
+          <value name="Battery" value="3"></value>
+          <value name="Supervision reports" value="4"></value>
+          <value name="Restore reports" value="5"></value>
+          <value name="Trouble" value="6"></value>
+          <value name="AC (mains)" value="7"></value>
+          <value name="Test" value="8"></value>
+          <value name="Battery defect" value="9"></value>
+        </attribute>
+      </attribute-set>
+      <attribute-set id="0x0010" description="Zone settings">
+        <attribute id="0x0010" name="IAS_CIE_Address" type="uid" access="rw" required="o" default="0"></attribute>
+        <attribute id="0x0011" name="Zone ID" type="u8" range="0x00,0xff" access="r" required="m"></attribute>
+        <attribute id="0x0012" name="Number Of ZoneSensitivity Levels Supported" type="u8" range="0x02,0xff" access="r" required="o" default="2"></attribute>
+        <attribute id="0x0013" name="Current Zone SensitivityLevel" type="u8" range="0x00,0xff" access="rw" required="o" default="0"></attribute>
+      </attribute-set>
+      <attribute-set id="0x8000" description="Develco specific" mfcode="0x1015">
+        <attribute id="0x8000" name="Zone Status Interval" type="u16" access="rw" required="o" mfcode="0x1015"></attribute>
+        <attribute id="0x8001" name="Alarm Off Delay" type="u16" access="rw" required="o" mfcode="0x1015"></attribute>
+      </attribute-set>
+      <attribute-set id="0xf000" description="Xiaomi specific" mfcode="0x1037">
+        <attribute id="0xfff0" name="Device config" type="u64" access="r" required="o" mfcode="0x115f"></attribute>
+      </attribute-set>
+      <command id="0x00" dir="recv" name="Zone Enroll Response" required="m">
+        <payload>
+          <attribute id="0x00" type="enum8" name="Enroll response code" required="m">
+            <value name="Success" value="0x00"></value>
+            <value name="Not supported" value="0x01"></value>
+            <value name="No enroll permit" value="0x02"></value>
+            <value name="Too many zones" value="0x03"></value>
           </attribute>
-          <attribute id="0x0001" name="Zone Type" type="enum16" range="0x0000,0xffff" access="r" required="m">
-            <value name="Standard CIE" value="0x0000"></value>
-            <value name="Motion sensor" value="0x000d"></value>
-            <value name="Contact switch" value="0x0015"></value>
-            <value name="Fire sensor" value="0x0028"></value>
-            <value name="Water sensor" value="0x002a"></value>
-            <value name="Carbon Monoxide (CO) sensor" value="0x002b"></value>
-            <value name="Personal emergency device" value="0x002c"></value>
-            <value name="Vibration / Movement sensor" value="0x002d"></value>
-            <value name="Remote Control" value="0x010f"></value>
-            <value name="Key fob" value="0x0115"></value>
-            <value name="Keypad" value="0x021d"></value>
-            <value name="Standard Warning Device" value="0x0225"></value>
-            <value name="Glass break sensor" value="0x0226"></value>
-            <value name="Security repeater" value="0x0229"></value>
-            <value name="Manufacturer specific" value="0x8000"></value>
-            <value name="Invalid Zone Type" value="0xffff"></value>
-          </attribute>
-          <attribute id="0x0002" type="bmp16" name="Zone Status" access="r" required="m">
+          <attribute id="0x01" type="u8" name="Zone ID" required="m"></attribute>
+        </payload>
+      </command>
+      <command id="0x01" dir="recv" name="Initiate Normal Operation Mode" required="o">
+        <payload>
+        </payload>
+      </command>
+      <command id="0x00" dir="send" name="Zone Status Change Notification" required="m">
+        <payload>
+          <attribute id="0x00" type="bmp16" name="Zone Status" required="m">
             <value name="Alarm 1" value="0"></value>
             <value name="Alarm 2" value="1"></value>
             <value name="Tamper" value="2"></value>
@@ -4515,269 +4555,226 @@ Displayed setpoint is not affected, but regulated setpoint will change. Can be u
             <value name="Test" value="8"></value>
             <value name="Battery defect" value="9"></value>
           </attribute>
-        </attribute-set>
-        <attribute-set id="0x0010" description="Zone settings">
-          <attribute id="0x0010" name="IAS_CIE_Address" type="uid" access="rw" required="o" default="0"></attribute>
-          <attribute id="0x0011" name="Zone ID" type="u8" range="0x00,0xff" access="r" required="m"></attribute>
-          <attribute id="0x0012" name="Number Of ZoneSensitivity Levels Supported" type="u8" range="0x02,0xff" access="r" required="o" default="2"></attribute>
-          <attribute id="0x0013" name="Current Zone SensitivityLevel" type="u8" range="0x00,0xff" access="rw" required="o" default="0"></attribute>
-        </attribute-set>
-        <attribute-set id="0x8000" description="Develco specific" mfcode="0x1015">
-          <attribute id="0x8000" name="Zone Status Interval" type="u16" access="rw" required="o" mfcode="0x1015"></attribute>
-          <attribute id="0x8001" name="Alarm Off Delay" type="u16" access="rw" required="o" mfcode="0x1015"></attribute>
-        </attribute-set>
-        <attribute-set id="0xf000" description="Xiaomi specific" mfcode="0x1037">
-          <attribute id="0xfff0" name="Device config" type="u64" access="r" required="o" mfcode="0x115f"></attribute>
-        </attribute-set>
-        <command id="0x00" dir="recv" name="Zone Enroll Response" required="m">
-          <payload>
-            <attribute id="0x00" type="enum8" name="Enroll response code" required="m">
-              <value name="Success" value="0x00"></value>
-              <value name="Not supported" value="0x01"></value>
-              <value name="No enroll permit" value="0x02"></value>
-              <value name="Too many zones" value="0x03"></value>
-            </attribute>
-            <attribute id="0x01" type="u8" name="Zone ID" required="m"></attribute>
-          </payload>
-        </command>
-        <command id="0x01" dir="recv" name="Initiate Normal Operation Mode" required="o">
-          <payload>
-          </payload>
-        </command>
-        <command id="0x00" dir="send" name="Zone Status Change Notification" required="m">
-          <payload>
-            <attribute id="0x00" type="bmp16" name="Zone Status" required="m">
-              <value name="Alarm 1" value="0"></value>
-              <value name="Alarm 2" value="1"></value>
-              <value name="Tamper" value="2"></value>
-              <value name="Battery" value="3"></value>
-              <value name="Supervision reports" value="4"></value>
-              <value name="Restore reports" value="5"></value>
-              <value name="Trouble" value="6"></value>
-              <value name="AC (mains)" value="7"></value>
-              <value name="Test" value="8"></value>
-              <value name="Battery defect" value="9"></value>
-            </attribute>
-            <attribute id="0x01" type="bmp8" name="Extended Status" default="0x00" required="m"></attribute>
-            <attribute id="0x02" type="u8" name="Zone ID" required="m"></attribute>
-            <attribute id="0x03" type="u16" name="Delay" required="m"></attribute>
-          </payload>
-        </command>
-        <command id="0x01" dir="send" name="Zone Enroll request" required="m">
-          <payload>
-            <attribute id="0x00" type="enum16" name="Zone Status" required="m">
-              <value name="Standard CIE" value="0x0000"></value>
-              <value name="Motion sensor" value="0x000d"></value>
-              <value name="Contact switch" value="0x0015"></value>
-              <value name="Fire sensor" value="0x0028"></value>
-              <value name="Water sensor" value="0x002a"></value>
-              <value name="Gas sensor" value="0x002b"></value>
-              <value name="Personal emergency device" value="0x002c"></value>
-              <value name="Vibration / Movement sensor" value="0x002d"></value>
-              <value name="Remote Control" value="0x010f"></value>
-              <value name="Key fob" value="0x0115"></value>
-              <value name="Keypad" value="0x021d"></value>
-              <value name="Standard Warning Device" value="0x0225"></value>
-              <value name="Invalid Zone Type" value="0xffff"></value>
-            </attribute>
-            <attribute id="0x01" type="u16" name="Manufacturer Code" required="m"></attribute>
-          </payload>
-        </command>
-      </server>
-      <client>
-      </client>
-    </cluster>
+          <attribute id="0x01" type="bmp8" name="Extended Status" default="0x00" required="m"></attribute>
+          <attribute id="0x02" type="u8" name="Zone ID" required="m"></attribute>
+          <attribute id="0x03" type="u16" name="Delay" required="m"></attribute>
+        </payload>
+      </command>
+      <command id="0x01" dir="send" name="Zone Enroll request" required="m">
+        <payload>
+          <attribute id="0x00" type="enum16" name="Zone Status" required="m">
+            <value name="Standard CIE" value="0x0000"></value>
+            <value name="Motion sensor" value="0x000d"></value>
+            <value name="Contact switch" value="0x0015"></value>
+            <value name="Fire sensor" value="0x0028"></value>
+            <value name="Water sensor" value="0x002a"></value>
+            <value name="Gas sensor" value="0x002b"></value>
+            <value name="Personal emergency device" value="0x002c"></value>
+            <value name="Vibration / Movement sensor" value="0x002d"></value>
+            <value name="Remote Control" value="0x010f"></value>
+            <value name="Key fob" value="0x0115"></value>
+            <value name="Keypad" value="0x021d"></value>
+            <value name="Standard Warning Device" value="0x0225"></value>
+            <value name="Invalid Zone Type" value="0xffff"></value>
+          </attribute>
+          <attribute id="0x01" type="u16" name="Manufacturer Code" required="m"></attribute>
+        </payload>
+      </command>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <cluster id="0x0501" name="IAS ACE">
-      <description>The IAS ACE cluster defines an interface to the functionality of any Ancillary Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE device can access a IAS CIE device and manipulate the IAS system, on behalf of a level-2 user.</description>
-      <server>
-        <command id="0x00" dir="recv" name="Arm" required="m">
-          <payload>
-            <attribute id="0x00" type="enum8" name="Arm Mode" required="m">
-              <value name="Disarm" value="0x00"></value>
-              <value name="Arm Day/Home Zones Only" value="0x01"></value>
-              <value name="Arm Night/Sleep Zones Only" value="0x02"></value>
-              <value name="Arm All Zones" value="0x03"></value>
-            </attribute>
-            <attribute id="0x01" type="cstring" name="Arm/Disarm Code" required="m"></attribute>
-            <attribute id="0x02" type="u8" name="Zone ID" required="m"></attribute>
-          </payload>
-        </command>
-        <command id="0x01" dir="recv" name="Bypass" required="m">
-          <payload>
-            <attribute id="0x00" type="u8" name="Number of Zones" required="m"></attribute>
-            <attribute id="0x01" type="u8" name="Zone ID" required="m"></attribute>
-            <attribute id="0x02" type="cstring" name="Arm/Disarm Code" required="m"></attribute>
-          </payload>
-        </command>
-        <command id="0x02" dir="recv" name="Emergency" required="m"></command>
-        <command id="0x03" dir="recv" name="Fire" required="m"></command>
-        <command id="0x04" dir="recv" name="Panic" required="m"></command>
-        <command id="0x05" dir="recv" name="Get Zone ID Map" required="m"></command>
-        <command id="0x06" dir="recv" name="Get Zone Information" required="m">
-          <payload>
-            <attribute id="0x00" type="u8" name="Zone ID" required="m"></attribute>
-          </payload>
-        </command>
-        <command id="0x07" dir="recv" name="Get Panel Status" required="m"></command>
-        <command id="0x08" dir="recv" name="Get Bypassed Zone List" required="m"></command>
-        <command id="0x09" dir="recv" name="Get Zone Status" required="m">
-          <payload>
-            <attribute id="0x00" type="u8" name="Starting Zone ID" required="m"></attribute>
-            <attribute id="0x01" type="u8" name="Max Number of Zone IDs" required="m"></attribute>
-            <attribute id="0x02" type="bool" name="Zone Status Mask Flag" required="m"></attribute>
-            <attribute id="0x03" type="bmp16" name="Zone Status Mask" required="m"></attribute>
+  <cluster id="0x0501" name="IAS ACE">
+    <description>The IAS ACE cluster defines an interface to the functionality of any Ancillary Control Equipment of the IAS system. Using this cluster, a ZigBee enabled ACE device can access a IAS CIE device and manipulate the IAS system, on behalf of a level-2 user.</description>
+    <server>
+      <command id="0x00" dir="recv" name="Arm" required="m">
+        <payload>
+          <attribute id="0x00" type="enum8" name="Arm Mode" required="m">
+            <value name="Disarm" value="0x00"></value>
+            <value name="Arm Day/Home Zones Only" value="0x01"></value>
+            <value name="Arm Night/Sleep Zones Only" value="0x02"></value>
+            <value name="Arm All Zones" value="0x03"></value>
+          </attribute>
+          <attribute id="0x01" type="cstring" name="Arm/Disarm Code" required="m"></attribute>
+          <attribute id="0x02" type="u8" name="Zone ID" required="m"></attribute>
+        </payload>
+      </command>
+      <command id="0x01" dir="recv" name="Bypass" required="m">
+        <payload>
+          <attribute id="0x00" type="u8" name="Number of Zones" required="m"></attribute>
+          <attribute id="0x01" type="u8" name="Zone ID" required="m"></attribute>
+          <attribute id="0x02" type="cstring" name="Arm/Disarm Code" required="m"></attribute>
+        </payload>
+      </command>
+      <command id="0x02" dir="recv" name="Emergency" required="m"></command>
+      <command id="0x03" dir="recv" name="Fire" required="m"></command>
+      <command id="0x04" dir="recv" name="Panic" required="m"></command>
+      <command id="0x05" dir="recv" name="Get Zone ID Map" required="m"></command>
+      <command id="0x06" dir="recv" name="Get Zone Information" required="m">
+        <payload>
+          <attribute id="0x00" type="u8" name="Zone ID" required="m"></attribute>
+        </payload>
+      </command>
+      <command id="0x07" dir="recv" name="Get Panel Status" required="m"></command>
+      <command id="0x08" dir="recv" name="Get Bypassed Zone List" required="m"></command>
+      <command id="0x09" dir="recv" name="Get Zone Status" required="m">
+        <payload>
+          <attribute id="0x00" type="u8" name="Starting Zone ID" required="m"></attribute>
+          <attribute id="0x01" type="u8" name="Max Number of Zone IDs" required="m"></attribute>
+          <attribute id="0x02" type="bool" name="Zone Status Mask Flag" required="m"></attribute>
+          <attribute id="0x03" type="bmp16" name="Zone Status Mask" required="m"></attribute>
+          <!--More to do here!!!-->
+        </payload>
+      </command>
+    </server>
+    <client>
+      <command id="0x00" dir="recv" name="Arm Response" required="m">
+        <payload>
+          <attribute id="0x00" type="enum8" name="Arm Notification" required="m">
+            <value name="All Zones Disarmed" value="0x00"></value>
+            <value name="Only Day/Home Zones Armed" value="0x01"></value>
+            <value name="Only Night/Sleep Zones Armed" value="0x02"></value>
+            <value name="All Zones Armed" value="0x03"></value>
+            <value name="Invalid Arm/Disarm Code" value="0x04"></value>
+            <value name="Not ready to arm" value="0x05"></value>
+            <value name="Already disarmed" value="0x06"></value>
+          </attribute>
+          <attribute id="0x01" type="cstring" name="Arm/Disarm Code" required="m"></attribute>
+          <attribute id="0x02" type="u8" name="Zone ID" required="m"></attribute>
+        </payload>
+      </command>
+      <command id="0x01" dir="recv" name="Get Zone ID Map Response" required="m">
+        <payload>
+          <attribute id="0x00" type="bmp16" name="Zone ID Map section 0" required="m"></attribute>
+          <!--More to do here!!!-->
+        </payload>
+      </command>
+      <command id="0x02" dir="recv" name="Get Zone Information Response" required="m">
+        <payload>
+          <attribute id="0x00" type="u8" name="Zone ID" required="m"></attribute>
+          <attribute id="0x01" type="enum16" name="Zone Type" required="m">
+            <value name="All Zones Disarmed" value="0x00"></value>
+            <value name="Only Day/Home Zones Armed" value="0x01"></value>
+            <value name="Only Night/Sleep Zones Armed" value="0x02"></value>
+            <value name="All Zones Armed" value="0x03"></value>
+            <value name="Invalid Arm/Disarm Code" value="0x04"></value>
+            <value name="Not ready to arm" value="0x05"></value>
+            <value name="Already disarmed" value="0x06"></value>
+          </attribute>
+          <attribute id="0x02" type="uid" name="IEEE address" required="m"></attribute>
+          <attribute id="0x03" type="cstring" name="Zone Label" required="m"></attribute>
+        </payload>
+      </command>
+      <command id="0x03" dir="recv" name="Zone Status Changed" required="m">
+        <payload>
+          <attribute id="0x00" type="u8" name="Zone ID" required="m"></attribute>
+          <attribute id="0x01" type="enum16" name="Zone Status" required="m">
             <!--More to do here!!!-->
-          </payload>
-        </command>
-      </server>
-      <client>
-        <command id="0x00" dir="recv" name="Arm Response" required="m">
-          <payload>
-            <attribute id="0x00" type="enum8" name="Arm Notification" required="m">
-              <value name="All Zones Disarmed" value="0x00"></value>
-              <value name="Only Day/Home Zones Armed" value="0x01"></value>
-              <value name="Only Night/Sleep Zones Armed" value="0x02"></value>
-              <value name="All Zones Armed" value="0x03"></value>
-              <value name="Invalid Arm/Disarm Code" value="0x04"></value>
-              <value name="Not ready to arm" value="0x05"></value>
-              <value name="Already disarmed" value="0x06"></value>
-            </attribute>
-            <attribute id="0x01" type="cstring" name="Arm/Disarm Code" required="m"></attribute>
-            <attribute id="0x02" type="u8" name="Zone ID" required="m"></attribute>
-          </payload>
-        </command>
-        <command id="0x01" dir="recv" name="Get Zone ID Map Response" required="m">
-          <payload>
-            <attribute id="0x00" type="bmp16" name="Zone ID Map section 0" required="m"></attribute>
-            <!--More to do here!!!-->
-          </payload>
-        </command>
-        <command id="0x02" dir="recv" name="Get Zone Information Response" required="m">
-          <payload>
-            <attribute id="0x00" type="u8" name="Zone ID" required="m"></attribute>
-            <attribute id="0x01" type="enum16" name="Zone Type" required="m">
-              <value name="All Zones Disarmed" value="0x00"></value>
-              <value name="Only Day/Home Zones Armed" value="0x01"></value>
-              <value name="Only Night/Sleep Zones Armed" value="0x02"></value>
-              <value name="All Zones Armed" value="0x03"></value>
-              <value name="Invalid Arm/Disarm Code" value="0x04"></value>
-              <value name="Not ready to arm" value="0x05"></value>
-              <value name="Already disarmed" value="0x06"></value>
-            </attribute>
-            <attribute id="0x02" type="uid" name="IEEE address" required="m"></attribute>
-            <attribute id="0x03" type="cstring" name="Zone Label" required="m"></attribute>
-          </payload>
-        </command>
-        <command id="0x03" dir="recv" name="Zone Status Changed" required="m">
-          <payload>
-            <attribute id="0x00" type="u8" name="Zone ID" required="m"></attribute>
-            <attribute id="0x01" type="enum16" name="Zone Status" required="m">
-              <!--More to do here!!!-->
-              <value name="All Zones Disarmed" value="0x00"></value>
-              <value name="Only Day/Home Zones Armed" value="0x01"></value>
-              <value name="Only Night/Sleep Zones Armed" value="0x02"></value>
-              <value name="All Zones Armed" value="0x03"></value>
-              <value name="Invalid Arm/Disarm Code" value="0x04"></value>
-              <value name="Not ready to arm" value="0x05"></value>
-              <value name="Already disarmed" value="0x06"></value>
-            </attribute>
-            <attribute id="0x02" type="enum8" name="Audible Notification" default="0x01" required="m">
-              <value name="Mute" value="0x00"></value>
-              <value name="Default sound" value="0x01"></value>
-            </attribute>
-            <attribute id="0x03" type="cstring" name="Zone Label" required="m"></attribute>
-          </payload>
-        </command>
-        <command id="0x04" dir="recv" name="Panel Status Changed" required="m">
-          <payload>
-            <attribute id="0x00" type="enum8" name="Panel Status" required="m">
-              <value name="Panel disarmed (all zones disarmed) and ready to arm" value="0x00"></value>
-              <value name="Armed stay" value="0x01"></value>
-              <value name="Armed night" value="0x02"></value>
-              <value name="Armed away" value="0x03"></value>
-              <value name="Exit delay" value="0x04"></value>
-              <value name="Entry delay" value="0x05"></value>
-              <value name="Not ready to arm" value="0x06"></value>
-              <value name="In alarm" value="0x07"></value>
-              <value name="Arming stay" value="0x08"></value>
-              <value name="Arming night" value="0x09"></value>
-              <value name="Arming away" value="0x0a"></value>
-            </attribute>
-            <attribute id="0x01" type="u8" name="Seconds Remaining" default="0x00" required="m"></attribute>
-            <attribute id="0x02" type="enum8" name="Audible Notification" default="0x01" required="m">
-              <value name="Mute" value="0x00"></value>
-              <value name="Default sound" value="0x01"></value>
-            </attribute>
-            <attribute id="0x03" type="enum8" name="Alarm Status" default="0x00" required="m">
-              <value name="No alarm" value="0x00"></value>
-              <value name="Burglar" value="0x01"></value>
-              <value name="Fire" value="0x02"></value>
-              <value name="Emergency" value="0x03"></value>
-              <value name="Police Panic" value="0x04"></value>
-              <value name="Fire Panic" value="0x05"></value>
-              <value name="Emergency Panic (i.e., medical issue)" value="0x06"></value>
-            </attribute>
-            <attribute id="0x04" type="cstring" name="Zone Label" required="m"></attribute>
-          </payload>
-        </command>
-        <command id="0x05" dir="recv" name="Get Panel Status Response" required="m">
-          <payload>
-            <attribute id="0x00" type="enum8" name="Panel Status" required="m">
-              <value name="Panel disarmed (all zones disarmed) and ready to arm" value="0x00"></value>
-              <value name="Armed stay" value="0x01"></value>
-              <value name="Armed night" value="0x02"></value>
-              <value name="Armed away" value="0x03"></value>
-              <value name="Exit delay" value="0x04"></value>
-              <value name="Entry delay" value="0x05"></value>
-              <value name="Not ready to arm" value="0x06"></value>
-              <value name="In alarm" value="0x07"></value>
-              <value name="Arming stay" value="0x08"></value>
-              <value name="Arming night" value="0x09"></value>
-              <value name="Arming away" value="0x0a"></value>
-            </attribute>
-            <attribute id="0x01" type="u8" name="Seconds Remaining" default="0x00" required="m"></attribute>
-            <attribute id="0x02" type="enum8" name="Audible Notification" default="0x01" required="m">
-              <value name="Mute" value="0x00"></value>
-              <value name="Default sound" value="0x01"></value>
-            </attribute>
-            <attribute id="0x03" type="enum8" name="Alarm Status" default="0x00" required="m">
-              <value name="No alarm" value="0x00"></value>
-              <value name="Burglar" value="0x01"></value>
-              <value name="Fire" value="0x02"></value>
-              <value name="Emergency" value="0x03"></value>
-              <value name="Police Panic" value="0x04"></value>
-              <value name="Fire Panic" value="0x05"></value>
-              <value name="Emergency Panic (i.e., medical issue)" value="0x06"></value>
-            </attribute>
-            <attribute id="0x04" type="cstring" name="Zone Label" required="m"></attribute>
-          </payload>
-        </command>
-        <command id="0x06" dir="recv" name="Set Bypassed Zone List" required="m">
-          <payload>
-            <attribute id="0x00" type="u8" name="Number of Zones" required="m"></attribute>
-            <attribute id="0x01" type="u8" name="Zone ID 1" required="m"></attribute>
-            <attribute id="0x02" type="u8" name="Zone ID 2" required="m"></attribute>
-            <attribute id="0x03" type="u8" name="Zone ID 3" required="m"></attribute>
-            <attribute id="0x04" type="u8" name="Zone ID 4" required="m"></attribute>
-            <attribute id="0x05" type="u8" name="Zone ID 5" required="m"></attribute>
-            <attribute id="0x06" type="u8" name="Zone ID 6" required="m"></attribute>
-            <attribute id="0x07" type="u8" name="Zone ID 7" required="m"></attribute>
-            <attribute id="0x08" type="u8" name="Zone ID 8" required="m"></attribute>
-          </payload>
-        </command>
-        <command id="0x07" dir="recv" name="Bypass Response" required="m">
-          <payload>
-            <attribute id="0x00" type="u8" name="Number of Zones" required="m"></attribute>
-            <attribute id="0x01" type="u8" name="Bypass Result for Zone ID 1" required="m"></attribute>
-            <attribute id="0x02" type="u8" name="Bypass Result for Zone ID 2" required="m"></attribute>
-            <attribute id="0x03" type="u8" name="Bypass Result for Zone ID 3" required="m"></attribute>
-            <attribute id="0x04" type="u8" name="Bypass Result for Zone ID 4" required="m"></attribute>
-            <attribute id="0x05" type="u8" name="Bypass Result for Zone ID 5" required="m"></attribute>
-            <attribute id="0x06" type="u8" name="Bypass Result for Zone ID 6" required="m"></attribute>
-            <attribute id="0x07" type="u8" name="Bypass Result for Zone ID 7" required="m"></attribute>
-            <attribute id="0x08" type="u8" name="Bypass Result for Zone ID 8" required="m"></attribute>
-            <!--
+            <value name="All Zones Disarmed" value="0x00"></value>
+            <value name="Only Day/Home Zones Armed" value="0x01"></value>
+            <value name="Only Night/Sleep Zones Armed" value="0x02"></value>
+            <value name="All Zones Armed" value="0x03"></value>
+            <value name="Invalid Arm/Disarm Code" value="0x04"></value>
+            <value name="Not ready to arm" value="0x05"></value>
+            <value name="Already disarmed" value="0x06"></value>
+          </attribute>
+          <attribute id="0x02" type="enum8" name="Audible Notification" default="0x01" required="m">
+            <value name="Mute" value="0x00"></value>
+            <value name="Default sound" value="0x01"></value>
+          </attribute>
+          <attribute id="0x03" type="cstring" name="Zone Label" required="m"></attribute>
+        </payload>
+      </command>
+      <command id="0x04" dir="recv" name="Panel Status Changed" required="m">
+        <payload>
+          <attribute id="0x00" type="enum8" name="Panel Status" required="m">
+            <value name="Panel disarmed (all zones disarmed) and ready to arm" value="0x00"></value>
+            <value name="Armed stay" value="0x01"></value>
+            <value name="Armed night" value="0x02"></value>
+            <value name="Armed away" value="0x03"></value>
+            <value name="Exit delay" value="0x04"></value>
+            <value name="Entry delay" value="0x05"></value>
+            <value name="Not ready to arm" value="0x06"></value>
+            <value name="In alarm" value="0x07"></value>
+            <value name="Arming stay" value="0x08"></value>
+            <value name="Arming night" value="0x09"></value>
+            <value name="Arming away" value="0x0a"></value>
+          </attribute>
+          <attribute id="0x01" type="u8" name="Seconds Remaining" default="0x00" required="m"></attribute>
+          <attribute id="0x02" type="enum8" name="Audible Notification" default="0x01" required="m">
+            <value name="Mute" value="0x00"></value>
+            <value name="Default sound" value="0x01"></value>
+          </attribute>
+          <attribute id="0x03" type="enum8" name="Alarm Status" default="0x00" required="m">
+            <value name="No alarm" value="0x00"></value>
+            <value name="Burglar" value="0x01"></value>
+            <value name="Fire" value="0x02"></value>
+            <value name="Emergency" value="0x03"></value>
+            <value name="Police Panic" value="0x04"></value>
+            <value name="Fire Panic" value="0x05"></value>
+            <value name="Emergency Panic (i.e., medical issue)" value="0x06"></value>
+          </attribute>
+          <attribute id="0x04" type="cstring" name="Zone Label" required="m"></attribute>
+        </payload>
+      </command>
+      <command id="0x05" dir="recv" name="Get Panel Status Response" required="m">
+        <payload>
+          <attribute id="0x00" type="enum8" name="Panel Status" required="m">
+            <value name="Panel disarmed (all zones disarmed) and ready to arm" value="0x00"></value>
+            <value name="Armed stay" value="0x01"></value>
+            <value name="Armed night" value="0x02"></value>
+            <value name="Armed away" value="0x03"></value>
+            <value name="Exit delay" value="0x04"></value>
+            <value name="Entry delay" value="0x05"></value>
+            <value name="Not ready to arm" value="0x06"></value>
+            <value name="In alarm" value="0x07"></value>
+            <value name="Arming stay" value="0x08"></value>
+            <value name="Arming night" value="0x09"></value>
+            <value name="Arming away" value="0x0a"></value>
+          </attribute>
+          <attribute id="0x01" type="u8" name="Seconds Remaining" default="0x00" required="m"></attribute>
+          <attribute id="0x02" type="enum8" name="Audible Notification" default="0x01" required="m">
+            <value name="Mute" value="0x00"></value>
+            <value name="Default sound" value="0x01"></value>
+          </attribute>
+          <attribute id="0x03" type="enum8" name="Alarm Status" default="0x00" required="m">
+            <value name="No alarm" value="0x00"></value>
+            <value name="Burglar" value="0x01"></value>
+            <value name="Fire" value="0x02"></value>
+            <value name="Emergency" value="0x03"></value>
+            <value name="Police Panic" value="0x04"></value>
+            <value name="Fire Panic" value="0x05"></value>
+            <value name="Emergency Panic (i.e., medical issue)" value="0x06"></value>
+          </attribute>
+          <attribute id="0x04" type="cstring" name="Zone Label" required="m"></attribute>
+        </payload>
+      </command>
+      <command id="0x06" dir="recv" name="Set Bypassed Zone List" required="m">
+        <payload>
+          <attribute id="0x00" type="u8" name="Number of Zones" required="m"></attribute>
+          <attribute id="0x01" type="u8" name="Zone ID 1" required="m"></attribute>
+          <attribute id="0x02" type="u8" name="Zone ID 2" required="m"></attribute>
+          <attribute id="0x03" type="u8" name="Zone ID 3" required="m"></attribute>
+          <attribute id="0x04" type="u8" name="Zone ID 4" required="m"></attribute>
+          <attribute id="0x05" type="u8" name="Zone ID 5" required="m"></attribute>
+          <attribute id="0x06" type="u8" name="Zone ID 6" required="m"></attribute>
+          <attribute id="0x07" type="u8" name="Zone ID 7" required="m"></attribute>
+          <attribute id="0x08" type="u8" name="Zone ID 8" required="m"></attribute>
+        </payload>
+      </command>
+      <command id="0x07" dir="recv" name="Bypass Response" required="m">
+        <payload>
+          <attribute id="0x00" type="u8" name="Number of Zones" required="m"></attribute>
+          <attribute id="0x01" type="u8" name="Bypass Result for Zone ID 1" required="m"></attribute>
+          <attribute id="0x02" type="u8" name="Bypass Result for Zone ID 2" required="m"></attribute>
+          <attribute id="0x03" type="u8" name="Bypass Result for Zone ID 3" required="m"></attribute>
+          <attribute id="0x04" type="u8" name="Bypass Result for Zone ID 4" required="m"></attribute>
+          <attribute id="0x05" type="u8" name="Bypass Result for Zone ID 5" required="m"></attribute>
+          <attribute id="0x06" type="u8" name="Bypass Result for Zone ID 6" required="m"></attribute>
+          <attribute id="0x07" type="u8" name="Bypass Result for Zone ID 7" required="m"></attribute>
+          <attribute id="0x08" type="u8" name="Bypass Result for Zone ID 8" required="m"></attribute>
+          <!--
               <value name="Zone bypassed" value="0x00"></value>
               <value name="Zone not bypassed" value="0x01"></value>
               <value name="Not allowed" value="0x02"></value>
@@ -4785,226 +4782,226 @@ Displayed setpoint is not affected, but regulated setpoint will change. Can be u
               <value name="Unknown Zone ID" value="0x04"></value>
               <value name="Invalid Arm/Disarm Code" value="0x05"></value>
             -->
-          </payload>
-        </command>
-        <command id="0x08" dir="recv" name="Get Zone Status Response" required="m">
-          <payload>
-            <attribute id="0x00" type="bool" name="Zone Status Complete" required="m"></attribute>
-            <attribute id="0x01" type="u8" name="Number of Zones" required="m"></attribute>
-            <attribute id="0x02" type="u8" name="Zone ID 1" required="m"></attribute>
-            <attribute id="0x03" type="bmp16" name="Zone ID 1 Zone Status" required="m"></attribute>
-            <attribute id="0x04" type="u8" name="Zone ID 2" required="m"></attribute>
-            <attribute id="0x05" type="bmp16" name="Zone ID 2 Zone Status" required="m"></attribute>
-            <attribute id="0x06" type="u8" name="Zone ID 3" required="m"></attribute>
-            <attribute id="0x07" type="bmp16" name="Zone ID 3 Zone Status" required="m"></attribute>
-            <attribute id="0x08" type="u8" name="Zone ID 4" required="m"></attribute>
-            <attribute id="0x09" type="bmp16" name="Zone ID 4 Zone Status" required="m"></attribute>
-          </payload>
-        </command>
-      </client>
-    </cluster>
+        </payload>
+      </command>
+      <command id="0x08" dir="recv" name="Get Zone Status Response" required="m">
+        <payload>
+          <attribute id="0x00" type="bool" name="Zone Status Complete" required="m"></attribute>
+          <attribute id="0x01" type="u8" name="Number of Zones" required="m"></attribute>
+          <attribute id="0x02" type="u8" name="Zone ID 1" required="m"></attribute>
+          <attribute id="0x03" type="bmp16" name="Zone ID 1 Zone Status" required="m"></attribute>
+          <attribute id="0x04" type="u8" name="Zone ID 2" required="m"></attribute>
+          <attribute id="0x05" type="bmp16" name="Zone ID 2 Zone Status" required="m"></attribute>
+          <attribute id="0x06" type="u8" name="Zone ID 3" required="m"></attribute>
+          <attribute id="0x07" type="bmp16" name="Zone ID 3 Zone Status" required="m"></attribute>
+          <attribute id="0x08" type="u8" name="Zone ID 4" required="m"></attribute>
+          <attribute id="0x09" type="bmp16" name="Zone ID 4 Zone Status" required="m"></attribute>
+        </payload>
+      </command>
+    </client>
+  </cluster>
 
-    <cluster id="0x0502" name="IAS WD">
-      <description>The IAS WD cluster provides an interface to the functionality of any Warning Device equipment of the IAS system. Using this cluster, a ZigBee enabled CIE device can access a ZigBee enabled IAS WD device and issue alarm warning indications (siren, strobe lighting, etc.) when a system alarm condition is detected.</description>
-      <server>
-        <attribute id="0x0000" name="Max Duration" type="u16" range="0x0000,0xfffe" access="rw" required="m" default="240"></attribute>
-	<attribute id="0xF000" name="Tuya Alarm mode" type="u8" access="rw" required="o">
-	      <value name="Disarm the alarm" value="0x00"></value>
-              <value name="Sound alarm" value="0x01"></value>
-              <value name="Light alarm" value="0x02"></value>
-              <value name="Sound and light alarm" value="0x03"></value>
-	</attribute>
-        <command id="0x00" dir="recv" name="Start warning" required="m">
-          <payload>
-            <attribute id="0x00" type="bmp8" name="Options" required="m">
-              <value name="Siren level 0" value="0"></value>
-              <value name="Siren level 1" value="1"></value>
-              <value name="Strobe" value="2"></value>
-              <value name="Warning mode 0" value="4"></value>
-              <value name="Warning mode 1" value="5"></value>
-              <value name="Warning mode 2" value="6"></value>
-              <value name="Warning mode 3" value="7"></value>
-            </attribute>
-            <attribute id="0x01" type="u16" name="Warning duration" required="m"></attribute>
-            <attribute id="0x02" type="u8" name="Strobe duty cycle" required="m" default="0x00"></attribute>
-            <attribute id="0x00" type="enum8" name="Strobe level" required="m">
-              <value name="Low" value="0x00"></value>
-              <value name="Medium" value="0x01"></value>
-              <value name="High" value="0x02"></value>
-              <value name="Very high" value="0x03"></value>
-            </attribute>
-          </payload>
-        </command>
-        <command id="0x01" dir="recv" name="Squawk" required="m">
-          <payload>
-            <attribute id="0x00" type="bmp8" name="Options" required="m">
-              <value name="Sqawk level 0" value="0"></value>
-              <value name="Sqawk level 1" value="1"></value>
-              <value name="Strobe" value="3"></value>
-              <value name="Sound for disarmed" value="4"></value>
-            </attribute>
-          </payload>
-        </command>
-      </server>
-      <client>
-      </client>
-    </cluster>
-  </domain>
+  <cluster id="0x0502" name="IAS WD">
+    <description>The IAS WD cluster provides an interface to the functionality of any Warning Device equipment of the IAS system. Using this cluster, a ZigBee enabled CIE device can access a ZigBee enabled IAS WD device and issue alarm warning indications (siren, strobe lighting, etc.) when a system alarm condition is detected.</description>
+    <server>
+      <attribute id="0x0000" name="Max Duration" type="u16" range="0x0000,0xfffe" access="rw" required="m" default="240"></attribute>
+      <attribute id="0xF000" name="Tuya Alarm mode" type="u8" access="rw" required="o">
+        <value name="Disarm the alarm" value="0x00"></value>
+        <value name="Sound alarm" value="0x01"></value>
+        <value name="Light alarm" value="0x02"></value>
+        <value name="Sound and light alarm" value="0x03"></value>
+      </attribute>
+      <command id="0x00" dir="recv" name="Start warning" required="m">
+        <payload>
+          <attribute id="0x00" type="bmp8" name="Options" required="m">
+            <value name="Siren level 0" value="0"></value>
+            <value name="Siren level 1" value="1"></value>
+            <value name="Strobe" value="2"></value>
+            <value name="Warning mode 0" value="4"></value>
+            <value name="Warning mode 1" value="5"></value>
+            <value name="Warning mode 2" value="6"></value>
+            <value name="Warning mode 3" value="7"></value>
+          </attribute>
+          <attribute id="0x01" type="u16" name="Warning duration" required="m"></attribute>
+          <attribute id="0x02" type="u8" name="Strobe duty cycle" required="m" default="0x00"></attribute>
+          <attribute id="0x00" type="enum8" name="Strobe level" required="m">
+            <value name="Low" value="0x00"></value>
+            <value name="Medium" value="0x01"></value>
+            <value name="High" value="0x02"></value>
+            <value name="Very high" value="0x03"></value>
+          </attribute>
+        </payload>
+      </command>
+      <command id="0x01" dir="recv" name="Squawk" required="m">
+        <payload>
+          <attribute id="0x00" type="bmp8" name="Options" required="m">
+            <value name="Sqawk level 0" value="0"></value>
+            <value name="Sqawk level 1" value="1"></value>
+            <value name="Strobe" value="3"></value>
+            <value name="Sound for disarmed" value="4"></value>
+          </attribute>
+        </payload>
+      </command>
+    </server>
+    <client>
+    </client>
+  </cluster>
+</domain>
 
-  <domain name="Security and safety" low_bound="0500" high_bound="05ff" description="The security and safety functional domain contains clusters and information to build devices in the security and safety domain, e.g. alarm units.">
-  </domain>
+<domain name="Security and safety" low_bound="0500" high_bound="05ff" description="The security and safety functional domain contains clusters and information to build devices in the security and safety domain, e.g. alarm units.">
+</domain>
 
-  <domain name="Protocol interfaces" low_bound="0600" high_bound="06ff" description="The protocol interfaces functional domain contains clusters and information to build devices to interface to other protocols, e.g. BACnet.">
-  </domain>
+<domain name="Protocol interfaces" low_bound="0600" high_bound="06ff" description="The protocol interfaces functional domain contains clusters and information to build devices to interface to other protocols, e.g. BACnet.">
+</domain>
 
-  <domain name="Smart energy" low_bound="0700" high_bound="07ff" description="TODO Smart Energy Description">
-    <cluster id="0x0700" name="Price">
-      <description>The Price Cluster provides the mechanism for communicating Gas, Energy, or Water pricing information within the premise. This pricing information is distributed to the ESP from either the utilities or from regional energy providers.</description>
-      <server>
-        <attribute id="0000" name="Tier1 Price Label" type="ostring" access="rw" required="o" range="0,12" default="Tier1"></attribute>
-        <attribute id="0001" name="Tier2 Price Label" type="ostring" access="rw" required="o" range="0,12" default="Tier2"></attribute>
-        <attribute id="0002" name="Tier3 Price Label" type="ostring" access="rw" required="o" range="0,12" default="Tier3"></attribute>
-        <attribute id="0003" name="Tier4 Price Label" type="ostring" access="rw" required="o" range="0,12" default="Tier4"></attribute>
-        <attribute id="0004" name="Tier5 Price Label" type="ostring" access="rw" required="o" range="0,12" default="Tier5"></attribute>
-        <attribute id="0005" name="Tier6 Price Label" type="ostring" access="rw" required="o" range="0,12" default="Tier6"></attribute>
-        <command id="00" dir="recv" name="Get Current Price" required="m">
-          <payload>
-            <attribute id="0x0000" type="bmp8" name="Command Options" required="m">
-              <value name="Requestor Rx On When Idle" value="0x00"/>
-            </attribute>
-          </payload>
-        </command>
-        <command id="01" dir="recv" name="Get Scheduled Prices" required="o">
-          <payload>
-            <attribute id="0x0000" type="utc" name="Start Time" required="m"></attribute>
-            <attribute id="0x0001" type="u8" name="Number of Events" required="m"></attribute>
-          </payload>
-        </command>
-      </server>
-      <client>
+<domain name="Smart energy" low_bound="0700" high_bound="07ff" description="TODO Smart Energy Description">
+  <cluster id="0x0700" name="Price">
+    <description>The Price Cluster provides the mechanism for communicating Gas, Energy, or Water pricing information within the premise. This pricing information is distributed to the ESP from either the utilities or from regional energy providers.</description>
+    <server>
+      <attribute id="0000" name="Tier1 Price Label" type="ostring" access="rw" required="o" range="0,12" default="Tier1"></attribute>
+      <attribute id="0001" name="Tier2 Price Label" type="ostring" access="rw" required="o" range="0,12" default="Tier2"></attribute>
+      <attribute id="0002" name="Tier3 Price Label" type="ostring" access="rw" required="o" range="0,12" default="Tier3"></attribute>
+      <attribute id="0003" name="Tier4 Price Label" type="ostring" access="rw" required="o" range="0,12" default="Tier4"></attribute>
+      <attribute id="0004" name="Tier5 Price Label" type="ostring" access="rw" required="o" range="0,12" default="Tier5"></attribute>
+      <attribute id="0005" name="Tier6 Price Label" type="ostring" access="rw" required="o" range="0,12" default="Tier6"></attribute>
+      <command id="00" dir="recv" name="Get Current Price" required="m">
+        <payload>
+          <attribute id="0x0000" type="bmp8" name="Command Options" required="m">
+            <value name="Requestor Rx On When Idle" value="0x00"/>
+          </attribute>
+        </payload>
+      </command>
+      <command id="01" dir="recv" name="Get Scheduled Prices" required="o">
+        <payload>
+          <attribute id="0x0000" type="utc" name="Start Time" required="m"></attribute>
+          <attribute id="0x0001" type="u8" name="Number of Events" required="m"></attribute>
+        </payload>
+      </command>
+    </server>
+    <client>
+      <!-- TODO -->
+    </client>
+  </cluster>
+
+  <cluster id="0x0701" name="Demand Response and Load Control">
+    <description>This cluster provides an interface to the functionality of Smart Energy Demand Response and Load Control. Devices targeted by this cluster include thermostats and devices that support load control.</description>
+    <client>
+      <attribute id="0000" name="Utility Enrolment Group" type="u8" access="rw" default="0" range="0x00,0xff" required="m"></attribute>
+      <attribute id="0001" name="Start Randomize Minutes" type="u8" access="rw" default="0x1e" range="0x00,0x3c" required="m"></attribute>
+      <attribute id="0002" name="Stop Randomize Minutes" type="u8" access="rw" default="0x1e" range="0x00,0x3c" required="m"></attribute>
+      <attribute id="0003" name="Device Class Value" type="u16" access="r" default="0x1e" range="0x00,0xff" required="m"></attribute>
+    </client>
+    <server>
+      <!-- TODO -->
+    </server>
+  </cluster>
+
+  <cluster id="0x0702" name="Simple Metering">
+    <description>The Simple Metering Cluster provides a mechanism to retrieve usage information from Electric, Gas, Water, and potentially Thermal metering devices.
+                 These devices can operate on either battery or mains power, and can have a wide variety of sophistication.</description>
+    <server>
+      <attribute-set id="0x0000" description="Reading Information Set">
+        <attribute id="0x0000" name="Current Summation Delivered" type="u48" access="r" required="m"></attribute>
+        <attribute id="0x0001" name="Current Summation Received" type="u48" access="r" required="o"></attribute>
+        <attribute id="0x041b" name="Unknown" type="u64" access="rw" required="o" mfcode="0x1037"></attribute>
         <!-- TODO -->
-      </client>
-    </cluster>
-
-    <cluster id="0x0701" name="Demand Response and Load Control">
-      <description>This cluster provides an interface to the functionality of Smart Energy Demand Response and Load Control. Devices targeted by this cluster include thermostats and devices that support load control.</description>
-      <client>
-        <attribute id="0000" name="Utility Enrolment Group" type="u8" access="rw" default="0" range="0x00,0xff" required="m"></attribute>
-        <attribute id="0001" name="Start Randomize Minutes" type="u8" access="rw" default="0x1e" range="0x00,0x3c" required="m"></attribute>
-        <attribute id="0002" name="Stop Randomize Minutes" type="u8" access="rw" default="0x1e" range="0x00,0x3c" required="m"></attribute>
-        <attribute id="0003" name="Device Class Value" type="u16" access="r" default="0x1e" range="0x00,0xff" required="m"></attribute>
-      </client>
-      <server>
+      </attribute-set>
+      <attribute-set id="0x0020" description="Lixee specific" mfcode="0x1037">
+        <attribute id="0x0020" name="PTEC Période Tarifaire en cours" type="cstring" access="r" required="m"></attribute>
+      </attribute-set>
+      <attribute-set id="0x0100" description="TOU Information Set">
+        <attribute id="0x0100" name="Index HCHC/EJPHN/BBRHCJB, Current Summation Delivered (1)" type="u48" access="r" required="m"></attribute>
+        <attribute id="0x0102" name="Index HCHP/EJPHPM/BBRHPJB, Current Summation Delivered(2)" type="u48" access="r" required="m"></attribute>
         <!-- TODO -->
-      </server>
-    </cluster>
-
-    <cluster id="0x0702" name="Simple Metering">
-      <description>The Simple Metering Cluster provides a mechanism to retrieve usage information from Electric, Gas, Water, and potentially Thermal metering devices.
-These devices can operate on either battery or mains power, and can have a wide variety of sophistication.</description>
-      <server>
-        <attribute-set id="0x0000" description="Reading Information Set">
-          <attribute id="0x0000" name="Current Summation Delivered" type="u48" access="r" required="m"></attribute>
-          <attribute id="0x0001" name="Current Summation Received" type="u48" access="r" required="o"></attribute>
-          <attribute id="0x041b" name="Unknown" type="u64" access="rw" required="o" mfcode="0x1037"></attribute>
-          <!-- TODO -->
-	</attribute-set>
-        <attribute-set id="0x0020" description="Lixee specific" mfcode="0x1037">
-            <attribute id="0x0020" name="PTEC Période Tarifaire en cours" type="cstring" access="r" required="m"></attribute>
-        </attribute-set>
-        <attribute-set id="0x0100" description="TOU Information Set">
-          <attribute id="0x0100" name="Index HCHC/EJPHN/BBRHCJB, Current Summation Delivered (1)" type="u48" access="r" required="m"></attribute>
-          <attribute id="0x0102" name="Index HCHP/EJPHPM/BBRHPJB, Current Summation Delivered(2)" type="u48" access="r" required="m"></attribute>
-          <!-- TODO -->
-        </attribute-set>
-        <attribute-set id="0x0200" description="Meter Status">
-          <attribute id="0x0200" name="Status" type="bmp8" default="00000000" access="r" required="m">
-            <value name="Check Meter" value="0"></value>
-            <value name="Low Battery" value="1"></value>
-            <value name="Tamper Detect" value="2"></value>
-            <value name="Power Failure" value="3"></value>
-            <value name="Power Quality" value="4"></value>
-            <value name="Leak Detect" value="5"></value>
-            <value name="Service Disconnect Open" value="6"></value>
-          </attribute>
-        </attribute-set>
-        <attribute-set id="0x0300" description="Formatting">
-          <attribute id="0x0300" name="Unit of Measure" type="enum8" default="0" access="r" required="m">
-            <value name="kW &amp; kWh binary" value="0"></value>
-            <value name="m³ &amp; m³/h binary" value="1"></value>
-            <value name="ft³ &amp; ft³/h binary" value="2"></value>
-            <value name="ccf &amp; ccf/h binary" value="3"></value>
-            <value name="US gl &amp; Us gl/h binary" value="4"></value>
-            <value name="IMP gl &amp; IMP gl/h binary" value="5"></value>
-            <value name="BTUs &amp; BTU/h binary" value="6"></value>
-            <value name="Liters &amp; l/h binary" value="7"></value>
-            <value name="kPA(gauge) binary" value="8"></value>
-            <value name="kPA(absolute) binary" value="9"></value>
-            <value name="kW &amp; kWh BCD" value="80"></value>
-            <value name="m³ &amp; m³/h BCD" value="81"></value>
-            <value name="ft³ &amp; ft³/h BCD" value="82"></value>
-            <value name="ccf &amp; ccf/h BCD" value="83"></value>
-            <value name="US gl &amp; Us gl/h BCD" value="84"></value>
-            <value name="IMP gl &amp; IMP gl/h BCD" value="85"></value>
-            <value name="BTUs &amp; BTU/h BCD" value="86"></value>
-            <value name="Liters &amp; l/h BCD" value="87"></value>
-            <value name="kPA(gauge) BCD" value="88"></value>
-            <value name="kPA(absolute) BCD" value="89"></value>
-          </attribute>
-          <attribute id="0x0301" name="Multiplier" type="u24" access="r" required="o"></attribute>
-          <attribute id="0x0302" name="Divisor" type="u24" access="r" required="o"></attribute>
-          <attribute id="0x0303" name="Summation Formatting" type="bmp8" access="r" required="m">
-            <value name="Number Digits Right" description="Number of Digets to the right of the Decimal Point" value="0,2"></value>
-            <value name="Number Digits Left" description="Number of Digets to the left of the Decimal Point" value="3,6"></value>
-            <value name="Suppress Leading Zeros" value="7"></value>
-          </attribute>
-          <attribute id="0x0304" name="Demand Formatting" type="bmp8" access="r" required="o">
-            <value name="Number Digits Right" description="Number of Digets to the right of the Decimal Point" value="0,2"></value>
-            <value name="Number Digits Left" description="Number of Digets to the left of the Decimal Point" value="3,6"></value>
-            <value name="Suppress Leading Zeros" value="7"></value>
-          </attribute>
-          <!-- TODO -->
-          <attribute id="0x0306" name="Metering Device Type" type="enum8" access="r" required="m">
-            <value name="Electric Metering" value="0"></value>
-            <value name="Gas Metering" value="1"></value>
-            <value name="Water Metering" value="2"></value>
-            <value name="Thermal Metering" value="3"></value>
-            <value name="Pressure Metering" value="4"></value>
-            <value name="Heat Metering" value="5"></value>
-            <value name="Cooling Metering" value="6"></value>
-            <value name="Mirrored Gas Metering" value="128"></value>
-            <value name="Mirrored Water Metering" value="129"></value>
-            <value name="Mirrored Thermal Metering" value="130"></value>
-            <value name="Mirrored Pressure Metering" value="131"></value>
-            <value name="Mirrored Heat Metering" value="132"></value>
-            <value name="Mirrored Cooling Metering" value="133"></value>
-          </attribute>
-          <attribute id="0x0308" name="Meter Serial Number" type="ostring" range="0,24" access="r" required="o"></attribute>
-          <!-- TODO -->
-        </attribute-set>
-        <attribute-set id="0x0300" description="Develco specific" mfcode="0x1015">
-          <attribute id="0x0300" name="Pulse Configuration" type="u16" access="rw" required="o" mfcode="0x1015"></attribute>
-          <attribute id="0x0301" name="Current Summation" type="u48" access="w" required="o" mfcode="0x1015"></attribute>
-          <attribute id="0x0302" name="Interface Mode" type="enum16" access="rw" required="o" mfcode="0x1015">
-            <value name="Pulse Counting on an Electricity Meter – Unit KWh" value="0x0000"></value>
-            <value name="Pulse Counting on a Gas Meter – Unit m3" value="0x0001"></value>
-            <value name="Pulse Counting on a Water Meter – Unit m3" value="0x0002"></value>
-            <value name="Kamstrup KMP Protocol" value="0x0100"></value>
-            <value name="Not Supported - Linky Protocol" value="0x0101"></value>
-            <value name="DLMS-COSEM - IEC62056-21 mod A" value="0x0102"></value>
-            <value name="P1 Dutch Standard – DSMR 2.3 Version" value="0x0103"></value>
-            <value name="P1 Dutch Standard – DSMR 4.0 Version" value="0x0104"></value>
-          </attribute>
-        </attribute-set>
-        <attribute-set id="0x0400" description="ESP Historical Consumption">
-          <attribute id="0x0400" name="Instantaneous Demand" type="s24" access="r" required="o"></attribute>
-        </attribute-set>
-        <attribute-set id="0x0500" description="Load Profile Configuration">
-        </attribute-set>
-        <attribute-set id="0x0600" description="Supply Limit">
-        </attribute-set>
+      </attribute-set>
+      <attribute-set id="0x0200" description="Meter Status">
+        <attribute id="0x0200" name="Status" type="bmp8" default="00000000" access="r" required="m">
+          <value name="Check Meter" value="0"></value>
+          <value name="Low Battery" value="1"></value>
+          <value name="Tamper Detect" value="2"></value>
+          <value name="Power Failure" value="3"></value>
+          <value name="Power Quality" value="4"></value>
+          <value name="Leak Detect" value="5"></value>
+          <value name="Service Disconnect Open" value="6"></value>
+        </attribute>
+      </attribute-set>
+      <attribute-set id="0x0300" description="Formatting">
+        <attribute id="0x0300" name="Unit of Measure" type="enum8" default="0" access="r" required="m">
+          <value name="kW &amp; kWh binary" value="0"></value>
+          <value name="m³ &amp; m³/h binary" value="1"></value>
+          <value name="ft³ &amp; ft³/h binary" value="2"></value>
+          <value name="ccf &amp; ccf/h binary" value="3"></value>
+          <value name="US gl &amp; Us gl/h binary" value="4"></value>
+          <value name="IMP gl &amp; IMP gl/h binary" value="5"></value>
+          <value name="BTUs &amp; BTU/h binary" value="6"></value>
+          <value name="Liters &amp; l/h binary" value="7"></value>
+          <value name="kPA(gauge) binary" value="8"></value>
+          <value name="kPA(absolute) binary" value="9"></value>
+          <value name="kW &amp; kWh BCD" value="80"></value>
+          <value name="m³ &amp; m³/h BCD" value="81"></value>
+          <value name="ft³ &amp; ft³/h BCD" value="82"></value>
+          <value name="ccf &amp; ccf/h BCD" value="83"></value>
+          <value name="US gl &amp; Us gl/h BCD" value="84"></value>
+          <value name="IMP gl &amp; IMP gl/h BCD" value="85"></value>
+          <value name="BTUs &amp; BTU/h BCD" value="86"></value>
+          <value name="Liters &amp; l/h BCD" value="87"></value>
+          <value name="kPA(gauge) BCD" value="88"></value>
+          <value name="kPA(absolute) BCD" value="89"></value>
+        </attribute>
+        <attribute id="0x0301" name="Multiplier" type="u24" access="r" required="o"></attribute>
+        <attribute id="0x0302" name="Divisor" type="u24" access="r" required="o"></attribute>
+        <attribute id="0x0303" name="Summation Formatting" type="bmp8" access="r" required="m">
+          <value name="Number Digits Right" description="Number of Digets to the right of the Decimal Point" value="0,2"></value>
+          <value name="Number Digits Left" description="Number of Digets to the left of the Decimal Point" value="3,6"></value>
+          <value name="Suppress Leading Zeros" value="7"></value>
+        </attribute>
+        <attribute id="0x0304" name="Demand Formatting" type="bmp8" access="r" required="o">
+          <value name="Number Digits Right" description="Number of Digets to the right of the Decimal Point" value="0,2"></value>
+          <value name="Number Digits Left" description="Number of Digets to the left of the Decimal Point" value="3,6"></value>
+          <value name="Suppress Leading Zeros" value="7"></value>
+        </attribute>
         <!-- TODO -->
-        <!-- dont support generated commands yet
+        <attribute id="0x0306" name="Metering Device Type" type="enum8" access="r" required="m">
+          <value name="Electric Metering" value="0"></value>
+          <value name="Gas Metering" value="1"></value>
+          <value name="Water Metering" value="2"></value>
+          <value name="Thermal Metering" value="3"></value>
+          <value name="Pressure Metering" value="4"></value>
+          <value name="Heat Metering" value="5"></value>
+          <value name="Cooling Metering" value="6"></value>
+          <value name="Mirrored Gas Metering" value="128"></value>
+          <value name="Mirrored Water Metering" value="129"></value>
+          <value name="Mirrored Thermal Metering" value="130"></value>
+          <value name="Mirrored Pressure Metering" value="131"></value>
+          <value name="Mirrored Heat Metering" value="132"></value>
+          <value name="Mirrored Cooling Metering" value="133"></value>
+        </attribute>
+        <attribute id="0x0308" name="Meter Serial Number" type="ostring" range="0,24" access="r" required="o"></attribute>
+        <!-- TODO -->
+      </attribute-set>
+      <attribute-set id="0x0300" description="Develco specific" mfcode="0x1015">
+        <attribute id="0x0300" name="Pulse Configuration" type="u16" access="rw" required="o" mfcode="0x1015"></attribute>
+        <attribute id="0x0301" name="Current Summation" type="u48" access="w" required="o" mfcode="0x1015"></attribute>
+        <attribute id="0x0302" name="Interface Mode" type="enum16" access="rw" required="o" mfcode="0x1015">
+          <value name="Pulse Counting on an Electricity Meter – Unit KWh" value="0x0000"></value>
+          <value name="Pulse Counting on a Gas Meter – Unit m3" value="0x0001"></value>
+          <value name="Pulse Counting on a Water Meter – Unit m3" value="0x0002"></value>
+          <value name="Kamstrup KMP Protocol" value="0x0100"></value>
+          <value name="Not Supported - Linky Protocol" value="0x0101"></value>
+          <value name="DLMS-COSEM - IEC62056-21 mod A" value="0x0102"></value>
+          <value name="P1 Dutch Standard – DSMR 2.3 Version" value="0x0103"></value>
+          <value name="P1 Dutch Standard – DSMR 4.0 Version" value="0x0104"></value>
+        </attribute>
+      </attribute-set>
+      <attribute-set id="0x0400" description="ESP Historical Consumption">
+        <attribute id="0x0400" name="Instantaneous Demand" type="s24" access="r" required="o"></attribute>
+      </attribute-set>
+      <attribute-set id="0x0500" description="Load Profile Configuration">
+      </attribute-set>
+      <attribute-set id="0x0600" description="Supply Limit">
+      </attribute-set>
+      <!-- TODO -->
+      <!-- dont support generated commands yet
         <command id="01" dir="send" name="Get Profile Response" required="o">
           <payload>
             <field type="utc" name="End Time"></field>
@@ -5031,2157 +5028,2161 @@ These devices can operate on either battery or mains power, and can have a wide 
           </payload>
         </command>
         -->
-        <command id="00" dir="recv" name="Get Profile" required="o">
-          <payload>
-            <attribute id="0x0000" type="u8" name="Interval Channel" required="m">
-              <value name="Consumption Delivered" value="0x00"/>
-              <value name="Consumption Received" value="0x01"/>
-            </attribute>
-            <attribute id="0x0001" type="utc" name="End Time" required="m"></attribute>
-            <attribute id="0x0002" type="u8" name="Number Of Periods" required="m"></attribute>
-          </payload>
-        </command>
-        <command id="01" dir="recv" name="Request Mirror Response" required="o">
-          <payload>
-            <attribute id="0x0000" type="u16" name="EndPoint ID" range="0x0001,0x00f0" required="m"></attribute>
-          </payload>
-        </command>
-        <command id="02" dir="recv" name="Mirror Removed" required="o">
-          <payload>
-            <attribute id="0x0000" type="u16" name="Removed EndPoint ID" range="0x0001,0x00f0" required="m"></attribute>
-          </payload>
-        </command>
-      </server>
-      <client>
-        <!-- TODO -->
-      </client>
-    </cluster>
-
-    <cluster id="0x0703" name="Message">
-      <description>This cluster provides an interface for passing text messages between ZigBee devices.</description>
-      <server>
-      </server>
-      <client>
-      </client>
+      <command id="00" dir="recv" name="Get Profile" required="o">
+        <payload>
+          <attribute id="0x0000" type="u8" name="Interval Channel" required="m">
+            <value name="Consumption Delivered" value="0x00"/>
+            <value name="Consumption Received" value="0x01"/>
+          </attribute>
+          <attribute id="0x0001" type="utc" name="End Time" required="m"></attribute>
+          <attribute id="0x0002" type="u8" name="Number Of Periods" required="m"></attribute>
+        </payload>
+      </command>
+      <command id="01" dir="recv" name="Request Mirror Response" required="o">
+        <payload>
+          <attribute id="0x0000" type="u16" name="EndPoint ID" range="0x0001,0x00f0" required="m"></attribute>
+        </payload>
+      </command>
+      <command id="02" dir="recv" name="Mirror Removed" required="o">
+        <payload>
+          <attribute id="0x0000" type="u16" name="Removed EndPoint ID" range="0x0001,0x00f0" required="m"></attribute>
+        </payload>
+      </command>
+    </server>
+    <client>
       <!-- TODO -->
-    </cluster>
+    </client>
+  </cluster>
 
-    <cluster id="0x0704" name="Smart Energy Tunneling (Complex Metering)">
-      <description>The tunneling cluster provides an interface for tunneling protocols.</description>
-      <server>
-        <attribute id="0000" name="Close Tunnel Timeout" type="u16" range="0x0001,0xFFFF" default="0xFFFF" access="r" required="m"></attribute>
-      </server>
-      <client>
-      </client>
+  <cluster id="0x0703" name="Message">
+    <description>This cluster provides an interface for passing text messages between ZigBee devices.</description>
+    <server>
+    </server>
+    <client>
+    </client>
+    <!-- TODO -->
+  </cluster>
+
+  <cluster id="0x0704" name="Smart Energy Tunneling (Complex Metering)">
+    <description>The tunneling cluster provides an interface for tunneling protocols.</description>
+    <server>
+      <attribute id="0000" name="Close Tunnel Timeout" type="u16" range="0x0001,0xFFFF" default="0xFFFF" access="r" required="m"></attribute>
+    </server>
+    <client>
+    </client>
+    <!-- TODO -->
+  </cluster>
+
+  <cluster id="0x0705" name="Prepayment">
+    <description></description>
+    <!-- TODO -->
+  </cluster>
+</domain>
+
+<domain name="Appliances" low_bound="0b00" high_bound="0b03" description="The Appliance clusters are typically used in ZigBee appliance management.">
+  <cluster id="0x001b" name="Appliance Control">
+    <description>The Appliance Control cluster provides an interface to remotely control and to program household appliances. Example of control is Start, Stop and Pause commands.</description>
+    <server>
       <!-- TODO -->
-    </cluster>
-
-    <cluster id="0x0705" name="Prepayment">
-      <description></description>
+    </server>
+    <client>
       <!-- TODO -->
-    </cluster>
-  </domain>
+    </client>
+  </cluster>
 
-  <domain name="Appliances" low_bound="0b00" high_bound="0b03" description="The Appliance clusters are typically used in ZigBee appliance management.">
-    <cluster id="0x001b" name="Appliance Control">
-      <description>The Appliance Control cluster provides an interface to remotely control and to program household appliances. Example of control is Start, Stop and Pause commands.</description>
-      <server>
-        <!-- TODO -->
-      </server>
-      <client>
-        <!-- TODO -->
-      </client>
-    </cluster>
+  <cluster id="0x0b00" name="Appliance Identification">
+    <description>Attributes and commands for determining basic information about a device and setting user device information. The Appliance Identification Cluster is a transposition of EN50523 "Identify Product" functional block.</description>
+    <server>
+      <!-- TODO -->
+    </server>
+    <client>
+      <!-- TODO -->
+    </client>
+  </cluster>
 
-    <cluster id="0x0b00" name="Appliance Identification">
-      <description>Attributes and commands for determining basic information about a device and setting user device information. The Appliance Identification Cluster is a transposition of EN50523 "Identify Product" functional block.</description>
-      <server>
-        <!-- TODO -->
-      </server>
-      <client>
-        <!-- TODO -->
-      </client>
-    </cluster>
+  <cluster id="0x0b01" name="Meter Identification">
+    <description>Attributes and commands that provide an interface to meter identification.</description>
+    <server>
+      <attribute id="0x0000" type="cstring" name="CompanyName" access="r" required="m"/>
+      <attribute id="0x0001" type="u16" name="MeterTypeID" access="r" required="m"/>
+      <attribute id="0x0004" type="u16" name="DataQualityID" access="r" required="m"/>
+      <attribute id="0x0005" type="cstring" name="CustomerName" access="r" required="m"/>
+      <attribute id="0x0006" type="ostring" name="Model" access="r" required="m"/>
+      <attribute id="0x0007" type="ostring" name="PartNumber" access="r" required="m"/>
+      <attribute id="0x0008" type="ostring" name="ProductRevision" access="r" required="m"/>
+      <attribute id="0x000a" type="ostring" name="SoftwareRevision" access="r" required="m"/>
+      <attribute id="0x000b" type="cstring" name="UtilityName" access="r" required="m"/>
+      <attribute id="0x000c" type="u16" name="POD" access="r" required="m"/>
+      <attribute id="0x000d" type="s24" name="AvailablePower" access="r" required="m"/>
+      <attribute id="0x000e" type="s24" name="PowerThreshold" access="r" required="m"/>
+    </server>
+    <client>
+      <!-- TODO -->
+    </client>
+  </cluster>
 
-    <cluster id="0x0b01" name="Meter Identification">
-      <description>Attributes and commands that provide an interface to meter identification.</description>
-      <server>
-        <attribute id="0x0000" type="cstring" name="CompanyName" access="r" required="m"/>
-        <attribute id="0x0001" type="u16" name="MeterTypeID" access="r" required="m"/>
-        <attribute id="0x0004" type="u16" name="DataQualityID" access="r" required="m"/>
-        <attribute id="0x0005" type="cstring" name="CustomerName" access="r" required="m"/>
-        <attribute id="0x0006" type="ostring" name="Model" access="r" required="m"/>
-        <attribute id="0x0007" type="ostring" name="PartNumber" access="r" required="m"/>
-        <attribute id="0x0008" type="ostring" name="ProductRevision" access="r" required="m"/>
-        <attribute id="0x000a" type="ostring" name="SoftwareRevision" access="r" required="m"/>
-        <attribute id="0x000b" type="cstring" name="UtilityName" access="r" required="m"/>
-        <attribute id="0x000c" type="u16" name="POD" access="r" required="m"/>
-        <attribute id="0x000d" type="s24" name="AvailablePower" access="r" required="m"/>
-        <attribute id="0x000e" type="s24" name="PowerThreshold" access="r" required="m"/>
-      </server>
-      <client>
-        <!-- TODO -->
-      </client>
-    </cluster>
+  <cluster id="0x0b02" name="Appliance Events and Alerts">
+    <description>Attributes and commands for transmitting or notifying the occurrence of an event, such as "temperature reached" and of an alert such as alarm, fault or warning. It is based on the "Signal event" syntax of EN50523 and completed where necessary.</description>
+    <server>
+      <command id="0x00" dir="recv" name="Get Alerts" required="m">
+        <description>The get group identifiers request command is used to retrieve the actual group identifiers that the endpoint is using in its multicast communication in controlling different (remote) devices.</description>
+      </command>
+    </server>
+    <client>
+      <!-- TODO -->
+    </client>
+  </cluster>
 
-    <cluster id="0x0b02" name="Appliance Events and Alerts">
-      <description>Attributes and commands for transmitting or notifying the occurrence of an event, such as "temperature reached" and of an alert such as alarm, fault or warning. It is based on the "Signal event" syntax of EN50523 and completed where necessary.</description>
-      <server>
-        <command id="0x00" dir="recv" name="Get Alerts" required="m">
-          <description>The get group identifiers request command is used to retrieve the actual group identifiers that the endpoint is using in its multicast communication in controlling different (remote) devices.</description>
-        </command>
-      </server>
-      <client>
-        <!-- TODO -->
-      </client>
-    </cluster>
+  <cluster id="0x0b03" name="Appliance Statistics">
+    <description>The Appliance Statistics provides a mechanism for transmitting appliance statistics to a collection unit (gateway). The statistics can be in format of data logs.</description>
+    <server>
+      <!-- TODO -->
+    </server>
+    <client>
+      <!-- TODO -->
+    </client>
+  </cluster>
+</domain>
 
-    <cluster id="0x0b03" name="Appliance Statistics">
-      <description>The Appliance Statistics provides a mechanism for transmitting appliance statistics to a collection unit (gateway). The statistics can be in format of data logs.</description>
-      <server>
-        <!-- TODO -->
-      </server>
-      <client>
-        <!-- TODO -->
-      </client>
-    </cluster>
-  </domain>
+<domain name="Light Link" useZcl="true" description="The light link domain contains clusters and information that provides ZLL specific functions and attributes.">
+  <cluster id="0x1000" name="Touchlink Commissioning">
+    <description>Attributes and commands for touchlink commissioning.</description>
+    <server>
+      <command id="0x41" dir="recv" name="Get group identifiers" required="m" response="0x41">
+        <description>The get group identifiers request command is used to retrieve the actual group identifiers that the endpoint is using in its multicast communication in controlling different (remote) devices.</description>
+        <payload>
+          <attribute id="0x0000" type="u8" name="Start index" showas="dec" required="m" default="0"></attribute>
+        </payload>
+      </command>
+      <command id="0x42" dir="recv" name="Get endpoint list" required="m" response="0x42">
+        <description>The get endpoint list request command is used to retrieve addressing information for each endpoint the device is using in its unicast communication in controlling different (remote) devices.</description>
+        <payload>
+          <attribute id="0x0000" type="u8" name="Start index" showas="dec" required="m" default="0"></attribute>
+        </payload>
+      </command>
+      <command id="0xd0" dir="recv" name="Write MAC address" required="m" vendor="0x1135">
+        <description>Non standard write MAC address (DDEL).</description>
+        <payload>
+          <attribute id="0x0000" type="u64" name="MAC address" showas="hex" required="m" default="0"></attribute>
+        </payload>
+      </command>
+    </server>
+    <client>
+      <command id="0x41" dir="recv" name="Get group identifiers response" required="m">
+        <description>The get group identifiers response command allows a remote device to respond to the get group identifiers request command.</description>
+        <payload>
+          <attribute id="0x0000" type="u8" name="Total" required="m" default="0"></attribute>
+          <attribute id="0x0001" type="u8" name="Start index" required="m" default="0"></attribute>
+          <attribute id="0x0002" type="u8" name="Count" required="m" default="0"></attribute>
+          <!-- TODO this will display only first item of the list -->
+          <attribute id="0x0003" type="u16" name="First group ID" showas="hex" required="m" default="0x0000"></attribute>
+          <attribute id="0x0004" type="u8" name="First group type" showas="hex" required="m" default="0x00"></attribute>
+        </payload>
+      </command>
+      <command id="0x42" dir="recv" name="Get endpoint list response" required="m">
+        <description>The get group identifiers response command allows a remote device to respond to the get group identifiers request command.</description>
+        <payload>
+          <attribute id="0x0000" type="u8" name="Total" required="m" default="0"></attribute>
+          <attribute id="0x0001" type="u8" name="Start index" required="m" default="0"></attribute>
+          <attribute id="0x0002" type="u8" name="Count" required="m" default="0"></attribute>
+          <!-- TODO this will display only first item of the list -->
+          <attribute id="0x0003" type="u16" name="NWK address" showas="hex" required="m" default="0x0000"></attribute>
+          <attribute id="0x0004" type="u8" name="Endpoint" showas="hex" required="m" default="0x00"></attribute>
+          <attribute id="0x0005" type="u16" name="Profile ID" showas="hex" required="m" default="0x0000"></attribute>
+          <attribute id="0x0006" type="u16" name="Device ID" showas="hex" required="m" default="0x0000"></attribute>
+          <attribute id="0x0007" type="u8" name="Version" showas="hex" required="m" default="0x00"></attribute>
+        </payload>
+      </command>
+    </client>
+  </cluster>
+</domain>
 
-  <domain name="Light Link" useZcl="true" description="The light link domain contains clusters and information that provides ZLL specific functions and attributes.">
-    <cluster id="0x1000" name="Touchlink Commissioning">
-      <description>Attributes and commands for touchlink commissioning.</description>
-      <server>
-        <command id="0x41" dir="recv" name="Get group identifiers" required="m" response="0x41">
-          <description>The get group identifiers request command is used to retrieve the actual group identifiers that the endpoint is using in its multicast communication in controlling different (remote) devices.</description>
-          <payload>
-            <attribute id="0x0000" type="u8" name="Start index" showas="dec" required="m" default="0"></attribute>
-          </payload>
-        </command>
-        <command id="0x42" dir="recv" name="Get endpoint list" required="m" response="0x42">
-          <description>The get endpoint list request command is used to retrieve addressing information for each endpoint the device is using in its unicast communication in controlling different (remote) devices.</description>
-          <payload>
-            <attribute id="0x0000" type="u8" name="Start index" showas="dec" required="m" default="0"></attribute>
-          </payload>
-        </command>
-        <command id="0xd0" dir="recv" name="Write MAC address" required="m" vendor="0x1135">
-          <description>Non standard write MAC address (DDEL).</description>
-          <payload>
-            <attribute id="0x0000" type="u64" name="MAC address" showas="hex" required="m" default="0"></attribute>
-          </payload>
-        </command>
-      </server>
-      <client>
-        <command id="0x41" dir="recv" name="Get group identifiers response" required="m">
-          <description>The get group identifiers response command allows a remote device to respond to the get group identifiers request command.</description>
-          <payload>
-            <attribute id="0x0000" type="u8" name="Total" required="m" default="0"></attribute>
-            <attribute id="0x0001" type="u8" name="Start index" required="m" default="0"></attribute>
-            <attribute id="0x0002" type="u8" name="Count" required="m" default="0"></attribute>
-            <!-- TODO this will display only first item of the list -->
-            <attribute id="0x0003" type="u16" name="First group ID" showas="hex" required="m" default="0x0000"></attribute>
-            <attribute id="0x0004" type="u8" name="First group type" showas="hex" required="m" default="0x00"></attribute>
-          </payload>
-        </command>
-        <command id="0x42" dir="recv" name="Get endpoint list response" required="m">
-          <description>The get group identifiers response command allows a remote device to respond to the get group identifiers request command.</description>
-          <payload>
-            <attribute id="0x0000" type="u8" name="Total" required="m" default="0"></attribute>
-            <attribute id="0x0001" type="u8" name="Start index" required="m" default="0"></attribute>
-            <attribute id="0x0002" type="u8" name="Count" required="m" default="0"></attribute>
-            <!-- TODO this will display only first item of the list -->
-            <attribute id="0x0003" type="u16" name="NWK address" showas="hex" required="m" default="0x0000"></attribute>
-            <attribute id="0x0004" type="u8" name="Endpoint" showas="hex" required="m" default="0x00"></attribute>
-            <attribute id="0x0005" type="u16" name="Profile ID" showas="hex" required="m" default="0x0000"></attribute>
-            <attribute id="0x0006" type="u16" name="Device ID" showas="hex" required="m" default="0x0000"></attribute>
-            <attribute id="0x0007" type="u8" name="Version" showas="hex" required="m" default="0x00"></attribute>
-          </payload>
-        </command>
-      </client>
-    </cluster>
-  </domain>
+<domain name="Green Power" useZcl="true" description="The green power domain contains clusters and information that provides ZGP specific functions and attributes.">
+  <cluster id="0x0021" name="Green Power">
+    <description>Attributes and commands.</description>
+    <server>
+      <attribute id="0x0000" name="Max Sink Table Entries" type="u8" default="0x00" access="r" required="m" showas="hex">
+        <description>Maximum number of Sink Table entries supported by this device.</description>
+      </attribute>
+      <attribute id="0x0001" name="Sink Table" type="lostring" default="0x0000" access="r" required="m" showas="hex">
+        <description>Sink Table, holding information about local bindings between a particular GPD and target‘s local endpoints.</description>
+      </attribute>
+      <attribute id="0x0002" name="Communication Mode" type="bmp8" default="0x01" access="rw" required="m" showas="hex">
+        <description>Default communication mode requested by this sink.</description>
+      </attribute>
+      <attribute id="0x0003" name="Commissioning Exit Mode" type="bmp8" default="0x02" access="rw" required="m" showas="hex">
+        <description>Conditions for the sink to exit the commissioning mode.</description>
+      </attribute>
+      <attribute id="0x0004" name="Commissioning Window" type="u16" default="0x00B4" access="rw" required="o" showas="hex">
+        <description>Default duration of the Commissioning window duration, in seconds, as requested by this sink.</description>
+      </attribute>
+      <attribute id="0x0005" name="Security Level" type="bmp8" default="0x06" access="rw" required="m" showas="hex">
+        <description>The minimum required security level to be supported by the paired GPDs.</description>
+      </attribute>
+      <attribute id="0x0006" name="Functionality" type="bmp24" default="0x0" access="r" required="m" showas="hex">
+        <description>The optional GP functionality supported by this sink.</description>
+      </attribute>
+      <attribute id="0x0007" name="Active Functionality" type="bmp24" default="0xffffff" access="r" required="m" showas="hex">
+        <description>The optional GP functionality supported by this sink that is active.</description>
+      </attribute>
+      <attribute id="0x0020" name="Shared Security Key Type" type="bmp8" default="0x00" access="r" required="m" showas="hex"></attribute>
+      <attribute id="0x0021" name="Shared Security Key" type="seckey" access="r" required="m" showas="hex"></attribute>
+      <attribute id="0x0022" name="GP Link Key" type="seckey" access="r" required="m" showas="hex"></attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
+  <device id="0x0060" name="GP Proxy" description=""></device>
+  <device id="0x0061" name="GP Proxy Basic" description=""></device>
+  <device id="0x0062" name="GP Target Plus" description=""></device>
+  <device id="0x0063" name="GP Target" description=""></device>
+  <device id="0x0064" name="GP Commissioning Tool" description=""></device>
+  <device id="0x0065" name="GP Combo" description=""></device>
+  <device id="0x0066" name="GP Combo Basic" description=""></device>
+</domain>
 
-  <domain name="Green Power" useZcl="true"
-    description="The green power domain contains clusters and information that provides ZGP specific functions and attributes.">
-    <cluster id="0x0021" name="Green Power">
-      <description>Attributes and commands.</description>
-      <server>
-        <attribute id="0x0000" name="Max Sink Table Entries" type="u8" default="0x00" access="r" required="m" showas="hex">
-          <description>Maximum number of Sink Table entries supported by this device.</description>
-        </attribute>
-        <attribute id="0x0001" name="Sink Table" type="lostring" default="0x0000" access="r" required="m" showas="hex">
-          <description>Sink Table, holding information about local bindings between a particular GPD and target‘s local endpoints.</description>
-        </attribute>
-        <attribute id="0x0002" name="Communication Mode" type="bmp8" default="0x01" access="rw" required="m" showas="hex">
-          <description>Default communication mode requested by this sink.</description>
-        </attribute>
-        <attribute id="0x0003" name="Commissioning Exit Mode" type="bmp8" default="0x02" access="rw" required="m" showas="hex">
-          <description>Conditions for the sink to exit the commissioning mode.</description>
-        </attribute>
-        <attribute id="0x0004" name="Commissioning Window" type="u16" default="0x00B4" access="rw" required="o" showas="hex">
-          <description>Default duration of the Commissioning window duration, in seconds, as requested by this sink.</description>
-        </attribute>
-        <attribute id="0x0005" name="Security Level" type="bmp8" default="0x06" access="rw" required="m" showas="hex">
-          <description>The minimum required security level to be supported by the paired GPDs.</description>
-        </attribute>
-        <attribute id="0x0006" name="Functionality" type="bmp24" default="0x0" access="r" required="m" showas="hex">
-          <description>The optional GP functionality supported by this sink.</description>
-        </attribute>
-        <attribute id="0x0007" name="Active Functionality" type="bmp24" default="0xffffff" access="r" required="m" showas="hex">
-          <description>The optional GP functionality supported by this sink that is active.</description>
-        </attribute>
-        <attribute id="0x0020" name="Shared Security Key Type" type="bmp8" default="0x00" access="r" required="m" showas="hex"></attribute>
-        <attribute id="0x0021" name="Shared Security Key" type="seckey" access="r" required="m" showas="hex"></attribute>
-        <attribute id="0x0022" name="GP Link Key" type="seckey" access="r" required="m" showas="hex"></attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
-    <device id="0x0060" name="GP Proxy" description=""></device>
-    <device id="0x0061" name="GP Proxy Basic" description=""></device>
-    <device id="0x0062" name="GP Target Plus" description=""></device>
-    <device id="0x0063" name="GP Target" description=""></device>
-    <device id="0x0064" name="GP Commissioning Tool" description=""></device>
-    <device id="0x0065" name="GP Combo" description=""></device>
-    <device id="0x0066" name="GP Combo Basic" description=""></device>
-  </domain>
+<domain name="Manufacturer Specific" useZcl="true" description="Manufacturer specific clusters.">
+  <!-- Dresden Elektronik -->
+  <cluster id="0xfc00" name="Spectral Measurement" mfcode="0x1135">
+    <description>Dresden Elektronik Specific clusters.</description>
+    <server>
+      <attribute id="0x0000" type="u8" name="On" required="m" access="rw" default="0">
+        <description>Enable Sensor </description>
+      </attribute>
+      <attribute id="0x0001" name="X-Value" type="u16" default="0x0000" access="r" required="m" showas="dec">
+        <description>X-Value</description>
+      </attribute>
+      <attribute id="0x0002" name="Y-Value" type="u16" default="0x0000" access="r" required="m" showas="dec">
+        <description>Y-Value</description>
+      </attribute>
+      <attribute id="0x0003" name="Z-Value" type="u16" default="0x0000" access="r" required="m" showas="dec">
+        <description>Z-Value</description>
+      </attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-  <domain name="Manufacturer Specific" useZcl="true" description="Manufacturer specific clusters.">
-    <!-- Dresden Elektronik -->
-    <cluster id="0xfc00" name="Spectral Measurement" mfcode="0x1135">
-      <description>Dresden Elektronik Specific clusters.</description>
-      <server>
-        <attribute id="0x0000" type="u8" name="On" required="m" access="rw" default="0">
-          <description>Enable Sensor </description>
-        </attribute>
-        <attribute id="0x0001" name="X-Value" type="u16" default="0x0000" access="r" required="m" showas="dec">
-          <description>X-Value</description>
-        </attribute>
-        <attribute id="0x0002" name="Y-Value" type="u16" default="0x0000" access="r" required="m" showas="dec">
-          <description>Y-Value</description>
-        </attribute>
-        <attribute id="0x0003" name="Z-Value" type="u16" default="0x0000" access="r" required="m" showas="dec">
-          <description>Z-Value</description>
-        </attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <!-- Hue -->
+  <cluster id="0xfc00" name="Hue Button" mfcode="0x100b">
+    <description>Hue-specific cluster for Hue dimmer family.</description>
+    <server>
+      <command id="0x00" dir="send" name="Button Action Notification" required="m">
+        <payload>
+          <attribute id="0x0000" type="u16" name="Button" required="m"/>
+          <attribute id="0x0001" type="enum8" name="Event Type" required="m">
+            <value name="Button" value="0x00"/>
+            <value name="Rotary" value="0x01"/>
+          </attribute>
+          <attribute id="0x0002" type="u8" name="" showas="hex" required="m">
+            <description>Type of next attribute</description>
+          </attribute>
+          <attribute id="0x0003" type="enum8" name="Action" required="m">
+            <value name="Press" value="0x00"/>
+            <value name="Hold / Start" value="0x01"/>
+            <value name="Release / Repeat" value="0x02"/>
+            <value name="Long Release" value="0x03"/>
+          </attribute>
+          <attribute id="0x0004" type="u8" name="" showas="hex" required="m">
+            <description>Type of next attribute</description>
+          </attribute>
+          <attribute id="0x0005" type="s16" name="Duration / Rotation" required="m"/>
+        </payload>
+      </command>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <!-- Hue -->
-    <cluster id="0xfc00" name="Hue Button" mfcode="0x100b">
-      <description>Hue-specific cluster for Hue dimmer family.</description>
-      <server>
-        <command id="0x00" dir="send" name="Button Action Notification" required="m">
-          <payload>
-            <attribute id="0x0000" type="u16" name="Button" required="m"/>
-            <attribute id="0x0001" type="enum8" name="Event Type" required="m">
-              <value name="Button" value="0x00"/>
-              <value name="Rotary" value="0x01"/>
-            </attribute>
-            <attribute id="0x0002" type="u8" name="" showas="hex" required="m">
-              <description>Type of next attribute</description>
-            </attribute>
-            <attribute id="0x0003" type="enum8" name="Action" required="m">
-              <value name="Press" value="0x00"/>
-              <value name="Hold / Start" value="0x01"/>
-              <value name="Release / Repeat" value="0x02"/>
-              <value name="Long Release" value="0x03"/>
-            </attribute>
-            <attribute id="0x0004" type="u8" name="" showas="hex" required="m">
-              <description>Type of next attribute</description>
-            </attribute>
-            <attribute id="0x0005" type="s16" name="Duration / Rotation" required="m"/>
-          </payload>
-        </command>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <cluster id="0xfc01" name="Hue Entertainment" mfcode="0x100b">
+    <description>Hue-specific cluster for Hue Entertainment.</description>
+    <server>
+      <attribute id="0x0000" name="Capabilities" type="bmp8" mfcode="0x100b" access="r" required="m">
+        <value name="Proxy" value="0"/>
+        <value name="Renderer" value="1"/>
+        <value name="Multiple Segements" value="2"/>
+        <value name="Supported" value="3"/>
+      </attribute>
+      <attribute id="0x0002" name="Segments" type="u8" mfcode="0x100b" access="r" default="1" required="o"></attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <cluster id="0xfc01" name="Hue Entertainment" mfcode="0x100b">
-      <description>Hue-specific cluster for Hue Entertainment.</description>
-      <server>
-        <attribute id="0x0000" name="Capabilities" type="bmp8" mfcode="0x100b" access="r" required="m">
-          <value name="Proxy" value="0"/>
-          <value name="Renderer" value="1"/>
-          <value name="Multiple Segements" value="2"/>
-          <value name="Supported" value="3"/>
-        </attribute>
-        <attribute id="0x0002" name="Segments" type="u8" mfcode="0x100b" access="r" default="1" required="o"></attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <cluster id="0xfc02" name="Hue Outlet" mfcode="0x100b">
+    <description>Hue-specific cluster for Hue smart plugs.</description>
+    <server>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <cluster id="0xfc02" name="Hue Outlet" mfcode="0x100b">
-      <description>Hue-specific cluster for Hue smart plugs.</description>
-      <server>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <cluster id="0xfc03" name="Hue Effects" mfcode="0x100b">
+    <description>Hue-specific cluster for Hue lights.</description>
+    <server>
+      <command id="0x00" dir="recv" name="Set Effect" vendor="0x100b" required="m">
+        <payload>
+          <attribute id="0x0000" type="u16" name="Command" showas="hex" default="0x0020" required="o"></attribute>
+          <attribute id="0x0001" type="enum8" name="Effect" required="m">
+            <value name="None" value="0x00"/>
+            <value name="Candle" value="0x01"/>
+            <value name="Fire" value="0x02"/>
+            <value name="Prism" value="0x03"/>
+            <value name="Sunrise" value="0x09"/>
+            <value name="Sparkle" value="0x0a"/>
+            <value name="Opal" value="0x0b"/>
+            <value name="Glisten" value="0x0c"/>
+            <value name="Sunset" value="0x0d"/>
+            <value name="Underwater" value="0x0e"/>
+            <value name="Cosmos" value="0x0f"/>
+            <value name="Sunbeam" value="0x10"/>
+            <value name="Enchant" value="0x11"/>
+          </attribute>
+        </payload>
+      </command>
+      <attribute id="0x0001" name="Capabilities" type="bmp32" mfcode="0x100b" access="r" required="m">
+        <value name="Unknown 00" value="0"/>
+        <value name="Unknown 01" value="1"/>
+        <value name="Effects" value="2"/>
+        <value name="Gradient" value="3"/>
+      </attribute>
+      <attribute id="0x0002" name="Light State" type="ostring" mfcode="0x100b" access="r" required="m"></attribute>
+      <attribute id="0x0010" name="Unknown 10" type="bmp16" mfcode="0x100b" access="r" required="m">
+        <value name="Unknown 00" value="0"/>
+      </attribute>
+      <attribute id="0x0011" name="Effects" type="bmp64" mfcode="0x100b" access="r" required="o">
+        <value name="Candle" value="0x01"/>
+        <value name="Fire" value="0x02"/>
+        <value name="Prism" value="0x03"/>
+        <value name="Sunrise" value="0x09"/>
+        <value name="Sparkle" value="0x0a"/>
+        <value name="Opal" value="0x0b"/>
+        <value name="Glisten" value="0x0c"/>
+        <value name="Sunset" value="0x0d"/>
+        <value name="Underwater" value="0x0e"/>
+        <value name="Cosmos" value="0x0f"/>
+        <value name="Sunbeam" value="0x10"/>
+        <value name="Enchant" value="0x11"/>
+      </attribute>
+      <attribute id="0x0012" name="Gradient Unknown 12" type="bmp32" mfcode="0x100b" access="r" required="o">
+        <value name="Unknown 00" value="0x00"/>
+        <value name="Unknwon 01" value="0x01"/>
+      </attribute>
+      <attribute id="0x0013" name="Gradient Styles" type="bmp16" mfcode="0x100b" access="r" required="o">
+        <value name="Linear" value="0x00"/>
+        <value name="Scattered" value="0x01"/>
+        <value name="Mirrored" value="0x02"/>
+      </attribute>
+      <attribute id="0x0030" name="Gradient Pixel Count" type="u8" mfcode="0x100b" access="r" required="o"></attribute>
+      <attribute id="0x0031" name="Gradient Pixel Length" type="u16" mfcode="0x100b" access="r" required="o">
+        <description>Physical length of a gradient pixel (in 0.1 mm).</description>
+      </attribute>
+      <attribute id="0x0032" name="Gradient Unknown 32" type="u8" mfcode="0x100b" access="rw" required="o"></attribute>
+      <attribute id="0x0033" name="Gradient Reverse Colors" type="u8" mfcode="0x100b" access="rw" required="o"></attribute>
+      <attribute id="0x0034" name="Gradient Unknown 34" type="u8" mfcode="0x100b" access="rw" required="o"></attribute>
+      <attribute id="0x0035" name="Gradient Unknown 35" type="u8" mfcode="0x100b" access="r" required="o"></attribute>
+      <attribute id="0x0036" name="Gradient Max Segments" type="u8" mfcode="0x100b" access="r" required="o"></attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <cluster id="0xfc03" name="Hue Effects" mfcode="0x100b">
-      <description>Hue-specific cluster for Hue lights.</description>
-      <server>
-        <command id="0x00" dir="recv" name="Set Effect" vendor="0x100b" required="m">
-          <payload>
-            <attribute id="0x0000" type="u16" name="Command" showas="hex" default="0x0020" required="o"></attribute>
-            <attribute id="0x0001" type="enum8" name="Effect" required="m">
-              <value name="None" value="0x00"/>
-              <value name="Candle" value="0x01"/>
-              <value name="Fire" value="0x02"/>
-              <value name="Prism" value="0x03"/>
-              <value name="Sunrise" value="0x09"/>
-              <value name="Sparkle" value="0x0a"/>
-              <value name="Opal" value="0x0b"/>
-              <value name="Glisten" value="0x0c"/>
-              <value name="Sunset" value="0x0d"/>
-              <value name="Underwater" value="0x0e"/>
-              <value name="Cosmos" value="0x0f"/>
-              <value name="Sunbeam" value="0x10"/>
-              <value name="Enchant" value="0x11"/>
-            </attribute>
-          </payload>
-        </command>
-        <attribute id="0x0001" name="Capabilities" type="bmp32" mfcode="0x100b" access="r" required="m">
-          <value name="Unknown 00" value="0"/>
-          <value name="Unknown 01" value="1"/>
-          <value name="Effects" value="2"/>
-          <value name="Gradient" value="3"/>
-        </attribute>
-        <attribute id="0x0002" name="Light State" type="ostring" mfcode="0x100b" access="r" required="m"></attribute>
-        <attribute id="0x0010" name="Unknown 10" type="bmp16" mfcode="0x100b" access="r" required="m">
-          <value name="Unknown 00" value="0"/>
-        </attribute>
-        <attribute id="0x0011" name="Effects" type="bmp64" mfcode="0x100b" access="r" required="o">
-          <value name="Candle" value="0x01"/>
-          <value name="Fire" value="0x02"/>
-          <value name="Prism" value="0x03"/>
-          <value name="Sunrise" value="0x09"/>
-          <value name="Sparkle" value="0x0a"/>
-          <value name="Opal" value="0x0b"/>
-          <value name="Glisten" value="0x0c"/>
-          <value name="Sunset" value="0x0d"/>
-          <value name="Underwater" value="0x0e"/>
-          <value name="Cosmos" value="0x0f"/>
-          <value name="Sunbeam" value="0x10"/>
-          <value name="Enchant" value="0x11"/>
-        </attribute>
-        <attribute id="0x0012" name="Gradient Unknown 12" type="bmp32" mfcode="0x100b" access="r" required="o">
-          <value name="Unknown 00" value="0x00"/>
-          <value name="Unknwon 01" value="0x01"/>
-        </attribute>
-        <attribute id="0x0013" name="Gradient Styles" type="bmp16" mfcode="0x100b" access="r" required="o">
-          <value name="Linear" value="0x00"/>
-          <value name="Scattered" value="0x01"/>
-          <value name="Mirrored" value="0x02"/>
-        </attribute>
-        <attribute id="0x0030" name="Gradient Pixel Count" type="u8" mfcode="0x100b" access="r" required="o"></attribute>
-        <attribute id="0x0031" name="Gradient Pixel Length" type="u16" mfcode="0x100b" access="r" required="o">
-          <description>Physical length of a gradient pixel (in 0.1 mm).</description>
-        </attribute>
-        <attribute id="0x0032" name="Gradient Unknown 32" type="u8" mfcode="0x100b" access="rw" required="o"></attribute>
-        <attribute id="0x0033" name="Gradient Reverse Colors" type="u8" mfcode="0x100b" access="rw" required="o"></attribute>
-        <attribute id="0x0034" name="Gradient Unknown 34" type="u8" mfcode="0x100b" access="rw" required="o"></attribute>
-        <attribute id="0x0035" name="Gradient Unknown 35" type="u8" mfcode="0x100b" access="r" required="o"></attribute>
-        <attribute id="0x0036" name="Gradient Max Segments" type="u8" mfcode="0x100b" access="r" required="o"></attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <cluster id="0xfc04" name="Hue MotionAware" mfcode="0x100b">
+    <description>Hue-specific cluster for Hue MotionAware.</description>
+    <server>
+      <command id="0x00" dir="recv" name="Configure" vendor="0x100b" required="m">
+        <description>Sent by bridge to each member to configure reporting.</description>
+        <payload>
+          <attribute id="0x0000" type="bmp16" name="Role" required="m">
+            <description>Proxy has all three roles, members only Sensor.</description>
+            <value name="Sensor" value="0"/>
+            <value name="Collector" value="1"/>
+            <value name="Sync" value="2"/>
+          </attribute>
+          <attribute id="0x0001" type="u32" name="ID" required="m"/>
+          <attribute id="0x0002" type="u8" name="# Members" required="m" default="3">
+            <description>Number of members in group: 3 or 4.</description>
+          </attribute>
+          <attribute id="0x0003" type="u8" name="Member Nr" required="m">
+            <description>Proxy has value 0, members 1, 2, 3.</description>
+          </attribute>
+          <attribute id="0x0004" type="u16" name="Unknown" required="m" default="0x0190" showas="hex">
+            <description>Only value 0x0190 has been observed.</description>
+          </attribute>
+          <attribute id="0x0005" type="u16" name="Unknown" required="m" default="0x0000">
+            <description>For groups of three, values 0, 133, 266 are used.  For groups of four, values 0, 100, 200, 300 are used.</description>
+          </attribute>
+        </payload>
+      </command>
+      <command id="0x00" dir="send" name="Report" vendor="0x100b" required="m">
+        <description>Sent by the proxy to the bridge.</description>
+        <payload>
+          <attribute id="0x0000" type="u32" name="ID" required="m"/>
+          <attribute id="0x0001" type="u8" name="Sequence" required="m"/>
+          <attribute id="0x0002" type="u32" name="Length" required="m"/>
+          <attribute id="0x0003" type="ostring" name="Data" required="m"/>
+        </payload>
+      </command>
+      <command id="0x10" dir="recv" name="Start" vendor="0x100b" required="m">
+        <description>Sent by bridge to each member to start sending reports.</description>
+        <payload>
+          <attribute id="0x0000" type="u32" name="ID" required="m"/>
+        </payload>
+      </command>
+      <command id="0x11" dir="recv" name="Stop" vendor="0x100b" required="m">
+        <description>Sent by bridge to the proxy to stop sending reports.</description>
+        <payload>
+          <attribute id="0x0000" type="u32" name="ID" required="m"/>
+        </payload>
+      </command>
+      <attribute id="0x0000" name="Capabilities" type="bmp16" mfcode="0x100b" access="r" required="m">
+        <value name="Sensor" value="0"/>
+        <value name="Collector" value="1"/>
+        <value name="Sync" value="2"/>
+        <value name="bit 3" value="3"/>
+        <value name="bit 4" value="4"/>
+        <value name="bit 5" value="5"/>
+        <value name="bit 6" value="6"/>
+        <value name="bit 7" value="7"/>
+        <value name="bit 8" value="8"/>
+        <value name="bit 9" value="9"/>
+        <value name="bit 10" value="10"/>
+        <value name="bit 11" value="11"/>
+        <value name="bit 12" value="12"/>
+        <value name="bit 13" value="13"/>
+        <value name="bit 14" value="14"/>
+        <value name="bit 15" value="15"/>
+      </attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <cluster id="0xfc04" name="Hue MotionAware" mfcode="0x100b">
-      <description>Hue-specific cluster for Hue MotionAware.</description>
-      <server>
-        <command id="0x00" dir="recv" name="Configure" vendor="0x100b" required="m">
-          <description>Sent by bridge to each member to configure reporting.</description>
-          <payload>
-            <attribute id="0x0000" type="bmp16" name="Role" required="m">
-              <description>Proxy has all three roles, members only Sensor.</description>
-              <value name="Sensor" value="0"/>
-              <value name="Collector" value="1"/>
-              <value name="Sync" value="2"/>
-            </attribute>
-            <attribute id="0x0001" type="u32" name="ID" required="m"/>
-            <attribute id="0x0002" type="u8" name="# Members" required="m" default="3">
-              <description>Number of members in group: 3 or 4.</description>
-            </attribute>
-            <attribute id="0x0003" type="u8" name="Member Nr" required="m">
-              <description>Proxy has value 0, members 1, 2, 3.</description>
-            </attribute>
-            <attribute id="0x0004" type="u16" name="Unknown" required="m" default="0x0190" showas="hex">
-              <description>Only value 0x0190 has been observed.</description>
-            </attribute>
-            <attribute id="0x0005" type="u16" name="Unknown" required="m" default="0x0000">
-              <description>For groups of three, values 0, 133, 266 are used.  For groups of four, values 0, 100, 200, 300 are used.</description>
-            </attribute>
-          </payload>
-        </command>
-        <command id="0x00" dir="send" name="Report" vendor="0x100b" required="m">
-          <description>Sent by the proxy to the bridge.</description>
-          <payload>
-            <attribute id="0x0000" type="u32" name="ID" required="m"/>
-            <attribute id="0x0001" type="u8" name="Sequence" required="m"/>
-            <attribute id="0x0002" type="u32" name="Length" required="m"/>
-            <attribute id="0x0003" type="ostring" name="Data" required="m"/>
-          </payload>
-        </command>
-        <command id="0x10" dir="recv" name="Start" vendor="0x100b" required="m">
-          <description>Sent by bridge to each member to start sending reports.</description>
-          <payload>
-            <attribute id="0x0000" type="u32" name="ID" required="m"/>
-          </payload>
-        </command>
-        <command id="0x11" dir="recv" name="Stop" vendor="0x100b" required="m">
-          <description>Sent by bridge to the proxy to stop sending reports.</description>
-          <payload>
-            <attribute id="0x0000" type="u32" name="ID" required="m"/>
-          </payload>
-        </command>
-        <attribute id="0x0000" name="Capabilities" type="bmp16" mfcode="0x100b" access="r" required="m">
-          <value name="Sensor" value="0"/>
-          <value name="Collector" value="1"/>
-          <value name="Sync" value="2"/>
-          <value name="bit 3" value="3"/>
-          <value name="bit 4" value="4"/>
-          <value name="bit 5" value="5"/>
-          <value name="bit 6" value="6"/>
-          <value name="bit 7" value="7"/>
-          <value name="bit 8" value="8"/>
-          <value name="bit 9" value="9"/>
-          <value name="bit 10" value="10"/>
-          <value name="bit 11" value="11"/>
-          <value name="bit 12" value="12"/>
-          <value name="bit 13" value="13"/>
-          <value name="bit 14" value="14"/>
-          <value name="bit 15" value="15"/>
-        </attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <cluster id="0xfc06" name="Hue Unknown" mfcode="0x100b">
+    <description>Hue-specific cluster.</description>
+    <server>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <cluster id="0xfc06" name="Hue Unknown" mfcode="0x100b">
-      <description>Hue-specific cluster.</description>
-      <server>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <cluster id="0xfc07" name="Hue Chime" mfcode="0x100b">
+    <description>Hue-specific cluster for Hue Chime.</description>
+    <server>
+      <command id="0x00" dir="recv" name="Mute" vendor="0x100b" required="m"/>
+      <command id="0x01" dir="recv" name="Unmute" vendor="0x100b" required="m"/>
+      <command id="0x02" dir="recv" name="Set Alarm" vendor="0x100b" required="m">
+        <payload>
+          <attribute id="0x0000" type="enum8" name="Action" required="m" default="0x01">
+            <value name="Set" value="0x00"/>
+            <value name="Set with Volume" value="0x01"/>
+            <value name="Clear" value="0x02"/>
+          </attribute>
+          <attribute id="0x0001" type="enum16" name="Action" required="m" default="0x0006">
+            <value name="Siren" value="0x0006"/>
+          </attribute>
+          <attribute id="0x0002" type="u16" name="0000" required="m" default="0x0000" showas="hex"/>
+          <attribute id="0x0003" type="u8" name="Volume" required="m" default="25"/>
+          <attribute id="0x0004" type="u24" name="000000" required="m" default="0x000000" showas="hex"/>
+        </payload>
+      </command>
+      <command id="0x03" dir="recv" name="Set Chime" vendor="0x100b" required="m">
+        <payload>
+          <attribute id="0x0000" type="enum8" name="Action" required="m" default="0x01">
+            <value name="Set" value="0x00"/>
+            <value name="Set with Volume" value="0x01"/>
+          </attribute>
+          <attribute id="0x0001" type="enum16" name="Action" required="m" default="0x000A">
+            <value name="Bleep" value="0x0002"/>
+            <value name="Ding Dong Classic" value="0x0003"/>
+            <value name="Ding Dong Modern" value="0x0004"/>
+            <value name="Rise" value="0x00000005"/>
+            <value name="Westminster Classic" value="0x0007"/>
+            <value name="Westminster Modern" value="0x0008"/>
+            <value name="Ding Dong Xylo" value="0x0009"/>
+            <value name="Hue Default" value="0x000A"/>
+            <value name="Sonar" value="0x000B"/>
+            <value name="Swing" value="0x000C"/>
+            <value name="Bright" value="0x000D"/>
+            <value name="Glow" value="0x000E"/>
+            <value name="Bounce" value="0x000F"/>
+            <value name="Reveal" value="0x0010"/>
+            <value name="Welcome" value="0x0011"/>
+            <value name="Bright Modern" value="0x0012"/>
+            <value name="Fairy" value="0x0013"/>
+            <value name="Galaxy" value="0x0014"/>
+            <value name="Echo" value="0x0015"/>
+          </attribute>
+          <attribute id="0x0002" type="u16" name="0000" required="m" default="0x0000" showas="hex"/>
+          <attribute id="0x0003" type="u8" name="Volume" required="m" default="25"/>
+        </payload>
+      </command>
+      <command id="0x04" dir="recv" name="Set Alert" vendor="0x100b" required="m">
+        <payload>
+          <attribute id="0x0000" type="enum8" name="Action" required="m" default="0x01">
+            <value name="Set" value="0x00"/>
+            <value name="Set with Volume" value="0x01"/>
+          </attribute>
+          <attribute id="0x0001" type="enum16" name="Action" required="m" default="0x0001">
+            <value name="Alert" value="0x0001"/>
+          </attribute>
+          <attribute id="0x0002" type="u16" name="0000" required="m" default="0x0000" showas="hex"/>
+          <attribute id="0x0003" type="u8" name="Volume" required="m" default="25"/>
+        </payload>
+      </command>
+      <attribute id="0x0000" name="Muted" type="bool" mfcode="0x100b" access="r" required="m"/>
+      <attribute id="0x0001" name="Sound" type="u32" mfcode="0x100b" access="r" required="m" showas="hex"/>
+      <attribute id="0x0002" name="unknown" type="u32" mfcode="0x100b" access="r" required="m" showas="hex"/>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <cluster id="0xfc07" name="Hue Chime" mfcode="0x100b">
-      <description>Hue-specific cluster for Hue Chime.</description>
-      <server>
-        <command id="0x00" dir="recv" name="Mute" vendor="0x100b" required="m"/>
-        <command id="0x01" dir="recv" name="Unmute" vendor="0x100b" required="m"/>
-        <command id="0x02" dir="recv" name="Set Alarm" vendor="0x100b" required="m">
-          <payload>
-            <attribute id="0x0000" type="enum8" name="Action" required="m" default="0x01">
-              <value name="Set" value="0x00"/>
-              <value name="Set with Volume" value="0x01"/>
-              <value name="Clear" value="0x02"/>
-            </attribute>
-            <attribute id="0x0001" type="enum16" name="Action" required="m" default="0x0006">
-              <value name="Siren" value="0x0006"/>
-            </attribute>
-            <attribute id="0x0002" type="u16" name="0000" required="m" default="0x0000" showas="hex"/>
-            <attribute id="0x0003" type="u8" name="Volume" required="m" default="25"/>
-            <attribute id="0x0004" type="u24" name="000000" required="m" default="0x000000" showas="hex"/>
-          </payload>
-        </command>
-        <command id="0x03" dir="recv" name="Set Chime" vendor="0x100b" required="m">
-          <payload>
-            <attribute id="0x0000" type="enum8" name="Action" required="m" default="0x01">
-              <value name="Set" value="0x00"/>
-              <value name="Set with Volume" value="0x01"/>
-            </attribute>
-            <attribute id="0x0001" type="enum16" name="Action" required="m" default="0x000A">
-              <value name="Bleep" value="0x0002"/>
-              <value name="Ding Dong Classic" value="0x0003"/>
-              <value name="Ding Dong Modern" value="0x0004"/>
-              <value name="Rise" value="0x00000005"/>
-              <value name="Westminster Classic" value="0x0007"/>
-              <value name="Westminster Modern" value="0x0008"/>
-              <value name="Ding Dong Xylo" value="0x0009"/>
-              <value name="Hue Default" value="0x000A"/>
-              <value name="Sonar" value="0x000B"/>
-              <value name="Swing" value="0x000C"/>
-              <value name="Bright" value="0x000D"/>
-              <value name="Glow" value="0x000E"/>
-              <value name="Bounce" value="0x000F"/>
-              <value name="Reveal" value="0x0010"/>
-              <value name="Welcome" value="0x0011"/>
-              <value name="Bright Modern" value="0x0012"/>
-              <value name="Fairy" value="0x0013"/>
-              <value name="Galaxy" value="0x0014"/>
-              <value name="Echo" value="0x0015"/>
-            </attribute>
-            <attribute id="0x0002" type="u16" name="0000" required="m" default="0x0000" showas="hex"/>
-            <attribute id="0x0003" type="u8" name="Volume" required="m" default="25"/>
-          </payload>
-        </command>
-        <command id="0x04" dir="recv" name="Set Alert" vendor="0x100b" required="m">
-          <payload>
-            <attribute id="0x0000" type="enum8" name="Action" required="m" default="0x01">
-              <value name="Set" value="0x00"/>
-              <value name="Set with Volume" value="0x01"/>
-            </attribute>
-            <attribute id="0x0001" type="enum16" name="Action" required="m" default="0x0001">
-              <value name="Alert" value="0x0001"/>
-            </attribute>
-            <attribute id="0x0002" type="u16" name="0000" required="m" default="0x0000" showas="hex"/>
-            <attribute id="0x0003" type="u8" name="Volume" required="m" default="25"/>
-          </payload>
-        </command>
-        <attribute id="0x0000" name="Muted" type="bool" mfcode="0x100b" access="r" required="m"/>
-        <attribute id="0x0001" name="Sound" type="u32" mfcode="0x100b" access="r" required="m" showas="hex"/>
-        <attribute id="0x0002" name="unknown" type="u32" mfcode="0x100b" access="r" required="m" showas="hex"/>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <!-- Hue for Lutron Aurora -->
+  <cluster id="0xfc00" name="Hue Button" mfcode="0x1144">
+    <description>Hue-specific cluster for Hue dimmer family.</description>
+    <server>
+      <command id="0x00" dir="send" name="Button Action Notification" required="m">
+        <payload>
+          <attribute id="0x0000" type="u16" name="Button" required="m"/>
+          <attribute id="0x0001" type="enum8" name="Event Type" required="m">
+            <value name="Button" value="0x00"/>
+            <value name="Rotary" value="0x01"/>
+          </attribute>
+          <attribute id="0x0002" type="u8" name="" showas="hex" required="m">
+            <description>Type of next attribute</description>
+          </attribute>
+          <attribute id="0x0003" type="enum8" name="Action" required="m">
+            <value name="Press" value="0x00"/>
+            <value name="Hold / Start" value="0x01"/>
+            <value name="Release / Repeat" value="0x02"/>
+            <value name="Long Release" value="0x03"/>
+          </attribute>
+          <attribute id="0x0004" type="u8" name="" showas="hex" required="m">
+            <description>Type of next attribute</description>
+          </attribute>
+          <attribute id="0x0005" type="s16" name="Duration / Rotation" required="m"/>
+        </payload>
+      </command>
+    </server>
+  </cluster>
 
-    <!-- Hue for Lutron Aurora -->
-    <cluster id="0xfc00" name="Hue Button" mfcode="0x1144">
-      <description>Hue-specific cluster for Hue dimmer family.</description>
-      <server>
-        <command id="0x00" dir="send" name="Button Action Notification" required="m">
-          <payload>
-            <attribute id="0x0000" type="u16" name="Button" required="m"/>
-            <attribute id="0x0001" type="enum8" name="Event Type" required="m">
-              <value name="Button" value="0x00"/>
-              <value name="Rotary" value="0x01"/>
-            </attribute>
-            <attribute id="0x0002" type="u8" name="" showas="hex" required="m">
-              <description>Type of next attribute</description>
-            </attribute>
-            <attribute id="0x0003" type="enum8" name="Action" required="m">
-              <value name="Press" value="0x00"/>
-              <value name="Hold / Start" value="0x01"/>
-              <value name="Release / Repeat" value="0x02"/>
-              <value name="Long Release" value="0x03"/>
-            </attribute>
-            <attribute id="0x0004" type="u8" name="" showas="hex" required="m">
-              <description>Type of next attribute</description>
-            </attribute>
-            <attribute id="0x0005" type="s16" name="Duration / Rotation" required="m"/>
-          </payload>
-        </command>
-      </server>
-    </cluster>
+  <cluster id="0xfc06" name="Hue Secure" mfcode="0x100b">
+    <description>Hue-specific cluster for Hue Secure Contact Sensor.</description>
+    <server>
+      <attribute id="0x0100" name="Contact" type="enum8" mfcode="0x100b" access="r" required="m">
+        <value name="Close" value="0"/>
+        <value name="Open" value="1"/>
+      </attribute>
+      <attribute id="0x0101" name="Last Contact Change" type="u32" mfcode="0x100b" access="r" required="m">
+        <description>The time in 0.1s since last change to the Contact state.</description>
+      </attribute>
+      <attribute id="0x0102" name="Tamper" type="enum8" mfcode="0x100b" access="r" required="m">
+        <value name="Battery Door Closed" value="0"/>
+        <value name="Battery Door Open" value="1"/>
+      </attribute>
+      <attribute id="0x0103" name="Last Tamper Change" type="u32" mfcode="0x100b" access="r" required="m">
+        <description>The time in 0.1s since last change to the Tamper state.</description>
+      </attribute>
+    </server>
+  </cluster>
 
-    <cluster id="0xfc06" name="Hue Secure" mfcode="0x100b">
-      <description>Hue-specific cluster for Hue Secure Contact Sensor.</description>
-      <server>
-        <attribute id="0x0100" name="Contact" type="enum8" mfcode="0x100b" access="r" required="m">
-          <value name="Close" value="0"/>
-          <value name="Open" value="1"/>
-        </attribute>
-        <attribute id="0x0101" name="Last Contact Change" type="u32" mfcode="0x100b" access="r" required="m">
-          <description>The time in 0.1s since last change to the Contact state.</description>
-        </attribute>
-        <attribute id="0x0102" name="Tamper" type="enum8" mfcode="0x100b" access="r" required="m">
-          <value name="Battery Door Closed" value="0"/>
-          <value name="Battery Door Open" value="1"/>
-        </attribute>
-        <attribute id="0x0103" name="Last Tamper Change" type="u32" mfcode="0x100b" access="r" required="m">
-          <description>The time in 0.1s since last change to the Tamper state.</description>
-        </attribute>
-      </server>
-    </cluster>
+  <!-- Sunricher C4 -->
+  <cluster id="0xfc00" name="Device Setup" mfcode="0x1224">
+    <description>Sunricher-specific cluster.</description>
+    <server>
+      <attribute id="0x0000" type="array" name="Input Configurations" access="rw" required="m" mfcode="0x1224"/>
+      <attribute id="0x0001" type="array" name="Input Actions" access="rw" required="m" mfcode="0x1224"/>
+    </server>
+  </cluster>
 
-    <!-- Sunricher C4 -->
-    <cluster id="0xfc00" name="Device Setup" mfcode="0x1224">
-      <description>Sunricher-specific cluster.</description>
-      <server>
-        <attribute id="0x0000" type="array" name="Input Configurations" access="rw" required="m" mfcode="0x1224"/>
-        <attribute id="0x0001" type="array" name="Input Actions" access="rw" required="m" mfcode="0x1224"/>
-      </server>
-    </cluster>
+  <!-- LiXee -->
+  <cluster id="0xff66" name="LiXee specific cluster" mfcode="0x1037">
+    <description>LiXee specific cluster.</description>
+    <server>
+      <attribute id="0x0000" type="cstring" name="Option tarifaire" access="r" required="m"/>
+      <attribute id="0x0001" type="cstring" name="Couleur de demain" access="r" required="m"/>
+      <attribute id="0x0002" type="u8" name="Horaire HP-HC" access="r" required="m" default="0x00"/>
+      <attribute id="0x0003" type="u8" name="Présence des potentiels" access="r" required="m" default="0x00"/>
+      <attribute id="0x0004" type="u8" name="Préavis début EJP" access="r" required="m" default="0x00"/>
+      <attribute id="0x0005" type="u16" name="Avertissement de Dépassement De Puissance Souscrite" access="r" required="m" default="0x00"/>
+      <attribute id="0x0006" type="u16" name="Avertissement de Dépassement D'intensité P1" access="r" required="m" default="0x00"/>
+      <attribute id="0x0007" type="u16" name="Avertissement de Dépassement D'intensité P2" access="r" required="m" default="0x00"/>
+      <attribute id="0x0008" type="u16" name="Avertissement de Dépassement D'intensité P3" access="r" required="m" default="0x00"/>
+      <attribute id="0x0010" type="cstring" name="Période tarifaire" access="r" required="m" default="0x00"/>
+      <attribute id="0x0200" type="cstring" name="Libellé tarif fournisseur en cours" access="r" required="m"/>
+      <attribute id="0x0203" type="u32" name="Energie active soutirée Distributeur, index 01" access="r" required="m" default="0x00"/>
+      <attribute id="0x0207" type="u16" name="Puissance app. Instantanée injectée" access="r" required="m" default="0x00"/>
+      <attribute id="0x0217" type="cstring" name="Registre de Statuts" access="r" required="m"/>
+      <attribute id="0x0300" type="u8" name="Protocole Linky" access="r" required="m" default="0x00"/>
+    </server>
+  </cluster>
 
-    <!-- LiXee -->
-    <cluster id="0xff66" name="LiXee specific cluster" mfcode="0x1037">
-      <description>LiXee specific cluster.</description>
-      <server>
-        <attribute id="0x0000" type="cstring" name="Option tarifaire" access="r" required="m"/>
-	<attribute id="0x0001" type="cstring" name="Couleur de demain" access="r" required="m"/>
-        <attribute id="0x0002" type="u8" name="Horaire HP-HC" access="r" required="m" default="0x00"/>
-        <attribute id="0x0003" type="u8" name="Présence des potentiels" access="r" required="m" default="0x00"/>
-        <attribute id="0x0004" type="u8" name="Préavis début EJP" access="r" required="m" default="0x00"/>
-        <attribute id="0x0005" type="u16" name="Avertissement de Dépassement De Puissance Souscrite" access="r" required="m" default="0x00"/>
-        <attribute id="0x0006" type="u16" name="Avertissement de Dépassement D'intensité P1" access="r" required="m" default="0x00"/>
-        <attribute id="0x0007" type="u16" name="Avertissement de Dépassement D'intensité P2" access="r" required="m" default="0x00"/>
-        <attribute id="0x0008" type="u16" name="Avertissement de Dépassement D'intensité P3" access="r" required="m" default="0x00"/>
-	<attribute id="0x0010" type="cstring" name="Période tarifaire" access="r" required="m" default="0x00"/>
-        <attribute id="0x0200" type="cstring" name="Libellé tarif fournisseur en cours" access="r" required="m"/>
-        <attribute id="0x0203" type="u32" name="Energie active soutirée Distributeur, index 01" access="r" required="m" default="0x00"/>
-        <attribute id="0x0207" type="u16" name="Puissance app. Instantanée injectée" access="r" required="m" default="0x00"/>
-        <attribute id="0x0217" type="cstring" name="Registre de Statuts" access="r" required="m"/>
-        <attribute id="0x0300" type="u8" name="Protocole Linky" access="r" required="m" default="0x00"/>
-      </server>
-    </cluster>
+  <!-- Tuya -->
+  <cluster id="0xe001" name="Tuya specific" mfcode="0x1141">
+    <description>Tuya Specific switch mode cluster.</description>
+    <server>
+      <attribute id="0xD010" type="enum8" name="Power On Behavior" default="0x02" access="rw" required="m">
+        <description>Power on behavior</description>
+        <value name="Off" value="0x00"></value>
+        <value name="On" value="0x01"></value>
+        <value name="Last state" value="0x02"></value>
+      </attribute>
+      <attribute id="0xD011" type="enum8" name="unknown" access="rw" required="m">
+        <description>Seems used in some switches then casting -tuya magic-</description>
+      </attribute>
+      <attribute id="0xD030" type="enum8" name="Switch mode" default="0x00" access="rw" required="m">
+        <description>Switch mode</description>
+        <value name="Toggle" value="0x00"></value>
+        <value name="State" value="0x01"></value>
+        <value name="Momentary" value="0x02"></value>
+      </attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
+  <cluster id="0xe002" name="Tuya specific" mfcode="0x1141">
+    <description>Tuya Specific alarm threshold cluster.</description>
+    <server>
+      <attribute id="0xD006" type="u8" name="alarm_temperature" access="rw" required="o">
+        <value name="Min alarm" value="0x00"></value>
+        <value name="Max alarm" value="0x01"></value>
+        <value name="Alarm off" value="0x02"></value>
+      </attribute>
+      <attribute id="0xD00A" type="u16" name="alarm_temperature_max" access="rw" required="o" />
+      <attribute id="0xD00B" type="u16" name="alarm_temperature_min" access="rw" required="o" />
+      <attribute id="0xD00C" type="u16" name="alarm_humidity_max" access="rw" required="o" />
+      <attribute id="0xD00E" type="u16" name="alarm_humidity_min" access="rw" required="o" />
+      <attribute id="0xD00F" type="u8" name="alarm_humidity" default="0x00" access="rw" required="o">
+        <value name="Min alarm" value="0x00"></value>
+        <value name="Max alarm" value="0x01"></value>
+        <value name="Alarm off" value="0x02"></value>
+      </attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
+  <cluster id="0xef00" name="Tuya specific" mfcode="0x1002">
+    <description>Tuya Specific clusters.</description>
+    <server>
+      <command id="00" dir="recv" name="Data Request" required="m">
+        <description>Request datapoint (fields are big-endian!)</description>
+        <payload>
+          <attribute id="0x0000" type="u16" name="Sequence number" required="m" showas="hex" default="0"></attribute>
+          <attribute id="0x0001" type="u8" name="DPID" required="m" showas="hex" default="0x00"></attribute>
+          <attribute id="0x0002" type="enum8" name="Type" required="m" showas="hex" default="0x00">
+            <value name="Raw" value="0x00"/>
+            <value name="Bool" value="0x01"/>
+            <value name="Value" value="0x02"/>
+            <value name="String" value="0x03"/>
+            <value name="Enum" value="0x04"/>
+            <value name="Bitmap" value="0x05"/>
+          </attribute>
+          <attribute id="0x0003" type="u16" name="Length" required="m" showas="hex" default="0x00"></attribute>
+          <attribute id="0x0004" type="u32" name="Value" required="m" showas="hex" default="0"></attribute>
+        </payload>
+      </command>
+      <command id="0x03" dir="recv" name="Data Query" required="m">
+        <description>Trigger report all datapoints.</description>
+      </command>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <!-- Tuya -->
-    <cluster id="0xe001" name="Tuya specific" mfcode="0x1141">
-			<description>Tuya Specific switch mode cluster.</description>
-			<server>
-			<attribute id="0xD010" type="enum8" name="Power On Behavior" default="0x02" access="rw" required="m">
-				<description>Power on behavior</description>
-					<value name="Off" value="0x00"></value>
-					<value name="On" value="0x01"></value>
-					<value name="Last state" value="0x02"></value>
-			</attribute>
-			<attribute id="0xD011" type="enum8" name="unknown" access="rw" required="m">
-				<description>Seems used in some switches then casting -tuya magic-</description>
-			</attribute>
-			<attribute id="0xD030" type="enum8" name="Switch mode" default="0x00" access="rw" required="m">
-				<description>Switch mode</description>
-					<value name="Toggle" value="0x00"></value>
-					<value name="State" value="0x01"></value>
-					<value name="Momentary" value="0x02"></value>
-			</attribute>
-			</server>
-			<client>
-			</client>
-		</cluster>
-   <cluster id="0xe002" name="Tuya specific" mfcode="0x1141">
-			<description>Tuya Specific alarm threshold cluster.</description>
-			<server>
-			<attribute id="0xD006" type="u8" name="alarm_temperature" access="rw" required="o">
-					<value name="Min alarm" value="0x00"></value>
-					<value name="Max alarm" value="0x01"></value>
-					<value name="Alarm off" value="0x02"></value>
-			</attribute>
-			<attribute id="0xD00A" type="u16" name="alarm_temperature_max" access="rw" required="o" />
-			<attribute id="0xD00B" type="u16" name="alarm_temperature_min" access="rw" required="o" />
-			<attribute id="0xD00C" type="u16" name="alarm_humidity_max" access="rw" required="o" />
-			<attribute id="0xD00E" type="u16" name="alarm_humidity_min" access="rw" required="o" />
-			<attribute id="0xD00F" type="u8" name="alarm_humidity" default="0x00" access="rw" required="o">
-					<value name="Min alarm" value="0x00"></value>
-					<value name="Max alarm" value="0x01"></value>
-					<value name="Alarm off" value="0x02"></value>
-			</attribute>
-			</server>
-			<client>
-			</client>
-    </cluster>
-    <cluster id="0xef00" name="Tuya specific" mfcode="0x1002">
-      <description>Tuya Specific clusters.</description>
-      <server>
-        <command id="00" dir="recv" name="Data Request" required="m">
-          <description>Request datapoint (fields are big-endian!)</description>
-          <payload>
-            <attribute id="0x0000" type="u16" name="Sequence number" required="m" showas="hex" default="0"></attribute>
-            <attribute id="0x0001" type="u8" name="DPID" required="m" showas="hex" default="0x00"></attribute>
-            <attribute id="0x0002" type="enum8" name="Type" required="m" showas="hex" default="0x00">
-              <value name="Raw" value="0x00"/>
-              <value name="Bool" value="0x01"/>
-              <value name="Value" value="0x02"/>
-              <value name="String" value="0x03"/>
-              <value name="Enum" value="0x04"/>
-              <value name="Bitmap" value="0x05"/>
-            </attribute>
-            <attribute id="0x0003" type="u16" name="Length" required="m" showas="hex" default="0x00"></attribute>
-            <attribute id="0x0004" type="u32" name="Value" required="m" showas="hex" default="0"></attribute>
-          </payload>
-        </command>
-        <command id="0x03" dir="recv" name="Data Query" required="m">
-          <description>Trigger report all datapoints.</description>
-        </command>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <!-- Legrand -->
+  <cluster id="0xfc01" name="Legrand - Specific clusters" mfcode="1021">
+    <description>Legrand Classic Specific clusters, used by all devices. But take care they are device specific.
+                 Dimmer switch without neutral : Option 1 = Dimmer on/off.
+                 Cable outlet : Option 1 = Fil pilote on/off.
+                 Contactor : On/off=0003 - HP/HC=0004.</description>
+    <server>
+      <attribute id="0x0000" type="dat16" name="Option 1" default="0x0101" access="rw" required="m" showas="hex">
+        <description>Choose correctly according to your device Dimmer OR fil pilote.
+                     Dimmer - Off=0100 - On=0101
+                     Fil pilote - Off=0001 - On=0002
+                     Contactor - On/off=0003 - HP/HC=0004</description>
+      </attribute>
+      <attribute id="0x0001" type="bool" name="Option 2" required="m" access="rw" default="0">
+        <description>Option 1</description>
+      </attribute>
+      <attribute id="0x0002" type="bool" name="Option 3" required="m" access="rw" default="0">
+        <description>Option 2</description>
+      </attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <!-- Legrand -->
-    <cluster id="0xfc01" name="Legrand - Specific clusters" mfcode="1021">
-      <description>Legrand Classic Specific clusters, used by all devices. But take care they are device specific.
-> Dimmer switch without neutral : Option 1 = Dimmer on/off.
-> Cable outlet : Option 1 = Fil pilote on/off.
-> Contactor : On/off=0003 - HP/HC=0004.</description>
-      <server>
-        <attribute id="0x0000" type="dat16" name="Option 1" default="0x0101" access="rw" required="m" showas="hex">
-          <description>Choose correctly according to your device Dimmer OR fil pilote.
-Dimmer > Off=0100 - On=0101
-Fil pilote > Off=0001 - On=0002
-Contactor > On/off=0003 - HP/HC=0004</description>
-        </attribute>
-        <attribute id="0x0001" type="bool" name="Option 2" required="m" access="rw" default="0">
-          <description>Option 1</description>
-        </attribute>
-        <attribute id="0x0002" type="bool" name="Option 3" required="m" access="rw" default="0">
-          <description>Option 2</description>
-        </attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <cluster id="0xfc40" name="Legrand - Specific clusters 2" mfcode="1021">
+    <description>Legrand Specific clusters, Used by cable outlet.</description>
+    <server>
+      <command id="00" dir="recv" name="Unknow" required="m">
+        <description>Set fil pilote mode</description>
+        <payload>
+          <attribute id="0x0000" type="enum8" name="Mode" required="m" default="0x00">
+            <value name="Comfort" value="0x00"></value>
+            <value name="Comfort -1" value="0x01"></value>
+            <value name="Comfort -2" value="0x02"></value>
+            <value name="Eco" value="0x03"></value>
+            <value name="Hors-Gel" value="0x04"></value>
+            <value name="Off" value="0x05"></value>
+          </attribute>
+        </payload>
+      </command>
+      <attribute id="0x0000" type="enum8" name="Mode" default="0x00" access="r" required="m">
+        <description>Heating mode</description>
+        <value name="Comfort" value="0x00"></value>
+        <value name="Comfort -1" value="0x01"></value>
+        <value name="Comfort -2" value="0x02"></value>
+        <value name="Eco" value="0x03"></value>
+        <value name="Hors-Gel" value="0x04"></value>
+        <value name="Off" value="0x05"></value>
+      </attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <cluster id="0xfc40" name="Legrand - Specific clusters 2" mfcode="1021">
-      <description>Legrand Specific clusters, Used by cable outlet.</description>
-      <server>
-        <command id="00" dir="recv" name="Unknow" required="m">
-          <description>Set fil pilote mode</description>
-          <payload>
-            <attribute id="0x0000" type="enum8" name="Mode" required="m" default="0x00">
-              <value name="Comfort" value="0x00"></value>
-              <value name="Comfort -1" value="0x01"></value>
-              <value name="Comfort -2" value="0x02"></value>
-              <value name="Eco" value="0x03"></value>
-              <value name="Hors-Gel" value="0x04"></value>
-              <value name="Off" value="0x05"></value>
-            </attribute>
-          </payload>
-        </command>
-        <attribute id="0x0000" type="enum8" name="Mode" default="0x00" access="r" required="m">
-          <description>Heating mode</description>
-          <value name="Comfort" value="0x00"></value>
-          <value name="Comfort -1" value="0x01"></value>
-          <value name="Comfort -2" value="0x02"></value>
-          <value name="Eco" value="0x03"></value>
-          <value name="Hors-Gel" value="0x04"></value>
-          <value name="Off" value="0x05"></value>
-        </attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <!-- ubisys -->
+  <cluster id="0xfc00" name="Device Setup" mfcode="0x10f2">
+    <description>Attributes and commands.</description>
+    <server>
+      <attribute id="0x0000" name="Input Configurations" type="array" default="0" access="r" required="m"></attribute>
+      <attribute id="0x0001" name="Input Actions" type="array" default="0" access="r" required="m"></attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <!-- ubisys -->
-    <cluster id="0xfc00" name="Device Setup" mfcode="0x10f2">
-      <description>Attributes and commands.</description>
-      <server>
-        <attribute id="0x0000" name="Input Configurations" type="array" default="0" access="r" required="m"></attribute>
-        <attribute id="0x0001" name="Input Actions" type="array" default="0" access="r" required="m"></attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <cluster id="0xfc01" name="Dimmer Setup" mfcode="0x10f2">
+    <description>Attributes and commands.</description>
+    <server>
+      <attribute id="0x0000" name="Capabilities" type="bmp8" default="00000000" access="r" required="m">
+        <value name="Forward Phase Control" value="0"></value>
+        <value name="Reverse Phase Control" value="1"></value>
+        <value name="Reactance Discriminator" value="5"></value>
+        <value name="Configurable Curve" value="6"></value>
+        <value name="Overload detection" value="7"></value>
+      </attribute>
+      <attribute id="0x0001" name="Status" type="bmp8" default="00000000" access="r" required="m">
+        <value name="Forward Phase Control" value="0"></value>
+        <value name="Reverse Phase Control" value="1"></value>
+        <value name="Operational" value="2"></value>
+        <value name="Overload" value="3"></value>
+        <value name="Capacitive Load" value="6"></value>
+        <value name="Inductive Load" value="7"></value>
+      </attribute>
+      <attribute id="0x0002" name="Mode" type="bmp8" default="00000000" access="r" required="m">
+        <value name="Automatic Phase Control" value="0"></value>
+        <value name="Forward Phase Control" value="1"></value>
+        <value name="Reverse Phase Control" value="2"></value>
+      </attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <cluster id="0xfc01" name="Dimmer Setup" mfcode="0x10f2">
-      <description>Attributes and commands.</description>
-      <server>
-        <attribute id="0x0000" name="Capabilities" type="bmp8" default="00000000" access="r" required="m">
-          <value name="Forward Phase Control" value="0"></value>
-          <value name="Reverse Phase Control" value="1"></value>
-          <value name="Reactance Discriminator" value="5"></value>
-          <value name="Configurable Curve" value="6"></value>
-          <value name="Overload detection" value="7"></value>
-        </attribute>
-        <attribute id="0x0001" name="Status" type="bmp8" default="00000000" access="r" required="m">
-          <value name="Forward Phase Control" value="0"></value>
-          <value name="Reverse Phase Control" value="1"></value>
-          <value name="Operational" value="2"></value>
-          <value name="Overload" value="3"></value>
-          <value name="Capacitive Load" value="6"></value>
-          <value name="Inductive Load" value="7"></value>
-        </attribute>
-        <attribute id="0x0002" name="Mode" type="bmp8" default="00000000" access="r" required="m">
-          <value name="Automatic Phase Control" value="0"></value>
-          <value name="Forward Phase Control" value="1"></value>
-          <value name="Reverse Phase Control" value="2"></value>
-        </attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <!-- Samjin -->
+  <cluster id="0xfc02" name="Samjin specific" mfcode="0x104e">
+    <description>Samjin manufacturer-specifc cluster for SmartThings multi sensor.</description>
+    <server>
+      <attribute id="0x0000" name="Motion Threshold Multiplier" type="u8" mfcode="0x104e" default="0" access="rw" required="m"></attribute>
+      <attribute id="0x0002" name="Motion Threshold" type="u16" mfcode="0x104e" default="0" access="rw" required="m"></attribute>
+      <attribute id="0x0010" name="Active" type="bmp8" mfcode="0x104e" default="0" access="r" required="m">
+        <value name="Active" value="0"></value>
+      </attribute>
+      <attribute id="0x0012" name="Acceleration X" type="s16" mfcode="0x104e" default="0" access="r" required="m"></attribute>
+      <attribute id="0x0013" name="Acceleration Y" type="s16" mfcode="0x104e" default="0" access="r" required="m"></attribute>
+      <attribute id="0x0014" name="Acceleration Z" type="s16" mfcode="0x104e" default="0" access="r" required="m"></attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <!-- Samjin -->
-    <cluster id="0xfc02" name="Samjin specific" mfcode="0x104e">
-      <description>Samjin manufacturer-specifc cluster for SmartThings multi sensor.</description>
-      <server>
-        <attribute id="0x0000" name="Motion Threshold Multiplier" type="u8" mfcode="0x104e" default="0" access="rw" required="m"></attribute>
-        <attribute id="0x0002" name="Motion Threshold" type="u16" mfcode="0x104e" default="0" access="rw" required="m"></attribute>
-        <attribute id="0x0010" name="Active" type="bmp8" mfcode="0x104e" default="0" access="r" required="m">
-          <value name="Active" value="0"></value>
-        </attribute>
-        <attribute id="0x0012" name="Acceleration X" type="s16" mfcode="0x104e" default="0" access="r" required="m"></attribute>
-        <attribute id="0x0013" name="Acceleration Y" type="s16" mfcode="0x104e" default="0" access="r" required="m"></attribute>
-        <attribute id="0x0014" name="Acceleration Z" type="s16" mfcode="0x104e" default="0" access="r" required="m"></attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <cluster id="0xfc02" name="Samjin" mfcode="0x110a">
+    <description>Samjin manufacturer-specifc cluster for SmartThings multi sensor.</description>
+    <server>
+      <attribute id="0x0000" name="Motion Threshold Multiplier" type="u8" mfcode="0x110a" default="0" access="rw" required="m"></attribute>
+      <attribute id="0x0002" name="Motion Threshold" type="u16" mfcode="0x110a" default="0" access="rw" required="m"></attribute>
+      <attribute id="0x0010" name="Active" type="bmp8" mfcode="0x110a" default="0" access="r" required="m">
+        <value name="Active" value="0"></value>
+      </attribute>
+      <attribute id="0x0012" name="Acceleration X" type="s16" mfcode="0x110a" default="0" access="r" required="m"></attribute>
+      <attribute id="0x0013" name="Acceleration Y" type="s16" mfcode="0x110a" default="0" access="r" required="m"></attribute>
+      <attribute id="0x0014" name="Acceleration Z" type="s16" mfcode="0x110a" default="0" access="r" required="m"></attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <cluster id="0xfc02" name="Samjin" mfcode="0x110a">
-      <description>Samjin manufacturer-specifc cluster for SmartThings multi sensor.</description>
-      <server>
-        <attribute id="0x0000" name="Motion Threshold Multiplier" type="u8" mfcode="0x110a" default="0" access="rw" required="m"></attribute>
-        <attribute id="0x0002" name="Motion Threshold" type="u16" mfcode="0x110a" default="0" access="rw" required="m"></attribute>
-        <attribute id="0x0010" name="Active" type="bmp8" mfcode="0x110a" default="0" access="r" required="m">
-          <value name="Active" value="0"></value>
-        </attribute>
-        <attribute id="0x0012" name="Acceleration X" type="s16" mfcode="0x110a" default="0" access="r" required="m"></attribute>
-        <attribute id="0x0013" name="Acceleration Y" type="s16" mfcode="0x110a" default="0" access="r" required="m"></attribute>
-        <attribute id="0x0014" name="Acceleration Z" type="s16" mfcode="0x110a" default="0" access="r" required="m"></attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <cluster id="0xfc02" name="Samjin" mfcode="0x1241">
+    <description>Samjin manufacturer-specifc cluster for SmartThings multi sensor.</description>
+    <server>
+      <attribute id="0x0000" name="Motion Threshold Multiplier" type="u8" mfcode="0x1241" default="0" access="rw" required="m"></attribute>
+      <attribute id="0x0010" name="Active" type="bmp8" mfcode="0x1241" default="0" access="r" required="m">
+        <value name="Active" value="0"></value>
+      </attribute>
+      <attribute id="0x0012" name="Acceleration X" type="s16" mfcode="0x1241" default="0" access="r" required="m"></attribute>
+      <attribute id="0x0013" name="Acceleration Y" type="s16" mfcode="0x1241" default="0" access="r" required="m"></attribute>
+      <attribute id="0x0014" name="Acceleration Z" type="s16" mfcode="0x1241" default="0" access="r" required="m"></attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <cluster id="0xfc02" name="Samjin" mfcode="0x1241">
-      <description>Samjin manufacturer-specifc cluster for SmartThings multi sensor.</description>
-      <server>
-        <attribute id="0x0000" name="Motion Threshold Multiplier" type="u8" mfcode="0x1241" default="0" access="rw" required="m"></attribute>
-        <attribute id="0x0010" name="Active" type="bmp8" mfcode="0x1241" default="0" access="r" required="m">
-          <value name="Active" value="0"></value>
-        </attribute>
-        <attribute id="0x0012" name="Acceleration X" type="s16" mfcode="0x1241" default="0" access="r" required="m"></attribute>
-        <attribute id="0x0013" name="Acceleration Y" type="s16" mfcode="0x1241" default="0" access="r" required="m"></attribute>
-        <attribute id="0x0014" name="Acceleration Z" type="s16" mfcode="0x1241" default="0" access="r" required="m"></attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <!-- SENGLED -->
+  <!-- Inspired from https://github.com/YuhangZho/EmberZNet5.3.0-GA/blob/ce8eb024f2ea536832a0d849c3808c6f21131155/em35x/tool/appbuilder/sengled_cluster.xml -->
+  <cluster id="0xfc01" name="Sengled control specific" mfcode="0x1160">
+    <description>Sengled specific cluster for control</description>
+    <server>
+      <attribute id="0x0000" name="Illumination threshold" type="u8" mfcode="0x1160" access="rw" required="o" default="0x01" range="0,1"></attribute>
+      <attribute id="0x0001" name="Automatic lights enable" type="bool" mfcode="0x1160" access="rw" required="o" default="0x01"></attribute>
+      <attribute id="0x0002" name="Save enable" type="bool" mfcode="0x1160" access="r" required="m" default="0x01"></attribute>
+      <attribute id="0x0003" name="comm Occupancy" type="u8" mfcode="0x1160" access="rw" required="o" default="0x0" range="0,1"></attribute>
+      <attribute id="0x0004" name="comm PIR occupied to unoccupied delay" type="u16" mfcode="0x1160" access="rw" required="o" default="0x005a" range="0,14400"></attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
+  <cluster id="0xfc02" name="Sengled Mobile Control specific" mfcode="0x1160">
+    <description>Sengled specific cluster for mobile control</description>
+    <server>
+    </server>
+    <client>
+      <command id="00" dir="recv" name="MobileControl" required="m" mfcode="0x1160">
+        <description>Command description for zcl Mobile Control.</description>
+        <payload>
+          <attribute id="0x0000" type="u16" name="control_type"></attribute>
+          <attribute id="0x0001" type="u16" name="control_data"></attribute>
+          <attribute id="0x0002" type="u16" name="transition_time"></attribute>
+        </payload>
+      </command>
+    </client>
+  </cluster>
+  <cluster id="0xfc03" name="Sengled RGB calibration specific" mfcode="0x1160">
+    <description>Sengled specific cluster for RGB calibration</description>
+    <server>
+      <attribute id="0x0000" name="Temp adc data" type="u16" mfcode="0x1160" access="rw" required="o" default="0x01ff" range="0,65535"></attribute>
+      <attribute id="0x0001" name="Red cali coeff" type="u32" mfcode="0x1160" access="rw" required="o" default="0x2710" range="0,4294967295"></attribute>
+      <attribute id="0x0002" name="Green cali coeff" type="u32" mfcode="0x1160" access="rw" required="o" default="0x2710" range="0,4294967295"></attribute>
+      <attribute id="0x0003" name="Blue cali coeff" type="u32" mfcode="0x1160" access="rw" required="o" default="0x2710" range="0,4294967295"></attribute>
+    </server>
+    <client>
+      <command id="00" dir="recv" name="rgb_calibration" required="m" mfcode="0x1160">
+        <description>Sengled TEST control</description>
+        <payload>
+          <attribute id="0x0000" type="u8" name="cali_cmd"></attribute>
+          <attribute id="0x0001" type="u16" name="cali_data"></attribute>
+        </payload>
+      </command>
+    </client>
+  </cluster>
+  <cluster id="0xfc04" name="Sengled light auto reset specific" mfcode="0x1160">
+    <description>Auto reset for Shangrui light</description>
+    <server>
+      <attribute id="0x0000" name="Auto reset" type="u8" mfcode="0x1160" access="rw" required="o" default="0x00"></attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <!-- SENGLED -->
-    <!-- Inspired from https://github.com/YuhangZho/EmberZNet5.3.0-GA/blob/ce8eb024f2ea536832a0d849c3808c6f21131155/em35x/tool/appbuilder/sengled_cluster.xml -->
-    <cluster id="0xfc01" name="Sengled control specific" mfcode="0x1160">
-		<description>Sengled specific cluster for control</description>
-			<server>
-				<attribute id="0x0000" name="Illumination threshold" type="u8" mfcode="0x1160" access="rw" required="o" default="0x01" range="0,1"> </attribute>
-				<attribute id="0x0001" name="Automatic lights enable" type="bool" mfcode="0x1160" access="rw" required="o" default="0x01"> </attribute>
-				<attribute id="0x0002" name="Save enable" type="bool" mfcode="0x1160" access="r" required="m" default="0x01"> </attribute>
-				<attribute id="0x0003" name="comm Occupancy" type="u8" mfcode="0x1160" access="rw" required="o" default="0x0" range="0,1"> </attribute>
-			    <attribute id="0x0004" name="comm PIR occupied to unoccupied delay" type="u16" mfcode="0x1160" access="rw" required="o" default="0x005a" range="0,14400"> </attribute>
-			</server>
-			<client>
-			</client>
-	   </cluster>
-     <cluster id="0xfc02" name="Sengled Mobile Control specific" mfcode="0x1160">
-			<description>Sengled specific cluster for mobile control</description>
-			<server>
-			</server>
-			<client>
-			<command id="00" dir="recv" name="MobileControl" required="m" mfcode="0x1160">
-				<description>Command description for zcl Mobile Control.</description>
-				<payload>
-					<attribute id="0x0000" type="u16" name="control_type"> </attribute>
-				        <attribute id="0x0001" type="u16" name="control_data"> </attribute>
-				        <attribute id="0x0002" type="u16" name="transition_time"> </attribute>
-				</payload>
-			</command>
-			</client>
-	  </cluster>
-	  <cluster id="0xfc03" name="Sengled RGB calibration specific" mfcode="0x1160">
-			<description>Sengled specific cluster for RGB calibration</description>
-			<server>
-				<attribute id="0x0000" name="Temp adc data" type="u16" mfcode="0x1160" access="rw" required="o" default="0x01ff" range="0,65535" > </attribute>
-				<attribute id="0x0001" name="Red cali coeff" type="u32" mfcode="0x1160" access="rw" required="o" default="0x2710" range="0,4294967295" > </attribute>
-				<attribute id="0x0002" name="Green cali coeff" type="u32" mfcode="0x1160" access="rw" required="o" default="0x2710" range="0,4294967295" > </attribute>
-				<attribute id="0x0003" name="Blue cali coeff" type="u32" mfcode="0x1160" access="rw" required="o" default="0x2710" range="0,4294967295" > </attribute>
-			</server>
-			<client>
-			<command id="00" dir="recv" name="rgb_calibration" required="m" mfcode="0x1160">
-				<description>Sengled TEST control</description>
-				<payload>
-					<attribute id="0x0000" type="u8" name="cali_cmd"> </attribute>
-				        <attribute id="0x0001" type="u16" name="cali_data"> </attribute>
-				</payload>
-			</command>
-			</client>
-	  </cluster>
-		<cluster id="0xfc04" name="Sengled light auto reset specific" mfcode="0x1160">
-			<description>Auto reset for Shangrui light</description>
-			<server>
-				<attribute id="0x0000" name="Auto reset" type="u8" mfcode="0x1160" access="rw" required="o" default="0x00"> </attribute>
-			</server>
-			<client>
-			</client>
-	  </cluster>
-    
-    <!-- OSRAM -->
-    <cluster id="0xfc0f" name="OSRAM specific" mfcode="0xbbaa">
-      <description>OSRAM manufacturer-specific cluster to set power-on defaults.</description>
-      <server>
-        <command id="0x01" dir="recv" name="Store Power-On Defaults" required="o"></command>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <!-- OSRAM -->
+  <cluster id="0xfc0f" name="OSRAM specific" mfcode="0xbbaa">
+    <description>OSRAM manufacturer-specific cluster to set power-on defaults.</description>
+    <server>
+      <command id="0x01" dir="recv" name="Store Power-On Defaults" required="o"></command>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <!-- LEDVANCE -->
-    <cluster id="0xfc01" name="LEDVANCE specific" mfcode="0x1189">
-      <description>LEDVANCE manufacturer-specific cluster to set power-on defaults.</description>
-      <server>
-        <command id="0x01" dir="recv" name="Store Power-On Defaults" required="o"></command>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <!-- LEDVANCE -->
+  <cluster id="0xfc01" name="LEDVANCE specific" mfcode="0x1189">
+    <description>LEDVANCE manufacturer-specific cluster to set power-on defaults.</description>
+    <server>
+      <command id="0x01" dir="recv" name="Store Power-On Defaults" required="o"></command>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <!-- E-Wand -->
-    <cluster id="0xfc10" name="E-Wand specific" mfcode="0x1263">
-      <description>E-Wand manufacturer specific window covering configuration.</description>
-      <server>
-        <command id="0x23" dir="recv" name="Set Direction" required="o">
-          <description></description>
-          <payload>
-            <attribute id="0x0000" type="enum8" name="Mode" required="m" default="0x00">
-              <value name="Standard" value="0x00"></value>
-              <value name="Reversed" value="0x01"></value>
-              <value name="Toggle" value="0x02"></value>
-            </attribute>
-          </payload>
-        </command>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <!-- E-Wand -->
+  <cluster id="0xfc10" name="E-Wand specific" mfcode="0x1263">
+    <description>E-Wand manufacturer specific window covering configuration.</description>
+    <server>
+      <command id="0x23" dir="recv" name="Set Direction" required="o">
+        <description></description>
+        <payload>
+          <attribute id="0x0000" type="enum8" name="Mode" required="m" default="0x00">
+            <value name="Standard" value="0x00"></value>
+            <value name="Reversed" value="0x01"></value>
+            <value name="Toggle" value="0x02"></value>
+          </attribute>
+        </payload>
+      </command>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <!-- IKEA -->
-    <cluster id="0xfc57" name="IKEA specific" mfcode="0x117c">
-      <description>Unknown cluster, found on the IKEA Vindstyrka Air Quality Sensor.</description>
-      <server>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <!-- IKEA -->
+  <cluster id="0xfc57" name="IKEA specific" mfcode="0x117c">
+    <description>Unknown cluster, found on the IKEA Vindstyrka Air Quality Sensor.</description>
+    <server>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <cluster id="0xfc7c" name="IKEA specific" mfcode="0x117c">
-      <description>IKEA control outlet cluster.</description>
-      <server>
-        <attribute id="0x0010" name="Unknown 1" type="u8" access="rw" required="m" showas="hex" mfcode="0x117c">
-          <description></description>
-        </attribute>
-        <attribute id="0xfffd" name="Cluster Revision" type="u16" required="m" access="rw" showas="hex" mfcode="0x117c">
-          <description></description>
-        </attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <cluster id="0xfc7c" name="IKEA specific" mfcode="0x117c">
+    <description>IKEA control outlet cluster.</description>
+    <server>
+      <attribute id="0x0010" name="Unknown 1" type="u8" access="rw" required="m" showas="hex" mfcode="0x117c">
+        <description></description>
+      </attribute>
+      <attribute id="0xfffd" name="Cluster Revision" type="u16" required="m" access="rw" showas="hex" mfcode="0x117c">
+        <description></description>
+      </attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <cluster id="0xfc7d" name="Air Purifier Control" mfcode="0x117c">
-      <description>Cluster to control the IKEA Starkvind Air Purifier.</description>
-      <server>
-        <attribute id="0x0000" name="Filter Run Time" type="u32" access="r" required="m" mfcode="0x117c"></attribute>
-        <attribute id="0x0001" name="Replace Filter" type="u8" access="r" required="m" mfcode="0x117c"></attribute>
-        <attribute id="0x0002" name="Filter Life Time" type="u32" access="rw" required="m" mfcode="0x117c"></attribute>
-        <attribute id="0x0003" name="Disable LEDs" type="bool" access="rw" required="m" mfcode="0x117c"></attribute>
-        <attribute id="0x0004" name="Air Quality" type="u16" access="r" required="m" mfcode="0x117c"></attribute>
-        <attribute id="0x0005" name="Lock Controls" type="bool" access="rw" required="m" mfcode="0x117c"></attribute>
-        <attribute id="0x0006" name="Target Mode" type="u8" access="rw" required="m" mfcode="0x117c"></attribute>
-        <attribute id="0x0007" name="Current Mode" type="u8" access="r" required="m" mfcode="0x117c"></attribute>
-        <attribute id="0x0008" name="Device Run Time" type="u32" access="r" required="m" mfcode="0x117c"></attribute>
-      </server>
-    </cluster>
+  <cluster id="0xfc7d" name="Air Purifier Control" mfcode="0x117c">
+    <description>Cluster to control the IKEA Starkvind Air Purifier.</description>
+    <server>
+      <attribute id="0x0000" name="Filter Run Time" type="u32" access="r" required="m" mfcode="0x117c"></attribute>
+      <attribute id="0x0001" name="Replace Filter" type="u8" access="r" required="m" mfcode="0x117c"></attribute>
+      <attribute id="0x0002" name="Filter Life Time" type="u32" access="rw" required="m" mfcode="0x117c"></attribute>
+      <attribute id="0x0003" name="Disable LEDs" type="bool" access="rw" required="m" mfcode="0x117c"></attribute>
+      <attribute id="0x0004" name="Air Quality" type="u16" access="r" required="m" mfcode="0x117c"></attribute>
+      <attribute id="0x0005" name="Lock Controls" type="bool" access="rw" required="m" mfcode="0x117c"></attribute>
+      <attribute id="0x0006" name="Target Mode" type="u8" access="rw" required="m" mfcode="0x117c"></attribute>
+      <attribute id="0x0007" name="Current Mode" type="u8" access="r" required="m" mfcode="0x117c"></attribute>
+      <attribute id="0x0008" name="Device Run Time" type="u32" access="r" required="m" mfcode="0x117c"></attribute>
+    </server>
+  </cluster>
 
-    <cluster id="0xfc7e" name="tVOC Measurement" mfcode="0x117c">
-      <description>Cluster to report tVOC on the IKEA Vindstyrka Air Quality Sensor.</description>
-      <server>
-        <attribute-set id="0x0000" description="tVOC Information">
-          <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m" mfcode="0x117c"></attribute>
-          <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m" mfcode="0x117c"></attribute>
-          <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m" mfcode="0x117c"></attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-	  
-    <!-- SONOFF -->
-    <cluster id="0xfc11" name="Sonoff specific" mfcode="0x1286">
-      <description>Cluster for light sensor and thermostat</description>
-      <server>
-        <attribute id="0x0000" name="Child lock" type="bool" access="rw" required="m"></attribute>
-        <attribute id="0x0003" name="Comfort temperature min" type="s16" access="rw" required="m"></attribute>
-        <attribute id="0x0004" name="Comfort temperature max" type="s16" access="rw" required="m"></attribute>
-        <attribute id="0x0005" name="Comfort humidity min" type="u16" access="rw" required="m"></attribute>
-        <attribute id="0x0006" name="Comfort humidity max" type="u16" access="rw" required="m"></attribute>
-        <attribute id="0x0007" name="Display unit" type="enum8" access="rw" required="m">
-            <value name="Celsius" value="0"></value>
-            <value name="Fahrenheit" value="1"></value>
-        </attribute>
-        <attribute id="0x2001" name="Illumination status" type="enum8" access="r" required="m">
-            <value name="Dark" value="0x00"></value>
-            <value name="Light" value="0x01"></value>
-        </attribute>
-        <attribute id="0x2003" name="Temperature offset" type="s16" access="rw" required="m"></attribute>
-        <attribute id="0x2004" name="Humidity offset" type="s16" access="rw" required="m"></attribute>
-        <attribute id="0x500C" name="Water valve state" type="enum8" access="rw" required="m">
-            <value name="Normal" value="0"></value>
-            <value name="Water shortage" value="1"></value>
-            <value name="Water leakage" value="2"></value>
-            <value name="Water shortage and leakage" value="3"></value>
-        </attribute>
-        <attribute id="0x5011" name="Auto close water shortage" type="u16" access="rw" required="m"></attribute>
-        <attribute id="0x6000" name="Window open detection" type="bool" access="rw" required="m"></attribute>
-        <attribute id="0x6002" name="Frost protection temperature" type="s16" access="rw" required="m"></attribute>
-        <attribute id="0x6003" name="Idle steps" type="u16" access="r" required="m"></attribute>
-        <attribute id="0x6005" name="Valve opening limit voltage" type="u16" access="r" required="m"></attribute>
-        <attribute id="0x6006" name="Valve closing limit voltage" type="u16" access="r" required="m"></attribute>
-        <attribute id="0x6007" name="Valve motor running voltage" type="u16" access="r" required="m"></attribute>
-        <attribute id="0x600B" name="Valve opening degree" type="u8" access="rw" required="m"></attribute>
-        <attribute id="0x600C" name="Valve closing degree" type="u8" access="rw" required="m"></attribute>
-        <attribute id="0x600D" name="External temperature sensor" type="s16" access="rw" required="m"></attribute>
-        <attribute id="0x600E" name="External temperature sensor enable" type="u8" access="rw" required="m"></attribute>
-        <attribute id="0x6011" name="Temperature accuracy" type="s16" access="rw" required="m"></attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
-	  
-    <!-- Leviton -->
-    <cluster id="0x8007" name="Leviton Specific Load Cluster" mfcode="0x109b">
-      <description>Additional features implemented in Leviton’s DG6HD.</description>
-      <server>
-        <attribute id="0x0001" type="u8" name="Min Dim Level" required="o" access="rw" range="0x00,0xFF" default="0x00">
-          <description>Minimum Level represents the minimum level the dimmer can be set to. This must be lower than Maximum Level.</description>
-        </attribute>
-        <attribute id="0x0002" type="u8" name="Max Dim Level" required="o" access="rw" range="0x00,0xFF" default="0xFF">
-          <description>Maximum Level represents the maximum level the dimmer can be set to. This must be greater than Minimum Level.</description>
-        </attribute>
-        <attribute id="0x0003" type="u8" name="Locator LED" required="o" access="rw" range="0x00,0xFF" default="0x00">
-          <description>Represents how the Locator LED functions. This can be set to ALWAYS ON (0x00), ALWAYS OFF (0X01), or a timed delay (0x02 to 0xFF). The Timed delay is always seconds -1. When using timed delay, the led will come on when a button is pressed.</description>
-        </attribute>
-        <attribute id="0x0004" type="u8" name="Dimming LED" required="o" access="rw" range="0x00,0xFF" default="0x00">
-          <description>Represents how the Dimming LED functions. This can be set to ALWAYS ON (0x00), ALWAYS OFF (0X01), or a timed delay (0x02 to 0xFF). The Timed delay is always seconds -1. When using timed delay, the led will come on when a button is pressed.</description>
-        </attribute>
-        <attribute id="0x0007" type="u8" name="Initial On Level" required="o" access="rw" range="0x00,0xFF" default="0x00">
-          <description>Initial On Level represents the desired level to be applied to a dimmer when an “On” button is pressed.
+  <cluster id="0xfc7e" name="tVOC Measurement" mfcode="0x117c">
+    <description>Cluster to report tVOC on the IKEA Vindstyrka Air Quality Sensor.</description>
+    <server>
+      <attribute-set id="0x0000" description="tVOC Information">
+        <attribute id="0x0000" name="Measured Value" type="float" access="r" default="0" required="m" mfcode="0x117c"></attribute>
+        <attribute id="0x0001" name="Min Measured Value" type="float" access="r" required="m" mfcode="0x117c"></attribute>
+        <attribute id="0x0002" name="Max Measured Value" type="float" access="r" required="m" mfcode="0x117c"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <!-- SONOFF -->
+  <cluster id="0xfc11" name="Sonoff specific" mfcode="0x1286">
+    <description>Cluster for light sensor and thermostat</description>
+    <server>
+      <attribute id="0x0000" name="Child lock" type="bool" access="rw" required="m"></attribute>
+      <attribute id="0x0003" name="Comfort temperature min" type="s16" access="rw" required="m"></attribute>
+      <attribute id="0x0004" name="Comfort temperature max" type="s16" access="rw" required="m"></attribute>
+      <attribute id="0x0005" name="Comfort humidity min" type="u16" access="rw" required="m"></attribute>
+      <attribute id="0x0006" name="Comfort humidity max" type="u16" access="rw" required="m"></attribute>
+      <attribute id="0x0007" name="Display unit" type="enum8" access="rw" required="m">
+        <value name="Celsius" value="0"></value>
+        <value name="Fahrenheit" value="1"></value>
+      </attribute>
+      <attribute id="0x2001" name="Illumination status" type="enum8" access="r" required="m">
+        <value name="Dark" value="0x00"></value>
+        <value name="Light" value="0x01"></value>
+      </attribute>
+      <attribute id="0x2003" name="Temperature offset" type="s16" access="rw" required="m"></attribute>
+      <attribute id="0x2004" name="Humidity offset" type="s16" access="rw" required="m"></attribute>
+      <attribute id="0x500C" name="Water valve state" type="enum8" access="rw" required="m">
+        <value name="Normal" value="0"></value>
+        <value name="Water shortage" value="1"></value>
+        <value name="Water leakage" value="2"></value>
+        <value name="Water shortage and leakage" value="3"></value>
+      </attribute>
+      <attribute id="0x5011" name="Auto close water shortage" type="u16" access="rw" required="m"></attribute>
+      <attribute id="0x6000" name="Window open detection" type="bool" access="rw" required="m"></attribute>
+      <attribute id="0x6002" name="Frost protection temperature" type="s16" access="rw" required="m"></attribute>
+      <attribute id="0x6003" name="Idle steps" type="u16" access="r" required="m"></attribute>
+      <attribute id="0x6005" name="Valve opening limit voltage" type="u16" access="r" required="m"></attribute>
+      <attribute id="0x6006" name="Valve closing limit voltage" type="u16" access="r" required="m"></attribute>
+      <attribute id="0x6007" name="Valve motor running voltage" type="u16" access="r" required="m"></attribute>
+      <attribute id="0x600B" name="Valve opening degree" type="u8" access="rw" required="m"></attribute>
+      <attribute id="0x600C" name="Valve closing degree" type="u8" access="rw" required="m"></attribute>
+      <attribute id="0x600D" name="External temperature sensor" type="s16" access="rw" required="m"></attribute>
+      <attribute id="0x600E" name="External temperature sensor enable" type="u8" access="rw" required="m"></attribute>
+      <attribute id="0x6011" name="Temperature accuracy" type="s16" access="rw" required="m"></attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
+
+  <!-- Leviton -->
+  <cluster id="0x8007" name="Leviton Specific Load Cluster" mfcode="0x109b">
+    <description>Additional features implemented in Leviton’s DG6HD.</description>
+    <server>
+      <attribute id="0x0001" type="u8" name="Min Dim Level" required="o" access="rw" range="0x00,0xFF" default="0x00">
+        <description>Minimum Level represents the minimum level the dimmer can be set to. This must be lower than Maximum Level.</description>
+      </attribute>
+      <attribute id="0x0002" type="u8" name="Max Dim Level" required="o" access="rw" range="0x00,0xFF" default="0xFF">
+        <description>Maximum Level represents the maximum level the dimmer can be set to. This must be greater than Minimum Level.</description>
+      </attribute>
+      <attribute id="0x0003" type="u8" name="Locator LED" required="o" access="rw" range="0x00,0xFF" default="0x00">
+        <description>Represents how the Locator LED functions. This can be set to ALWAYS ON (0x00), ALWAYS OFF (0X01), or a timed delay (0x02 to 0xFF). The Timed delay is always seconds -1. When using timed delay, the led will come on when a button is pressed.</description>
+      </attribute>
+      <attribute id="0x0004" type="u8" name="Dimming LED" required="o" access="rw" range="0x00,0xFF" default="0x00">
+        <description>Represents how the Dimming LED functions. This can be set to ALWAYS ON (0x00), ALWAYS OFF (0X01), or a timed delay (0x02 to 0xFF). The Timed delay is always seconds -1. When using timed delay, the led will come on when a button is pressed.</description>
+      </attribute>
+      <attribute id="0x0007" type="u8" name="Initial On Level" required="o" access="rw" range="0x00,0xFF" default="0x00">
+        <description>Initial On Level represents the desired level to be applied to a dimmer when an “On” button is pressed.
 		  0x00 : Go to the last level set.
 		  0x01-0xFF : Go to a specific level</description>
-        </attribute>
-        <attribute id="0x0008" type="bool" name="Power Restore" default="1" access="rw" required="o">
-	  <description>Power Restore represents the option to turn the switch/dimmer back to its previous level when powered up, or remain off.</description>
-            <value name="Leave Load Off" value="0"></value>
-            <value name="Go to the last level set" value="1"></value>
-        </attribute>
-	<attribute id="0x0009" type="u8" name="Press and Hold Time" required="o" access="rw" range="0x00,0xFF" default="0x32">
-          <description>Represents the ramp time when pressing and holding the dim/brighten button on a dimmer. This value represents the amount of time needed to go from 0% to 100%. This time value is in 0.1s increments</description>
-        </attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+      </attribute>
+      <attribute id="0x0008" type="bool" name="Power Restore" default="1" access="rw" required="o">
+        <description>Power Restore represents the option to turn the switch/dimmer back to its previous level when powered up, or remain off.</description>
+        <value name="Leave Load Off" value="0"></value>
+        <value name="Go to the last level set" value="1"></value>
+      </attribute>
+      <attribute id="0x0009" type="u8" name="Press and Hold Time" required="o" access="rw" range="0x00,0xFF" default="0x32">
+        <description>Represents the ramp time when pressing and holding the dim/brighten button on a dimmer. This value represents the amount of time needed to go from 0% to 100%. This time value is in 0.1s increments</description>
+      </attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <!-- LUMI -->
-    <cluster id="0xfcc0" name="Lumi specific" mfcode="0x115f">
-      <description>Lumi specific attributes.</description>
-      <server>
-        <attribute-set id="0x0000" description="Unknown">
-          <attribute id="0x0001" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0002" name="Power Outages" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0003" name="Unknown" type="enum8" mfcode="0x115f" access="r" required="m">
-            <value name="0" value="0x00"></value>
-            <value name="1" value="0x01"></value>
-            <value name="2" value="0x02"></value>
-            <value name="3" value="0x03"></value>
-            <value name="4" value="0x04"></value>
-          </attribute>
-          <attribute id="0x0006" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0007" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0008" name="Unknown (write only)" type="ostring" mfcode="0x115f" access="w" required="m"></attribute>
-          <attribute id="0x0009" name="Device operation mode" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x000A" name="Switch mode" type="u8" mfcode="0x115f" access="rw" required="m">
-            <description>Switch mode: 1 - event based switching, 2 - zigbee group switching, 3 - Xiaomi specific switching</description>
-          </attribute>
-          <attribute id="0x000C" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x000D" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x00E8" name="Restart Device" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x00E9" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x00EA" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x00EB" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x00ED" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x00EE" name="Firmware" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x00F0" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x00F1" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x00F3" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x00F4" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x00F5" name="Unknown" type="u32" mfcode="0x115f" access="r" required="m"></attribute>
-          <attribute id="0x00F6" name="Reporting Interval" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x00F7" name="Unknown" type="ostring" mfcode="0x115f" access="r" required="m"></attribute>
-          <attribute id="0x00F8" name="Unknown" type="u64" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x00F9" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x00FA" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x00FB" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x00FC" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x00FE" name="Serial Number" type="cstring" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x00FF" name="Unknown (write only)" type="ostring" mfcode="0x115f" access="w" required="m"></attribute>
-          <attribute id="0x0100" name="Unknown" type="u8" mfcode="0x115f" access="r" required="m"></attribute>
-          <attribute id="0x0102" name="Motion cool off time" type="u8" mfcode="0x115f" access="rw" required="m">
-            <description>Time in seconds when RTCGQ13LM sets motion to false if no further motion has been detected</description>
-          </attribute>
-          <attribute id="0x010C" name="Detection sensitivity" type="u8" mfcode="0x115f" access="rw" required="m">
-            <description>Motion sensitivity: 1 - low, 2 - medium, 3 - high</description>
-          </attribute>
-          <attribute id="0x0112" name="Unknown" type="u32" mfcode="0x115f" access="r" required="m"></attribute>
-          <attribute id="0x0114" name="TVOC unit config" type="u8" mfcode="0x115f" access="rw" required="m">
-            <description>0 - µg/m³ + °C, 1 - ppb + °C, 16 - µg/m³ + °F, 17 - ppb + °F</description>
-          </attribute>
-          <attribute id="0x0125" name="Multiclick mode" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0126" name="Buzer manual mute" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0127" name="Self test" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0129" name="Air Quality" type="u8" mfcode="0x115f" access = "r" required="o">
-            <description>Air Quality: 1 - excellent, 2 - good, 3 - moderate, 4 - poor, 5 unhealthy</description>
-          </attribute>
-          <attribute id="0x0135" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0136" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0137" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0138" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x013A" name="Smoke" type="bool" mfcode="0x115f" access="r" required="m"></attribute>
-          <attribute id="0x013B" name="Smoke density" type="u8" mfcode="0x115f" access="r" required="m"></attribute>
-          <attribute id="0x013C" name="HeartBeat indicator" type="u8" mfcode="0x115f" access="r" required="m"></attribute>
-          <attribute id="0x013D" name="Buzer manual alarm 1" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x013E" name="Buzer manual alarm 2" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0142" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x014B" name="linkage alarm" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x014C" name="linkage alarm state" type="bool" mfcode="0x115f" access="r" required="m"></attribute>
-          <attribute id="0x014D" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x014F" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0152" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0157" name="Spatial Learning" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x015B" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0160" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0162" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0163" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0164" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0165" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x016A" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x016B" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x016C" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0170" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0192" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0193" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0194" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0195" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0196" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0197" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0198" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0199" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x019A" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0200" name="Child lock off" type="u8" mfcode="0x115f" access="rw" required="m">
-            <description>Child lock off: 0 - false, 1 - true</description>
-          </attribute>
-          <attribute id="0x0201" name="Restore Power on Outage" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0202" name="Auto-off after 20m below Threshold" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0203" name="Device LED off (9pm-9am)" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0204" name="Min. Power Change for Report (W)" type="float" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0205" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m">
-            <description>Attribute 0x0205 has range between 1 and 50 only</description>
-          </attribute>
-          <attribute id="0x0206" name="Power Threshold for Auto-off" type="float" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0207" name="Consumer Connected" type="bool" mfcode="0x115f" access="r" required="m"></attribute>
-          <attribute id="0x020B" name="Max. Load Exceeded at (W)" type="float" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x020C" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x020D" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x020E" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x023B" name="Unknown" type="float" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x023E" name="LED off-time" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x02d0" name="Interlock" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
-        </attribute-set>
-        <attribute-set id="0x0270" description="Smart Radiator Thermostat E1">
-            <attribute id="0x0270" name="Calibrate" type="u8" mfcode="0x115f" access="rw" required="m"> 
-                <description>Write 1 to calibrate</description>
-            </attribute>
-            <attribute id="0x0271" name="Mode" type="u8" mfcode="0x115f" access="rw" required="m"> 
-                <description>Heating state: 0 - off, 1 - on</description>
-            </attribute>
-            <attribute id="0x0272" name="Preset" type="u8" mfcode="0x115f" access="rw" required="m" default="0"> 
-                <description>Preset: 0 - manual, 1 - auto, 2 - away</description>
-            </attribute>
-            <attribute id="0x0273" name="Window detection" type="u8" mfcode="0x115f" access="rw" required="m">
-                <description>Window detection: 0 - off, 1 - on</description>
-            </attribute>
-            <attribute id="0x0274" name="Valve fault detection" type="u8" mfcode="0x115f" access="rw" required="m">
-                <description>Valve fault detection: 0 - off, 1 - on</description>
-            </attribute>
-            <attribute id="0x0275" name="Valve fault alarm" type="u8" mfcode="0x115f" access="r" required="m">
-                <description>Valve fault alarm: 0 - false, 1 - true</description>
-            </attribute>
-            <attribute id="0x0277" name="Child lock on" type="u8" mfcode="0x115f" access="rw" required="m">
-                <description>Child lock on: 0 - false, 1 - true</description>
-            </attribute>
-            <attribute id="0x0279" name="Away preset temperature" type="u32" mfcode="0x115f" access="rw" required="m"> </attribute>
-            <attribute id="0x027a" name="Window open" type="u8" mfcode="0x115f" access="r" required="m">
-                <description>Window open: 0 - false, 1 - true</description>
-            </attribute>
-            <attribute id="0x027b" name="Calibrated" type="u8" mfcode="0x115f" access="r" required="m">
-                <description>Calibrated: 0 - false, 1 - true</description>
-            </attribute>
-            <attribute id="0x027e" name="External sensor" type="u8" mfcode="0x115f" access="r" required="m">
-                <description>Temperature sensor: 0 - internal, 1 - external</description>
-            </attribute>
-        </attribute-set>
-        <attribute-set id="0x0400" description="Aqara Roller Shade Driver E1">
-          <attribute id="0x0400" name="Reverse Direction" type="bool" mfcode="0x115f" access="rw" required="o">
-            <description>Reverse the direction of up/open and down/close.</description>
-          </attribute>
-          <attribute id="0x0402" name="Positions Stored" type="bool" mfcode="0x115f" access="rw" required="o">
-            <description>Position clearing: write false to clear the stored up/open and down/close positions.</description>
-          </attribute>
-          <attribute id="0x0407" name="Store Position" type="u8" mfcode="0x115f" access="rw" required="o">
-            <description>Position setting: write 1 to store the up/open position, 2 to store the down/close position.</description>
-          </attribute>
-          <attribute id="0x0408" name="Speed" type="u8" mfcode="0x115f" access="rw" required="o">
-            <description>Motor speed: 2: high, 1: medium, 0: low.</description>
-          </attribute>
-          <attribute id="0x0409" name="Charging" type="u8" mfcode="0x115f" access="r" required="o">
-            <description>Battery charging state: 1: charging, 2: not charging.</description>
-          </attribute>
-          <attribute id="0x040a" name="Battery" type="u8" mfcode="0x115f" access="r" required="m">
-          </attribute>
-        </attribute-set>
-        <attribute-set id="0x0500" description="Aqara LED Strip T1">
-          <attribute id="0x0515" name="Min Dim Level (%)" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0516" name="Max Dim Level (%)" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0517" name="PowerOn OnOff" type="u8" mfcode="0x115f" access="rw" required="m">
-            <description>OnOff state on power on: 0: on, 1: previous, 2: off.</description>
-          </attribute>
-          <attribute id="0x051B" name="Segments" type="u8" mfcode="0x115f" access="rw" required="m">
-            <description>Number of 20cm segments.</description>
-          </attribute>
-          <attribute id="0x051C" name="Music Sync" type="u8" mfcode="0x115f" access="rw" required="m">
-            <description>Music Sync: 0: off, 1: on.</description>
-          </attribute>
-          <attribute id="0x051D" name="Music Sync Effect" type="u8" mfcode="0x115f" access="rw" required="m">
-            <description>Music Sync Effecy: 0: random, 1: breathing, 2: rainbow, 3: chasing.</description>
-          </attribute>
-          <attribute id="0x051E" name="Music Sync Sensitivity" type="u8" mfcode="0x115f" access="rw" required="m">
-            <description>Music Sync Sensitivity: 0: low, 2: high.</description>
-          </attribute>
-        </attribute-set>
-        <attribute-set id="0x0700" description="Unknown">
-          <attribute id="0x0700" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0701" name="Unknown" type="s8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0702" name="Unknown" type="s8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0703" name="Unknown" type="s8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0704" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0705" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0740" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0780" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0781" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0782" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x0783" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0x07C0" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
-          <attribute id="0xF000" name="Report Consumer Connected" type="u8" mfcode="0x115f" access="rw" required="m">
-            <description>Report Consumer Connected: 1 - false, 0 - true</description>
-          </attribute>
-          <attribute id="0xF001" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0xF002" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"> </attribute>
-          <attribute id="0xFFF2" name="External temperature" type="ostring" mfcode="0x115f" access="r" required="m">
-            <description>Could used to write external temperature values to TRV</description>
-          </attribute>
-          <attribute id="0xFFFD" name="Cluster Revision" type="u16" mfcode="0x115f" access="rw" required="m"> </attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-    <!-- AQARA -->
-    <cluster id="0xfcc0" name="Aqara specific" mfcode="0x1234">
-      <description>Aqara specific attributes.</description>
-      <server>
-        <attribute-set id="0x0000" description="Unknown">
-          <attribute id="0x0001" name="Unknown" type="u16" access="rw" required="m"></attribute>
-          <attribute id="0x0002" name="Power Outages" type="u16" access="rw" required="m"></attribute>
-          <attribute id="0x0003" name="Unknown" type="enum8" access="r" required="m">
-            <value name="0" value="0x00"></value>
-            <value name="1" value="0x01"></value>
-            <value name="2" value="0x02"></value>
-            <value name="3" value="0x03"></value>
-            <value name="4" value="0x04"></value>
-          </attribute>
-          <attribute id="0x0006" name="Unknown" type="ostring" access="rw" required="m"></attribute>
-          <attribute id="0x0007" name="Unknown" type="ostring" access="rw" required="m"></attribute>
-          <attribute id="0x0008" name="Unknown (write only)" type="ostring" access="w" required="m"></attribute>
-          <attribute id="0x0009" name="Device operation mode" type="u8" access="rw" required="m"></attribute>
-          <attribute id="0x000A" name="Switch mode" type="u8" access="rw" required="m">
-            <description>Switch mode: 1 - event based switching, 2 - zigbee group switching, 3 - Xiaomi specific switching</description>
-          </attribute>
-          <attribute id="0x000C" name="Unknown" type="ostring" access="rw" required="m"></attribute>
-          <attribute id="0x000D" name="Unknown" type="u8" access="rw" required="m"></attribute>
-          <attribute id="0x00E4" name="Unknown" type="u32" access="rw" required="m"></attribute>
-          <attribute id="0x00E8" name="Device Running" type="bool" access="rw" required="m">
-            <description>Set to false to reboot the device.</description>
-          </attribute>
-          <attribute id="0x00E9" name="Unknown" type="u8" access="rw" required="m"></attribute>
-          <attribute id="0x00EA" name="Unknown" type="ostring" access="rw" required="m"></attribute>
-          <attribute id="0x00EB" name="Unknown" type="u16" access="rw" required="m"></attribute>
-          <attribute id="0x00ED" name="Unknown" type="u32" access="rw" required="m"></attribute>
-          <attribute id="0x00EE" name="Unknown" type="u32" access="rw" required="m"></attribute>
-          <attribute id="0x00F0" name="Unknown" type="u8" access="rw" required="m"></attribute>
-          <attribute id="0x00F1" name="Unknown" type="u8" access="rw" required="m"></attribute>
-          <attribute id="0x00F3" name="Unknown" type="u8" access="rw" required="m"></attribute>
-          <attribute id="0x00F4" name="Unknown" type="u8" access="rw" required="m"></attribute>
-          <attribute id="0x00F5" name="Unknown" type="u32" access="r" required="m"></attribute>
-          <attribute id="0x00F6" name="Reporting Interval" type="u16" access="rw" required="m"></attribute>
-          <attribute id="0x00F7" name="Unknown" type="ostring" access="r" required="m"></attribute>
-          <attribute id="0x00F8" name="Unknown" type="u64" access="rw" required="m"></attribute>
-          <attribute id="0x00F9" name="Unknown" type="u16" access="rw" required="m"></attribute>
-          <attribute id="0x00FA" name="Unknown" type="bool" access="rw" required="m"></attribute>
-          <attribute id="0x00FB" name="Unknown" type="u8" access="rw" required="m"></attribute>
-          <attribute id="0x00FC" name="Unknown" type="bool" access="rw" required="m"></attribute>
-          <attribute id="0x00FE" name="Serial Number" type="cstring" access="rw" required="m"></attribute>
-          <attribute id="0x00FF" name="Unknown (write only)" type="ostring" access="w" required="m"></attribute>
-          <attribute id="0x0100" name="Unknown" type="u8" access="r" required="m"></attribute>
-          <attribute id="0x0102" name="Motion cool off time" type="u8" access="rw" required="m">
-            <description>Time in seconds when RTCGQ13LM sets motion to false if no further motion has been detected</description>
-          </attribute>
-          <attribute id="0x010C" name="Motion Sensitivity" type="u8" access="rw" required="m">
-            <description>Motion sensitivity: 1 - low, 2 - medium, 3 - high</description>
-          </attribute>
-          <attribute id="0x0112" name="Unknown" type="u32" access="r" required="m"></attribute>
-          <attribute id="0x0114" name="TVOC unit config" type="u8" access="rw" required="m">
-            <description>0 - µg/m³ + °C, 1 - ppb + °C, 16 - µg/m³ + °F, 17 - ppb + °F</description>
-          </attribute>
-          <attribute id="0x0125" name="Multiclick mode" type="u8" access="rw" required="m"></attribute>
-          <attribute id="0x0133" name="Unknown" type="u8" access="rw" required="m"></attribute>
-          <attribute id="0x0134" name="Unknown" type="ostring" access="rw" required="m"></attribute>
-          <attribute id="0x0135" name="Unknown" type="u8" access="rw" required="m"></attribute>
-          <attribute id="0x0136" name="Unknown" type="u16" access="rw" required="m"></attribute>
-          <attribute id="0x0137" name="Unknown" type="u8" access="rw" required="m"></attribute>
-          <attribute id="0x0138" name="Unknown" type="u16" access="rw" required="m"></attribute>
-          <attribute id="0x0142" name="Presence" type="u8" access="r" required="m"></attribute>
-          <attribute id="0x0143" name="Presence Event" type="u8" access="r" required="m">
-            <description>Presence Event: 0 - enter, 1 - leave, 2 - enter left, 3 - right leave, 4 - enter right', 5 - left leave, 6 - approaching, 7 - absenting</description>
-          </attribute>
-          <attribute id="0x0144" name="Device Mode" type="u8" access="rw" required="m">
-            <description>Device mode: 0 - undirected, 1 - leftright</description>
-          </attribute>
-          <attribute id="0x0145" name="Unknown" type="bool" access="rw" required="m"></attribute>
-          <attribute id="0x0146" name="Trigger Distance" type="u8" access="rw" required="m">
-            <description>Trigger distance: 0 - far, 1 - medium, 2 - near</description>
-          </attribute>
-          <attribute id="0x0147" name="Unknown" type="u8" access="rw" required="m"></attribute>
-          <attribute id="0x0148" name="Unknown" type="u8" access="rw" required="m"></attribute>
-          <attribute id="0x0149" name="Unknown" type="u8" access="rw" required="m"></attribute>
-          <attribute id="0x0150" name="Set Detection Region" type="ostring" access="rw" required="m"></attribute>
-          <attribute id="0x0151" name="Report Detection Region" type="ostring" access="rw" required="m"></attribute>
-          <attribute id="0x0152" name="Unknown" type="u8" access="rw" required="m"></attribute>
-          <attribute id="0x0153" name="Set Exits and Entrances" type="u32" access="rw" required="m"></attribute>
-          <attribute id="0x0154" name="Set Interference Region" type="u32" access="rw" required="m"></attribute>
-          <attribute id="0x0155" name="Report Grid" type="u8" access="rw" required="m"></attribute>
-          <attribute id="0x0156" name="Set Edge" type="u32" access="rw" required="m"></attribute>
-          <attribute id="0x0157" name="Reset Presence" type="u8" access="w" required="m"></attribute>
-          <attribute id="0x0159" name="Unknown" type="u8" access="rw" required="m"></attribute>
-          <attribute id="0x015A" name="Unknown" type="u8" access="rw" required="m"></attribute>
-          <attribute id="0x015B" name="Detection Range" type="u32" access="rw" required="m">
-            <description>Detection Range in cm, from 0 to 600, in increments of 30.</description>
-          </attribute>
-          <attribute id="0x015C" name="Unknown" type="u8" access="rw" required="m"></attribute>
-          <attribute id="0x015D" name="Unknown" type="u8" access="rw" required="m"></attribute>
-          <attribute id="0x015E" name="Unknown" type="u8" access="rw" required="m"></attribute>
-          <attribute id="0x015F" name="Position" type="u32" access="r" required="m">
-            <description>Distance to detected person, in cm.</description>
-          </attribute>
-          <attribute id="0x0160" name="Occupancy" type="u8" access="r" required="m">
-            <description>4 = Occupancy; 2 = No occupancy.</description>
-          </attribute>
-          <attribute id="0x0200" name="Child lock off" type="u8" access="rw" required="m">
-            <description>Child lock off: 0 - false, 1 - true</description>
-          </attribute>
-          <attribute id="0x0201" name="Restore Power on Outage" type="bool" access="rw" required="m"></attribute>
-          <attribute id="0x0202" name="Auto-off after 20m below Threshold" type="bool" access="rw" required="m"></attribute>
-          <attribute id="0x0203" name="Device LED off (9pm-9am)" type="bool" access="rw" required="m"></attribute>
-          <attribute id="0x0204" name="Min. Power Change for Report (W)" type="float" access="rw" required="m"></attribute>
-          <attribute id="0x0205" name="Unknown" type="u8" access="rw" required="m">
-            <description>Attribute 0x0205 has range between 1 and 50 only</description>
-          </attribute>
-          <attribute id="0x0206" name="Power Threshold for Auto-off" type="float" access="rw" required="m"></attribute>
-          <attribute id="0x0207" name="Consumer Connected" type="bool" access="r" required="m"></attribute>
-          <attribute id="0x020B" name="Max. Load Exceeded at (W)" type="float" access="rw" required="m"></attribute>
-          <attribute id="0x020C" name="Unknown" type="u8" access="rw" required="m"></attribute>
-          <attribute id="0x020D" name="Unknown" type="u8" access="rw" required="m"></attribute>
-          <attribute id="0x020E" name="Unknown" type="u16" access="rw" required="m"></attribute>
-          <attribute id="0x023B" name="Unknown" type="float" access="rw" required="m"></attribute>
-          <attribute id="0x023E" name="Unknown" type="u32" access="rw" required="m"></attribute>
-          <attribute id="0x0270" name="Calibrate" type="u8" access="rw" required="m"> 
-              <description>Write 1 to calibrate</description>
-          </attribute>
-          <attribute id="0x0271" name="Mode" type="u8" access="rw" required="m"> 
-              <description>Heating state: 0 - off, 1 - on</description>
-          </attribute>
-          <attribute id="0x0272" name="Preset" type="u8" access="rw" required="m" default="0"> 
-              <description>Preset: 0 - manual, 1 - auto, 2 - away</description>
-          </attribute>
-          <attribute id="0x0273" name="Window detection" type="u8" access="rw" required="m">
-              <description>Window detection: 0 - off, 1 - on</description>
-          </attribute>
-          <attribute id="0x0274" name="Valve fault detection" type="u8" access="rw" required="m">
-              <description>Valve fault detection: 0 - off, 1 - on</description>
-          </attribute>
-          <attribute id="0x0275" name="Valve fault alarm" type="u8" access="r" required="m">
-              <description>Valve fault alarm: 0 - false, 1 - true</description>
-          </attribute>
-          <attribute id="0x0277" name="Child lock on" type="u8" access="rw" required="m">
-              <description>Child lock on: 0 - false, 1 - true</description>
-          </attribute>
-          <attribute id="0x0279" name="Away preset temperature" type="u32" access="rw" required="m"> </attribute>
-          <attribute id="0x027a" name="Window open" type="u8" access="r" required="m">
-              <description>Window open: 0 - false, 1 - true</description>
-          </attribute>
-          <attribute id="0x027b" name="Calibrated" type="u8" access="r" required="m">
-              <description>Calibrated: 0 - false, 1 - true</description>
-          </attribute>
-          <attribute id="0x027e" name="External sensor" type="u8" access="r" required="m">
-              <description>Temperature sensor: 0 - internal, 1 - external</description>
-          </attribute>
-          <attribute id="0x0402" name="Positions Stored" type="bool" access="rw" required="o">
-            <description>Position clearing: write false to clear the stored up/open and down/close positions.</description>
-          </attribute>
-          <attribute id="0x040a" name="Battery" type="u8" access="r" required="m"> </attribute>
-          <attribute id="0xFFF2" name="External temperature" type="ostring" access="r" required="m">
-            <description>Could used to write external temperature values to TRV</description>
-          </attribute>
-          <attribute id="0xFFFD" name="Cluster Revision" type="u16" access="rw" required="m"> </attribute>
-        </attribute-set>
-      </server>
-      <client>
-      </client>
-    </cluster>
-    <!-- SINOPE -->
-    <cluster id="0xff01" name="Sinope specific" mfcode="0x119c">
-      <description>Sinope specific cluster attributes</description>
-      <server>
-	<attribute id="0x0002" name="Keypad lock" type="u8" mfcode="0x119c" access="rw" required="m"> 
-	  <value name="Unlocked" value="0x00"></value>
-          <value name="Locked" value="0x01"></value>
-	</attribute>
-	<attribute id="0x0010" name="Outdoor Temp on Display" type="s16" mfcode="0x119c" access="rw" required="m"> <description>Celcius * 100</description> </attribute>
-	<attribute id="0x0011" name="Outdoor Temp on Display Timeout" type="u16" mfcode="0x119c" access="rw" required="m"> 
-		<description>Delay in seconds before reverting to setpoint display if no more outdoor temp is received</description>
-	</attribute>
-	<attribute id="0x0012" name="Config 2nd Display " type="enum8" mfcode="0x119c" access="rw" required="m"> 
-			<value name="Auto" value="0x00"></value>
-			<value name="Setpoint" value="0x01"></value>
-		        <value name="Outside Temp" value="0x02"></value>
-	</attribute>
-	<attribute id="0x0020" name="Current Time on Display" type="u32" mfcode="0x119c" access="rw" required="m"> 
-		 <description>Seconds since year 2000</description>
-	</attribute>
-	<attribute id="0x0050" name="On Led Color" type="u24" mfcode="0x119c" access="rw" required="m"> 
-	  <value name="Lim" value="0x0affdc"></value>
-          <value name="Amber" value="0x000a4b"></value>
-	  <value name="Fushia" value="0x64ffff"></value>
-	  <value name="Perle" value="0x000a4b"></value>
-	  <value name="Blue" value="0xffff00"></value>
-	</attribute>
-	<attribute id="0x0051" name="Off Led Color" type="u24" mfcode="0x119c" access="rw" required="m"> 
-	  <value name="Lim" value="0x0affdc"></value>
-          <value name="Amber" value="0x000a4b"></value>
-	  <value name="Fushia" value="0x64ffff"></value>
-	  <value name="Perle" value="0x000a4b"></value>
-	  <value name="Blue" value="0xffff00"></value>
-	</attribute>
-	<attribute id="0x0052" name="On Led Intensity" type="u8" mfcode="0x119c" range="0,100" access="rw" required="m"> </attribute>
-	<attribute id="0x0053" name="Off Led Intensity" type="u8" mfcode="0x119c" range="0,100" access="rw" required="m"> </attribute>
-	<attribute id="0x0054" name="Unknown" type="u8" mfcode="0x119c" access="rw" required="m"> </attribute>
-	<attribute id="0x0055" name="Min Intensity" type="u16" mfcode="0x119c" range="0,3000" access="rw" required="m"> </attribute>
-	<attribute id="0x0060" name="Connected Load" type="u16" mfcode="0x119c" access="r" required="m">
-		<description>Watt/hr</description>
-	</attribute>
-	<attribute id="0x0070" name="Current Load" type="bmp8" mfcode="0x119c" access="r" required="m"> 
-		 <description>Watt/hr</description>
-	</attribute>
-	<attribute id="0x0071" name="Eco Mode" type="s8" mfcode="0x119c" range="-100,100" default="-128" access="rw" required="m"> 
-		 <description>Eco mode in percent</description>
-	</attribute>
-	<attribute id="0x0072" name="Eco Mode 1" type="u8" mfcode="0x119c" range="0,99" default="255" access="rw" required="m"> </attribute>
-	<attribute id="0x0073" name="Eco Mode 2" type="u8" mfcode="0x119c" range="0,100" default="255" access="rw" required="m"> </attribute>
-        <attribute id="0x0076" name="drConfigWaterTempMin" type="u8" mfcode="0x119c" access="rw" required="m"> <description>45 or 0</description></attribute>
-        <attribute id="0x0077" name="drConfigWaterTempTime" type="u8" mfcode="0x119c" access="rw" required="m"> </attribute>
-	<attribute id="0x0078" name="drWTTimeOn" type="u16" mfcode="0x119c" access="r" required="m"> </attribute>
-	<attribute id="0x00A0" name="Timer" type="u16" mfcode="0x119c" access="rw" required="m"> <description>Number of seconds</description> </attribute>
-        <attribute id="0x0105" name="Floor Control Mode" type="enum8" mfcode="0x119c" access="rw" required="m">
-          <value name="Ambient" value="0x01"></value>
-          <value name="Floor" value="0x02"></value>
+  <!-- LUMI -->
+  <cluster id="0xfcc0" name="Lumi specific" mfcode="0x115f">
+    <description>Lumi specific attributes.</description>
+    <server>
+      <attribute-set id="0x0000" description="Unknown">
+        <attribute id="0x0001" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0002" name="Power Outages" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0003" name="Unknown" type="enum8" mfcode="0x115f" access="r" required="m">
+          <value name="0" value="0x00"></value>
+          <value name="1" value="0x01"></value>
+          <value name="2" value="0x02"></value>
+          <value name="3" value="0x03"></value>
+          <value name="4" value="0x04"></value>
         </attribute>
-	<attribute id="0x0106" name="Aux Output Mode" type="enum8" mfcode="0x119c" access="rw" required="m">
-			<value name="Off" value="0x00"></value>
-			<value name="Expansion module" value="0x01"></value>
-	</attribute>
-	<attribute id="0x0108" name="Ambient Max Heat Setpoint Limit" type="s16" mfcode="0x119c" access="rw" required="m"> 
-			<description>temp: celcius*100, valid only if floor control mode is selected</description>
-	</attribute>
-        <attribute id="0x0109" name="Floor Min Heat Setpoint Limit" type="s16" mfcode="0x119c" access="rw" required="m"></attribute>
-        <attribute id="0x010A" name="Floor Max Heat Setpoint Limit" type="s16" mfcode="0x119c" access="rw" required="m"></attribute>
-        <attribute id="0x010B" name="Temperature Sensor" type="enum8" mfcode="0x119c" access="rw" required="m">
-          <value name="10k" value="0x00"></value>
-          <value name="12k" value="0x01"></value>
+        <attribute id="0x0006" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0007" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0008" name="Unknown (write only)" type="ostring" mfcode="0x115f" access="w" required="m"></attribute>
+        <attribute id="0x0009" name="Device operation mode" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x000A" name="Switch mode" type="u8" mfcode="0x115f" access="rw" required="m">
+          <description>Switch mode: 1 - event based switching, 2 - zigbee group switching, 3 - Xiaomi specific switching</description>
         </attribute>
-        <attribute id="0x010C" name="Floor Limit Status" type="enum8" mfcode="0x119c" access="r" required="m">
-          <value name="Off" value="0x00"></value>
-	  <value name="floorLimitLowReached" value="0x01"></value>
-	  <value name="floorLimitMaxReached" value="0x02"></value>
-	  <value name="floorAirLimitMaxReached" value="0x03"></value>
+        <attribute id="0x000C" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x000D" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x00E8" name="Restart Device" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x00E9" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x00EA" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x00EB" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x00ED" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x00EE" name="Firmware" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x00F0" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x00F1" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x00F3" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x00F4" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x00F5" name="Unknown" type="u32" mfcode="0x115f" access="r" required="m"></attribute>
+        <attribute id="0x00F6" name="Reporting Interval" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x00F7" name="Unknown" type="ostring" mfcode="0x115f" access="r" required="m"></attribute>
+        <attribute id="0x00F8" name="Unknown" type="u64" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x00F9" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x00FA" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x00FB" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x00FC" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x00FE" name="Serial Number" type="cstring" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x00FF" name="Unknown (write only)" type="ostring" mfcode="0x115f" access="w" required="m"></attribute>
+        <attribute id="0x0100" name="Unknown" type="u8" mfcode="0x115f" access="r" required="m"></attribute>
+        <attribute id="0x0102" name="Motion cool off time" type="u8" mfcode="0x115f" access="rw" required="m">
+          <description>Time in seconds when RTCGQ13LM sets motion to false if no further motion has been detected</description>
         </attribute>
-        <attribute id="0x0114" name="Time Format on Display" type="enum8" mfcode="0x119c" access="rw" required="m">
-          <value name="24h" value="0x00"></value>
-          <value name="12h" value="0x01"></value>
+        <attribute id="0x010C" name="Detection sensitivity" type="u8" mfcode="0x115f" access="rw" required="m">
+          <description>Motion sensitivity: 1 - low, 2 - medium, 3 - high</description>
         </attribute>
-        <attribute id="0x0115" name="GFCi Status" type="enum8" mfcode="0x119c" access="r" required="m">
-          <value name="Ok" value="0x00"></value>
-          <value name="Error" value="0x01"></value>
+        <attribute id="0x0112" name="Unknown" type="u32" mfcode="0x115f" access="r" required="m"></attribute>
+        <attribute id="0x0114" name="TVOC unit config" type="u8" mfcode="0x115f" access="rw" required="m">
+          <description>0 - µg/m³ + °C, 1 - ppb + °C, 16 - µg/m³ + °F, 17 - ppb + °F</description>
         </attribute>
-	<attribute id="0x0118" name="Aux Connected Load" type="u16" mfcode="0x119c" default="0xffff" access="r" required="m">
-		<description>watt/hr, 0xffff=off</description>
-	</attribute>
-	<attribute id="0x0119" name="Connected Load" type="u16" mfcode="0x119c" access="r" required="m">
-		<description>Watt</description>
-	</attribute>
-	<attribute id="0x0128" name="Pump protection" type="enum8" mfcode="0x119c" access="rw" required="m">
-					<value name="Off" value="0xff"></value>
-					<value name="On" value="0x01"></value>
-	</attribute>	
-	<attribute id="0x012D" name="Report Local Temperature" type="s16" mfcode="0x119c" access="r" required="m">
-		<description>Celcius * 100</description>
-	</attribute>
-	<attribute id="0x0283" name="ColdLoadPickupStatus" type="u8" mfcode="0x119c" access="r" required="m"> </attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+        <attribute id="0x0125" name="Multiclick mode" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0126" name="Buzer manual mute" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0127" name="Self test" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0129" name="Air Quality" type="u8" mfcode="0x115f" access = "r" required="o">
+          <description>Air Quality: 1 - excellent, 2 - good, 3 - moderate, 4 - poor, 5 unhealthy</description>
+        </attribute>
+        <attribute id="0x0135" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0136" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0137" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0138" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x013A" name="Smoke" type="bool" mfcode="0x115f" access="r" required="m"></attribute>
+        <attribute id="0x013B" name="Smoke density" type="u8" mfcode="0x115f" access="r" required="m"></attribute>
+        <attribute id="0x013C" name="HeartBeat indicator" type="u8" mfcode="0x115f" access="r" required="m"></attribute>
+        <attribute id="0x013D" name="Buzer manual alarm 1" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x013E" name="Buzer manual alarm 2" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0142" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x014B" name="linkage alarm" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x014C" name="linkage alarm state" type="bool" mfcode="0x115f" access="r" required="m"></attribute>
+        <attribute id="0x014D" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x014F" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0152" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0157" name="Spatial Learning" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x015B" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0160" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0162" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0163" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0164" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0165" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x016A" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x016B" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x016C" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0170" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0192" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0193" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0194" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0195" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0196" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0197" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0198" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0199" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x019A" name="Unknown" type="ostring" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0200" name="Child lock off" type="u8" mfcode="0x115f" access="rw" required="m">
+          <description>Child lock off: 0 - false, 1 - true</description>
+        </attribute>
+        <attribute id="0x0201" name="Restore Power on Outage" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0202" name="Auto-off after 20m below Threshold" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0203" name="Device LED off (9pm-9am)" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0204" name="Min. Power Change for Report (W)" type="float" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0205" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m">
+          <description>Attribute 0x0205 has range between 1 and 50 only</description>
+        </attribute>
+        <attribute id="0x0206" name="Power Threshold for Auto-off" type="float" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0207" name="Consumer Connected" type="bool" mfcode="0x115f" access="r" required="m"></attribute>
+        <attribute id="0x020B" name="Max. Load Exceeded at (W)" type="float" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x020C" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x020D" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x020E" name="Unknown" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x023B" name="Unknown" type="float" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x023E" name="LED off-time" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x02d0" name="Interlock" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
+      </attribute-set>
+      <attribute-set id="0x0270" description="Smart Radiator Thermostat E1">
+        <attribute id="0x0270" name="Calibrate" type="u8" mfcode="0x115f" access="rw" required="m">
+          <description>Write 1 to calibrate</description>
+        </attribute>
+        <attribute id="0x0271" name="Mode" type="u8" mfcode="0x115f" access="rw" required="m">
+          <description>Heating state: 0 - off, 1 - on</description>
+        </attribute>
+        <attribute id="0x0272" name="Preset" type="u8" mfcode="0x115f" access="rw" required="m" default="0">
+          <description>Preset: 0 - manual, 1 - auto, 2 - away</description>
+        </attribute>
+        <attribute id="0x0273" name="Window detection" type="u8" mfcode="0x115f" access="rw" required="m">
+          <description>Window detection: 0 - off, 1 - on</description>
+        </attribute>
+        <attribute id="0x0274" name="Valve fault detection" type="u8" mfcode="0x115f" access="rw" required="m">
+          <description>Valve fault detection: 0 - off, 1 - on</description>
+        </attribute>
+        <attribute id="0x0275" name="Valve fault alarm" type="u8" mfcode="0x115f" access="r" required="m">
+          <description>Valve fault alarm: 0 - false, 1 - true</description>
+        </attribute>
+        <attribute id="0x0277" name="Child lock on" type="u8" mfcode="0x115f" access="rw" required="m">
+          <description>Child lock on: 0 - false, 1 - true</description>
+        </attribute>
+        <attribute id="0x0279" name="Away preset temperature" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x027a" name="Window open" type="u8" mfcode="0x115f" access="r" required="m">
+          <description>Window open: 0 - false, 1 - true</description>
+        </attribute>
+        <attribute id="0x027b" name="Calibrated" type="u8" mfcode="0x115f" access="r" required="m">
+          <description>Calibrated: 0 - false, 1 - true</description>
+        </attribute>
+        <attribute id="0x027e" name="External sensor" type="u8" mfcode="0x115f" access="r" required="m">
+          <description>Temperature sensor: 0 - internal, 1 - external</description>
+        </attribute>
+      </attribute-set>
+      <attribute-set id="0x0400" description="Aqara Roller Shade Driver E1">
+        <attribute id="0x0400" name="Reverse Direction" type="bool" mfcode="0x115f" access="rw" required="o">
+          <description>Reverse the direction of up/open and down/close.</description>
+        </attribute>
+        <attribute id="0x0402" name="Positions Stored" type="bool" mfcode="0x115f" access="rw" required="o">
+          <description>Position clearing: write false to clear the stored up/open and down/close positions.</description>
+        </attribute>
+        <attribute id="0x0407" name="Store Position" type="u8" mfcode="0x115f" access="rw" required="o">
+          <description>Position setting: write 1 to store the up/open position, 2 to store the down/close position.</description>
+        </attribute>
+        <attribute id="0x0408" name="Speed" type="u8" mfcode="0x115f" access="rw" required="o">
+          <description>Motor speed: 2: high, 1: medium, 0: low.</description>
+        </attribute>
+        <attribute id="0x0409" name="Charging" type="u8" mfcode="0x115f" access="r" required="o">
+          <description>Battery charging state: 1: charging, 2: not charging.</description>
+        </attribute>
+        <attribute id="0x040a" name="Battery" type="u8" mfcode="0x115f" access="r" required="m">
+        </attribute>
+      </attribute-set>
+      <attribute-set id="0x0500" description="Aqara LED Strip T1">
+        <attribute id="0x0515" name="Min Dim Level (%)" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0516" name="Max Dim Level (%)" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0517" name="PowerOn OnOff" type="u8" mfcode="0x115f" access="rw" required="m">
+          <description>OnOff state on power on: 0: on, 1: previous, 2: off.</description>
+        </attribute>
+        <attribute id="0x051B" name="Segments" type="u8" mfcode="0x115f" access="rw" required="m">
+          <description>Number of 20cm segments.</description>
+        </attribute>
+        <attribute id="0x051C" name="Music Sync" type="u8" mfcode="0x115f" access="rw" required="m">
+          <description>Music Sync: 0: off, 1: on.</description>
+        </attribute>
+        <attribute id="0x051D" name="Music Sync Effect" type="u8" mfcode="0x115f" access="rw" required="m">
+          <description>Music Sync Effecy: 0: random, 1: breathing, 2: rainbow, 3: chasing.</description>
+        </attribute>
+        <attribute id="0x051E" name="Music Sync Sensitivity" type="u8" mfcode="0x115f" access="rw" required="m">
+          <description>Music Sync Sensitivity: 0: low, 2: high.</description>
+        </attribute>
+      </attribute-set>
+      <attribute-set id="0x0700" description="Unknown">
+        <attribute id="0x0700" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0701" name="Unknown" type="s8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0702" name="Unknown" type="s8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0703" name="Unknown" type="s8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0704" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0705" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0740" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0780" name="Unknown" type="bool" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0781" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0782" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x0783" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0x07C0" name="Unknown" type="u8" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0xF000" name="Report Consumer Connected" type="u8" mfcode="0x115f" access="rw" required="m">
+          <description>Report Consumer Connected: 1 - false, 0 - true</description>
+        </attribute>
+        <attribute id="0xF001" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0xF002" name="Unknown" type="u32" mfcode="0x115f" access="rw" required="m"></attribute>
+        <attribute id="0xFFF2" name="External temperature" type="ostring" mfcode="0x115f" access="r" required="m">
+          <description>Could used to write external temperature values to TRV</description>
+        </attribute>
+        <attribute id="0xFFFD" name="Cluster Revision" type="u16" mfcode="0x115f" access="rw" required="m"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+  <!-- AQARA -->
+  <cluster id="0xfcc0" name="Aqara specific" mfcode="0x1234">
+    <description>Aqara specific attributes.</description>
+    <server>
+      <attribute-set id="0x0000" description="Unknown">
+        <attribute id="0x0001" name="Unknown" type="u16" access="rw" required="m"></attribute>
+        <attribute id="0x0002" name="Power Outages" type="u16" access="rw" required="m"></attribute>
+        <attribute id="0x0003" name="Unknown" type="enum8" access="r" required="m">
+          <value name="0" value="0x00"></value>
+          <value name="1" value="0x01"></value>
+          <value name="2" value="0x02"></value>
+          <value name="3" value="0x03"></value>
+          <value name="4" value="0x04"></value>
+        </attribute>
+        <attribute id="0x0006" name="Unknown" type="ostring" access="rw" required="m"></attribute>
+        <attribute id="0x0007" name="Unknown" type="ostring" access="rw" required="m"></attribute>
+        <attribute id="0x0008" name="Unknown (write only)" type="ostring" access="w" required="m"></attribute>
+        <attribute id="0x0009" name="Device operation mode" type="u8" access="rw" required="m"></attribute>
+        <attribute id="0x000A" name="Switch mode" type="u8" access="rw" required="m">
+          <description>Switch mode: 1 - event based switching, 2 - zigbee group switching, 3 - Xiaomi specific switching</description>
+        </attribute>
+        <attribute id="0x000C" name="Unknown" type="ostring" access="rw" required="m"></attribute>
+        <attribute id="0x000D" name="Unknown" type="u8" access="rw" required="m"></attribute>
+        <attribute id="0x00E4" name="Unknown" type="u32" access="rw" required="m"></attribute>
+        <attribute id="0x00E8" name="Device Running" type="bool" access="rw" required="m">
+          <description>Set to false to reboot the device.</description>
+        </attribute>
+        <attribute id="0x00E9" name="Unknown" type="u8" access="rw" required="m"></attribute>
+        <attribute id="0x00EA" name="Unknown" type="ostring" access="rw" required="m"></attribute>
+        <attribute id="0x00EB" name="Unknown" type="u16" access="rw" required="m"></attribute>
+        <attribute id="0x00ED" name="Unknown" type="u32" access="rw" required="m"></attribute>
+        <attribute id="0x00EE" name="Unknown" type="u32" access="rw" required="m"></attribute>
+        <attribute id="0x00F0" name="Unknown" type="u8" access="rw" required="m"></attribute>
+        <attribute id="0x00F1" name="Unknown" type="u8" access="rw" required="m"></attribute>
+        <attribute id="0x00F3" name="Unknown" type="u8" access="rw" required="m"></attribute>
+        <attribute id="0x00F4" name="Unknown" type="u8" access="rw" required="m"></attribute>
+        <attribute id="0x00F5" name="Unknown" type="u32" access="r" required="m"></attribute>
+        <attribute id="0x00F6" name="Reporting Interval" type="u16" access="rw" required="m"></attribute>
+        <attribute id="0x00F7" name="Unknown" type="ostring" access="r" required="m"></attribute>
+        <attribute id="0x00F8" name="Unknown" type="u64" access="rw" required="m"></attribute>
+        <attribute id="0x00F9" name="Unknown" type="u16" access="rw" required="m"></attribute>
+        <attribute id="0x00FA" name="Unknown" type="bool" access="rw" required="m"></attribute>
+        <attribute id="0x00FB" name="Unknown" type="u8" access="rw" required="m"></attribute>
+        <attribute id="0x00FC" name="Unknown" type="bool" access="rw" required="m"></attribute>
+        <attribute id="0x00FE" name="Serial Number" type="cstring" access="rw" required="m"></attribute>
+        <attribute id="0x00FF" name="Unknown (write only)" type="ostring" access="w" required="m"></attribute>
+        <attribute id="0x0100" name="Unknown" type="u8" access="r" required="m"></attribute>
+        <attribute id="0x0102" name="Motion cool off time" type="u8" access="rw" required="m">
+          <description>Time in seconds when RTCGQ13LM sets motion to false if no further motion has been detected</description>
+        </attribute>
+        <attribute id="0x010C" name="Motion Sensitivity" type="u8" access="rw" required="m">
+          <description>Motion sensitivity: 1 - low, 2 - medium, 3 - high</description>
+        </attribute>
+        <attribute id="0x0112" name="Unknown" type="u32" access="r" required="m"></attribute>
+        <attribute id="0x0114" name="TVOC unit config" type="u8" access="rw" required="m">
+          <description>0 - µg/m³ + °C, 1 - ppb + °C, 16 - µg/m³ + °F, 17 - ppb + °F</description>
+        </attribute>
+        <attribute id="0x0125" name="Multiclick mode" type="u8" access="rw" required="m"></attribute>
+        <attribute id="0x0133" name="Unknown" type="u8" access="rw" required="m"></attribute>
+        <attribute id="0x0134" name="Unknown" type="ostring" access="rw" required="m"></attribute>
+        <attribute id="0x0135" name="Unknown" type="u8" access="rw" required="m"></attribute>
+        <attribute id="0x0136" name="Unknown" type="u16" access="rw" required="m"></attribute>
+        <attribute id="0x0137" name="Unknown" type="u8" access="rw" required="m"></attribute>
+        <attribute id="0x0138" name="Unknown" type="u16" access="rw" required="m"></attribute>
+        <attribute id="0x0142" name="Presence" type="u8" access="r" required="m"></attribute>
+        <attribute id="0x0143" name="Presence Event" type="u8" access="r" required="m">
+          <description>Presence Event: 0 - enter, 1 - leave, 2 - enter left, 3 - right leave, 4 - enter right', 5 - left leave, 6 - approaching, 7 - absenting</description>
+        </attribute>
+        <attribute id="0x0144" name="Device Mode" type="u8" access="rw" required="m">
+          <description>Device mode: 0 - undirected, 1 - leftright</description>
+        </attribute>
+        <attribute id="0x0145" name="Unknown" type="bool" access="rw" required="m"></attribute>
+        <attribute id="0x0146" name="Trigger Distance" type="u8" access="rw" required="m">
+          <description>Trigger distance: 0 - far, 1 - medium, 2 - near</description>
+        </attribute>
+        <attribute id="0x0147" name="Unknown" type="u8" access="rw" required="m"></attribute>
+        <attribute id="0x0148" name="Unknown" type="u8" access="rw" required="m"></attribute>
+        <attribute id="0x0149" name="Unknown" type="u8" access="rw" required="m"></attribute>
+        <attribute id="0x0150" name="Set Detection Region" type="ostring" access="rw" required="m"></attribute>
+        <attribute id="0x0151" name="Report Detection Region" type="ostring" access="rw" required="m"></attribute>
+        <attribute id="0x0152" name="Unknown" type="u8" access="rw" required="m"></attribute>
+        <attribute id="0x0153" name="Set Exits and Entrances" type="u32" access="rw" required="m"></attribute>
+        <attribute id="0x0154" name="Set Interference Region" type="u32" access="rw" required="m"></attribute>
+        <attribute id="0x0155" name="Report Grid" type="u8" access="rw" required="m"></attribute>
+        <attribute id="0x0156" name="Set Edge" type="u32" access="rw" required="m"></attribute>
+        <attribute id="0x0157" name="Reset Presence" type="u8" access="w" required="m"></attribute>
+        <attribute id="0x0159" name="Unknown" type="u8" access="rw" required="m"></attribute>
+        <attribute id="0x015A" name="Unknown" type="u8" access="rw" required="m"></attribute>
+        <attribute id="0x015B" name="Detection Range" type="u32" access="rw" required="m">
+          <description>Detection Range in cm, from 0 to 600, in increments of 30.</description>
+        </attribute>
+        <attribute id="0x015C" name="Unknown" type="u8" access="rw" required="m"></attribute>
+        <attribute id="0x015D" name="Unknown" type="u8" access="rw" required="m"></attribute>
+        <attribute id="0x015E" name="Unknown" type="u8" access="rw" required="m"></attribute>
+        <attribute id="0x015F" name="Position" type="u32" access="r" required="m">
+          <description>Distance to detected person, in cm.</description>
+        </attribute>
+        <attribute id="0x0160" name="Occupancy" type="u8" access="r" required="m">
+          <description>4 = Occupancy; 2 = No occupancy.</description>
+        </attribute>
+        <attribute id="0x0200" name="Child lock off" type="u8" access="rw" required="m">
+          <description>Child lock off: 0 - false, 1 - true</description>
+        </attribute>
+        <attribute id="0x0201" name="Restore Power on Outage" type="bool" access="rw" required="m"></attribute>
+        <attribute id="0x0202" name="Auto-off after 20m below Threshold" type="bool" access="rw" required="m"></attribute>
+        <attribute id="0x0203" name="Device LED off (9pm-9am)" type="bool" access="rw" required="m"></attribute>
+        <attribute id="0x0204" name="Min. Power Change for Report (W)" type="float" access="rw" required="m"></attribute>
+        <attribute id="0x0205" name="Unknown" type="u8" access="rw" required="m">
+          <description>Attribute 0x0205 has range between 1 and 50 only</description>
+        </attribute>
+        <attribute id="0x0206" name="Power Threshold for Auto-off" type="float" access="rw" required="m"></attribute>
+        <attribute id="0x0207" name="Consumer Connected" type="bool" access="r" required="m"></attribute>
+        <attribute id="0x020B" name="Max. Load Exceeded at (W)" type="float" access="rw" required="m"></attribute>
+        <attribute id="0x020C" name="Unknown" type="u8" access="rw" required="m"></attribute>
+        <attribute id="0x020D" name="Unknown" type="u8" access="rw" required="m"></attribute>
+        <attribute id="0x020E" name="Unknown" type="u16" access="rw" required="m"></attribute>
+        <attribute id="0x023B" name="Unknown" type="float" access="rw" required="m"></attribute>
+        <attribute id="0x023E" name="Unknown" type="u32" access="rw" required="m"></attribute>
+        <attribute id="0x0270" name="Calibrate" type="u8" access="rw" required="m">
+          <description>Write 1 to calibrate</description>
+        </attribute>
+        <attribute id="0x0271" name="Mode" type="u8" access="rw" required="m">
+          <description>Heating state: 0 - off, 1 - on</description>
+        </attribute>
+        <attribute id="0x0272" name="Preset" type="u8" access="rw" required="m" default="0">
+          <description>Preset: 0 - manual, 1 - auto, 2 - away</description>
+        </attribute>
+        <attribute id="0x0273" name="Window detection" type="u8" access="rw" required="m">
+          <description>Window detection: 0 - off, 1 - on</description>
+        </attribute>
+        <attribute id="0x0274" name="Valve fault detection" type="u8" access="rw" required="m">
+          <description>Valve fault detection: 0 - off, 1 - on</description>
+        </attribute>
+        <attribute id="0x0275" name="Valve fault alarm" type="u8" access="r" required="m">
+          <description>Valve fault alarm: 0 - false, 1 - true</description>
+        </attribute>
+        <attribute id="0x0277" name="Child lock on" type="u8" access="rw" required="m">
+          <description>Child lock on: 0 - false, 1 - true</description>
+        </attribute>
+        <attribute id="0x0279" name="Away preset temperature" type="u32" access="rw" required="m"></attribute>
+        <attribute id="0x027a" name="Window open" type="u8" access="r" required="m">
+          <description>Window open: 0 - false, 1 - true</description>
+        </attribute>
+        <attribute id="0x027b" name="Calibrated" type="u8" access="r" required="m">
+          <description>Calibrated: 0 - false, 1 - true</description>
+        </attribute>
+        <attribute id="0x027e" name="External sensor" type="u8" access="r" required="m">
+          <description>Temperature sensor: 0 - internal, 1 - external</description>
+        </attribute>
+        <attribute id="0x0402" name="Positions Stored" type="bool" access="rw" required="o">
+          <description>Position clearing: write false to clear the stored up/open and down/close positions.</description>
+        </attribute>
+        <attribute id="0x040a" name="Battery" type="u8" access="r" required="m"></attribute>
+        <attribute id="0xFFF2" name="External temperature" type="ostring" access="r" required="m">
+          <description>Could used to write external temperature values to TRV</description>
+        </attribute>
+        <attribute id="0xFFFD" name="Cluster Revision" type="u16" access="rw" required="m"></attribute>
+      </attribute-set>
+    </server>
+    <client>
+    </client>
+  </cluster>
+  <!-- SINOPE -->
+  <cluster id="0xff01" name="Sinope specific" mfcode="0x119c">
+    <description>Sinope specific cluster attributes</description>
+    <server>
+      <attribute id="0x0002" name="Keypad lock" type="u8" mfcode="0x119c" access="rw" required="m">
+        <value name="Unlocked" value="0x00"></value>
+        <value name="Locked" value="0x01"></value>
+      </attribute>
+      <attribute id="0x0010" name="Outdoor Temp on Display" type="s16" mfcode="0x119c" access="rw" required="m">
+        <description>Celcius * 100</description>
+      </attribute>
+      <attribute id="0x0011" name="Outdoor Temp on Display Timeout" type="u16" mfcode="0x119c" access="rw" required="m">
+        <description>Delay in seconds before reverting to setpoint display if no more outdoor temp is received</description>
+      </attribute>
+      <attribute id="0x0012" name="Config 2nd Display " type="enum8" mfcode="0x119c" access="rw" required="m">
+        <value name="Auto" value="0x00"></value>
+        <value name="Setpoint" value="0x01"></value>
+        <value name="Outside Temp" value="0x02"></value>
+      </attribute>
+      <attribute id="0x0020" name="Current Time on Display" type="u32" mfcode="0x119c" access="rw" required="m">
+        <description>Seconds since year 2000</description>
+      </attribute>
+      <attribute id="0x0050" name="On Led Color" type="u24" mfcode="0x119c" access="rw" required="m">
+        <value name="Lim" value="0x0affdc"></value>
+        <value name="Amber" value="0x000a4b"></value>
+        <value name="Fushia" value="0x64ffff"></value>
+        <value name="Perle" value="0x000a4b"></value>
+        <value name="Blue" value="0xffff00"></value>
+      </attribute>
+      <attribute id="0x0051" name="Off Led Color" type="u24" mfcode="0x119c" access="rw" required="m">
+        <value name="Lim" value="0x0affdc"></value>
+        <value name="Amber" value="0x000a4b"></value>
+        <value name="Fushia" value="0x64ffff"></value>
+        <value name="Perle" value="0x000a4b"></value>
+        <value name="Blue" value="0xffff00"></value>
+      </attribute>
+      <attribute id="0x0052" name="On Led Intensity" type="u8" mfcode="0x119c" range="0,100" access="rw" required="m"></attribute>
+      <attribute id="0x0053" name="Off Led Intensity" type="u8" mfcode="0x119c" range="0,100" access="rw" required="m"></attribute>
+      <attribute id="0x0054" name="Unknown" type="u8" mfcode="0x119c" access="rw" required="m"></attribute>
+      <attribute id="0x0055" name="Min Intensity" type="u16" mfcode="0x119c" range="0,3000" access="rw" required="m"></attribute>
+      <attribute id="0x0060" name="Connected Load" type="u16" mfcode="0x119c" access="r" required="m">
+        <description>Watt/hr</description>
+      </attribute>
+      <attribute id="0x0070" name="Current Load" type="bmp8" mfcode="0x119c" access="r" required="m">
+        <description>Watt/hr</description>
+      </attribute>
+      <attribute id="0x0071" name="Eco Mode" type="s8" mfcode="0x119c" range="-100,100" default="-128" access="rw" required="m">
+        <description>Eco mode in percent</description>
+      </attribute>
+      <attribute id="0x0072" name="Eco Mode 1" type="u8" mfcode="0x119c" range="0,99" default="255" access="rw" required="m"></attribute>
+      <attribute id="0x0073" name="Eco Mode 2" type="u8" mfcode="0x119c" range="0,100" default="255" access="rw" required="m"></attribute>
+      <attribute id="0x0076" name="drConfigWaterTempMin" type="u8" mfcode="0x119c" access="rw" required="m">
+        <description>45 or 0</description>
+      </attribute>
+      <attribute id="0x0077" name="drConfigWaterTempTime" type="u8" mfcode="0x119c" access="rw" required="m"></attribute>
+      <attribute id="0x0078" name="drWTTimeOn" type="u16" mfcode="0x119c" access="r" required="m"></attribute>
+      <attribute id="0x00A0" name="Timer" type="u16" mfcode="0x119c" access="rw" required="m">
+        <description>Number of seconds</description>
+      </attribute>
+      <attribute id="0x0105" name="Floor Control Mode" type="enum8" mfcode="0x119c" access="rw" required="m">
+        <value name="Ambient" value="0x01"></value>
+        <value name="Floor" value="0x02"></value>
+      </attribute>
+      <attribute id="0x0106" name="Aux Output Mode" type="enum8" mfcode="0x119c" access="rw" required="m">
+        <value name="Off" value="0x00"></value>
+        <value name="Expansion module" value="0x01"></value>
+      </attribute>
+      <attribute id="0x0108" name="Ambient Max Heat Setpoint Limit" type="s16" mfcode="0x119c" access="rw" required="m">
+        <description>temp: celcius*100, valid only if floor control mode is selected</description>
+      </attribute>
+      <attribute id="0x0109" name="Floor Min Heat Setpoint Limit" type="s16" mfcode="0x119c" access="rw" required="m"></attribute>
+      <attribute id="0x010A" name="Floor Max Heat Setpoint Limit" type="s16" mfcode="0x119c" access="rw" required="m"></attribute>
+      <attribute id="0x010B" name="Temperature Sensor" type="enum8" mfcode="0x119c" access="rw" required="m">
+        <value name="10k" value="0x00"></value>
+        <value name="12k" value="0x01"></value>
+      </attribute>
+      <attribute id="0x010C" name="Floor Limit Status" type="enum8" mfcode="0x119c" access="r" required="m">
+        <value name="Off" value="0x00"></value>
+        <value name="floorLimitLowReached" value="0x01"></value>
+        <value name="floorLimitMaxReached" value="0x02"></value>
+        <value name="floorAirLimitMaxReached" value="0x03"></value>
+      </attribute>
+      <attribute id="0x0114" name="Time Format on Display" type="enum8" mfcode="0x119c" access="rw" required="m">
+        <value name="24h" value="0x00"></value>
+        <value name="12h" value="0x01"></value>
+      </attribute>
+      <attribute id="0x0115" name="GFCi Status" type="enum8" mfcode="0x119c" access="r" required="m">
+        <value name="Ok" value="0x00"></value>
+        <value name="Error" value="0x01"></value>
+      </attribute>
+      <attribute id="0x0118" name="Aux Connected Load" type="u16" mfcode="0x119c" default="0xffff" access="r" required="m">
+        <description>watt/hr, 0xffff=off</description>
+      </attribute>
+      <attribute id="0x0119" name="Connected Load" type="u16" mfcode="0x119c" access="r" required="m">
+        <description>Watt</description>
+      </attribute>
+      <attribute id="0x0128" name="Pump protection" type="enum8" mfcode="0x119c" access="rw" required="m">
+        <value name="Off" value="0xff"></value>
+        <value name="On" value="0x01"></value>
+      </attribute>
+      <attribute id="0x012D" name="Report Local Temperature" type="s16" mfcode="0x119c" access="r" required="m">
+        <description>Celcius * 100</description>
+      </attribute>
+      <attribute id="0x0283" name="ColdLoadPickupStatus" type="u8" mfcode="0x119c" access="r" required="m"></attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <!-- INNR -->
-    <cluster id="0xfc82" name="innr specific" mfcode="0x1166">
-      <description>innr specific attributes.</description>
-      <server>
-        <attribute id="0x0006" name="Unknown" type="cstring" mfcode="0x1166" access="rw" required="m"></attribute>
-        <attribute id="0x0010" name="Unknown" type="u32" mfcode="0x1166" access="r" required="m"></attribute>
-        <attribute id="0x0011" name="Unknown" type="u32" mfcode="0x1166" access="r" required="m"></attribute>
-        <attribute id="0x0012" name="Unknown" type="u32" mfcode="0x1166" access="r" required="m"></attribute>
-        <attribute id="0x0013" name="Unknown" type="u32" mfcode="0x1166" access="rw" required="m"></attribute>
-        <attribute id="0x0014" name="Unknown" type="u32" mfcode="0x1166" access="rw" required="m"></attribute>
-        <attribute id="0x0015" name="Unknown" type="u32" mfcode="0x1166" access="rw" required="m"></attribute>
-        <attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x1166" access="r" required="m"></attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
-    <cluster id="0xfd01" name="innr specific 2" mfcode="0x1166">
-      <description>innr specific attributes 2.</description>
-      <server>
-        <attribute id="0x0004" name="Key Report Mask Read/Write" mfcode="0x1166" type="u8" default="0" access="rw" required="m">
-        </attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <!-- INNR -->
+  <cluster id="0xfc82" name="innr specific" mfcode="0x1166">
+    <description>innr specific attributes.</description>
+    <server>
+      <attribute id="0x0006" name="Unknown" type="cstring" mfcode="0x1166" access="rw" required="m"></attribute>
+      <attribute id="0x0010" name="Unknown" type="u32" mfcode="0x1166" access="r" required="m"></attribute>
+      <attribute id="0x0011" name="Unknown" type="u32" mfcode="0x1166" access="r" required="m"></attribute>
+      <attribute id="0x0012" name="Unknown" type="u32" mfcode="0x1166" access="r" required="m"></attribute>
+      <attribute id="0x0013" name="Unknown" type="u32" mfcode="0x1166" access="rw" required="m"></attribute>
+      <attribute id="0x0014" name="Unknown" type="u32" mfcode="0x1166" access="rw" required="m"></attribute>
+      <attribute id="0x0015" name="Unknown" type="u32" mfcode="0x1166" access="rw" required="m"></attribute>
+      <attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x1166" access="r" required="m"></attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
+  <cluster id="0xfd01" name="innr specific 2" mfcode="0x1166">
+    <description>innr specific attributes 2.</description>
+    <server>
+      <attribute id="0x0004" name="Key Report Mask Read/Write" mfcode="0x1166" type="u8" default="0" access="rw" required="m">
+      </attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <!-- IMMAX -->
-    <cluster id="0xfc82" name="Immax specific" mfcode="0x1037">
-      <description>Immax specific attributes.</description>
-      <server>
-        <attribute id="0x0010" name="Turned on since" type="u32" mfcode="0x1037" access="r" required="m"></attribute>
-        <attribute id="0x0011" name="Turned on (total)" type="u32" mfcode="0x1037" access="r" required="m"></attribute>
-        <attribute id="0x0012" name="Consumption since turned on" type="u32" mfcode="0x1037" access="r" required="m"></attribute>
-        <attribute id="0x0013" name="Unknown" type="u32" mfcode="0x1037" access="rw" required="m"></attribute>
-        <attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x1037" access="r" required="m"></attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <!-- IMMAX -->
+  <cluster id="0xfc82" name="Immax specific" mfcode="0x1037">
+    <description>Immax specific attributes.</description>
+    <server>
+      <attribute id="0x0010" name="Turned on since" type="u32" mfcode="0x1037" access="r" required="m"></attribute>
+      <attribute id="0x0011" name="Turned on (total)" type="u32" mfcode="0x1037" access="r" required="m"></attribute>
+      <attribute id="0x0012" name="Consumption since turned on" type="u32" mfcode="0x1037" access="r" required="m"></attribute>
+      <attribute id="0x0013" name="Unknown" type="u32" mfcode="0x1037" access="rw" required="m"></attribute>
+      <attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x1037" access="r" required="m"></attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <!-- BOSCH -->
-    <cluster id="0xfcac" name="Bosch specific" mfcode="0x1209">
-      <description>Bosch specific attributes.</description>
-      <server>
-        <attribute id="0x0000" name="Device setup time remaining" type="u16" mfcode="0x1209" access="rw" required="m"></attribute>
-        <attribute id="0x0001" name="Motion alert reset" type="u16" mfcode="0x1209" access="rw" required="m"></attribute>
-        <attribute id="0x0002" name="Device setup time" type="u16" mfcode="0x1209" access="rw" required="m"></attribute>
-        <attribute id="0x0003" name="Audio alert on motion" type="bool" mfcode="0x1209" access="rw" required="m"></attribute>
-        <attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x1209" access="r" required="m"></attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <!-- BOSCH -->
+  <cluster id="0xfcac" name="Bosch specific" mfcode="0x1209">
+    <description>Bosch specific attributes.</description>
+    <server>
+      <attribute id="0x0000" name="Device setup time remaining" type="u16" mfcode="0x1209" access="rw" required="m"></attribute>
+      <attribute id="0x0001" name="Motion alert reset" type="u16" mfcode="0x1209" access="rw" required="m"></attribute>
+      <attribute id="0x0002" name="Device setup time" type="u16" mfcode="0x1209" access="rw" required="m"></attribute>
+      <attribute id="0x0003" name="Audio alert on motion" type="bool" mfcode="0x1209" access="rw" required="m"></attribute>
+      <attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x1209" access="r" required="m"></attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <cluster id="0xfca0" name="Bosch specific" mfcode="0x1209">
-      <description>Bosch specific attributes.</description>
-      <server>
-        <attribute id="0x0000" name="Device mode" type="enum8" mfcode="0x1209" access="rw" required="m">
-          <value name="Disabled" value="0x00"></value>
-          <value name="Shutter" value="0x01"></value>
-          <value name="Light" value="0x04"></value>
-        </attribute>
-        <attribute id="0x0001" name="Switch type" type="enum8" mfcode="0x1209" access="rw" required="m">
-          <value name="Undefined" value="0x00"></value>
-          <value name="Momentary" value="0x01"></value>
-          <value name="Momentary (sides switched)" value="0x02"></value>
-          <value name="Rocker" value="0x03"></value>
-          <value name="Rocker (sides switched)" value="0x04"></value>
-        </attribute>
-        <attribute id="0x0002" name="Calibration opening time" type="u32" mfcode="0x1209" access="rw" required="m"></attribute>
-        <attribute id="0x0003" name="Calibration closing time" type="u32" mfcode="0x1209" access="rw" required="m"></attribute>
-        <attribute id="0x0005" name="Calibration button hold time" type="u8" mfcode="0x1209" access="rw" required="m"></attribute>
-        <attribute id="0x0008" name="Child lock" type="bool" mfcode="0x1209" access="rw" required="m"></attribute>
-        <attribute id="0x000F" name="Calibration motor start delay" type="u8" mfcode="0x1209" access="rw" required="m"></attribute>
-        <attribute id="0x0013" name="Motor state" type="enum8" mfcode="0x1209" access="r" required="m">
-          <value name="Idle" value="0x00"></value>
-          <value name="Opening" value="0x01"></value>
-          <value name="Closing" value="0x02"></value>
-        </attribute>
-        <attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x1209" access="r" required="m"></attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <cluster id="0xfca0" name="Bosch specific" mfcode="0x1209">
+    <description>Bosch specific attributes.</description>
+    <server>
+      <attribute id="0x0000" name="Device mode" type="enum8" mfcode="0x1209" access="rw" required="m">
+        <value name="Disabled" value="0x00"></value>
+        <value name="Shutter" value="0x01"></value>
+        <value name="Light" value="0x04"></value>
+      </attribute>
+      <attribute id="0x0001" name="Switch type" type="enum8" mfcode="0x1209" access="rw" required="m">
+        <value name="Undefined" value="0x00"></value>
+        <value name="Momentary" value="0x01"></value>
+        <value name="Momentary (sides switched)" value="0x02"></value>
+        <value name="Rocker" value="0x03"></value>
+        <value name="Rocker (sides switched)" value="0x04"></value>
+      </attribute>
+      <attribute id="0x0002" name="Calibration opening time" type="u32" mfcode="0x1209" access="rw" required="m"></attribute>
+      <attribute id="0x0003" name="Calibration closing time" type="u32" mfcode="0x1209" access="rw" required="m"></attribute>
+      <attribute id="0x0005" name="Calibration button hold time" type="u8" mfcode="0x1209" access="rw" required="m"></attribute>
+      <attribute id="0x0008" name="Child lock" type="bool" mfcode="0x1209" access="rw" required="m"></attribute>
+      <attribute id="0x000F" name="Calibration motor start delay" type="u8" mfcode="0x1209" access="rw" required="m"></attribute>
+      <attribute id="0x0013" name="Motor state" type="enum8" mfcode="0x1209" access="r" required="m">
+        <value name="Idle" value="0x00"></value>
+        <value name="Opening" value="0x01"></value>
+        <value name="Closing" value="0x02"></value>
+      </attribute>
+      <attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x1209" access="r" required="m"></attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <cluster id="0xfdee" name="AIR Measurement Config" mfcode="0x1155">
-      <description>BOSCH Thermotechnik indoor air quality configuration</description>
-      <server>
-        <attribute id="0x4001" name="Unknown" type="enum8" required="m" access="r" default="0">
-          <description></description>
-        </attribute>
-        <attribute id="0x4002" name="Unknown" type="lcstring" access="r" required="m">
-          <description></description>
-        </attribute>
-        <attribute id="0x4003" name="Unknown" type="ostring" required="m" access="r">
-          <description></description>
-        </attribute>
-        <attribute id="0x4004" name="Unknown" type="u8" required="m" access="r" default="0">
-          <description></description>
-        </attribute>
-        <attribute id="0x4005" name="Unknown" type="u8" required="m" access="r" default="0">
-          <description></description>
-        </attribute>
-        <attribute id="0x4006" name="Unknown" type="u32" required="m" access="r" default="0">
-          <description></description>
-        </attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <cluster id="0xfdee" name="AIR Measurement Config" mfcode="0x1155">
+    <description>BOSCH Thermotechnik indoor air quality configuration</description>
+    <server>
+      <attribute id="0x4001" name="Unknown" type="enum8" required="m" access="r" default="0">
+        <description></description>
+      </attribute>
+      <attribute id="0x4002" name="Unknown" type="lcstring" access="r" required="m">
+        <description></description>
+      </attribute>
+      <attribute id="0x4003" name="Unknown" type="ostring" required="m" access="r">
+        <description></description>
+      </attribute>
+      <attribute id="0x4004" name="Unknown" type="u8" required="m" access="r" default="0">
+        <description></description>
+      </attribute>
+      <attribute id="0x4005" name="Unknown" type="u8" required="m" access="r" default="0">
+        <description></description>
+      </attribute>
+      <attribute id="0x4006" name="Unknown" type="u32" required="m" access="r" default="0">
+        <description></description>
+      </attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <cluster id="0xfdef" name="AIR Measurement" mfcode="0x1155">
-      <description>BOSCH Thermotechnik indoor air quality</description>
-      <server>
-        <attribute id="0x4001" name="Air pressure" type="u16" required="m" access="r" default="0">
-          <description>Air pressure (mBar)</description>
-        </attribute>
-        <attribute id="0x4002" name="Temperature" type="s16" access="r" required="m">
-          <description>Temperature (°C)</description>
-        </attribute>
-        <attribute id="0x4003" name="Humidity" type="u8" required="m" access="r" default="0">
-          <description>Relative humidity (%)</description>
-        </attribute>
-        <attribute id="0x4004" name="Air quality" type="u16" required="m" access="r" default="0">
-          <description>Air quality VOC (ppm) </description>
-        </attribute>
-        <attribute id="0x4005" name="Brightness" type="u16" required="m" access="r" default="0">
-          <description>Ambient light brightness (lux)</description>
-        </attribute>
-        <attribute id="0x4006" name="Loudness" type="u8" required="m" access="r" default="0">
-          <description>Noise level (dB)</description>
-        </attribute>
-        <attribute id="0x4008" name="timestamp" type="u32" required="m" access="r" default="0">
-          <description>Relative timestamp since start(seconds)</description>
-        </attribute>
-        <attribute id="0x4009" name="Trigger" type="enum8" required="m" access="r" default="0">
-          <value name="by timer" value="0x00"></value>
-          <value name="by double tap" value="0x01"></value>
-          <description>Trigger of this measurement</description>
-        </attribute>
-        <attribute id="0x400B" name="ModeOfOperation" type="enum8" required="m" access="r" default="0">
-          <value name="normal, day mode" value="0x00"></value>
-          <value name="night, up side down" value="0x01"></value>
-          <description>Device orientation</description>
-        </attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <cluster id="0xfdef" name="AIR Measurement" mfcode="0x1155">
+    <description>BOSCH Thermotechnik indoor air quality</description>
+    <server>
+      <attribute id="0x4001" name="Air pressure" type="u16" required="m" access="r" default="0">
+        <description>Air pressure (mBar)</description>
+      </attribute>
+      <attribute id="0x4002" name="Temperature" type="s16" access="r" required="m">
+        <description>Temperature (°C)</description>
+      </attribute>
+      <attribute id="0x4003" name="Humidity" type="u8" required="m" access="r" default="0">
+        <description>Relative humidity (%)</description>
+      </attribute>
+      <attribute id="0x4004" name="Air quality" type="u16" required="m" access="r" default="0">
+        <description>Air quality VOC (ppm) </description>
+      </attribute>
+      <attribute id="0x4005" name="Brightness" type="u16" required="m" access="r" default="0">
+        <description>Ambient light brightness (lux)</description>
+      </attribute>
+      <attribute id="0x4006" name="Loudness" type="u8" required="m" access="r" default="0">
+        <description>Noise level (dB)</description>
+      </attribute>
+      <attribute id="0x4008" name="timestamp" type="u32" required="m" access="r" default="0">
+        <description>Relative timestamp since start(seconds)</description>
+      </attribute>
+      <attribute id="0x4009" name="Trigger" type="enum8" required="m" access="r" default="0">
+        <value name="by timer" value="0x00"></value>
+        <value name="by double tap" value="0x01"></value>
+        <description>Trigger of this measurement</description>
+      </attribute>
+      <attribute id="0x400B" name="ModeOfOperation" type="enum8" required="m" access="r" default="0">
+        <value name="normal, day mode" value="0x00"></value>
+        <value name="night, up side down" value="0x01"></value>
+        <description>Device orientation</description>
+      </attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <!-- DEVELCO -->
-    <cluster id="0xfc03" name="VOC Measurement" mfcode="0x1015">
-      <description>Develco specific attributes.</description>
-      <server>
-        <attribute id="0x0000" name="Measured value" type="u16" mfcode="0x1015" access="r" required="m"></attribute>
-        <attribute id="0x0001" name="Min. measured value" type="u16" mfcode="0x1015" access="r" required="m"></attribute>
-        <attribute id="0x0002" name="Max. measured value" type="u16" mfcode="0x1015" access="r" required="m"></attribute>
-        <attribute id="0x0003" name="Resolution" type="u16" mfcode="0x1015" access="r" required="m"></attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <!-- DEVELCO -->
+  <cluster id="0xfc03" name="VOC Measurement" mfcode="0x1015">
+    <description>Develco specific attributes.</description>
+    <server>
+      <attribute id="0x0000" name="Measured value" type="u16" mfcode="0x1015" access="r" required="m"></attribute>
+      <attribute id="0x0001" name="Min. measured value" type="u16" mfcode="0x1015" access="r" required="m"></attribute>
+      <attribute id="0x0002" name="Max. measured value" type="u16" mfcode="0x1015" access="r" required="m"></attribute>
+      <attribute id="0x0003" name="Resolution" type="u16" mfcode="0x1015" access="r" required="m"></attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <!-- NIKO -->
-    <cluster id="0xfc00" name="Niko specific" mfcode="0x125f">
-      <description>Niko specific attributes.
+  <!-- NIKO -->
+  <cluster id="0xfc00" name="Niko specific" mfcode="0x125f">
+    <description>Niko specific attributes.
+        LED color: 0 - off, 255 - white, 65280 - blue, 16711680 - red
+        Child lock on: 0, Child lock off: 1
+        LED on: 1, LED off: 0
+        0x0300: Switches permission to write either to 0x0202 (1) or to 0x0302 (0)
+        Writing 1 to 0x0202 and 0x0302 makes 0x0300 writable. Then writing 1 to 0x0300 sets 0x0300 bitmap from 0x11 to 0x12, but block all other writes to 0x03XX attributes.</description>
+    <server>
+      <attribute id="0x0000" name="Unknown" type="bmp8" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0100" name="LED color" type="u24" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0101" name="Child lock" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0102" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0103" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0104" name="LED on/off" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0200" name="Connected to power since" type="u32" mfcode="0x125f" access="r" required="m"></attribute>
+      <attribute id="0x0201" name="Unknown" type="u48" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0202" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0300" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0301" name="Unknown" type="bmp8" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0302" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0303" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0304" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0305" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0306" name="Unknown" type="u32" mfcode="0x125f" access="r" required="m"></attribute>
+      <attribute id="0x0307" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0308" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0309" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x030A" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0400" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0401" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0500" name="Unknown" type="u16" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0501" name="Unknown" type="u16" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0502" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0503" name="Unknown" type="u16" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0504" name="Unknown" type="u16" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0505" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0506" name="Unknown" type="u8" mfcode="0x125f" access="r" required="m"></attribute>
+      <attribute id="0x0507" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0508" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0600" name="Unknown" type="seckey" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0x0601" name="Unknown" type="seckey" mfcode="0x125f" access="rw" required="m"></attribute>
+      <attribute id="0xFFFD" name="Cluster Revision" type="u16" mfcode="0x125f" access="rw" required="m"></attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-LED color: 0 - off, 255 - white, 65280 - blue, 16711680 - red
-Child lock on: 0, Child lock off: 1
-LED on: 1, LED off: 0
-0x0300: Switches permission to write either to 0x0202 (1) or to 0x0302 (0)
-Writing 1 to 0x0202 and 0x0302 makes 0x0300 writable. Then writing 1 to 0x0300 sets 0x0300 bitmap from 0x11 to 0x12, but block all other writes to 0x03XX attributes.</description>
-      <server>
-        <attribute id="0x0000" name="Unknown" type="bmp8" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0100" name="LED color" type="u24" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0101" name="Child lock" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0102" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0103" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0104" name="LED on/off" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0200" name="Connected to power since" type="u32" mfcode="0x125f" access="r" required="m"></attribute>
-        <attribute id="0x0201" name="Unknown" type="u48" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0202" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0300" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0301" name="Unknown" type="bmp8" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0302" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0303" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0304" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0305" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0306" name="Unknown" type="u32" mfcode="0x125f" access="r" required="m"></attribute>
-        <attribute id="0x0307" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0308" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0309" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x030A" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0400" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0401" name="Unknown" type="u32" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0500" name="Unknown" type="u16" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0501" name="Unknown" type="u16" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0502" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0503" name="Unknown" type="u16" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0504" name="Unknown" type="u16" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0505" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0506" name="Unknown" type="u8" mfcode="0x125f" access="r" required="m"></attribute>
-        <attribute id="0x0507" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0508" name="Unknown" type="u8" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0600" name="Unknown" type="seckey" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0x0601" name="Unknown" type="seckey" mfcode="0x125f" access="rw" required="m"></attribute>
-        <attribute id="0xFFFD" name="Cluster Revision" type="u16" mfcode="0x125f" access="rw" required="m"></attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <!-- DATEK -->
+  <cluster id="0xfee1" name="Datek on/off configuration" mfcode="0x1337">
+    <description>Datek on/off configuration attributes.</description>
+    <server>
+      <attribute id="0x0000" name="Off if offline" type="u8" mfcode="0x1337" access="rw" required="m"></attribute>
+      <attribute id="0x0001" name="Frost guard temperature" type="u8" mfcode="0x1337" access="rw" required="m"></attribute>
+      <attribute id="0x0002" name="Frost guard temperature hysteresis" type="u8" mfcode="0x1337" access="rw" required="m"></attribute>
+      <attribute id="0x0003" name="Frost guard mins between change" type="u8" mfcode="0x1337" access="rw" required="m"></attribute>
+      <attribute id="0x0004" name="On time" type="u16" mfcode="0x1337" access="rw" required="m"></attribute>
+      <attribute id="0x0010" name="On/off configuration mode" type="enum8" mfcode="0x1337" access="rw" required="m">
+        <value name="Off" value="0x00"></value>
+        <value name="On" value="0x01"></value>
+      </attribute>
+      <attribute id="0xFFFD" name="Cluster revision" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <!-- DATEK -->
-    <cluster id="0xfee1" name="Datek on/off configuration" mfcode="0x1337">
-      <description>Datek on/off configuration attributes.</description>
-      <server>
-        <attribute id="0x0000" name="Off if offline" type="u8" mfcode="0x1337" access="rw" required="m"></attribute>
-        <attribute id="0x0001" name="Frost guard temperature" type="u8" mfcode="0x1337" access="rw" required="m"></attribute>
-        <attribute id="0x0002" name="Frost guard temperature hysteresis" type="u8" mfcode="0x1337" access="rw" required="m"></attribute>
-        <attribute id="0x0003" name="Frost guard mins between change" type="u8" mfcode="0x1337" access="rw" required="m"></attribute>
-        <attribute id="0x0004" name="On time" type="u16" mfcode="0x1337" access="rw" required="m"></attribute>
-        <attribute id="0x0010" name="On/off configuration mode" type="enum8" mfcode="0x1337" access="rw" required="m">
-          <value name="Off" value="0x00"></value>
-          <value name="On" value="0x01"></value>
-        </attribute>
-        <attribute id="0xFFFD" name="Cluster revision" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+  <cluster id="0xfeed" name="Datek diagnostics" mfcode="0x1337">
+    <description>Datek diagnostics cluster attributes.</description>
+    <server>
+      <attribute id="0x0000" name="Last reset info" type="u8" mfcode="0x1337" access="r" required="m"></attribute>
+      <attribute id="0x0001" name="Last extended reset info" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
+      <attribute id="0x0002" name="Reboot counter" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
+      <attribute id="0x0003" name="Last hop LQI" type="u8" mfcode="0x1337" access="r" required="m"></attribute>
+      <attribute id="0x0004" name="Last hop RSSI" type="s8" mfcode="0x1337" access="r" required="m"></attribute>
+      <attribute id="0x0005" name="Tx power" type="s8" mfcode="0x1337" access="r" required="m"></attribute>
+      <attribute id="0x0010" name="Button 0 click counter" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
+      <attribute id="0x0020" name="Button 0 ms click counter" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
+      <attribute id="0x0100" name="Electrical measurement avg" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
+      <attribute id="0x0101" name="Electrical measurement raw" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
+      <attribute id="0x0102" name="Electrical measurement noise w load" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
+      <attribute id="0x0103" name="Electrical measurement noise w/o load" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
+      <attribute id="0xFFFD" name="Cluster revision" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <cluster id="0xfeed" name="Datek diagnostics" mfcode="0x1337">
-      <description>Datek diagnostics cluster attributes.</description>
-      <server>
-        <attribute id="0x0000" name="Last reset info" type="u8" mfcode="0x1337" access="r" required="m"></attribute>
-        <attribute id="0x0001" name="Last extended reset info" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
-        <attribute id="0x0002" name="Reboot counter" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
-        <attribute id="0x0003" name="Last hop LQI" type="u8" mfcode="0x1337" access="r" required="m"></attribute>
-        <attribute id="0x0004" name="Last hop RSSI" type="s8" mfcode="0x1337" access="r" required="m"></attribute>
-        <attribute id="0x0005" name="Tx power" type="s8" mfcode="0x1337" access="r" required="m"></attribute>
-        <attribute id="0x0010" name="Button 0 click counter" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
-        <attribute id="0x0020" name="Button 0 ms click counter" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
-        <attribute id="0x0100" name="Electrical measurement avg" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
-        <attribute id="0x0101" name="Electrical measurement raw" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
-        <attribute id="0x0102" name="Electrical measurement noise w load" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
-        <attribute id="0x0103" name="Electrical measurement noise w/o load" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
-        <attribute id="0xFFFD" name="Cluster revision" type="u16" mfcode="0x1337" access="r" required="m"></attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
-
-    <!-- SCHNEIDER ELECTRIC -->
-    <cluster id="0xfc04" name="Schneider specific" mfcode="0x105e">
-      <description>Schneider manufacturer-specifc cluster.</description>
-      <server>
-        <attribute id="0x0000" name="Indicator Luminance Level" type="u8" default="0" mfcode="0x105e" access="rw" required="o">
-          <description>Brightness of indication front LED.
+  <!-- SCHNEIDER ELECTRIC -->
+  <cluster id="0xfc04" name="Schneider specific" mfcode="0x105e">
+    <description>Schneider manufacturer-specifc cluster.</description>
+    <server>
+      <attribute id="0x0000" name="Indicator Luminance Level" type="u8" default="0" mfcode="0x105e" access="rw" required="o">
+        <description>Brightness of indication front LED.
             0 = 100 percent
             1 = 80 percent
             2 = 60 percent
             3 = 40 percent
             4 = 20 percent
             5 = 0 percent</description>
-        </attribute>
-        <attribute id="0x0002" name="LED indication" type="u8" default="1" mfcode="0x105e" access="rw" required="m">
-          <description>Allows to select the LED indicator mode:
+      </attribute>
+      <attribute id="0x0002" name="LED indication" type="u8" default="1" mfcode="0x105e" access="rw" required="m">
+        <description>Allows to select the LED indicator mode:
             0: Consistent With Load - The LED on the Socket Outlet is On when the device is On
             1: Reverse With Load - The LED on the Socket Outlet is On when the device is Off
             2: Always Off - The LED on the Socket Outlet is always Off
             3: Always On - The LED on the Socket Outlet is always On</description>
-        </attribute>
-        <attribute id="0x0050" name="Local Control" type="enum8" default="0" mfcode="0x105e" access="rw" required="m">
-          <description>0 = local control is active
+      </attribute>
+      <attribute id="0x0050" name="Local Control" type="enum8" default="0" mfcode="0x105e" access="rw" required="m">
+        <description>0 = local control is active
             1 = local control is inactive
             User can not:
-            A) control device locally (OF/OFF)
-            B) activate e-mode
+            A: control device locally (OF/OFF)
+            B: activate e-mode
             User can:
-            A) clear alarm locally</description>
-          <value name="Local control is active" value="0"></value>
-          <value name="Local control is inactive" value="1"></value>
-        </attribute>
-        <attribute id="0xfffd" name="Cluster revision" type="u16" mfcode="0x105e" default="1" access="r" required="m"></attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+            A: clear alarm locally</description>
+        <value name="Local control is active" value="0"></value>
+        <value name="Local control is inactive" value="1"></value>
+      </attribute>
+      <attribute id="0xfffd" name="Cluster revision" type="u16" mfcode="0x105e" default="1" access="r" required="m"></attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <cluster id="0xff17" name="Schneider specific" mfcode="0x105e">
-      <description>Schneider manufacturer-specifc cluster.</description>
-      <server>
-        <attribute id="0x0000" name="Switch Indication" type="enum8" mfcode="0x105e" access="rw" required="m">
-          <description>Attribute is shared between all endpoints where this cluster is presented.
+  <cluster id="0xff17" name="Schneider specific" mfcode="0x105e">
+    <description>Schneider manufacturer-specifc cluster.</description>
+    <server>
+      <attribute id="0x0000" name="Switch Indication" type="enum8" mfcode="0x105e" access="rw" required="m">
+        <description>Attribute is shared between all endpoints where this cluster is presented.
             Attribute defines the meaning of indicator (LED) on the device, which provides the feedback to user about state of output.
-          </description>
-          <value name="Indicator is on when load is on" value="0"></value>
-          <value name="Indicator is always on" value="1"></value>
-          <value name="Indicator is on when load is off" value="2"></value>
-          <value name="Indicator is always off" value="3"></value>
-        </attribute>
-        <attribute id="0x0001" name="Switch Actions" type="enum8" mfcode="0x105e" access="rw" required="m">
-          <description>Default values depends on endpoint and device type. More info you find in device description.
+        </description>
+        <value name="Indicator is on when load is on" value="0"></value>
+        <value name="Indicator is always on" value="1"></value>
+        <value name="Indicator is on when load is off" value="2"></value>
+        <value name="Indicator is always off" value="3"></value>
+      </attribute>
+      <attribute id="0x0001" name="Switch Actions" type="enum8" mfcode="0x105e" access="rw" required="m">
+        <description>Default values depends on endpoint and device type. More info you find in device description.
             If value is one of non defined, switch does not send any action when pressed.
-          </description>
-          <value name="Lift (locked)" value="0"></value>
-          <value name="Lift and tilt (locked)" value="1"></value>
-          <value name="Lift (unlocked)" value="2"></value>
-          <value name="Lift and tilt (unlocked)" value="3"></value>
-          <value name="Unknown (4)" value="4"></value>
-          <value name="Unknown (5)" value="5"></value>
-          <value name="Unknown (6)" value="6"></value>
-          <value name="Unknown (7)" value="7"></value>
-        </attribute>
-        <attribute id="0x0010" name="Up Scene ID" type="u8" mfcode="0x105e" access="rw" required="m">
-          <description>The Up Scene ID attribute represents the Scene Id field value of any Scene command cluster transmitted by the
+        </description>
+        <value name="Lift (locked)" value="0"></value>
+        <value name="Lift and tilt (locked)" value="1"></value>
+        <value name="Lift (unlocked)" value="2"></value>
+        <value name="Lift and tilt (unlocked)" value="3"></value>
+        <value name="Unknown (4)" value="4"></value>
+        <value name="Unknown (5)" value="5"></value>
+        <value name="Unknown (6)" value="6"></value>
+        <value name="Unknown (7)" value="7"></value>
+      </attribute>
+      <attribute id="0x0010" name="Up Scene ID" type="u8" mfcode="0x105e" access="rw" required="m">
+        <description>The Up Scene ID attribute represents the Scene Id field value of any Scene command cluster transmitted by the
             device when user activates is rocker up side according to the rocker configuration. See Switch Actions attribute.
-          </description>
-        </attribute>
-        <attribute id="0x0011" name="Up Group ID" type="u16" mfcode="0x105e" access="rw" required="m">
+        </description>
+      </attribute>
+      <attribute id="0x0011" name="Up Group ID" type="u16" mfcode="0x105e" access="rw" required="m">
         <description>The Up Group ID attribute represents the Group Id field value of any Scene command cluster transmitted by the
           device when user activates is rocker up side according to the rocker configuration. Value greater than 0xFFF7 means, no
           command is sent. See Switch Actions attribute.
         </description>
-        </attribute>
-        <attribute id="0x0020" name="Down Scene ID" type="u8" mfcode="0x105e" access="rw" required="m">
+      </attribute>
+      <attribute id="0x0020" name="Down Scene ID" type="u8" mfcode="0x105e" access="rw" required="m">
         <description>The Down Scene ID attribute represents the Scene Id field value of any Scene command cluster transmitted by the
           device when user activates is rocker down side according to the rocker configuration. See Switch Actions attribute.
         </description>
-        </attribute>
-        <attribute id="0x0021" name="Down Group ID" type="u16" mfcode="0x105e" access="rw" required="m">
+      </attribute>
+      <attribute id="0x0021" name="Down Group ID" type="u16" mfcode="0x105e" access="rw" required="m">
         <description>The Down Group ID attribute represents the Group Id field value of any Scene command cluster transmitted by the
           device when user activates is rocker down side according to the rocker configuration. Value greater than 0xFFF7 means, no
           command is sent. See Switch Actions attribute.
         </description>
-        </attribute>
-        <attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x105e" access="r" required="m"></attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
-  </domain>
+      </attribute>
+      <attribute id="0xfffd" name="Cluster Revision" type="u16" mfcode="0x105e" access="r" required="m"></attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
+</domain>
 
-  <!-- Shelly -->
-  <domain name="Shelly Manufacturer Specific" useZcl="true" description="Shelly Manufacturer specific clusters.">
-    <cluster id="0xfc01" name="Shelly RPC Cluster" mfcode="0x1490">
-      <description>The Shelly RPC Cluster is a custom Zigbee cluster that acts as a channel for the Shelly RPC protocol. It accepts incoming frames and makes outgoing ones available for collection.</description>
-      <server>
-        <attribute id="0x0000" name="Data" type="cstring" mfcode="0x1490" access="rw" required="o">
-          <description>The Data attribute is used both to submit frames to the device and to read frames back from the device.</description>
-        </attribute>
-        <attribute id="0x0001" name="TxCtl" type="u32" mfcode="0x1490" access="w" required="o">
-          <description>Before sending a frame, the length of the frame must be written in the TxCtl attribute. Then, the data can be transmitted to the device by sequential write requests to the Data attribute.
+<!-- Shelly -->
+<domain name="Shelly Manufacturer Specific" useZcl="true" description="Shelly Manufacturer specific clusters.">
+  <cluster id="0xfc01" name="Shelly RPC Cluster" mfcode="0x1490">
+    <description>The Shelly RPC Cluster is a custom Zigbee cluster that acts as a channel for the Shelly RPC protocol. It accepts incoming frames and makes outgoing ones available for collection.</description>
+    <server>
+      <attribute id="0x0000" name="Data" type="cstring" mfcode="0x1490" access="rw" required="o">
+        <description>The Data attribute is used both to submit frames to the device and to read frames back from the device.</description>
+      </attribute>
+      <attribute id="0x0001" name="TxCtl" type="u32" mfcode="0x1490" access="w" required="o">
+        <description>Before sending a frame, the length of the frame must be written in the TxCtl attribute. Then, the data can be transmitted to the device by sequential write requests to the Data attribute.
             Chunking can be arbitrary, but the result must add up to the specified length exactly, at which point the frame will be processed.
             Writing to TxCtl clears out any half-written frame that might be buffered, so the writer needs to ensure that there is only one frame in flight at any time.</description>
-        </attribute>
-        <attribute id="0x0002" name="RxCtl" type="u32" mfcode="0x1490" access="r" required="o">
-          <description>The RxCtl attribute contains the length of the frame that the device wishes to transmit back.
+      </attribute>
+      <attribute id="0x0002" name="RxCtl" type="u32" mfcode="0x1490" access="r" required="o">
+        <description>The RxCtl attribute contains the length of the frame that the device wishes to transmit back.
             If this value is not zero, frame data will be returned in response to sequential read requests to the Data attribute. In this case, chunking will be determined by the device.</description>
-        </attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
+      </attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
 
-    <cluster id="0xfc02" name="Shelly WiFi Setup Cluster" mfcode="0x1490">
-      <description>The Shelly WiFi Setup Cluster is a custom Zigbee cluster that allows Zigbee networks to read, modify, and apply the station configuration of the Shelly WiFi component.</description>
-      <server>
-        <attribute id="0x0000" name="Status" type="cstring" mfcode="0x1490" access="r" required="o"> </attribute>
-        <attribute id="0x0001" name="IP" type="cstring" mfcode="0x1490" access="r" required="o"> </attribute>
-        <attribute id="0x0002" name="Action" type="u8" mfcode="0x1490" access="w" required="o" range="0,1">
-          <description>Writing the value of 0 to the Action attribute will reset all attributes to the current device configuration. Writing the value of 1 will set and automatically apply the configuration
+  <cluster id="0xfc02" name="Shelly WiFi Setup Cluster" mfcode="0x1490">
+    <description>The Shelly WiFi Setup Cluster is a custom Zigbee cluster that allows Zigbee networks to read, modify, and apply the station configuration of the Shelly WiFi component.</description>
+    <server>
+      <attribute id="0x0000" name="Status" type="cstring" mfcode="0x1490" access="r" required="o"></attribute>
+      <attribute id="0x0001" name="IP" type="cstring" mfcode="0x1490" access="r" required="o"></attribute>
+      <attribute id="0x0002" name="Action" type="u8" mfcode="0x1490" access="w" required="o" range="0,1">
+        <description>Writing the value of 0 to the Action attribute will reset all attributes to the current device configuration. Writing the value of 1 will set and automatically apply the configuration
             currently available in the Zigbee attributes.</description>
-        </attribute>
-        <attribute id="0x0003" name="DHCP" type="bool" mfcode="0x1490" access="r" required="o"> </attribute>
-        <attribute id="0x0004" name="Enable" type="bool" mfcode="0x1490" access="rw" required="o"> </attribute>
-        <attribute id="0x0005" name="SSID" type="cstring" mfcode="0x1490" access="rw" required="o"> </attribute>
-        <attribute id="0x0006" name="Password" type="cstring" mfcode="0x1490" access="w" required="o"> </attribute>
-        <attribute id="0x0007" name="StaticIP" type="cstring" mfcode="0x1490" access="rw" required="o"> </attribute>
-        <attribute id="0x0008" name="NetMask" type="cstring" mfcode="0x1490" access="rw" required="o"> </attribute>
-        <attribute id="0x0009" name="Gateway" type="cstring" mfcode="0x1490" access="rw" required="o"> </attribute>
-        <attribute id="0x000a" name="NameServer" type="cstring" mfcode="0x1490" access="rw" required="o"> </attribute>
-      </server>
-      <client>
-      </client>
-    </cluster>
-  </domain>
+      </attribute>
+      <attribute id="0x0003" name="DHCP" type="bool" mfcode="0x1490" access="r" required="o"></attribute>
+      <attribute id="0x0004" name="Enable" type="bool" mfcode="0x1490" access="rw" required="o"></attribute>
+      <attribute id="0x0005" name="SSID" type="cstring" mfcode="0x1490" access="rw" required="o"></attribute>
+      <attribute id="0x0006" name="Password" type="cstring" mfcode="0x1490" access="w" required="o"></attribute>
+      <attribute id="0x0007" name="StaticIP" type="cstring" mfcode="0x1490" access="rw" required="o"></attribute>
+      <attribute id="0x0008" name="NetMask" type="cstring" mfcode="0x1490" access="rw" required="o"></attribute>
+      <attribute id="0x0009" name="Gateway" type="cstring" mfcode="0x1490" access="rw" required="o"></attribute>
+      <attribute id="0x000a" name="NameServer" type="cstring" mfcode="0x1490" access="rw" required="o"></attribute>
+    </server>
+    <client>
+    </client>
+  </cluster>
+</domain>
 
-  <profile id="0xc001" name="Shelly Specific Profile" description="Profile used by Shelly." version="1.0" rev="1" icon="dev-unknown.svg">
-    <device id="0x2001" name="Devce Configuration" description=""></device>
-    <domain-ref name="Shelly Manufacturer Specific" low_bound="0xfc00" />
-  </profile>
+<profile id="0xc001" name="Shelly Specific Profile" description="Profile used by Shelly." version="1.0" rev="1" icon="dev-unknown.svg">
+  <device id="0x2001" name="Devce Configuration" description=""></device>
+  <domain-ref name="Shelly Manufacturer Specific" low_bound="0xfc00" />
+</profile>
 
-  <profile id="0104" name="Home Automation" description="This profile defines device descriptions and standard practices for applications needed in a residential or light commercial environment. Installation scenarios range from a single room to an entire home up to 20,000 square feet (approximately 1850m2)." version="1.0" rev="25" icon="ha.png">
-    <domain-ref name="General" low_bound="0000" />
-    <domain-ref name="Measurement and Sensing" low_bound="0400" />
-    <domain-ref name="Lighting" low_bound="0300" />
-    <domain-ref name="HVAC" low_bound="0200" />
-    <domain-ref name="Closures" low_bound="0100" />
-    <domain-ref name="Security and Safety" low_bound="0500" />
-    <domain-ref name="Smart Energy" low_bound="0x0700" />
-    <domain-ref name="Appliances" low_bound="0x0b00" />
-    <domain-ref name="Light Link" low_bound="1000" />
-    <domain-ref name="Manufacturer Specific" low_bound="0xfc00" />
-    <device id="0x000c" name="Simple sensor" icon="dev-light-sensor.png">
-      <description></description>
-    </device>
-    <device id="0x0010" name="On/off plug-in unit" description=""></device>
-    <device id="0x0051" name="Smart plug" description=""></device>
-    <device id="0x0100" name="On/off light" description="" icon="dev-on-off-light.png"></device>
-    <device id="0x0110" name="Dimmable plug-in unit" description="" icon="dev-on-off-light.png"></device>
-    <device id="0x0200" name="Color light" description="" icon="dev-on-off-light.png"></device>
-    <device id="0x0210" name="Extended color light" description="" icon="dev-on-off-light.png"></device>
-    <device id="0x0220" name="Color temperature light" description="" icon="dev-on-off-light.png"></device>
-    <device id="0x0800" name="Color controller" description=""></device>
-    <device id="0x0810" name="Color scene controller" description=""></device>
-    <device id="0x0820" name="Non color controller" description=""></device>
-    <device id="0x0830" name="Non color scene controller" description=""></device>
-    <device id="0x0840" name="Control bridge" description=""></device>
-    <device id="0x0850" name="On/off sensor" description=""></device>
-  </profile>
+<profile id="0104" name="Home Automation" description="This profile defines device descriptions and standard practices for applications needed in a residential or light commercial environment. Installation scenarios range from a single room to an entire home up to 20,000 square feet (approximately 1850m2)." version="1.0" rev="25" icon="ha.png">
+  <domain-ref name="General" low_bound="0000" />
+  <domain-ref name="Measurement and Sensing" low_bound="0400" />
+  <domain-ref name="Lighting" low_bound="0300" />
+  <domain-ref name="HVAC" low_bound="0200" />
+  <domain-ref name="Closures" low_bound="0100" />
+  <domain-ref name="Security and Safety" low_bound="0500" />
+  <domain-ref name="Smart Energy" low_bound="0x0700" />
+  <domain-ref name="Appliances" low_bound="0x0b00" />
+  <domain-ref name="Light Link" low_bound="1000" />
+  <domain-ref name="Manufacturer Specific" low_bound="0xfc00" />
+  <device id="0x000c" name="Simple sensor" icon="dev-light-sensor.png">
+    <description></description>
+  </device>
+  <device id="0x0010" name="On/off plug-in unit" description=""></device>
+  <device id="0x0051" name="Smart plug" description=""></device>
+  <device id="0x0100" name="On/off light" description="" icon="dev-on-off-light.png"></device>
+  <device id="0x0110" name="Dimmable plug-in unit" description="" icon="dev-on-off-light.png"></device>
+  <device id="0x0200" name="Color light" description="" icon="dev-on-off-light.png"></device>
+  <device id="0x0210" name="Extended color light" description="" icon="dev-on-off-light.png"></device>
+  <device id="0x0220" name="Color temperature light" description="" icon="dev-on-off-light.png"></device>
+  <device id="0x0800" name="Color controller" description=""></device>
+  <device id="0x0810" name="Color scene controller" description=""></device>
+  <device id="0x0820" name="Non color controller" description=""></device>
+  <device id="0x0830" name="Non color scene controller" description=""></device>
+  <device id="0x0840" name="Control bridge" description=""></device>
+  <device id="0x0850" name="On/off sensor" description=""></device>
+</profile>
 
-  <profile id="0109" name="Smart Energy" description="This profile defines device descriptions and standard practices for Demand Response and Load Management 'Smart Energy' applications needed in a Smart Energy based residential or light commercial environment." version="1.0" rev="15" icon="se.png">
-    <domain-ref name="General" low_bound="0000" />
-    <domain-ref name="Smart Energy" low_bound="0700" />
-  </profile>
+<profile id="0109" name="Smart Energy" description="This profile defines device descriptions and standard practices for Demand Response and Load Management 'Smart Energy' applications needed in a Smart Energy based residential or light commercial environment." version="1.0" rev="15" icon="se.png">
+  <domain-ref name="General" low_bound="0000" />
+  <domain-ref name="Smart Energy" low_bound="0700" />
+</profile>
 
-  <profile id="0xc05e" name="Light Link" description="This profile defines device descriptions and standard practices for ZigBee Light Link." version="1.0" rev="15" icon="zll.png">
-    <domain-ref name="General" low_bound="0000" />
-    <domain-ref name="Light Link" low_bound="1000" />
-    <domain-ref name="Lighting" low_bound="0300" />
-    <domain-ref name="Measurement and Sensing" low_bound="0400" />
-    <domain-ref name="Smart Energy" low_bound="0x0700" />
-    <domain-ref name="Manufacturer Specific" low_bound="0xfc00" />
-    <device id="0x0000" name="On/off light" description="" icon="dev-on-off-light.png"></device>
-    <device id="0x0010" name="On/off plug-in unit" description=""></device>
-    <device id="0x0100" name="Dimmable light" description="" icon="dev-on-off-light.png"></device>
-    <device id="0x0110" name="Dimmable plug-in unit" description="" icon="dev-on-off-light.png"></device>
-    <device id="0x0200" name="Color light" description="" icon="dev-on-off-light.png"></device>
-    <device id="0x0210" name="Extended color light" description="" icon="dev-on-off-light.png"></device>
-    <device id="0x0220" name="Color temperature light" description="" icon="dev-on-off-light.png"></device>
-    <device id="0x0800" name="Color controller" description=""></device>
-    <device id="0x0810" name="Color scene controller" description=""></device>
-    <device id="0x0820" name="Non color controller" description=""></device>
-    <device id="0x0830" name="Non color scene controller" description=""></device>
-    <device id="0x0840" name="Control bridge" description=""></device>
-    <device id="0x0850" name="On/off sensor" description=""></device>
-  </profile>
+<profile id="0xc05e" name="Light Link" description="This profile defines device descriptions and standard practices for ZigBee Light Link." version="1.0" rev="15" icon="zll.png">
+  <domain-ref name="General" low_bound="0000" />
+  <domain-ref name="Light Link" low_bound="1000" />
+  <domain-ref name="Lighting" low_bound="0300" />
+  <domain-ref name="Measurement and Sensing" low_bound="0400" />
+  <domain-ref name="Smart Energy" low_bound="0x0700" />
+  <domain-ref name="Manufacturer Specific" low_bound="0xfc00" />
+  <device id="0x0000" name="On/off light" description="" icon="dev-on-off-light.png"></device>
+  <device id="0x0010" name="On/off plug-in unit" description=""></device>
+  <device id="0x0100" name="Dimmable light" description="" icon="dev-on-off-light.png"></device>
+  <device id="0x0110" name="Dimmable plug-in unit" description="" icon="dev-on-off-light.png"></device>
+  <device id="0x0200" name="Color light" description="" icon="dev-on-off-light.png"></device>
+  <device id="0x0210" name="Extended color light" description="" icon="dev-on-off-light.png"></device>
+  <device id="0x0220" name="Color temperature light" description="" icon="dev-on-off-light.png"></device>
+  <device id="0x0800" name="Color controller" description=""></device>
+  <device id="0x0810" name="Color scene controller" description=""></device>
+  <device id="0x0820" name="Non color controller" description=""></device>
+  <device id="0x0830" name="Non color scene controller" description=""></device>
+  <device id="0x0840" name="Control bridge" description=""></device>
+  <device id="0x0850" name="On/off sensor" description=""></device>
+</profile>
 
-  <profile id="0xa1e0" name="Green Power" description="This profile defines device descriptions and standard practices for ZigBee Green Power." version="1.1" rev="15" icon="zll.png">
-    <domain-ref name="Green Power" low_bound="0x0021" />
-  </profile>
+<profile id="0xa1e0" name="Green Power" description="This profile defines device descriptions and standard practices for ZigBee Green Power." version="1.1" rev="15" icon="zll.png">
+  <domain-ref name="Green Power" low_bound="0x0021" />
+</profile>
 
-  <profile id="0xc105" name="Drop-In Networking" description="This profile defines the Digi Drop-In Networking used by the XBee." version="1.0" rev="15" icon="dev-unknown.svg">
-    <device id="0x0001" name="XBee" description="" icon="dev-range-extender.png"></device>
-  </profile>
+<profile id="0xc105" name="Drop-In Networking" description="This profile defines the Digi Drop-In Networking used by the XBee." version="1.0" rev="15" icon="dev-unknown.svg">
+  <device id="0x0001" name="XBee" description="" icon="dev-range-extender.png"></device>
+</profile>
 
-  <profile id="0xde00" name="dresden elektronik" description="Profile used by dresden elektronik." version="1.0" rev="15" icon="de.png">
-    <device id="0x0001" name="Configuration Tool" description="" icon="dev-configuration-tool.png"></device>
-  </profile>
+<profile id="0xde00" name="dresden elektronik" description="Profile used by dresden elektronik." version="1.0" rev="15" icon="de.png">
+  <device id="0x0001" name="Configuration Tool" description="" icon="dev-configuration-tool.png"></device>
+</profile>
 
-  <profile id="0xc0c9" name="Develco Private Profile" description="Profile used by dresden elektronik." version="1.0" rev="15" icon="dev-unknown.svg">
-    <device id="0x0001" name="Develco Utility" description="Private profile for internal Develco Products use only."></device>
-  </profile>
+<profile id="0xc0c9" name="Develco Private Profile" description="Profile used by dresden elektronik." version="1.0" rev="15" icon="dev-unknown.svg">
+  <device id="0x0001" name="Develco Utility" description="Private profile for internal Develco Products use only."></device>
+</profile>
 
-  <profile id="0xc4c8" name="Leviton Manufacturer Specific Profile" description="Profile used by Leviton Decora Smart switch." version="1.0" rev="1" icon="dev-on-off-light.png">
-    <domain-ref name="Lighting" low_bound="0300" />
-    <domain-ref name="Manufacturer Specific" low_bound="0xfc00" />
-  </profile>
+<profile id="0xc4c8" name="Leviton Manufacturer Specific Profile" description="Profile used by Leviton Decora Smart switch." version="1.0" rev="1" icon="dev-on-off-light.png">
+  <domain-ref name="Lighting" low_bound="0300" />
+  <domain-ref name="Manufacturer Specific" low_bound="0xfc00" />
+</profile>
 
-  <devices>
-    <!-- Generic -->
-    <device id="0x0000" name="On/Off Switch" description="" icon="dev-on-off-switch.png">
-    </device>
-    <device id="0x0001" name="Level Control Switch">
-      <description></description>
-    </device>
-    <device id="0x0002" name="On/Off Output">
-      <description></description>
-    </device>
-    <device id="0x0003" name="Level Controllable Output">
-      <description></description>
-    </device>
-    <device id="0x0004" name="Scene Selector">
-      <description></description>
-    </device>
-    <device id="0x0005" name="Configuration Tool" description="" icon="dev-configuration-tool.png">
-      <description></description>
-    </device>
-    <device id="0x0006" name="Remote Control">
-      <description></description>
-    </device>
-    <device id="0x0007" name="Combined Interface" description="" icon="dev-combined-interface.svg">
-      <description></description>
-    </device>
-    <device id="0x0008" name="Range Extender" icon="dev-range-extender.png">
-      <description></description>
-    </device>
-    <device id="0x0009" name="Mains Power Outlet">
-      <description></description>
-    </device>
-    <device id="0x000a" name="Door Lock">
-      <description></description>
-    </device>
-    <device id="0x000b" name="Door Lock Controller">
-      <description></description>
-    </device>
-    <device id="0x000c" name="Simple Sensor">
-      <description></description>
-    </device>
-    <device id="0x000d" name="Consumption Awareness Device">
-      <description></description>
-    </device>
-    <device id="0x0050" name="Home Gateway">
-      <description></description>
-    </device>
-    <device id="0x0051" name="Smart Plug">
-      <description></description>
-    </device>
-    <device id="0x0052" name="White Goods">
-      <description></description>
-    </device>
-    <device id="0x0053" name="Meter Interface">
-      <description></description>
-    </device>
-    <!-- Lighting -->
-    <device id="0x0100" name="On/Off Light" icon="dev-on-off-light.png">
-      <description></description>
-    </device>
-    <device id="0x0101" name="Dimmable Light" icon="dev-on-off-light.png">
-      <description></description>
-    </device>
-    <device id="0x0102" name="Color Dimmable Light" icon="dev-on-off-light.png">
-      <description></description>
-    </device>
-    <device id="0x0103" name="On/Off Light Switch" icon="dev-on-off-switch.png">
-      <description></description>
-    </device>
-    <device id="0x0104" name="Dimmer Switch">
-      <description></description>
-    </device>
-    <device id="0x0105" name="Color Dimmer Switch">
-      <description></description>
-    </device>
-    <device id="0x0106" name="Light Sensor" icon="dev-light-sensor.png">
-      <description></description>
-    </device>
-    <device id="0x0107" name="Occupancy Sensor" icon="dev-occupancy-sensor.png">
-      <description></description>
-    </device>
-    <device id="0x0108" name="On/off ballast" icon="dev-on-off-light.png">
-      <description></description>
-    </device>
-    <device id="0x0109" name="Dimmable ballast" icon="dev-on-off-light.png">
-      <description></description>
-    </device>
-    <device id="0x010a" name="On/off plugin unit" icon="dev-on-off-light.png">
-      <description></description>
-    </device>
-    <device id="0x010b" name="Dimmable plugin unit" icon="dev-on-off-light.png">
-      <description></description>
-    </device>
-    <device id="0x010c" name="Color temperature light" icon="dev-on-off-light.png">
-      <description></description>
-    </device>
-    <device id="0x010d" name="Extended color light" icon="dev-on-off-light.png">
-      <description></description>
-    </device>
-    <device id="0x010e" name="Light level sensor" icon="dev-light-sensor.png">
-      <description></description>
-    </device>
-    <!-- Closures -->
-    <device id="0x0200" name="Shade">
-      <description></description>
-    </device>
-    <device id="0x0201" name="Shade Controller">
-      <description></description>
-    </device>
-    <device id="0x0202" name="Window Covering Device">
-      <description></description>
-    </device>
-    <device id="0x0203" name="Window Covering Controller">
-      <description></description>
-    </device>
-    <!-- HVAC -->
-    <device id="0x0300" name="Heating/Cooling Unit">
-      <description></description>
-    </device>
-    <device id="0x0301" name="Thermostat" description="" icon="dev-thermostat.png">
-      <description></description>
-    </device>
-    <device id="0x0302" name="Temperature Sensor" icon="dev-temperature-sensor.png">
-      <description></description>
-    </device>
-    <device id="0x0303" name="Pump">
-      <description></description>
-    </device>
-    <device id="0x0304" name="Pump Controller">
-      <description></description>
-    </device>
-    <device id="0x0305" name="Pressure Sensor">
-      <description></description>
-    </device>
-    <device id="0x0306" name="Flow Sensor">
-      <description></description>
-    </device>
-    <device id="0x0307" name="Mini Split AC">
-      <description></description>
-    </device>
-    <!-- Intruder Alarm Systems -->
-    <device id="0x0400" name="IAS Control and Indicating Equipment">
-      <description></description>
-    </device>
-    <device id="0x0401" name="IAS Ancillary Control Equipment">
-      <description></description>
-    </device>
-    <device id="0x0402" name="IAS Zone">
-      <description></description>
-    </device>
-    <device id="0x0403" name="IAS Warning Device">
-      <description></description>
-    </device>
-    <!-- Smart Energy -->
-    <device id="0x0500" name="Energy Service Portal">
-      <description></description>
-    </device>
-    <device id="0x0501" name="Metering Device">
-      <description></description>
-    </device>
-    <device id="0x0502" name="In-Premise Display">
-      <description></description>
-    </device>
-    <device id="0x0503" name="Programmable Communicating Thermostat (PCT)" description="" icon="dev-prog-thermostat.png">
-      <description></description>
-    </device>
-    <device id="0x0504" name="Load Control Device">
-      <description></description>
-    </device>
-    <device id="0x0505" name="Smart Appliance">
-      <description></description>
-    </device>
-    <device id="0x0506" name="Prepayment Terminal">
-      <description></description>
-    </device>
-    <device id="0x0507" name="Device Management">
-      <description></description>
-    </device>
-  </devices>
+<devices>
+  <!-- Generic -->
+  <device id="0x0000" name="On/Off Switch" description="" icon="dev-on-off-switch.png">
+  </device>
+  <device id="0x0001" name="Level Control Switch">
+    <description></description>
+  </device>
+  <device id="0x0002" name="On/Off Output">
+    <description></description>
+  </device>
+  <device id="0x0003" name="Level Controllable Output">
+    <description></description>
+  </device>
+  <device id="0x0004" name="Scene Selector">
+    <description></description>
+  </device>
+  <device id="0x0005" name="Configuration Tool" description="" icon="dev-configuration-tool.png">
+    <description></description>
+  </device>
+  <device id="0x0006" name="Remote Control">
+    <description></description>
+  </device>
+  <device id="0x0007" name="Combined Interface" description="" icon="dev-combined-interface.svg">
+    <description></description>
+  </device>
+  <device id="0x0008" name="Range Extender" icon="dev-range-extender.png">
+    <description></description>
+  </device>
+  <device id="0x0009" name="Mains Power Outlet">
+    <description></description>
+  </device>
+  <device id="0x000a" name="Door Lock">
+    <description></description>
+  </device>
+  <device id="0x000b" name="Door Lock Controller">
+    <description></description>
+  </device>
+  <device id="0x000c" name="Simple Sensor">
+    <description></description>
+  </device>
+  <device id="0x000d" name="Consumption Awareness Device">
+    <description></description>
+  </device>
+  <device id="0x0050" name="Home Gateway">
+    <description></description>
+  </device>
+  <device id="0x0051" name="Smart Plug">
+    <description></description>
+  </device>
+  <device id="0x0052" name="White Goods">
+    <description></description>
+  </device>
+  <device id="0x0053" name="Meter Interface">
+    <description></description>
+  </device>
+  <!-- Lighting -->
+  <device id="0x0100" name="On/Off Light" icon="dev-on-off-light.png">
+    <description></description>
+  </device>
+  <device id="0x0101" name="Dimmable Light" icon="dev-on-off-light.png">
+    <description></description>
+  </device>
+  <device id="0x0102" name="Color Dimmable Light" icon="dev-on-off-light.png">
+    <description></description>
+  </device>
+  <device id="0x0103" name="On/Off Light Switch" icon="dev-on-off-switch.png">
+    <description></description>
+  </device>
+  <device id="0x0104" name="Dimmer Switch">
+    <description></description>
+  </device>
+  <device id="0x0105" name="Color Dimmer Switch">
+    <description></description>
+  </device>
+  <device id="0x0106" name="Light Sensor" icon="dev-light-sensor.png">
+    <description></description>
+  </device>
+  <device id="0x0107" name="Occupancy Sensor" icon="dev-occupancy-sensor.png">
+    <description></description>
+  </device>
+  <device id="0x0108" name="On/off ballast" icon="dev-on-off-light.png">
+    <description></description>
+  </device>
+  <device id="0x0109" name="Dimmable ballast" icon="dev-on-off-light.png">
+    <description></description>
+  </device>
+  <device id="0x010a" name="On/off plugin unit" icon="dev-on-off-light.png">
+    <description></description>
+  </device>
+  <device id="0x010b" name="Dimmable plugin unit" icon="dev-on-off-light.png">
+    <description></description>
+  </device>
+  <device id="0x010c" name="Color temperature light" icon="dev-on-off-light.png">
+    <description></description>
+  </device>
+  <device id="0x010d" name="Extended color light" icon="dev-on-off-light.png">
+    <description></description>
+  </device>
+  <device id="0x010e" name="Light level sensor" icon="dev-light-sensor.png">
+    <description></description>
+  </device>
+  <!-- Closures -->
+  <device id="0x0200" name="Shade">
+    <description></description>
+  </device>
+  <device id="0x0201" name="Shade Controller">
+    <description></description>
+  </device>
+  <device id="0x0202" name="Window Covering Device">
+    <description></description>
+  </device>
+  <device id="0x0203" name="Window Covering Controller">
+    <description></description>
+  </device>
+  <!-- HVAC -->
+  <device id="0x0300" name="Heating/Cooling Unit">
+    <description></description>
+  </device>
+  <device id="0x0301" name="Thermostat" description="" icon="dev-thermostat.png">
+    <description></description>
+  </device>
+  <device id="0x0302" name="Temperature Sensor" icon="dev-temperature-sensor.png">
+    <description></description>
+  </device>
+  <device id="0x0303" name="Pump">
+    <description></description>
+  </device>
+  <device id="0x0304" name="Pump Controller">
+    <description></description>
+  </device>
+  <device id="0x0305" name="Pressure Sensor">
+    <description></description>
+  </device>
+  <device id="0x0306" name="Flow Sensor">
+    <description></description>
+  </device>
+  <device id="0x0307" name="Mini Split AC">
+    <description></description>
+  </device>
+  <!-- Intruder Alarm Systems -->
+  <device id="0x0400" name="IAS Control and Indicating Equipment">
+    <description></description>
+  </device>
+  <device id="0x0401" name="IAS Ancillary Control Equipment">
+    <description></description>
+  </device>
+  <device id="0x0402" name="IAS Zone">
+    <description></description>
+  </device>
+  <device id="0x0403" name="IAS Warning Device">
+    <description></description>
+  </device>
+  <!-- Smart Energy -->
+  <device id="0x0500" name="Energy Service Portal">
+    <description></description>
+  </device>
+  <device id="0x0501" name="Metering Device">
+    <description></description>
+  </device>
+  <device id="0x0502" name="In-Premise Display">
+    <description></description>
+  </device>
+  <device id="0x0503" name="Programmable Communicating Thermostat (PCT)" description="" icon="dev-prog-thermostat.png">
+    <description></description>
+  </device>
+  <device id="0x0504" name="Load Control Device">
+    <description></description>
+  </device>
+  <device id="0x0505" name="Smart Appliance">
+    <description></description>
+  </device>
+  <device id="0x0506" name="Prepayment Terminal">
+    <description></description>
+  </device>
+  <device id="0x0507" name="Device Management">
+    <description></description>
+  </device>
+</devices>
 </zcl>
 


### PR DESCRIPTION
A few new Sonoff clusters were discovered and documented on [zigpy](https://github.com/search?q=repo%3Azigpy%2Fzha-device-handlers%200xfc11&type=code). The PR #8510 department also contributed, thank you very much.

Zigpy uses `manufacturer code=None` for all attributes in cluster `0xFC11`.