### PR TITLE
Update DDF for SRAIN-01 rain sensor

### DIFF
--- a/devices/tuya/_TZ3210_TS0207_rain_light_sensor.json
+++ b/devices/tuya/_TZ3210_TS0207_rain_light_sensor.json
@@ -87,8 +87,7 @@
             "at": "0x0021",
             "cl": "0x0001",
             "ep": 1,
-            "eval": "Item.val = Attr.val / 2",
-            "fn": "zcl:attr"
+            "eval": "Item.val = Attr.val / 2"
           },
           "default": 0
         },
@@ -194,8 +193,7 @@
             "at": "0x0021",
             "cl": "0x0001",
             "ep": 1,
-            "eval": "Item.val = Attr.val / 2",
-            "fn": "zcl:attr"
+            "eval": "Item.val = Attr.val / 2"
           },
           "default": 0
         },


### PR DESCRIPTION
Add:
Product name: RB-SRAIN01
Manufacturer: _TZ3210_p68kms0l
Model identifier:TS0207

See #8556

Changed:
The rainfall intensity is displayed as `state/voltage` in the water leak sensor. 
![mV](https://github.com/user-attachments/assets/f0f456e5-04d8-4859-a48a-2afbec856647)


- Change `TYPE_HUMIDITY_SENSOR` to `TYPE_WATER_LEAK_SENSOR`
- Add light script
- JSON name corrected

```typescript
            tuyaDatapoints: [
                [4, "battery", tuya.valueConverter.raw],
                [101, "illuminance", tuya.valueConverter.raw],
                [102, "illuminance_average_20min", tuya.valueConverter.raw],
                [103, "illuminance_maximum_today", tuya.valueConverter.raw],
                [104, "cleaning_reminder", tuya.valueConverter.trueFalse0],
                [105, "rain_intensity", tuya.valueConverter.raw], // [mV]
            ],
        },

```