### PR TITLE
Remove incorrect `manufacturername` from Tuya smoke sensor (_TZE283_rccxox8p)

### DIFF
--- a/devices/tuya/_TZE200_TS0601_smoke_detector.json
+++ b/devices/tuya/_TZE200_TS0601_smoke_detector.json
@@ -5,11 +5,9 @@
     "_TZE200_m9skfctm",
     "_TZE200_vzekyi4c",
     "_TZE200_rccxox8p",
-    "_TZE283_rccxox8p",
     "_TZE284_rccxox8p"
   ],
   "modelid": [
-    "TS0601",
     "TS0601",
     "TS0601",
     "TS0601",


### PR DESCRIPTION
Unfortunately, the user made a typo back then and `_TZE283_rccxox8p` doesn't give it.