### PR TITLE
Update DDF for Moes ZM-105-M 1-gang dimmer module

### DIFF
--- a/devices/moes/Moes_MS-105-M_1_gang_dimmer_module.json
+++ b/devices/moes/Moes_MS-105-M_1_gang_dimmer_module.json
@@ -132,6 +132,43 @@
           }
         },
         {
+          "name": "config/duration",
+          "description": "The duration to turn device off after a certain time.",
+          "parse": {
+            "dpid": 6,
+            "eval": "Item.val = Attr.val",
+            "fn": "tuya"
+          },
+          "write": {
+            "dpid": 6,
+            "dt": "0x2b",
+            "eval": "Item.val",
+            "fn": "tuya"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "config/ledindication",
+          "description": "Turn the backlight on or off",
+          "parse": {
+            "dpid": 21,
+            "eval": "Item.val = Attr.val",
+            "fn": "tuya"
+          },
+          "write": {
+            "dpid": 21,
+            "dt": "0x10",
+            "eval": "Item.val == 1 ? 1 : 0;",
+            "fn": "tuya"
+          },
+          "read": {
+            "fn": "none"
+          },
+          "default": 0
+        },
+        {
           "name": "config/on/startup",
           "values": [
             [

--- a/devices/moes/Moes_MS-105-M_1_gang_dimmer_module.json
+++ b/devices/moes/Moes_MS-105-M_1_gang_dimmer_module.json
@@ -101,6 +101,23 @@
           }
         },
         {
+          "name": "config/on/startup",
+          "parse": {
+            "fn": "tuya",
+            "dpid": 14,
+            "eval": "Item.val = Attr.val"
+          },
+          "write": {
+            "fn": "tuya",
+            "dpid": 14,
+            "dt": "0x30",
+            "eval": "Item.val"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
           "name": "state/alert",
           "default": "none",
           "public": false

--- a/devices/moes/Moes_MS-105-M_1_gang_dimmer_module.json
+++ b/devices/moes/Moes_MS-105-M_1_gang_dimmer_module.json
@@ -101,6 +101,37 @@
           }
         },
         {
+          "name": "config/devicemode",
+          "values": [
+            [
+              "led",
+              0
+            ],
+            [
+              "incandescent",
+              1
+            ],
+            [
+              "halogen",
+              2
+            ]
+          ],
+          "parse": {
+            "fn": "tuya",
+            "dpid": 4,
+            "eval": "if (Attr.val == 0) { Item.val = 'led' } else if (Attr.val == 1) { Item.val = 'incandescent' } else { Item.val = 'halogen' }"
+          },
+          "write": {
+            "fn": "tuya",
+            "dpid": 4,
+            "dt": "0x30",
+            "eval": "if (Item.val == 'led') { 0 } else if (Item.val == 'incandescent') { 1 } else { halogen }"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
           "name": "config/on/startup",
           "values": [
             [

--- a/devices/moes/Moes_MS-105-M_1_gang_dimmer_module.json
+++ b/devices/moes/Moes_MS-105-M_1_gang_dimmer_module.json
@@ -67,6 +67,40 @@
           "name": "attr/uniqueid"
         },
         {
+          "name": "config/bri/max",
+          "parse": {
+            "fn": "tuya",
+            "dpid": 5,
+            "eval": "Item.val = (Attr.val / 1000.0) * 254.0;"
+          },
+          "write": {
+            "fn": "tuya",
+            "dpid": 5,
+            "dt": "0x2b",
+            "eval": "(Item.val / 254.0) * 1000.0;"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
+          "name": "config/bri/min",
+          "parse": {
+            "fn": "tuya",
+            "dpid": 3,
+            "eval": "Item.val = (Attr.val / 1000.0) * 254.0;"
+          },
+          "write": {
+            "fn": "tuya",
+            "dpid": 3,
+            "dt": "0x2b",
+            "eval": "(Item.val / 254.0) * 1000.0;"
+          },
+          "read": {
+            "fn": "none"
+          }
+        },
+        {
           "name": "state/alert",
           "default": "none",
           "public": false

--- a/devices/moes/Moes_MS-105-M_1_gang_dimmer_module.json
+++ b/devices/moes/Moes_MS-105-M_1_gang_dimmer_module.json
@@ -102,16 +102,30 @@
         },
         {
           "name": "config/on/startup",
+          "values": [
+            [
+              "off",
+              0
+            ],
+            [
+              "on",
+              1
+            ],
+            [
+              "previous",
+              2
+            ]
+          ],
           "parse": {
             "fn": "tuya",
             "dpid": 14,
-            "eval": "Item.val = Attr.val"
+            "eval": "if (Attr.val == 0) { Item.val = 'off' } else if (Attr.val == 1) { Item.val = 'on' } else { Item.val = 'previous' }"
           },
           "write": {
             "fn": "tuya",
             "dpid": 14,
             "dt": "0x30",
-            "eval": "Item.val"
+            "eval": "if (Item.val == 'off') { 0 } else if (Item.val == 'on') { 1 } else { previous }"
           },
           "read": {
             "fn": "none"


### PR DESCRIPTION
I think these attributes could be useful for some users with these dimmer modules.

- Add `config/bri/min`
- Add `config/bri/max`
- Add `config/on/startup` = `power_on_behavior`
- Add `config/devicemode` = `light_type`
- Add `config/duration` = `countdown`
- Add `config/ledindication` = `backlight_mode`

These attributes are known for this type of device:
```typescript
        meta: {
            tuyaDatapoints: [
                [1, "state", tuya.valueConverter.onOff, {skip: tuya.skip.stateOnAndBrightnessPresent}],
                [2, "brightness", tuya.valueConverter.scale0_254to0_1000],
                [3, "min_brightness", tuya.valueConverter.scale0_254to0_1000],
                [
                    4,
                    "light_type",
                    tuya.valueConverterBasic.lookup({
                        led: tuya.enum(0),
                        incandescent: tuya.enum(1),
                        halogen: tuya.enum(2),
                    }),
                ],
                [5, "max_brightness", tuya.valueConverter.scale0_254to0_1000],
                [6, "countdown", tuya.valueConverter.countdown],
                [
                    14,
                    "power_on_behavior",
                    tuya.valueConverterBasic.lookup({
                        off: tuya.enum(0),
                        on: tuya.enum(1),
                        previous: tuya.enum(2),
                    }),
                ],
                [21, "backlight_mode", tuya.valueConverter.backlightModeOffNormalInverted],
            ],
        },

```