### PR TITLE
DDF for Namron 4512789 smart plug

### DIFF
--- a/devices/namron/4512789_smart_plug.json
+++ b/devices/namron/4512789_smart_plug.json
@@ -1,0 +1,304 @@
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": [
+    "Namron AS"
+  ],
+  "modelid": [
+    "4512789"
+  ],
+  "vendor": "Namron",
+  "product": "Zigbee Smart Plug 16A IP44",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_SMART_PLUG",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        { "name": "attr/id" },
+        { "name": "attr/lastannounced" },
+        { "name": "attr/lastseen" },
+        { "name": "attr/manufacturername" },
+        { "name": "attr/modelid" },
+        { "name": "attr/name" },
+        {
+          "name": "attr/swversion",
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x4000"
+          },
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x4000",
+            "eval": "Item.val = Attr.val"
+          },
+          "refresh.interval": 86400
+        },
+        { "name": "attr/type" },
+        { "name": "attr/uniqueid" },
+        { "name": "config/on/startup" },
+        { "name": "state/alert", "default": "none" },
+        { "name": "state/on", "refresh.interval": 360 },
+        { "name": "state/reachable" }
+      ]
+    },
+    {
+      "type": "$TYPE_CONSUMPTION_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0702"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0051",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0702"
+        ]
+      },
+      "items": [
+        { "name": "attr/id" },
+        { "name": "attr/lastannounced" },
+        { "name": "attr/lastseen" },
+        { "name": "attr/manufacturername" },
+        { "name": "attr/modelid" },
+        { "name": "attr/name" },
+        { "name": "attr/swversion" },
+        { "name": "attr/type" },
+        { "name": "attr/uniqueid" },
+        { "name": "config/on" },
+        { "name": "config/reachable" },
+        {
+          "name": "state/consumption",
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0702",
+            "at": "0x0000"
+          },
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0702",
+            "at": "0x0000",
+            "eval": "Item.val = Attr.val"
+          },
+          "refresh.interval": 360,
+          "default": 0
+        },
+        { "name": "state/lastupdated" }
+      ]
+    },
+    {
+      "type": "$TYPE_POWER_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0B04"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0051",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0B04"
+        ]
+      },
+      "items": [
+        { "name": "attr/id" },
+        { "name": "attr/lastannounced" },
+        { "name": "attr/lastseen" },
+        { "name": "attr/manufacturername" },
+        { "name": "attr/modelid" },
+        { "name": "attr/name" },
+        { "name": "attr/swversion" },
+        { "name": "attr/type" },
+        { "name": "attr/uniqueid" },
+        { "name": "config/on" },
+        { "name": "config/reachable" },
+        {
+          "name": "state/current",
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0B04",
+            "at": "0x0508"
+          },
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0B04",
+            "at": "0x0508",
+            "eval": "if (Attr.val != 65535) { Item.val = Attr.val }"
+          },
+          "refresh.interval": 360,
+          "default": 0
+        },
+        { "name": "state/lastupdated" },
+        {
+          "name": "state/power",
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0B04",
+            "at": "0x050B"
+          },
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0B04",
+            "at": "0x050B",
+            "eval": "if (Attr.val != -32768) { Item.val = Attr.val }"
+          },
+          "refresh.interval": 360,
+          "default": 0
+        },
+        {
+          "name": "state/voltage",
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0B04",
+            "at": "0x0505"
+          },
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0B04",
+            "at": "0x0505",
+            "eval": "if (Attr.val != 65535) { Item.val = Attr.val }"
+          },
+          "refresh.interval": 360,
+          "default": 0
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_TEMPERATURE_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0002"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0051",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0002"
+        ]
+      },
+      "items": [
+        { "name": "attr/id" },
+        { "name": "attr/lastannounced" },
+        { "name": "attr/lastseen" },
+        { "name": "attr/manufacturername" },
+        { "name": "attr/modelid" },
+        { "name": "attr/name" },
+        { "name": "attr/swversion" },
+        { "name": "attr/type" },
+        { "name": "attr/uniqueid" },
+        { "name": "config/offset", "default": 0 },
+        { "name": "config/on" },
+        { "name": "config/reachable" },
+        { "name": "state/lastupdated" },
+        {
+          "name": "state/temperature",
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0002",
+            "at": "0x0000"
+          },
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0002",
+            "at": "0x0000",
+            "eval": "if (Attr.val != -32768 && Attr.val != 32768) { Item.val = Attr.val + (R.item('config/offset').val * 100) }"
+          },
+          "refresh.interval": 360,
+          "default": 0
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0006",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 300
+        },
+        {
+          "at": "0x4003",
+          "dt": "0x30",
+          "min": 1,
+          "max": 3600
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0702",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x25",
+          "min": 1,
+          "max": 300,
+          "change": "0x000000000000000000000001"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0B04",
+      "report": [
+        {
+          "at": "0x0505",
+          "dt": "0x21",
+          "min": 1,
+          "max": 300,
+          "change": "0x000A"
+        },
+        {
+          "at": "0x0508",
+          "dt": "0x21",
+          "min": 1,
+          "max": 300,
+          "change": "0x0064"
+        },
+        {
+          "at": "0x050B",
+          "dt": "0x29",
+          "min": 1,
+          "max": 300,
+          "change": "0x000A"
+        }
+      ]
+    }
+  ]
+}

