### PR TITLE
Add DDF zcl:cluster parse fn command

### DIFF
--- a/device.cpp
+++ b/device.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2021-2026 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -690,7 +690,8 @@ bool DEV_ZclRead(Device *device, ResourceItem *item, deCONZ::ZclClusterId_t clus
     ZCL_Param param{};
     param.valid = 1;
     param.endpoint = sd->endpoint();
-    param.clusterId = static_cast<quint16>(clusterId);
+    param.clusterIds[0] = static_cast<quint16>(clusterId);
+    param.clusterCount = 1;
     param.attributes[0] = static_cast<quint16>(attrId);
     param.attributeCount = 1;
 
@@ -1824,7 +1825,7 @@ static void DEV_UpdateReportTracker(Device *device, const ResourceItem *item)
 
     for (size_t i = 0; i < zclParam.attributeCount && i < zclParam.attributes.size(); i++)
     {
-        ReportTracker &tracker = DEV_GetOrCreateReportTracker(device, zclParam.clusterId, zclParam.attributes[i], zclParam.endpoint);
+        ReportTracker &tracker = DEV_GetOrCreateReportTracker(device, zclParam.clusterIds[0], zclParam.attributes[i], zclParam.endpoint);
         tracker.lastReport = item->lastZclReport();
     }
 }

--- a/device_access_fn.cpp
+++ b/device_access_fn.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2021-2026 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -126,36 +126,36 @@ enum DA_Constants
 
 struct ParseFunction
 {
-    ParseFunction(const QString &_name, const int _arity, ParseFunction_t _fn) :
+    ParseFunction(const std::string &_name, const int _arity, ParseFunction_t _fn) :
         name(_name),
         arity(_arity),
         fn(_fn)
     { }
-    QString name;
+    std::string name;
     int arity = 0; // number of parameters given by the device description file
     ParseFunction_t fn = nullptr;
 };
 
 struct ReadFunction
 {
-    ReadFunction(const QString &_name, const int _arity, ReadFunction_t _fn) :
+    ReadFunction(const std::string &_name, const int _arity, ReadFunction_t _fn) :
         name(_name),
         arity(_arity),
         fn(_fn)
     { }
-    QString name;
+    std::string name;
     int arity = 0; // number of parameters given by the device description file
     ReadFunction_t fn = nullptr;
 };
 
 struct WriteFunction
 {
-    WriteFunction(const QString &_name, const int _arity, WriteFunction_t _fn) :
+    WriteFunction(const std::string &_name, const int _arity, WriteFunction_t _fn) :
         name(_name),
         arity(_arity),
         fn(_fn)
     { }
-    QString name;
+    std::string name;
     int arity = 0; // number of parameters given by the device description file
     WriteFunction_t fn = nullptr;
 };
@@ -199,7 +199,32 @@ static ZCL_Param getZclParam(const QVariantMap &param)
     bool ok = true;
 
     result.endpoint = param.contains("ep") ? variantToUint(param["ep"], UINT8_MAX, &ok) : quint8(AutoEndpoint);
-    result.clusterId = ok ? variantToUint(param["cl"], UINT16_MAX, &ok) : 0;
+
+    const auto cl = param[QLatin1String("cl")];
+    if (cl.type() == QVariant::List)
+    {
+        for (const auto &c : cl.toList())
+        {
+            if (result.clusterCount >= ZCL_Param::MaxClusters)
+                break;
+            bool ok2 = false;
+            const uint16_t val = variantToUint(c, UINT16_MAX, &ok2);
+            if (ok2)
+            {
+                result.clusterIds[result.clusterCount++] = val;
+            }
+        }
+        if (result.clusterCount == 0)
+        {
+            ok = false;
+        }
+    }
+    else
+    {
+        result.clusterIds[0] = ok ? variantToUint(cl, UINT16_MAX, &ok) : 0;
+        result.clusterCount = ok ? 1 : 0;
+    }
+
     result.manufacturerCode = ok && param.contains("mf") ? variantToUint(param["mf"], UINT16_MAX, &ok) : 0;
 
     if (param.contains(QLatin1String("cmd"))) // optional
