### PR TITLE
DDF clones for Tuya smart Knob (TS004F)

### DIFF
--- a/devices/tuya/_TZ3000_TS004F_smart_knob.json
+++ b/devices/tuya/_TZ3000_TS004F_smart_knob.json
@@ -7,9 +7,15 @@
     "_TZ3000_csflgqj2",
     "_TZ3000_ixla93vd",
     "_TZ3000_qja6nq5z",
-    "_TZ3000_uri7ongn"
+    "_TZ3000_uri7ongn",
+    "_TZ3000_402vrq2i",
+    "_TZ3000_gwkzibhs",
+    "_TZ3000_ugi8ky6u"
   ],
   "modelid": [
+    "TS004F",
+    "TS004F",
+    "TS004F",
     "TS004F",
     "TS004F",
     "TS004F",


### PR DESCRIPTION
```
  "manufacturername": [
    "_TZ3000_4fjiwweb",
    "_TZ3000_abrsvsou",
    "_TZ3000_csflgqj2",
    "_TZ3000_ixla93vd",
    "_TZ3000_qja6nq5z",
    "_TZ3000_uri7ongn",
    "_TZ3000_402vrq2i",
    "_TZ3000_gwkzibhs",
    "_TZ3000_ugi8ky6u"
  ],
  "modelid": [
    "TS004F",
    "TS004F",
    "TS004F",
    "TS004F",
    "TS004F",
    "TS004F",
    "TS004F",
    "TS004F",
    "TS004F"
  ],
```

See https://github.com/dresden-elektronik/deconz-rest-plugin/issues/8620