### PR TITLE
Update DDF for Sonoff TRVZB thermostat

### DIFF
--- a/devices/sonoff/trvzb-thermostat.json
+++ b/devices/sonoff/trvzb-thermostat.json
@@ -80,6 +80,32 @@
           "name": "config/checkin"
         },
         {
+          "name": "config/externalsensortemp",
+          "refresh.interval": 360,
+          "read": {
+            "at": "0x600D",
+            "cl": "0xFC11",
+            "ep": 1,
+            "fn": "zcl:attr"
+          },
+          "parse": {
+            "at": "0x600D",
+            "cl": "0xFC11",
+            "ep": 1,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl:attr"
+          },
+          "write": {
+            "at": "0x600D",
+            "cl": "0xFC11",
+            "dt": "0x29",
+            "ep": 1,
+            "eval": "Item.val",
+            "fn": "zcl:attr"
+          },
+          "default": 0
+        },
+        {
           "name": "config/heatsetpoint",
           "refresh.interval": 3660
         },


### PR DESCRIPTION
User @iseeberg79 had already prepared everything well, but it was too much in his PR #8510. For `config/frostprotection`, I think the deCONZ GUI control is sufficient, but it can always be added later.

- Add `config/externalsensortemp`
- Add `config/locked`
- Add `config/windowopen_set`
- Add `state/on`

Bindings are not necessary, I believe.