### PR TITLE
Rename XML attribute for identifying manufacturer specific commands

### DIFF
--- a/general.xml
+++ b/general.xml
@@ -488,7 +488,7 @@
           <attribute id="0xfffe" name="Unknown3" type="enum8" default="0" access="rw" required="o"></attribute>
         </attribute-set>
         <command id="00" dir="recv" name="Reset to Factory Defaults" required="o"></command>
-        <command id="0xc0" dir="recv" name="Hue Capabilities" vendor="0x100b" required="o" response="0xc1">
+        <command id="0xc0" dir="recv" name="Hue Capabilities" mfcode="0x100b" required="o" response="0xc1">
           <payload>
             <attribute id="0x0000" type="u8" name="0x00" default="0x00" showas="hex" required="m"></attribute>
             <attribute id="0x0001" type="u32" name="Offset" default="0x00" showas="hex" required="m"></attribute>
@@ -497,7 +497,7 @@
         </command>
       </server>
       <client>
-        <command id="0xc1" dir="recv" name="Hue Capabilities Response" vendor="0x100b" required="o">
+        <command id="0xc1" dir="recv" name="Hue Capabilities Response" mfcode="0x100b" required="o">
           <payload>
             <attribute id="0x0000" type="u16" name="Status" showas="hex" required="m"></attribute>
             <attribute id="0x0001" type="u32" name="Offset" showas="hex" required="m"></attribute>
@@ -773,7 +773,7 @@
             <attribute id="0x0001" type="u8" name="Scene ID" required="m" showas="hex" default="0x00"></attribute>
           </payload>
         </command>
-        <command id="0x07" dir="recv" name="IKEA step" required="o" vendor="0x117c">
+        <command id="0x07" dir="recv" name="IKEA step" required="o" mfcode="0x117c">
           <description>Command sent by TRADFRI remote control on press left or right.  Set Direction to 1 for left or leave at 0 for right.  Leave the Unknown parameters at their default values.</description>
           <payload>
             <attribute id="0x0000" type="u8" name="Direction" required="m" default="0x0"></attribute>
@@ -781,14 +781,14 @@
             <attribute id="0x0002" type="u16" name="Unknown" required="m" showas="hex" default="0x000d"></attribute>
           </payload>
         </command>
-        <command id="0x08" dir="recv" name="IKEA move" required="o" vendor="0x117c">
+        <command id="0x08" dir="recv" name="IKEA move" required="o" mfcode="0x117c">
           <description>Command sent by TRADFRI remote control on hold left or right.  Set Direction to 1 for left or leave at 0 for right.  Leave the Unknown parameter at its default value.</description>
           <payload>
             <attribute id="0x0000" type="u8" name="Direction" required="m" default="0x0"></attribute>
             <attribute id="0x0001" type="u16" name="Unknown" required="m" showas="hex" default="0x000d"></attribute>
           </payload>
         </command>
-        <command id="0x09" dir="recv" name="IKEA stop" required="o" vendor="0x117c">
+        <command id="0x09" dir="recv" name="IKEA stop" required="o" mfcode="0x117c">
           <description>Command sent by TRADFRI remote control on release (after hold).  Leave the Unknown parameter at its default value.</description>
           <payload>
             <attribute id="0x0000" type="u16" name="Unknown" required="m" showas="hex" default="0x0000"></attribute>
@@ -5226,7 +5226,7 @@
             <attribute id="0x0000" type="u8" name="Start index" showas="dec" required="m" default="0"></attribute>
           </payload>
         </command>
-        <command id="0xd0" dir="recv" name="Write MAC address" required="m" vendor="0x1135">
+        <command id="0xd0" dir="recv" name="Write MAC address" required="m" mfcode="0x1135">
           <description>Non standard write MAC address (DDEL).</description>
           <payload>
             <attribute id="0x0000" type="u64" name="MAC address" showas="hex" required="m" default="0"></attribute>
@@ -5386,7 +5386,7 @@
     <cluster id="0xfc03" name="Hue Effects" mfcode="0x100b">
       <description>Hue-specific cluster for Hue lights.</description>
       <server>
