### PR TITLE
Change HOBEIAN ZG-204ZV to Tuya (dpid)

### DIFF
--- a/devices/hobeian/hobeian_presence_temperature_humidity_lightlevel_sensor.json
+++ b/devices/hobeian/hobeian_presence_temperature_humidity_lightlevel_sensor.json
@@ -13,7 +13,7 @@
   ],
   "vendor": "HOBEIAN",
   "product": "Human presence sensor with temperature, humidity and light sensor (ZG-204ZV)",
-  "sleeper": false,
+  "sleeper": true,
   "status": "Gold",
   "subdevices": [
     {
@@ -67,6 +67,7 @@
         },
         {
           "name": "config/battery",
+          "awake": true,
           "parse": {
             "fn": "tuya",
             "dpid": 110,
@@ -151,6 +152,7 @@
         },
         {
           "name": "state/presence",
+          "awake": true,
           "read": {
             "fn": "none"
           },
@@ -214,6 +216,7 @@
         },
         {
           "name": "config/battery",
+          "awake": true,
           "parse": {
             "fn": "tuya",
             "dpid": 110,
@@ -239,6 +242,7 @@
         },
         {
           "name": "state/temperature",
+          "awake": true,
           "parse": {
             "fn": "tuya",
             "dpid": 111,
@@ -302,6 +306,7 @@
         },
         {
           "name": "config/battery",
+          "awake": true,
           "parse": {
             "fn": "tuya",
             "dpid": 110,
@@ -324,6 +329,7 @@
         },
         {
           "name": "state/humidity",
+          "awake": true,
           "parse": {
             "fn": "tuya",
             "dpid": 101,
@@ -390,6 +396,7 @@
         },
         {
           "name": "config/battery",
+          "awake": true,
           "parse": {
             "fn": "tuya",
             "dpid": 110,
@@ -426,6 +433,7 @@
         },
         {
           "name": "state/lux",
+          "awake": true,
           "parse": {
             "dpid": 106,
             "script": "../generic/illuminance_cluster/lux_to_lightlevel.js",


### PR DESCRIPTION
This will fully add the device to Tuya (dpid) and the following items.
- Add `config/ledindication`
- Add `config/fadingtime`
- Change to Tuya swversion

These attributes are known for this type of device:
```typescript
        meta: {
            tuyaDatapoints: [
                [1, "presence", tuya.valueConverter.trueFalse1],
                [106, "illuminance", tuya.valueConverter.raw],
                [102, "fading_time", tuya.valueConverter.raw],
                [2, "motion_detection_sensitivity", tuya.valueConverter.raw],
                [108, "indicator", tuya.valueConverter.onOff],
                [110, "battery", tuya.valueConverter.raw],
                [111, "temperature", tuya.valueConverter.divideBy10],
                [101, "humidity", tuya.valueConverter.raw],
                [109, "temperature_unit", tuya.valueConverter.temperatureUnit],
                [105, "temperature_calibration", tuya.valueConverter.divideBy10],
                [104, "humidity_calibration", tuya.valueConverter.raw],
                [107, "illuminance_interval", tuya.valueConverter.raw],
            ],
        },

```