### PR TITLE
Change Arteco ZS-304Z to Tuya (dpid)

### DIFF
--- a/devices/arteco/ZS-304Z_temp_hum_light_moist_sensor.json
+++ b/devices/arteco/ZS-304Z_temp_hum_light_moist_sensor.json
@@ -5,7 +5,7 @@
   "modelid": "ZS-304Z",
   "vendor": "Arteco",
   "product": "Soil moisture sensor (ZS-304Z)",
-  "sleeper": false,
+  "sleeper": true,
   "status": "Gold",
   "subdevices": [
     {
@@ -59,6 +59,7 @@
         },
         {
           "name": "config/battery",
+          "awake": true,
           "parse": {
             "fn": "tuya",
             "dpid": 14,
@@ -84,6 +85,7 @@
         },
         {
           "name": "state/temperature",
+          "awake": true,
           "parse": {
             "fn": "tuya",
             "dpid": 5,
@@ -147,6 +149,7 @@
         },
         {
           "name": "config/battery",
+          "awake": true,
           "parse": {
             "fn": "tuya",
             "dpid": 14,
@@ -172,6 +175,7 @@
         },
         {
           "name": "state/humidity",
+          "awake": true,
           "parse": {
             "fn": "tuya",
             "dpid": 101,
@@ -235,6 +239,7 @@
         },
         {
           "name": "config/battery",
+          "awake": true,
           "parse": {
             "fn": "tuya",
             "dpid": 14,
@@ -257,6 +262,7 @@
         },
         {
           "name": "state/moisture",
+          "awake": true,
           "parse": {
             "fn": "tuya",
             "dpid": 3,
@@ -323,6 +329,7 @@
         },
         {
           "name": "config/battery",
+          "awake": true,
           "parse": {
             "fn": "tuya",
             "dpid": 14,
@@ -359,6 +366,7 @@
         },
         {
           "name": "state/lux",
+          "awake": true,
           "parse": {
             "dpid": 102,
             "script": "../generic/illuminance_cluster/lux_to_lightlevel.js",
@@ -422,6 +430,7 @@
         },
         {
           "name": "config/battery",
+          "awake": true,
           "parse": {
             "fn": "tuya",
             "dpid": 14,
@@ -443,6 +452,7 @@
         },
         {
           "name": "state/water",
+          "awake": true,
           "parse": {
             "fn": "tuya",
             "dpid": 111,


### PR DESCRIPTION
This will completely configure the device to use Tuya (dpid).

These attributes are known for this type of device:
```typescript
    meta: {
        tuyaDatapoints: [
            [3, 'soil_moisture', tuya.valueConverter.raw],
            [5, 'temperature', tuya.valueConverter.divideBy10],
            [101,'humidity', tuya.valueConverter.raw],
            [102,'illuminance', tuya.valueConverter.raw],
            [14,'battery_state', tuya.valueConverterBasic.lookup({'low':tuya.enum(0),'middle':tuya.enum(1),'high':tuya.enum(2)})],
            [103, "soil_sampling", tuya.valueConverter.raw],
            [104,'soil_calibration', tuya.valueConverter.raw],
            [105,'humidity_calibration', tuya.valueConverter.raw],
            [106,"illuminance_calibration", tuya.valueConverter.raw],
            [107,'temperature_calibration', tuya.valueConverter.divideBy10],
            [110,"soil_warning", tuya.valueConverter.raw],
            [111,"water_warning", tuya.valueConverterBasic.lookup({'none': tuya.enum(0),'alarm':tuya.enum(1)})]
        ],
    },
```