### PR TITLE
DDF clone for Nous A6Z outdoor plug (_TZ3000_266azbg3)

### DIFF
--- a/devices/tuya/_TZ3000_TS011F_smart_plug.json
+++ b/devices/tuya/_TZ3000_TS011F_smart_plug.json
@@ -12,9 +12,11 @@
     "_TZ3000_typdpbpg",
     "_TZ3210_5ct6e7ye",
     "_TZ3210_rwmitwj4",
-    "_TZ3210_w0qqde0g"
+    "_TZ3210_w0qqde0g",
+    "_TZ3000_266azbg3"
   ],
   "modelid": [
+    "TS011F",
     "TS011F",
     "TS011F",
     "TS011F",


### PR DESCRIPTION
since I had a bunch of Nous A1Z smart plugs (_TZ3000_2putqrmw), which worked like a charme, I bought the Nous A6Z Outdoor Plug (_TZ3000_266azbg3) having high hopes that it also works out of the box. 

Switching the plug on/off worked. However, the energy consumption and power parameters did not work. To solve that, I simply used the same DDF for the A6Z as deconz used for the A1Z and voilà, energy monitoring also works now.

