### PR TITLE
Update DDF for Aqara smart radiator thermostat E1

### DIFF
--- a/devices/xiaomi/xiaomi_srt-a01_thermostat.json
+++ b/devices/xiaomi/xiaomi_srt-a01_thermostat.json
@@ -231,7 +231,7 @@
           "write": {
             "at": "0x0274",
             "cl": "0xFCC0",
-            "dt": "0x10",
+            "dt": "0x20",
             "ep": 1,
             "eval": "Item.val",
             "fn": "zcl:attr",
@@ -258,7 +258,7 @@
           "write": {
             "at": "0x0273",
             "cl": "0xFCC0",
-            "dt": "0x10",
+            "dt": "0x20",
             "ep": 1,
             "eval": "Item.val",
             "fn": "zcl:attr",

--- a/devices/xiaomi/xiaomi_srt-a01_thermostat.json
+++ b/devices/xiaomi/xiaomi_srt-a01_thermostat.json
@@ -233,7 +233,7 @@
             "cl": "0xFCC0",
             "dt": "0x20",
             "ep": 1,
-            "eval": "Item.val",
+            "eval": "if (Item.val == true) { 1 } else { 0 }",
             "fn": "zcl:attr",
             "mf": "0x115f"
           }
@@ -260,7 +260,7 @@
             "cl": "0xFCC0",
             "dt": "0x20",
             "ep": 1,
-            "eval": "Item.val",
+            "eval": "if (Item.val == true) { 1 } else { 0 }",
             "fn": "zcl:attr",
             "mf": "0x115f"
           }

--- a/devices/xiaomi/xiaomi_srt-a01_thermostat.json
+++ b/devices/xiaomi/xiaomi_srt-a01_thermostat.json
@@ -22,7 +22,7 @@
         "endpoint": "0x01",
         "in": [
           "0x0000",
-          "0xfcc0",
+          "0xFCC0",
           "0x0201"
         ]
       },
@@ -65,17 +65,17 @@
         {
           "name": "config/battery",
           "read": {
-            "at": "0x040a",
-            "cl": "0xfcc0",
+            "at": "0x040A",
+            "cl": "0xFCC0",
             "ep": 1,
             "fn": "zcl:attr",
             "mf": "0x115f"
           },
           "parse": {
-            "at": "0x040a",
-            "cl": "0xfcc0",
+            "at": "0x040A",
+            "cl": "0xFCC0",
             "ep": 1,
-            "eval": "Item.val = Attr.val;",
+            "eval": "Item.val = Attr.val",
             "fn": "zcl:attr",
             "mf": "0x115f"
           },
@@ -93,7 +93,7 @@
             "at": "0x0012",
             "cl": "0x0201",
             "ep": 1,
-            "eval": "Item.val = Attr.val;",
+            "eval": "Item.val = Attr.val",
             "fn": "zcl:attr"
           },
           "default": 0
