### PR TITLE
DDF clone for Tuya temperature & humidity sensor (Wing/TS0201)

### DIFF
--- a/devices/tuya/_TZ3000_TS0201_temp_hum_sensor.json
+++ b/devices/tuya/_TZ3000_TS0201_temp_hum_sensor.json
@@ -16,6 +16,7 @@
     "_TZ3000_bjawzodf",
     "_TZ3000_rdhukkmi",
     "_TZ3000_dowj6gyi",
+    "Wing",
     "Zbeacon",
     "Zbeacon"
   ],
@@ -32,6 +33,7 @@
     "TS0201",
     "TS0201",
     "TY0201",
+    "TS0201",
     "TS0201",
     "TS0201",
     "TS0201",


### PR DESCRIPTION
Product name: Zigbee 3.0 Temp & Humidity sensor
Manufacturer: Wing
Model identifier: TS0201

See #8529