### PR TITLE
DDF clone for ION LED dimmer (ID200W-ZIGB)

### DIFF
--- a/devices/moes/Moes_MS-105-M_1_gang_dimmer_module.json
+++ b/devices/moes/Moes_MS-105-M_1_gang_dimmer_module.json
@@ -3,9 +3,13 @@
   "uuid": "09286594-6296-427e-9919-8eb9c31ac189",
   "manufacturername": [
     "_TZE200_la2c2uo9",
-    "_TZE204_dcnsggvz"
+    "_TZE204_dcnsggvz",
+    "_TZE200_4mh6tyyo",
+    "_TZE200_ykgar0ow"
   ],
   "modelid": [
+    "TS0601",
+    "TS0601",
     "TS0601",
     "TS0601"
   ],


### PR DESCRIPTION
Product name: ION Industries LED Zigbee Dimmer 200 Watt
Manufacturer: ION Industries
Model identifier: TS0601

See #8516