### PR TITLE
DDF for Shelly Flood Gen4 (S4SN-0071A)

### DIFF
--- a/devices/shelly/shelly_flood_gen4.json
+++ b/devices/shelly/shelly_flood_gen4.json
@@ -45,7 +45,11 @@
           "name": "attr/name"
         },
         {
-          "name": "attr/swversion"
+          "name": "attr/swversion",
+          "static": "N/A",
+          "read": {
+            "fn": "none"
+          }
         },
         {
           "name": "attr/type"


### PR DESCRIPTION
The DDF is fixing this issue #8345, and the information comes from [Z2M](https://github.com/koenkk/zigbee2mqtt/issues/28553).