@@ -590,7 +615,7 @@ bool parseZclAttribute(Resource *r, ResourceItem *item, const deCONZ::ApsDataInd
 
     const auto &zclParam = item->zclParam();
 
-    if (ind.clusterId() != zclParam.clusterId)
+    if (ind.clusterId() != zclParam.clusterIds[0])
     {
         return result;
     }
@@ -723,7 +748,8 @@ bool parseTuyaData(Resource *r, ResourceItem *item, const deCONZ::ApsDataIndicat
         }
         param.valid = 1;
         param.endpoint = ind.srcEndpoint();
-        param.clusterId = ind.clusterId();
+        param.clusterIds[0] = ind.clusterId();
+        param.clusterCount = 1;
         param.attributeCount = 1;
 
         item->setParseFunction(parseTuyaData);
@@ -1222,11 +1248,13 @@ bool parseXiaomiSpecial(Resource *r, ResourceItem *item, const deCONZ::ApsDataIn
         ZCL_Param param;
 
         param.endpoint = BroadcastEndpoint; // default
-        param.clusterId = 0x0000;
+        param.clusterIds[0] = 0x0000;
+        param.clusterCount = 1;
         
         if (ind.clusterId() == 0xfcc0)
         {
-            param.clusterId = 0xfcc0;
+            param.clusterIds[0] = 0xfcc0;
+            param.clusterCount = 1;
             param.manufacturerCode = 0x115f;
         }
 
@@ -1748,7 +1776,7 @@ static DA_ReadResult readZclAttribute(const Resource *r, const ResourceItem *ite
     if (param.endpoint == AutoEndpoint)
     {
         param.endpoint = resolveAutoEndpoint(r);
-        param.endpoint = DEV_ResolveDestinationEndpoint(extAddr->toNumber(), param.endpoint, param.clusterId, param.frameControl);
+        param.endpoint = DEV_ResolveDestinationEndpoint(extAddr->toNumber(), param.endpoint, param.clusterIds[0], param.frameControl);
 
         if (param.endpoint == AutoEndpoint)
         {
@@ -1761,7 +1789,7 @@ static DA_ReadResult readZclAttribute(const Resource *r, const ResourceItem *ite
     result.isEnqueued = zclResult.isEnqueued;
     result.apsReqId = zclResult.apsReqId;
     result.sequenceNumber = zclResult.sequenceNumber;
-    result.clusterId = param.clusterId;
+    result.clusterId = param.clusterIds[0];
     result.ignoreResponseSequenceNumber = param.ignoreResponseSeq == 1;
 
     return result;
@@ -1814,7 +1842,7 @@ bool writeZclAttribute(const Resource *r, const ResourceItem *item, deCONZ::ApsC
     if (param.endpoint == AutoEndpoint)
     {
         param.endpoint = resolveAutoEndpoint(r);
-        param.endpoint = DEV_ResolveDestinationEndpoint(extAddr->toNumber(), param.endpoint, param.clusterId, param.frameControl);
+        param.endpoint = DEV_ResolveDestinationEndpoint(extAddr->toNumber(), param.endpoint, param.clusterIds[0], param.frameControl);
 
         if (param.endpoint == AutoEndpoint)
         {
@@ -1939,7 +1967,7 @@ static DA_ReadResult sendZclCommand(const Resource *r, const ResourceItem *item,
     if (param.endpoint == BroadcastEndpoint || param.endpoint == AutoEndpoint)
     {
         param.endpoint = resolveAutoEndpoint(r);
-        param.endpoint = DEV_ResolveDestinationEndpoint(extAddr->toNumber(), param.endpoint, param.clusterId, param.frameControl);
+        param.endpoint = DEV_ResolveDestinationEndpoint(extAddr->toNumber(), param.endpoint, param.clusterIds[0], param.frameControl);
 
         if (param.endpoint == BroadcastEndpoint || param.endpoint == AutoEndpoint)
         {
@@ -1952,7 +1980,7 @@ static DA_ReadResult sendZclCommand(const Resource *r, const ResourceItem *item,
     result.isEnqueued = zclResult.isEnqueued;
     result.apsReqId = zclResult.apsReqId;
     result.sequenceNumber = zclResult.sequenceNumber;
-    result.clusterId = param.clusterId;
+    result.clusterId = param.clusterIds[0];
     result.ignoreResponseSequenceNumber = param.ignoreResponseSeq == 1;
 
     return result;
@@ -1977,36 +2005,127 @@ bool writeZclCommand(const Resource *r, const ResourceItem *item, deCONZ::ApsCon
     return result.isEnqueued;
 }
 
+/*! A minimal parse function that filters only by cluster ID and delegates all
+    ZCL parsing to the JavaScript handler.
+
+    {"fn": "zcl:cluster", "cl": "0xFC00", "eval": "..."}
+    {"fn": "zcl:cluster", "cl": ["0xFC00", "0xFC01"], "script": "handler.js"}
+
+    Available JS globals: ZclFrame (cmd, payloadSize, isClCmd, at), SrcEp, ClusterId, R, Item
+ */
+bool parseZclCluster(Resource *r, ResourceItem *item, const deCONZ::ApsDataIndication &ind, const deCONZ::ZclFrame &zclFrame, const QVariant &parseParameters)
+{
+    bool result = false;
+
+    if (!item->parseFunction())
+    {
+        const auto map = parseParameters.toMap();
+        const auto cl = map["cl"];
+
+        ZCL_Param param{};
+        param.valid = 1;
+
+        if (cl.type() == QVariant::List)
+        {
+            for (const auto &c : cl.toList())
+            {
+                if (param.clusterCount >= ZCL_Param::MaxClusters)
+                    break;
+                bool ok = false;
+                const uint16_t val = variantToUint(c, UINT16_MAX, &ok);
+                if (ok)
+                {
+                    param.clusterIds[param.clusterCount++] = val;
+                }
+            }
+        }
+        else
+        {
+            bool ok = false;
+            const uint16_t val = variantToUint(cl, UINT16_MAX, &ok);
+            if (ok)
+            {
+                param.clusterIds[0] = val;
+                param.clusterCount = 1;
+            }
+        }
+
+        if (param.clusterCount == 0)
+            return result;
+
+        param.endpoint = BroadcastEndpoint;
+        if (map.contains("ep"))
+        {
+            bool ok = false;
+            const auto ep = variantToUint(map["ep"], UINT8_MAX, &ok);
+            if (ok)
+                param.endpoint = ep;
+        }
+
+        item->setParseFunction(parseZclCluster);
+        item->setZclProperties(param);
+    }
+
+    const auto &zp = item->zclParam();
+
+    if (zp.endpoint < BroadcastEndpoint && zp.endpoint != ind.srcEndpoint())
+    {
+        return result;
+    }
+
+    bool clusterMatch = (ind.clusterId() == zp.clusterIds[0]);
+    if (!clusterMatch && zp.clusterCount > 0)
+    {
+        for (size_t i = 0; i < zp.clusterCount && i < ZCL_Param::MaxClusters; i++)
+        {
+            if (ind.clusterId() == zp.clusterIds[i])
+            {
+                clusterMatch = true;
+                break;
+            }
+        }
+    }
+
+    if (!clusterMatch)
+        return result;
+
+    if (evalZclFrame(r, item, ind, zclFrame, parseParameters))
+        result = true;
+
+    return result;
+}
+
 ParseFunction_t DA_GetParseFunction(const QVariant &params)
 {
     ParseFunction_t result = nullptr;
 
-    const std::array<ParseFunction, 8> functions =
+    const std::array<ParseFunction, 9> functions =
     {
-        ParseFunction(QLatin1String("zcl"), 1, parseZclAttribute), // Deprecated
-        ParseFunction(QLatin1String("zcl:attr"), 1, parseZclAttribute),
-        ParseFunction(QLatin1String("zcl:cmd"), 1, parseZclAttribute),
-        ParseFunction(QLatin1String("xiaomi:special"), 1, parseXiaomiSpecial),
-        ParseFunction(QLatin1String("ias:zonestatus"), 1, parseIasZoneNotificationAndStatus),
-        ParseFunction(QLatin1String("tuya"), 1, parseTuyaData),
-        ParseFunction(QLatin1String("numtostr"), 1, parseNumericToString),
-        ParseFunction(QLatin1String("time"), 1, parseAndSyncTime)
+        ParseFunction("zcl", 1, parseZclAttribute), // Deprecated
+        ParseFunction("zcl:attr", 1, parseZclAttribute),
+        ParseFunction("zcl:cmd", 1, parseZclAttribute),
+        ParseFunction("zcl:cluster", 1, parseZclCluster),
+        ParseFunction("xiaomi:special", 1, parseXiaomiSpecial),
+        ParseFunction("ias:zonestatus", 1, parseIasZoneNotificationAndStatus),
+        ParseFunction("tuya", 1, parseTuyaData),
+        ParseFunction("numtostr", 1, parseNumericToString),
+        ParseFunction("time", 1, parseAndSyncTime)
     };
 
-    QString fnName;
+    std::string fnName;
 
     if (params.type() == QVariant::Map)
     {
         const auto params1 = params.toMap();
         if (params1.isEmpty())
         {  }
-        else if (params1.contains(QLatin1String("fn")))
+        else if (params1.contains("fn"))
         {
-            fnName = params1["fn"].toString();
+            fnName = params1["fn"].toString().toStdString();
         }
         else
         {
-            fnName = QLatin1String("zcl:attr"); // default
+            fnName = "zcl:attr"; // default
         }
     }
 
@@ -2028,26 +2147,26 @@ ReadFunction_t DA_GetReadFunction(const QVariant &params)
 
     const std::array<ReadFunction, 4> functions =
     {
-        ReadFunction(QLatin1String("zcl"), 1, readZclAttribute), // Deprecated
-        ReadFunction(QLatin1String("zcl:attr"), 1, readZclAttribute),
-        ReadFunction(QLatin1String("zcl:cmd"), 1, sendZclCommand),
-        ReadFunction(QLatin1String("tuya"), 1, readTuyaAllData)
+        ReadFunction("zcl", 1, readZclAttribute), // Deprecated
+        ReadFunction("zcl:attr", 1, readZclAttribute),
+        ReadFunction("zcl:cmd", 1, sendZclCommand),
+        ReadFunction("tuya", 1, readTuyaAllData)
     };
 
-    QString fnName;
+    std::string fnName;
 
     if (params.type() == QVariant::Map)
     {
         const auto params1 = params.toMap();
         if (params1.isEmpty())
         {  }
-        else if (params1.contains(QLatin1String("fn")))
+        else if (params1.contains("fn"))
         {
-            fnName = params1["fn"].toString();
+            fnName = params1["fn"].toString().toStdString();
         }
         else
         {
-            fnName = QLatin1String("zcl:attr"); // default
+            fnName = "zcl:attr"; // default
         }
     }
 
@@ -2069,26 +2188,26 @@ WriteFunction_t DA_GetWriteFunction(const QVariant &params)
 
     const std::array<WriteFunction, 4> functions =
     {
-        WriteFunction(QLatin1String("zcl"), 1, writeZclAttribute), // Deprecated
-        WriteFunction(QLatin1String("zcl:attr"), 1, writeZclAttribute),
-        WriteFunction(QLatin1String("zcl:cmd"), 1, writeZclCommand),
-        WriteFunction(QLatin1String("tuya"), 1, writeTuyaData)
+        WriteFunction("zcl", 1, writeZclAttribute), // Deprecated
+        WriteFunction("zcl:attr", 1, writeZclAttribute),
+        WriteFunction("zcl:cmd", 1, writeZclCommand),
+        WriteFunction("tuya", 1, writeTuyaData)
     };
 
-    QString fnName;
+    std::string fnName;
 
     if (params.type() == QVariant::Map)
     {
         const auto params1 = params.toMap();
         if (params1.isEmpty())
         {  }
-        else if (params1.contains(QLatin1String("fn")))
+        else if (params1.contains("fn"))
         {
-            fnName = params1["fn"].toString();
+            fnName = params1["fn"].toString().toStdString();
         }
         else
         {
-            fnName = QLatin1String("zcl:attr"); // default
+            fnName = "zcl:attr"; // default
         }
     }
 

--- a/device_js/device_js_duktape.cpp
+++ b/device_js/device_js_duktape.cpp
@@ -1049,6 +1049,37 @@ void DJS_InitDuktape(DeviceJsPrivate *d)
     }
     duk_pop(ctx);
 
+    // 'button_event' global function for button event handling.
+    // Adapted from https://github.com/dresden-elektronik/deconz-rest-plugin/pull/8631#issuecomment-4902059135
+    // Called with array of arrays, each with 3 elements [clusterId, commandId | commandIds[], button | function]
+    // Note: array functions aren't supported by DucktapeJS hence use function(){ return 1001; }.
+
+    // Example: Ikea on/off switch
+    // move 0x01
+    // move w. onoff 0x05
+    // stop w. onoff 0x07
+    // button_event([
+    //     [6, 1, 1002],
+    //     [6, 0, 2002],
+    //     [8, 5, 1001],
+    //     [8, 7, function(){ return (Item.val === 1001 ? 1003 : 2003); }],
+    //     [8, 1, 2001]
+    // ])
+
+    const char *PF_button_event = "function button_event(list) {"
+                                  "for (var i = 0; i < list.length; i++) { var e = list[i];"
+                                  "if (!Array.isArray(e) || e.length !== 3) return;"
+                                  "if (ClusterId === e[0] && (ZclFrame.cmd === e[1] || (Array.isArray(e[1]) && e[1].indexOf(ZclFrame.cmd) >= 0))) {"
+                                  "Item.val = typeof e[2] === 'function' ? e[2]() : e[2]; return;"
+                                  "}} }";
+
+    if (duk_peval_string(ctx, PF_button_event) != 0)
+    {
+        const char *str = duk_safe_to_string(ctx, -1);
+        DBG_Printf(DBG_JS, "failed to define button_event: %s\n", str);
+    }
+    duk_pop(ctx);
+
     U_ASSERT(d->arena.size > 0);
 
     // snaphot of the memory state to jump back on reset()

--- a/zcl/zcl.cpp
+++ b/zcl/zcl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2021-2026 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -61,7 +61,7 @@ ZCL_Result ZCL_ReadAttributes(const ZCL_Param &param, quint64 extAddress, quint1
     req.setDstAddressMode(deCONZ::ApsExtAddress);
     req.dstAddress().setExt(extAddress);
     req.dstAddress().setNwk(nwkAddress);
-    req.setClusterId(param.clusterId);
+    req.setClusterId(param.clusterIds[0]);
     req.setProfileId(HA_PROFILE_ID);
     req.setSrcEndpoint(0x01); // todo dynamic
 
@@ -72,11 +72,11 @@ ZCL_Result ZCL_ReadAttributes(const ZCL_Param &param, quint64 extAddress, quint1
     zclFrame.setCommandId(deCONZ::ZclReadAttributesId);
 
     DBG_Printf(DBG_ZCL, "ZCL read attr 0x%016llX, ep: 0x%02X, cl: 0x%04X, attr: 0x%04X, mfcode: 0x%04X, aps.id: %u, zcl.seq: %u\n",
-               extAddress, param.endpoint, param.clusterId, param.attributes.front(), param.manufacturerCode, req.id(), zclFrame.sequenceNumber());
+               extAddress, param.endpoint, param.clusterIds[0], param.attributes.front(), param.manufacturerCode, req.id(), zclFrame.sequenceNumber());
 
     result.sequenceNumber = zclFrame.sequenceNumber();
 
-    if (param.clusterId == 0x0019) // assume device only has client OTA cluster
+    if (param.clusterIds[0] == 0x0019) // assume device only has client OTA cluster
     {
         fcDirection = deCONZ::ZclFCDirectionServerToClient;
     }
@@ -124,7 +124,7 @@ ZCL_Result ZCL_WriteAttribute(const ZCL_Param &param, quint64 extAddress, quint1
 {
     ZCL_Result result{};
 
-    DBG_Printf(DBG_INFO, "writeZclAttribute, ep: 0x%02X, cl: 0x%04X, attr: 0x%04X, type: 0x%02X, mfcode: 0x%04X\n", param.endpoint, param.clusterId, param.attributes.front(), attribute->dataType(), param.manufacturerCode);
+    DBG_Printf(DBG_INFO, "writeZclAttribute, ep: 0x%02X, cl: 0x%04X, attr: 0x%04X, type: 0x%02X, mfcode: 0x%04X\n", param.endpoint, param.clusterIds[0], param.attributes.front(), attribute->dataType(), param.manufacturerCode);
 
     deCONZ::ApsDataRequest req;
     deCONZ::ZclFrame zclFrame;
@@ -134,7 +134,7 @@ ZCL_Result ZCL_WriteAttribute(const ZCL_Param &param, quint64 extAddress, quint1
     req.setDstAddressMode(deCONZ::ApsNwkAddress);
     req.dstAddress().setExt(extAddress);
     req.dstAddress().setNwk(nwkAddress);
-    req.setClusterId(param.clusterId);
+    req.setClusterId(param.clusterIds[0]);
     req.setProfileId(HA_PROFILE_ID);
     req.setSrcEndpoint(1); // TODO
 
@@ -195,7 +195,7 @@ ZCL_Result ZCL_SendCommand(const ZCL_Param &param, quint64 extAddress, quint16 n
     req.setDstAddressMode(deCONZ::ApsExtAddress);
     req.dstAddress().setExt(extAddress);
     req.dstAddress().setNwk(nwkAddress);
-    req.setClusterId(param.clusterId);
+    req.setClusterId(param.clusterIds[0]);
     req.setProfileId(HA_PROFILE_ID);
     req.setSrcEndpoint(0x01); // todo dynamic
 
@@ -206,7 +206,7 @@ ZCL_Result ZCL_SendCommand(const ZCL_Param &param, quint64 extAddress, quint16 n
     zclFrame.setCommandId(param.commandId);
 
     DBG_Printf(DBG_ZCL, "ZCL cmd attr 0x%016llX, ep: 0x%02X, cl: 0x%04X, cmd: 0x%02X, mfcode: 0x%04X, aps.id: %u, zcl.seq: %u\n",
-               extAddress, param.endpoint, param.clusterId, param.commandId, param.manufacturerCode, req.id(), zclFrame.sequenceNumber());
+               extAddress, param.endpoint, param.clusterIds[0], param.commandId, param.manufacturerCode, req.id(), zclFrame.sequenceNumber());
 
     result.sequenceNumber = zclFrame.sequenceNumber();
 

--- a/zcl/zcl.h
+++ b/zcl/zcl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 dresden elektronik ingenieurtechnik gmbh.
+ * Copyright (c) 2021-2026 dresden elektronik ingenieurtechnik gmbh.
  * All rights reserved.
  *
  * The software in this package is published under the terms of the BSD
@@ -23,12 +23,13 @@ namespace deCONZ
 
 struct ZCL_Param
 {
-    enum Constants { MaxAttributes = 8 };
+    enum Constants { MaxAttributes = 8, MaxClusters = 4 };
     std::array<uint16_t, MaxAttributes> attributes;
-    uint16_t clusterId = 0;
+    uint16_t clusterIds[MaxClusters] = {};
     uint16_t manufacturerCode = 0;
     uint16_t commandId = 0;
     uint8_t endpoint = 0;
+    uint8_t clusterCount = 0;
     struct {
         uint8_t valid : 1;
         uint8_t hasCommandId : 1;


### PR DESCRIPTION
The `zcl:cluster` DDF parse function allows specifying multiple clusters as filter. Mostly useful for moving switches from button_maps.json to pure DDF implementation.

```
{"fn": "zcl:cluster", "cl": "0xFC00", "eval": "..."}
{"fn": "zcl:cluster", "cl": ["0xFC00", "0xFC01"], "script": "handler.js"}
```

Note this function doesn't support specifying `cmd`, `mf` and `attr`, these must be handled in respective Javascript handler. The `ep` endpoint parameter is 255 (any source endpoint) by default.
Seperate PRs will use this to move switches out of `button_maps.json`.

**Edit:** as suggested by @ebaauw there is also a new global Javascript function `button_event` for declarative handling similar to `button_maps.json`.

```
button_event([
  [clusterId, commandId | commandIds[], button | function]
])

```

Example for Ikea on/off switch:

```
{
          "name": "state/buttonevent",
          "parse": {
            "fn": "zcl:cluster",
            "cl": ["0x0006", "0x0008"],
            "script": "tradfri_on_off_buttonevent.js"
          },
          "awake": true
}
```
**tradfri_on_off_buttonevent.js**
```js
// move 0x01, move w. onoff 0x05, stop w. onoff 0x07
// [clusterId, commandId, button | function]
button_event([
  [6, 1, 1002],
  [6, 0, 2002],
  [8, 5, 1001],
  [8, 7, function(){ return (Item.val === 1001 ? 1003 : 2003); }],
  [8, 1, 2001]
])
```
