### PR TITLE
DDF add a clone for _TZ3000_okaz9tjs smart plug

### DIFF
--- a/devices/tuya/_TZ3000_TS011F_smart_plug.json
+++ b/devices/tuya/_TZ3000_TS011F_smart_plug.json
@@ -13,9 +13,11 @@
     "_TZ3210_5ct6e7ye",
     "_TZ3210_rwmitwj4",
     "_TZ3210_w0qqde0g",
-    "_TZ3000_266azbg3"
+    "_TZ3000_266azbg3",
+    "Zbeacon"
   ],
   "modelid": [
+    "TS011F",
     "TS011F",
     "TS011F",
     "TS011F",


### PR DESCRIPTION
- Product name: Tuya smart plug
- Manufacturer: Zbeacon
- Model identifier: TS011F

See https://github.com/dresden-elektronik/deconz-rest-plugin/pull/8549#issuecomment-4398659549