### PR TITLE
DDF add support for hobeian double gang plug

### DIFF
--- a/devices/hobeian/hobeian_double_gang_plug.json
+++ b/devices/hobeian/hobeian_double_gang_plug.json
@@ -1,0 +1,128 @@
+
+{
+  "schema": "devcap1.schema.json",
+  "manufacturername": "HOBEIAN",
+  "modelid": "ZG-305Z",
+  "product": "Tuya 2 gang wired switch",
+  "sleeper": false,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_ON_OFF_PLUGIN_UNIT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/tuya_unlock"
+        },
+        {
+          "name": "state/on",
+          "read": {
+            "fn": "tuya"
+          },
+          "write": {
+            "dpid": 1,
+            "dt": "0x10",
+            "eval": "Item.val == 1 ? 1 : 0;",
+            "fn": "tuya"
+          },
+          "parse": {
+            "dpid": 1,
+            "eval": "Item.val = Attr.val;",
+            "fn": "tuya"
+          }
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_ON_OFF_PLUGIN_UNIT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x02"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion"
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "state/on",
+          "read": {
+            "fn": "tuya"
+          },
+          "write": {
+            "dpid": 2,
+            "dt": "0x10",
+            "eval": "Item.val == 1 ? 1 : 0;",
+            "fn": "tuya"
+          },
+          "parse": {
+            "dpid": 2,
+            "eval": "Item.val = Attr.val;",
+            "fn": "tuya"
+          }
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Product name : HZ-Smart-Sensor
Manufacturer : HOBEIAN
Model identifier : ZG-305Z
Device type to add: Switch

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/8610