### PR TITLE
DDF clone for Sonoff SNZB-04PR2

### DIFF
--- a/devices/sonoff/snzb-04_open_close_sensor.json
+++ b/devices/sonoff/snzb-04_open_close_sensor.json
@@ -6,14 +6,16 @@
     "eWeLink",
     "zbeacon",
     "eWeLink",
-    "eWeLink"
+    "eWeLink",
+    "SONOFF"
   ],
   "modelid": [
     "CK-TLSR8656-SS5-01(7003)",
     "DS01",
     "DS01",
+    "SNZB-04",
     "SNZB-04P",
-    "SNZB-04"
+    "SNZB-04PR2"
   ],
   "vendor": "Sonoff/eWeLink",
   "product": "Open/close sensor (DS01)",
@@ -119,8 +121,8 @@
         {
           "at": "0x0021",
           "dt": "0x20",
-          "min": 3600,
-          "max": 7200,
+          "min": 7200,
+          "max": 43200,
           "change": "0x00000002"
         }
       ]


### PR DESCRIPTION
Product name: SenseGuard DW Gen2
Manufacturer: Sonoff
Model identifier: SNZB-04PR2

See #8591