### PR TITLE
feat: DDF clone for Tuya Smart plug with power monitor (_TZ3210_2putqrmw)

### DIFF
--- a/devices/tuya/_TZ3000_TS011F_smart_plug.json
+++ b/devices/tuya/_TZ3000_TS011F_smart_plug.json
@@ -13,10 +13,12 @@
     "_TZ3210_5ct6e7ye",
     "_TZ3210_rwmitwj4",
     "_TZ3210_w0qqde0g",
+    "_TZ3210_2putqrmw",
     "_TZ3000_266azbg3",
     "Zbeacon"
   ],
   "modelid": [
+    "TS011F",
     "TS011F",
     "TS011F",
     "TS011F",


### PR DESCRIPTION
Added additional model ID for the TS011F smart plug.