### PR TITLE
DDF clone for Tuya rain sensor (_TZ3000_otwpdq1d)

### DIFF
--- a/devices/tuya/_TZ3000_TS0207_rain_sensor.json
+++ b/devices/tuya/_TZ3000_TS0207_rain_sensor.json
@@ -1,8 +1,14 @@
 {
   "schema": "devcap1.schema.json",
   "uuid": "33d78af8-da01-4e00-af65-9bcbfd6ce0cf",
-  "manufacturername": "_TZ3000_imdfhhud",
-  "modelid": "TS0207",
+  "manufacturername": [
+    "_TZ3000_imdfhhud",
+    "_TZ3000_otwpdq1d"
+  ],
+  "modelid": [
+    "TS0207",
+    "TS0207"
+  ],
   "vendor": "Tuya",
   "product": "Rain sensor (TS0207)",
   "sleeper": true,
@@ -113,7 +119,7 @@
           "at": "0x0021",
           "dt": "0x20",
           "min": 7200,
-          "max": 14400,
+          "max": 43200,
           "change": "0x00000001"
         }
       ]


### PR DESCRIPTION
Product name: IH-YS01-ZigBee Rain sensor Tuya
Manufacturer: Shenzhen Yihong Lighting Co.,Ltd
Model identifier: TS0207

See #8593
