### PR TITLE
Update light_zb3_C_festavia.json, copy/pasta LCX016 support

### DIFF
--- a/devices/philips/light_zb3_C_festavia.json
+++ b/devices/philips/light_zb3_C_festavia.json
@@ -4,14 +4,18 @@
   "manufacturername": [
     "$MF_SIGNIFY",
     "$MF_SIGNIFY",
+    "$MF_SIGNIFY",
+    "$MF_PHILIPS",
     "$MF_PHILIPS",
     "$MF_PHILIPS"
   ],
   "modelid": [
     "LCX012",
     "LCX015",
+    "LCX016",
     "LCX012",
-    "LCX015"
+    "LCX015",
+    "LCX016"
   ],
   "vendor": "Philips",
   "product": "Hue festavia string lights",


### PR DESCRIPTION
Attempt at adding in LCX016 support, dunno if it's this simple.

I have missing features on the LCX016 that appear for LCX015, if you need more info, i can provide, but only have phoscon setup on a headless pi.