-        <command id="0x00" dir="recv" name="Set Effect" vendor="0x100b" required="m">
+        <command id="0x00" dir="recv" name="Set Effect" mfcode="0x100b" required="m">
           <payload>
             <attribute id="0x0000" type="u16" name="Command" showas="hex" default="0x0020" required="o"></attribute>
             <attribute id="0x0001" type="enum8" name="Effect" required="m">
@@ -5456,7 +5456,7 @@
     <cluster id="0xfc04" name="Hue MotionAware" mfcode="0x100b">
       <description>Hue-specific cluster for Hue MotionAware.</description>
       <server>
-        <command id="0x00" dir="recv" name="Configure" vendor="0x100b" required="m">
+        <command id="0x00" dir="recv" name="Configure" mfcode="0x100b" required="m">
           <description>Sent by bridge to each member to configure reporting.</description>
           <payload>
             <attribute id="0x0000" type="bmp16" name="Role" required="m">
@@ -5480,7 +5480,7 @@
             </attribute>
           </payload>
         </command>
-        <command id="0x00" dir="send" name="Report" vendor="0x100b" required="m">
+        <command id="0x00" dir="send" name="Report" mfcode="0x100b" required="m">
           <description>Sent by the proxy to the bridge.</description>
           <payload>
             <attribute id="0x0000" type="u32" name="ID" required="m"/>
@@ -5489,13 +5489,13 @@
             <attribute id="0x0003" type="ostring" name="Data" required="m"/>
           </payload>
         </command>
-        <command id="0x10" dir="recv" name="Start" vendor="0x100b" required="m">
+        <command id="0x10" dir="recv" name="Start" mfcode="0x100b" required="m">
           <description>Sent by bridge to each member to start sending reports.</description>
           <payload>
             <attribute id="0x0000" type="u32" name="ID" required="m"/>
           </payload>
         </command>
-        <command id="0x11" dir="recv" name="Stop" vendor="0x100b" required="m">
+        <command id="0x11" dir="recv" name="Stop" mfcode="0x100b" required="m">
           <description>Sent by bridge to the proxy to stop sending reports.</description>
           <payload>
             <attribute id="0x0000" type="u32" name="ID" required="m"/>
@@ -5539,9 +5539,9 @@
     <cluster id="0xfc07" name="Hue Chime" mfcode="0x100b">
       <description>Hue-specific cluster for Hue Chime.</description>
       <server>
-        <command id="0x00" dir="recv" name="Mute" vendor="0x100b" required="m"/>
-        <command id="0x01" dir="recv" name="Unmute" vendor="0x100b" required="m"/>
-        <command id="0x02" dir="recv" name="Set Alarm" vendor="0x100b" required="m">
+        <command id="0x00" dir="recv" name="Mute" mfcode="0x100b" required="m"/>
+        <command id="0x01" dir="recv" name="Unmute" mfcode="0x100b" required="m"/>
+        <command id="0x02" dir="recv" name="Set Alarm" mfcode="0x100b" required="m">
           <payload>
             <attribute id="0x0000" type="enum8" name="Action" required="m" default="0x01">
               <value name="Set" value="0x00"/>
@@ -5556,7 +5556,7 @@
             <attribute id="0x0004" type="u24" name="000000" required="m" default="0x000000" showas="hex"/>
           </payload>
         </command>
-        <command id="0x03" dir="recv" name="Set Chime" vendor="0x100b" required="m">
+        <command id="0x03" dir="recv" name="Set Chime" mfcode="0x100b" required="m">
           <payload>
             <attribute id="0x0000" type="enum8" name="Action" required="m" default="0x01">
               <value name="Set" value="0x00"/>
@@ -5587,7 +5587,7 @@
             <attribute id="0x0003" type="u8" name="Volume" required="m" default="25"/>
           </payload>
         </command>
-        <command id="0x04" dir="recv" name="Set Alert" vendor="0x100b" required="m">
+        <command id="0x04" dir="recv" name="Set Alert" mfcode="0x100b" required="m">
           <payload>
             <attribute id="0x0000" type="enum8" name="Action" required="m" default="0x01">
               <value name="Set" value="0x00"/>


### PR DESCRIPTION
Streamline XML attribute naming.

Relies on https://github.com/dresden-elektronik/deconz-lib/pull/6