--- a/devices/namron/4512789_smart_plug.json
+++ b/devices/namron/4512789_smart_plug.json
@@ -1,13 +1,9 @@
 {
   "schema": "devcap1.schema.json",
-  "manufacturername": [
-    "Namron AS"
-  ],
-  "modelid": [
-    "4512789"
-  ],
+  "manufacturername": "Namron AS",
+  "modelid": "4512789",
   "vendor": "Namron",
-  "product": "Zigbee Smart Plug 16A IP44",
+  "product": "Smart plug 16A IP44",
   "sleeper": false,
   "status": "Gold",
   "subdevices": [
@@ -19,35 +15,154 @@
         "0x01"
       ],
       "items": [
-        { "name": "attr/id" },
-        { "name": "attr/lastannounced" },
-        { "name": "attr/lastseen" },
-        { "name": "attr/manufacturername" },
-        { "name": "attr/modelid" },
-        { "name": "attr/name" },
         {
-          "name": "attr/swversion",
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on/startup"
+        },
+        {
+          "name": "state/alert",
+          "default": "none"
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 360
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_POWER_SENSOR",
+      "restapi": "/sensors",
+      "uuid": [
+        "$address.ext",
+        "0x01",
+        "0x0b04"
+      ],
+      "fingerprint": {
+        "profile": "0x0104",
+        "device": "0x0051",
+        "endpoint": "0x01",
+        "in": [
+          "0x0000",
+          "0x0B04"
+        ]
+      },
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
+        {
+          "name": "state/current",
           "read": {
             "fn": "zcl:attr",
             "ep": 1,
-            "cl": "0x0000",
-            "at": "0x4000"
+            "cl": "0x0B04",
+            "at": "0x0508"
           },
           "parse": {
             "fn": "zcl:attr",
             "ep": 1,
-            "cl": "0x0000",
-            "at": "0x4000",
-            "eval": "Item.val = Attr.val"
+            "cl": "0x0B04",
+            "at": "0x0508",
+            "eval": "if (Attr.val != 65535) { Item.val = Attr.val }"
           },
-          "refresh.interval": 86400
+          "refresh.interval": 360
         },
-        { "name": "attr/type" },
-        { "name": "attr/uniqueid" },
-        { "name": "config/on/startup" },
-        { "name": "state/alert", "default": "none" },
-        { "name": "state/on", "refresh.interval": 360 },
-        { "name": "state/reachable" }
+        {
+          "name": "state/lastupdated"
+        },
+        {
+          "name": "state/power",
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0B04",
+            "at": "0x050B"
+          },
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0B04",
+            "at": "0x050B",
+            "eval": "if (Attr.val != -32768) { Item.val = Attr.val }"
+          },
+          "refresh.interval": 360
+        },
+        {
+          "name": "state/voltage",
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0B04",
+            "at": "0x0505"
+          },
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0B04",
+            "at": "0x0505",
+            "eval": "if (Attr.val != 65535) { Item.val = Attr.val }"
+          },
+          "refresh.interval": 360
+        }
       ]
     },
     {
@@ -68,17 +183,39 @@
         ]
       },
       "items": [
-        { "name": "attr/id" },
-        { "name": "attr/lastannounced" },
-        { "name": "attr/lastseen" },
-        { "name": "attr/manufacturername" },
-        { "name": "attr/modelid" },
-        { "name": "attr/name" },
-        { "name": "attr/swversion" },
-        { "name": "attr/type" },
-        { "name": "attr/uniqueid" },
-        { "name": "config/on" },
-        { "name": "config/reachable" },
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on"
+        },
+        {
+          "name": "config/reachable"
+        },
         {
           "name": "state/consumption",
           "read": {
@@ -94,146 +231,10 @@
             "at": "0x0000",
             "eval": "Item.val = Attr.val"
           },
-          "refresh.interval": 360,
-          "default": 0
-        },
-        { "name": "state/lastupdated" }
-      ]
-    },
-    {
-      "type": "$TYPE_POWER_SENSOR",
-      "restapi": "/sensors",
-      "uuid": [
-        "$address.ext",
-        "0x01",
-        "0x0B04"
-      ],
-      "fingerprint": {
-        "profile": "0x0104",
-        "device": "0x0051",
-        "endpoint": "0x01",
-        "in": [
-          "0x0000",
-          "0x0B04"
-        ]
-      },
-      "items": [
-        { "name": "attr/id" },
-        { "name": "attr/lastannounced" },
-        { "name": "attr/lastseen" },
-        { "name": "attr/manufacturername" },
-        { "name": "attr/modelid" },
-        { "name": "attr/name" },
-        { "name": "attr/swversion" },
-        { "name": "attr/type" },
-        { "name": "attr/uniqueid" },
-        { "name": "config/on" },
-        { "name": "config/reachable" },
-        {
-          "name": "state/current",
-          "read": {
-            "fn": "zcl:attr",
-            "ep": 1,
-            "cl": "0x0B04",
-            "at": "0x0508"
-          },
-          "parse": {
-            "fn": "zcl:attr",
-            "ep": 1,
-            "cl": "0x0B04",
-            "at": "0x0508",
-            "eval": "if (Attr.val != 65535) { Item.val = Attr.val }"
-          },
-          "refresh.interval": 360,
-          "default": 0
-        },
-        { "name": "state/lastupdated" },
-        {
-          "name": "state/power",
-          "read": {
-            "fn": "zcl:attr",
-            "ep": 1,
-            "cl": "0x0B04",
-            "at": "0x050B"
-          },
-          "parse": {
-            "fn": "zcl:attr",
-            "ep": 1,
-            "cl": "0x0B04",
-            "at": "0x050B",
-            "eval": "if (Attr.val != -32768) { Item.val = Attr.val }"
-          },
-          "refresh.interval": 360,
-          "default": 0
+          "refresh.interval": 360
         },
         {
-          "name": "state/voltage",
-          "read": {
-            "fn": "zcl:attr",
-            "ep": 1,
-            "cl": "0x0B04",
-            "at": "0x0505"
-          },
-          "parse": {
-            "fn": "zcl:attr",
-            "ep": 1,
-            "cl": "0x0B04",
-            "at": "0x0505",
-            "eval": "if (Attr.val != 65535) { Item.val = Attr.val }"
-          },
-          "refresh.interval": 360,
-          "default": 0
-        }
-      ]
-    },
-    {
-      "type": "$TYPE_TEMPERATURE_SENSOR",
-      "restapi": "/sensors",
-      "uuid": [
-        "$address.ext",
-        "0x01",
-        "0x0002"
-      ],
-      "fingerprint": {
-        "profile": "0x0104",
-        "device": "0x0051",
-        "endpoint": "0x01",
-        "in": [
-          "0x0000",
-          "0x0002"
-        ]
-      },
-      "items": [
-        { "name": "attr/id" },
-        { "name": "attr/lastannounced" },
-        { "name": "attr/lastseen" },
-        { "name": "attr/manufacturername" },
-        { "name": "attr/modelid" },
-        { "name": "attr/name" },
-        { "name": "attr/swversion" },
-        { "name": "attr/type" },
-        { "name": "attr/uniqueid" },
-        { "name": "config/offset", "default": 0 },
-        { "name": "config/on" },
-        { "name": "config/reachable" },
-        { "name": "state/lastupdated" },
-        {
-          "name": "state/temperature",
-          "read": {
-            "fn": "zcl:attr",
-            "ep": 1,
-            "cl": "0x0002",
-            "at": "0x0000"
-          },
-          "parse": {
-            "fn": "zcl:attr",
-            "ep": 1,
-            "cl": "0x0002",
-            "at": "0x0000",
-            "eval": "if (Attr.val != -32768 && Attr.val != 32768) { Item.val = Attr.val + (R.item('config/offset').val * 100) }"
-          },
-          "refresh.interval": 360,
-          "default": 0
+          "name": "state/lastupdated"
         }
       ]
     }
@@ -249,26 +250,6 @@
           "dt": "0x10",
           "min": 1,
           "max": 300
-        },
-        {
-          "at": "0x4003",
-          "dt": "0x30",
-          "min": 1,
-          "max": 3600
-        }
-      ]
-    },
-    {
-      "bind": "unicast",
-      "src.ep": 1,
-      "cl": "0x0702",
-      "report": [
-        {
-          "at": "0x0000",
-          "dt": "0x25",
-          "min": 1,
-          "max": 300,
-          "change": "0x000000000000000000000001"
         }
       ]
     },
@@ -297,6 +278,20 @@
           "min": 1,
           "max": 300,
           "change": "0x000A"
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "cl": "0x0702",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x25",
+          "min": 1,
+          "max": 300,
+          "change": "0x000000000000000000000001"
         }
       ]
     }


### PR DESCRIPTION
Adds DDF for Namron AS 4512789 smart plug.

Includes:
- On/Off support
- Simple Metering on 0x0702
- Electrical Measurement current/power/voltage on 0x0B04
- Device temperature on 0x0002

Validated locally against deCONZ JSON schema and promoted to Gold status after successful device testing.