### PR TITLE
Add Sonoff Hydro DUO Smart Water Valve (SWV-ZF2)

### DIFF
--- a/devices/sonoff/swv-zf2_hydro_duo_smart_water_valve.json
+++ b/devices/sonoff/swv-zf2_hydro_duo_smart_water_valve.json
@@ -41,7 +41,8 @@
             "fn": "zcl:attr",
             "ep": 1,
             "cl": "0x0000",
-            "at": "0x0001"
+            "at": "0x0001",
+            "eval": "Item.val = Attr.val"
           },
           "read": {
             "fn": "zcl:attr",
@@ -101,7 +102,8 @@
             "fn": "zcl:attr",
             "ep": 2,
             "cl": "0x0000",
-            "at": "0x0001"
+            "at": "0x0001",
+            "eval": "Item.val = Attr.val"
           },
           "read": {
             "fn": "zcl:attr",

--- a/devices/sonoff/swv-zf2_hydro_duo_smart_water_valve.json
+++ b/devices/sonoff/swv-zf2_hydro_duo_smart_water_valve.json
@@ -5,7 +5,7 @@
   "modelid": "SWV-ZF2",
   "vendor": "Sonoff",
   "product": "Hydro DUO Smart Water Valve (SWV-ZF2)",
-  "sleeper": true,
+  "sleeper": false,
   "status": "Gold",
   "subdevices": [
     {

--- a/devices/sonoff/swv-zf2_hydro_duo_smart_water_valve.json
+++ b/devices/sonoff/swv-zf2_hydro_duo_smart_water_valve.json
@@ -1,0 +1,162 @@
+{
+  "schema": "devcap1.schema.json",
+  "uuid": "5d286ec6-aa75-4e3a-9a92-9d8176eb72ce",
+  "manufacturername": "SONOFF",
+  "modelid": "SWV-ZF2",
+  "vendor": "Sonoff",
+  "product": "Hydro DUO Smart Water Valve (SWV-ZF2)",
+  "sleeper": true,
+  "status": "Gold",
+  "subdevices": [
+    {
+      "type": "$TYPE_ON_OFF_OUTPUT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x01"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "refresh.interval": 86400,
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x0001"
+          },
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 1,
+            "cl": "0x0000",
+            "at": "0x0001"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on/startup"
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 360
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    },
+    {
+      "type": "$TYPE_ON_OFF_OUTPUT",
+      "restapi": "/lights",
+      "uuid": [
+        "$address.ext",
+        "0x02"
+      ],
+      "items": [
+        {
+          "name": "attr/id"
+        },
+        {
+          "name": "attr/lastannounced"
+        },
+        {
+          "name": "attr/lastseen"
+        },
+        {
+          "name": "attr/manufacturername"
+        },
+        {
+          "name": "attr/modelid"
+        },
+        {
+          "name": "attr/name"
+        },
+        {
+          "name": "attr/swversion",
+          "refresh.interval": 86400,
+          "parse": {
+            "fn": "zcl:attr",
+            "ep": 2,
+            "cl": "0x0000",
+            "at": "0x0001"
+          },
+          "read": {
+            "fn": "zcl:attr",
+            "ep": 2,
+            "cl": "0x0000",
+            "at": "0x0001"
+          }
+        },
+        {
+          "name": "attr/type"
+        },
+        {
+          "name": "attr/uniqueid"
+        },
+        {
+          "name": "config/on/startup"
+        },
+        {
+          "name": "state/on",
+          "refresh.interval": 360
+        },
+        {
+          "name": "state/reachable"
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bind": "unicast",
+      "src.ep": 1,
+      "dst.ep": 1,
+      "cl": "0x0006",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 300
+        }
+      ]
+    },
+    {
+      "bind": "unicast",
+      "src.ep": 2,
+      "dst.ep": 2,
+      "cl": "0x0006",
+      "report": [
+        {
+          "at": "0x0000",
+          "dt": "0x10",
+          "min": 1,
+          "max": 300
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Sonoff Hydro DUO Smart Water Valve (SWV-ZF2)

Dual-channel mains-powered water valve with two independent On/Off outputs.

**Related issue:** [#8634](https://github.com/dresden-elektronik/deconz-rest-plugin/issues/8634) — SONOFF SWV-ZF2 Hydro DUO Smart Water Valve (device request by @dirandad)
**Zigbee2MQTT reference:** [SWV-ZF2 device page](https://www.zigbee2mqtt.io/devices/SWV-ZF2.html)

### Device specs
- **Vendor:** Sonoff
- **Model ID:** SWV-ZF2
- **Manufacturer name:** SONOFF
- **Clusters:** 2 × On/Off cluster (0x0006) on ep 1 & 2
- **Power:** Mains (no battery)
- **Sleeper:** No

### Subdevices

| Endpoint | Type | API |
|----------|------|-----|
| 1 | $TYPE_ON_OFF_OUTPUT | /lights |
| 2 | $TYPE_ON_OFF_OUTPUT | /lights |

### Bindings
- Ep 1 → On/Off (0x0006), report on/off (0x0000) every 1–300 s
- Ep 2 → On/Off (0x0006), report on/off (0x0000) every 1–300 s

---

### Known limitations — features not yet exposed by this DDF

The device exposes a rich set of irrigation-control capabilities via Sonoff's manufacturer-specific cluster (`0xFA40` / `64128`). Zigbee2MQTT handles these; deCONZ DDF does not currently support manufacturer clusters, so none of the following are available:

#### Safety & diagnostics
| Feature | Type | Description |
|---------|------|-------------|
| `child_lock` | binary (true/false) | Prevents physical input on the device |
| `valve_abnormal_state` | enum (18 values) | Fault states: nozzle_clogged, valve_stuck_open/closed, water_leak_detected, no_water_flow, etc. |
| `valve_alarm_settings` | composite | Alarm thresholds for abnormal state detection |

#### Irrigation scheduling (per endpoint)
| Feature | Type | Description |
|---------|------|-------------|
| `irrigation_plan_settings_1/2` | composite × 5 plans each | Full schedule: plan_index, enable_state, loop_type_mode (day_interval / weekdays), start_time, irrigation_duration/volume, fail_safe timeout |
| `irrigation_schedule_status` | enum | Currently active plan state per endpoint |
| `manual_default_settings` | composite | Single-run defaults: irrigation_duration (min), mode (duration/capacity), amount, fail_safe |

#### Weather & seasonal overrides
| Feature | Type | Description |
|---------|------|-------------|
| `rain_delay` / `rain_delay_end_datetime` | text/datetime | Pause all schedules until a given date/time |
| `seasonal_watering_adjustment` | numeric (1–500%) | Seasonal multiplier applied to all plans |

#### Live & historical metrics
| Feature | Type | Description |
|---------|------|-------------|
| `real_time_irrigation_duration/volume` | numeric | Current session duration and volume |
| `hour_irrigation_duration/volume` | numeric | Last hour totals |
| `24_hours_records` / `30_days_records` / `180_days_records` | arrays | Historical usage data |

#### Configuration
| Feature | Type | Description |
|---------|------|-------------|
| `water_flow_unit` | enum (L/min, gal/min, m³/h) | Display unit for volume readings |
| `battery` | numeric (%) | Backup battery level monitoring |

> **Note:** This is distinct from the single-valve SWV-ZB which also includes a water leak sensor. The SWV-ZF2 appears to have an IAS Zone cluster as well, but it has not been tested or integrated yet.