### PR TITLE
Change `config/windowopen_set` to `config/windowopendetectionenabled` [1]

### DIFF
--- a/devices/danfoss/etrv0100_thermostat.json
+++ b/devices/danfoss/etrv0100_thermostat.json
@@ -35,6 +35,7 @@
         "device": "0x0301",
         "endpoint": "0x01",
         "in": [
+          "0x0000",
           "0x0001",
           "0x0201",
           "0x0204",
@@ -79,7 +80,7 @@
         },
         {
           "name": "config/battery",
-          "refresh.interval": 86400,
+          "refresh.interval": 43260,
           "parse": {
             "at": "0x0021",
             "cl": "0x0001",
@@ -127,7 +128,7 @@
         },
         {
           "name": "config/externalsensortemp",
-          "refresh.interval": 3600,
+          "refresh.interval": 3660,
           "read": {
             "at": "0x4015",
             "cl": "0x0201",
@@ -191,7 +192,7 @@
         },
         {
           "name": "config/heatsetpoint",
-          "refresh.interval": 3600,
+          "refresh.interval": 3660,
           "write": {
             "fn": "zcl:cmd",
             "ep": "0x01",
@@ -235,7 +236,7 @@
         },
         {
           "name": "config/mode",
-          "refresh.interval": 3600,
+          "refresh.interval": 3660,
           "read": {
             "at": "0x4030",
             "cl": "0x0201",
@@ -375,7 +376,6 @@
         },
         {
           "name": "config/windowopendetectionenabled",
-          "deprecated": "2026-03-10",
           "refresh.interval": 3660,
           "read": {
             "at": "0x4051",
@@ -446,7 +446,6 @@
         },
         {
           "name": "state/on",
-          "refresh.interval": 3660,
           "parse": {
             "at": "0x0008",
             "cl": "0x0201",
@@ -542,7 +541,7 @@
         },
         {
           "name": "config/battery",
-          "refresh.interval": 86400,
+          "refresh.interval": 43260,
           "parse": {
             "at": "0x0021",
             "cl": "0x0001",
@@ -562,18 +561,18 @@
         },
         {
           "name": "state/lastset",
-          "refresh.interval": 3700
+          "refresh.interval": 10860
         },
         {
           "name": "state/lastupdated"
         },
         {
           "name": "state/localtime",
-          "refresh.interval": 3700
+          "refresh.interval": 10860
         },
         {
           "name": "state/utc",
-          "refresh.interval": 3700
+          "refresh.interval": 10860
         }
       ]
     }
@@ -588,7 +587,7 @@
         {
           "at": "0x0021",
           "dt": "0x20",
-          "min": 3600,
+          "min": 7200,
           "max": 43200,
           "change": "0x00000002"
         }

--- a/devices/tuya/_TZE200_TYST11_trv.json
+++ b/devices/tuya/_TZE200_TYST11_trv.json
@@ -185,8 +185,7 @@
           }
         },
         {
-          "name": "config/windowopen_set",
-          "deprecated": "2026-03-10",
+          "name": "config/windowopendetectionenabled",
           "parse": {
             "fn": "tuya",
             "dpid": 18,

--- a/devices/tuya/_TZE200_h4cgnbzg_trv.json
+++ b/devices/tuya/_TZE200_h4cgnbzg_trv.json
@@ -120,8 +120,7 @@
           "name": "config/reachable"
         },
         {
-          "name": "config/windowopen_set",
-          "deprecated": "2026-03-10",
+          "name": "config/windowopendetectionenabled",
           "parse": {
             "fn": "tuya",
             "dpid": 8,


### PR DESCRIPTION
Currently there are two resource items for the same thing, and this PR will change it to `config/windowopen_set.`

```json
{
  "schema": "resourceitem1.schema.json",
  "id": "config/windowopen_set",
  "datatype": "Bool",
  "access": "RW",
  "public": true,
  "description": "Enable or disable the window open detection.",
  "default": false
}
```
```json
{
  "schema": "resourceitem1.schema.json",
  "id": "config/windowopendetectionenabled",
  "datatype": "Bool",
  "access": "RW",
  "public": true,
  "description": "Turns the window open detection feature on or off.",
  "default": true
}
```
In the hope that `config/windowopendetectionenabled` is not yet so widespread.