@@ -102,22 +102,22 @@
           "name": "config/locked",
           "read": {
             "at": "0x0277",
-            "cl": "0xfcc0",
+            "cl": "0xFCC0",
             "ep": 1,
             "fn": "zcl:attr",
             "mf": "0x115f"
           },
           "parse": {
             "at": "0x0277",
-            "cl": "0xfcc0",
+            "cl": "0xFCC0",
             "ep": 1,
-            "eval": "Item.val = Attr.val;",
+            "eval": "Item.val = Attr.val",
             "fn": "zcl:attr",
             "mf": "0x115f"
           },
           "write": {
             "at": "0x0277",
-            "cl": "0xfcc0",
+            "cl": "0xFCC0",
             "dt": "0x20",
             "ep": 1,
             "eval": "if (Item.val == true) { 1 } else { 0 }",
@@ -128,6 +128,27 @@
         },
         {
           "name": "config/offset",
+          "read": {
+            "at": "0x0010",
+            "cl": "0x0201",
+            "ep": 1,
+            "fn": "zcl:attr"
+          },
+          "write": {
+            "at": "0x0010",
+            "cl": "0x0201",
+            "dt": "0x28",
+            "ep": 1,
+            "eval": "Item.val / 10;",
+            "fn": "zcl:attr"
+          },
+          "parse": {
+            "at": "0x0010",
+            "cl": "0x0201",
+            "ep": 1,
+            "eval": "Item.val = Attr.val * 10;",
+            "fn": "zcl:attr"
+          },
           "default": 0
         },
         {
@@ -137,14 +158,14 @@
           "name": "config/mode",
           "read": {
             "at": "0x0271",
-            "cl": "0xfcc0",
+            "cl": "0xFCC0",
             "ep": 1,
             "fn": "zcl:attr",
             "mf": "0x115f"
           },
           "parse": {
             "at": "0x0271",
-            "cl": "0xfcc0",
+            "cl": "0xFCC0",
             "ep": 1,
             "eval": "Item.val = ['off', 'heat'][Attr.val];",
             "fn": "zcl:attr",
@@ -152,7 +173,7 @@
           },
           "write": {
             "at": "0x0271",
-            "cl": "0xfcc0",
+            "cl": "0xFCC0",
             "dt": "0x20",
             "ep": 1,
             "eval": "if (Item.val == 'off') { 0 } else if (Item.val == 'heat') { 1 }",
@@ -164,14 +185,14 @@
           "name": "config/preset",
           "read": {
             "at": "0x0272",
-            "cl": "0xfcc0",
+            "cl": "0xFCC0",
             "ep": 1,
             "fn": "zcl:attr",
             "mf": "0x115f"
           },
           "parse": {
             "at": "0x0272",
-            "cl": "0xfcc0",
+            "cl": "0xFCC0",
             "ep": 1,
             "eval": "Item.val = ['manual', 'auto', 'holiday'][Attr.val];",
             "fn": "zcl:attr",
@@ -179,7 +200,7 @@
           },
           "write": {
             "at": "0x0272",
-            "cl": "0xfcc0",
+            "cl": "0xFCC0",
             "dt": "0x20",
             "ep": 1,
             "eval": "if (Item.val == 'manual') { 0 } else if (Item.val == 'auto') { 1 } else if (Item.val == 'holiday') { 2 }",
@@ -191,16 +212,89 @@
           "name": "config/reachable"
         },
         {
+          "name": "config/setvalve",
+          "read": {
+            "at": "0x0274",
+            "cl": "0xFCC0",
+            "ep": 1,
+            "fn": "zcl:attr",
+            "mf": "0x115f"
+          },
+          "parse": {
+            "at": "0x0274",
+            "cl": "0xFCC0",
+            "ep": 1,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl:attr",
+            "mf": "0x115f"
+          },
+          "write": {
+            "at": "0x0274",
+            "cl": "0xFCC0",
+            "dt": "0x10",
+            "ep": 1,
+            "eval": "Item.val",
+            "fn": "zcl:attr",
+            "mf": "0x115f"
+          }
+        },
+        {
+          "name": "config/windowopendetectionenabled",
+          "read": {
+            "at": "0x0273",
+            "cl": "0xFCC0",
+            "ep": 1,
+            "fn": "zcl:attr",
+            "mf": "0x115f"
+          },
+          "parse": {
+            "at": "0x0273",
+            "cl": "0xFCC0",
+            "ep": 1,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl:attr",
+            "mf": "0x115f"
+          },
+          "write": {
+            "at": "0x0273",
+            "cl": "0xFCC0",
+            "dt": "0x10",
+            "ep": 1,
+            "eval": "Item.val",
+            "fn": "zcl:attr",
+            "mf": "0x115f"
+          }
+        },
+        {
+          "name": "state/errorcode",
+          "read": {
+            "at": "0x0275",
+            "cl": "0xFCC0",
+            "ep": 1,
+            "fn": "zcl:attr",
+            "mf": "0x115f"
+          },
+          "parse": {
+            "at": "0x0275",
+            "cl": "0xFCC0",
+            "ep": 1,
+            "eval": "Item.val = Attr.val",
+            "fn": "zcl:attr",
+            "mf": "0x115f"
+          },
+          "default": 0
+        },
+        {
           "name": "state/lastupdated"
         },
         {
           "name": "state/on",
-          "refresh.interval": 5,
+          "refresh.interval": 300,
           "parse": {
             "at": "0x0271",
-            "cl": "0xfcc0",
+            "cl": "0xFCC0",
             "ep": 1,
-            "eval": "Item.val = Attr.val;",
+            "eval": "Item.val = Attr.val",
             "fn": "zcl:attr",
             "mf": "0x115f"
           }
@@ -217,7 +311,7 @@
             "at": "0x0000",
             "cl": "0x0201",
             "ep": 1,
-            "eval": "Item.val = Attr.val;",
+            "eval": "Item.val = Attr.val",
             "fn": "zcl:attr"
           },
           "default": 0
@@ -225,15 +319,15 @@
         {
           "name": "state/windowopen",
           "read": {
-            "at": "0x027a",
-            "cl": "0xfcc0",
+            "at": "0x027A",
+            "cl": "0xFCC0",
             "ep": 1,
             "fn": "zcl:attr",
             "mf": "0x115f"
           },
           "parse": {
-            "at": "0x027a",
-            "cl": "0xfcc0",
+            "at": "0x027A",
+            "cl": "0xFCC0",
             "ep": 1,
             "eval": "Item.val = (Attr.val == 1);",
             "fn": "zcl:attr",


### PR DESCRIPTION
The DDF could be further extended using [_TZE200_TYST11_trv](https://github.com/dresden-elektronik/deconz-rest-plugin/blob/master/devices/tuya/_TZE200_TYST11_trv.json).

- Change `config/offset`
- Add `config/setvalve`
- Add `config/windowopendetectionenabled`
- Add `state/errorcode`