### PR TITLE
Fix parsing general.xml

### DIFF
--- a/general.xml
+++ b/general.xml
@@ -2689,7 +2689,7 @@
           <attribute id="0x400F" name="Unknown" type="u16" access="rw" required="o" mfcode="0x1209"></attribute>
           <attribute id="0x4020" name="Valve position" type="enum8" access="rw" required="o" mfcode="0x1209"></attribute>
           <attribute id="0x4021" name="Unknown" type="u16" access="rw" required="o" mfcode="0x1209"></attribute>
-          <attribute id="0x4022" name="Valve adaptation status" type="enum8" access="rw" required="o" mfcode="0x1209"></attribute>
+          <attribute id="0x4022" name="Valve adaptation status" type="enum8" access="rw" required="o" mfcode="0x1209">
           <value name="Unknown" value="0x00"></value>
           <value name="Ready to calibrate" value="0x01"></value>
           <value name="Calibration in progress" value="0x02"></value>


### PR DESCRIPTION
while loading deCONZ the parser fails due open/closing element mismatch.
When opening the general.xml in a browser the following error can be seen:

```
XML Parsing Error: mismatched tag. Expected: </attribute-set>.
Location: file:///home/mpi/src/deconz/src/plugins/de_web/general.xml
Line Number 2698, Column 11:
        </attribute>
----------^
```

This seems to be a regression from https://github.com/dresden-elektronik/deconz-rest-plugin/pull/8467

@mattreim can you have a look if the fix in this PR is correct?