### PR TITLE
DDF clone for Tuya temperature & humidity sensor (_TZE200_qrztc3ev)

### DIFF
--- a/devices/tuya/_TZE200_TS0601_humidity_temperature.json
+++ b/devices/tuya/_TZE200_TS0601_humidity_temperature.json
@@ -3,10 +3,12 @@
   "uuid": "eafcb72b-f595-4cf0-a4a5-7958798d4253",
   "manufacturername": [
     "_TZE200_9yapgbuv",
+    "_TZE200_qrztc3ev",
     "_TZE204_d7lpruvi",
     "_TZE284_d7lpruvi"
   ],
   "modelid": [
+    "TS0601",
     "TS0601",
     "TS0601",
     "TS0601"


### PR DESCRIPTION
Product name: GIRIER ZigBee 3.0 Sensore
Manufacturer:_TZE200_qrztc3ev
Model identifier: TS0601

See #8530