### PR TITLE
DDF for Arteco ZS-304Z soil moisture sensor

### DIFF
--- a/devices/arteco/ZS-304Z_temp_hum_light_moist_sensor.json
+++ b/devices/arteco/ZS-304Z_temp_hum_light_moist_sensor.json
@@ -366,31 +366,30 @@
           "name": "config/reachable"
         },
         {
-          "name": "config/tholddark",
-          "default": 12000
+          "name": "config/tholddark"
         },
         {
-          "name": "config/tholdoffset",
-          "default": 7000
+          "name": "config/tholdoffset"
         },
         {
-          "name": "state/dark",
-          "default": false
+          "name": "state/dark"
         },
         {
-          "name": "state/daylight",
-          "default": false
+          "name": "state/daylight"
         },
         {
           "name": "state/lastupdated"
         },
         {
-          "name": "state/lightlevel",
+          "name": "state/lightlevel"
+        },
+        {
+          "name": "state/lux",
           "awake": true,
           "parse": {
-            "fn": "tuya",
             "dpid": 102,
-            "eval": "Item.val = Attr.val"
+            "script": "../generic/illuminance_cluster/lux_to_lightlevel.js",
+            "fn": "tuya"
           },
           "read": {
             "fn": "none"


### PR DESCRIPTION
Product name: Zigbee Sensore di Umidità del Suolo Misuratore
Manufacturer: Arteco
Model identifier: ZS-304Z

See #8532