### PR TITLE
Change endpoint 3 to 4 on ubisys S1-R (5601)

### DIFF
--- a/devices/ubisys/s1_5501.json
+++ b/devices/ubisys/s1_5501.json
@@ -2,15 +2,13 @@
   "schema": "devcap1.schema.json",
   "uuid": "d275912e-9490-4deb-9225-c17b882703ae",
   "manufacturername": [
-    "ubisys",
     "ubisys"
   ],
   "modelid": [
-    "S1 (5501)",
-    "S1-R (5601)"
+    "S1 (5501)"
   ],
   "vendor": "ubisys",
-  "product": "Power switch (S1 (5501)/S1-R (5601))",
+  "product": "Power switch (S1 (5501))",
   "sleeper": false,
   "status": "Gold",
   "subdevices": [

--- a/devices/ubisys/s1r_5601.json
+++ b/devices/ubisys/s1r_5601.json
@@ -1,16 +1,13 @@
 {
   "schema": "devcap1.schema.json",
-  "uuid": "d275912e-9490-4deb-9225-c17b882703ae",
   "manufacturername": [
-    "ubisys",
     "ubisys"
   ],
   "modelid": [
-    "S1 (5501)",
     "S1-R (5601)"
   ],
   "vendor": "ubisys",
-  "product": "Power switch (S1 (5501)/S1-R (5601))",
+  "product": "Power switch (S1-R (5601))",
   "sleeper": false,
   "status": "Gold",
   "subdevices": [
@@ -183,13 +180,13 @@
       "restapi": "/sensors",
       "uuid": [
         "$address.ext",
-        "0x03",
+        "0x04",
         "0x0b04"
       ],
       "fingerprint": {
         "profile": "0x0104",
         "device": "0x0501",
-        "endpoint": "0x03",
+        "endpoint": "0x04",
         "in": [
           "0x0000",
           "0x0B04"
@@ -235,13 +232,13 @@
           "read": {
             "at": "0x0508",
             "cl": "0x0b04",
-            "ep": 3,
+            "ep": 4,
             "fn": "zcl:attr"
           },
           "parse": {
             "at": "0x0508",
             "cl": "0x0b04",
-            "ep": 3,
+            "ep": 4,
             "eval": "if (Attr.val != 65535) { Item.val = Attr.val; }"
           }
         },
@@ -254,7 +251,7 @@
           "read": {
             "at": "0x050b",
             "cl": "0x0b04",
-            "ep": 3,
+            "ep": 4,
             "fn": "zcl:attr"
           }
         },
@@ -264,7 +261,7 @@
           "read": {
             "at": "0x0505",
             "cl": "0x0b04",
-            "ep": 3,
+            "ep": 4,
             "fn": "zcl:attr"
           }
         }
@@ -275,13 +272,13 @@
       "restapi": "/sensors",
       "uuid": [
         "$address.ext",
-        "0x03",
+        "0x04",
         "0x0702"
       ],
       "fingerprint": {
         "profile": "0x0104",
         "device": "0x0501",
-        "endpoint": "0x03",
+        "endpoint": "0x04",
         "in": [
           "0x0000",
           "0x0702"
@@ -327,13 +324,13 @@
           "read": {
             "at": "0x0000",
             "cl": "0x0702",
-            "ep": 3,
+            "ep": 4,
             "fn": "zcl:attr"
           },
           "parse": {
             "at": "0x0000",
             "cl": "0x0702",
-            "ep": 3,
+            "ep": 4,
             "eval": "Item.val = Attr.val"
           }
         },
@@ -346,13 +343,13 @@
           "read": {
             "at": "0x0400",
             "cl": "0x0702",
-            "ep": 3,
+            "ep": 4,
             "fn": "zcl:attr"
           },
           "parse": {
             "at": "0x0400",
             "cl": "0x0702",
-            "ep": 3,
+            "ep": 4,
             "eval": "Item.val = Attr.val"
           }
         }
@@ -387,7 +384,7 @@
     },
     {
       "bind": "unicast",
-      "src.ep": 3,
+      "src.ep": 4,
       "cl": "0x0702",
       "report": [
         {


### PR DESCRIPTION
On my S1-R endpoint 4 is used instead of 3. The official documentation also shows this:
https://www.ubisys.de/downloads/ubisys-s1-technical-reference.pdf

<img width="865" height="631" alt="Screenshot 2026-03-10 at 21 43 06" src="https://github.com/user-attachments/assets/5f240fe8-bb3f-428c-95a8-ba1b4e69142f" />


In this PR I updated the endpoint by duplicating the files and modifying only for the S1-R.

Screenshot of my device:

<img width="367" height="974" alt="Screenshot 2026-03-10 at 21 17 19" src="https://github.com/user-attachments/assets/58f81120-8654-42fc-aad9-bf7f5f4f57e6" />
