### PR TITLE
Provide DDF button names in buttonevent introspection

### DIFF
--- a/device_descriptions.cpp
+++ b/device_descriptions.cpp
@@ -3467,6 +3467,41 @@ static DeviceDescription::SubDevice DDF_ParseSubDevice(DDF_ParseContext *pctx, c
         }
 #endif
 
+        if (obj.value(QLatin1String("buttons")).isObject())
+        {
+            const auto buttons = obj.value(QLatin1String("buttons")).toObject();
+
+
+            for (auto bi = buttons.constBegin(); bi != buttons.constEnd(); bi++)
+            {
+                bool ok = false;
+                const unsigned button = bi.key().toUInt(&ok);
+
+                if (!ok || !bi.value().isObject())
+                {
+                    continue;
+                }
+
+                const auto buttonObj = bi.value().toObject();
+                const auto name = buttonObj.value(QLatin1String("name")).toString().trimmed();
+
+                if (name.isEmpty())
+                {
+                    continue;
+                }
+
+                AT_AtomIndex atiButtonName;
+                const auto nameUtf8 = name.toUtf8();
+
+                if (AT_AddAtom(nameUtf8.constData(), nameUtf8.size(), &atiButtonName))
+                {
+                    result.buttonNameAtomIndices[button] = atiButtonName.index;
+                }
+            }
+        }
+
+
+
         if (obj.value(QLatin1String("buttonevents")).isObject())
         {
             const auto buttonEvents = obj.value(QLatin1String("buttonevents")).toObject();

--- a/device_descriptions.h
+++ b/device_descriptions.h
@@ -11,6 +11,7 @@
 #ifndef DEVICE_DESCRIPTIONS_H
 #define DEVICE_DESCRIPTIONS_H
 
+#include <map>
 #include <QObject>
 #include <QVariantMap>
 #include "resource.h"
@@ -191,6 +192,7 @@ public:
         std::vector<Item> items;
         SensorFingerprint fingerPrint;
         std::vector<unsigned> buttonEvents;
+        std::map<unsigned, unsigned> buttonNameAtomIndices;
     };
 
     std::vector<SubDevice> subDevices;

--- a/rest_devices.cpp
+++ b/rest_devices.cpp
@@ -500,10 +500,8 @@ static void putJsonQVariantValue(JsonObject &obj, std::string key, const QVarian
     }
 }
 
-static void putItemParameter(JsonObject &item, const char *name, const QVariantMap &param)
+static void putItemParameterObject(JsonObject &obj, const QVariantMap &param)
 {
-    JsonObject parse = item.createNestedObject(name);
-
     const auto end = param.constEnd();
     for (auto cur = param.constBegin(); cur != end; cur++)
     {
@@ -512,12 +510,37 @@ static void putItemParameter(JsonObject &item, const char *name, const QVariantM
             // no script cached 'eval' value
             if (!param.contains(QLatin1String("script")))
             {
-                putJsonQVariantValue(parse, "eval", cur.value());
+                putJsonQVariantValue(obj, "eval", cur.value());
             }
         }
         else
         {
-            putJsonQVariantValue(parse, cur.key().toStdString(), cur.value());
+            putJsonQVariantValue(obj, cur.key().toStdString(), cur.value());
+        }
+    }
+}
+
+static void putItemParameter(JsonObject &item, const char *name, const QVariant &param)
+{
+    if (param.type() == QVariant::Map)
+    {
+        JsonObject obj = item.createNestedObject(name);
+        putItemParameterObject(obj, param.toMap());
+    }
+    else if (param.type() == QVariant::List)
+    {
+        JsonArray arr = item.createNestedArray(name);
+        for (const auto &entry : param.toList())
+        {
+            if (entry.type() == QVariant::Map)
+            {
+                JsonObject obj = arr.createNestedObject();
+                putItemParameterObject(obj, entry.toMap());
+            }
+            else
+            {
+                putJsonArrayQVariantValue(arr, entry);
+            }
         }
     }
 }
@@ -665,9 +688,9 @@ bool ddfSerializeV1(JsonDoc &doc, const DeviceDescription &ddf, char *buf, size_
 
                 if (!i.isStatic)
                 {
-                    if (!i.readParameters.isNull()  && (ddfFull || !i.isGenericRead))  { putItemParameter(item, "read", i.readParameters.toMap()); }
-                    if (!i.writeParameters.isNull() && (ddfFull || !i.isGenericWrite)) { putItemParameter(item, "write", i.writeParameters.toMap()); }
-                    if (!i.parseParameters.isNull() && (ddfFull || !i.isGenericParse)) { putItemParameter(item, "parse", i.parseParameters.toMap()); }
+                    if (!i.readParameters.isNull()  && (ddfFull || !i.isGenericRead))  { putItemParameter(item, "read", i.readParameters); }
+                    if (!i.writeParameters.isNull() && (ddfFull || !i.isGenericWrite)) { putItemParameter(item, "write", i.writeParameters); }
+                    if (!i.parseParameters.isNull() && (ddfFull || !i.isGenericParse)) { putItemParameter(item, "parse", i.parseParameters); }
                 }
                 if (!i.defaultValue.isNull())
                 {
@@ -888,6 +911,36 @@ QLatin1String RIS_ButtonEventActionToString(int buttonevent)
     return QLatin1String("UNKNOWN");
 }
 
+static QString RIS_ButtonNameFromAtomIndex(unsigned atomIndex)
+{
+    const AT_Atom nameAtom = AT_GetAtomByIndex({atomIndex});
+
+    if (nameAtom.data)
+    {
+        return QString::fromUtf8((const char*)nameAtom.data, nameAtom.len);
+    }
+
+    return { };
+}
+
+static QString RIS_ButtonNameFromButtonMeta(const ButtonMeta *buttonsMeta, int button)
+{
+    if (!buttonsMeta)
+    {
+        return { };
+    }
+
+    const auto i = std::find_if(buttonsMeta->buttons.cbegin(), buttonsMeta->buttons.cend(),
+                                [button](const auto &x){ return x.button == button; });
+
+    if (i != buttonsMeta->buttons.cend())
+    {
+        return RIS_ButtonNameFromAtomIndex(i->nameAtomeIndex);
+    }
+
+    return { };
+}
+
 /*! Returns generic introspection for a \c ResourceItem.
  */
 QVariantMap RIS_IntrospectGenericItem(const ResourceItemDescriptor &rid)
@@ -919,6 +972,25 @@ QVariantMap RIS_IntrospectButtonEventItem(const ResourceItemDescriptor &rid, con
         return result;
     }
 
+    // TODO dependency on plugin needs to be removed to make this testable
+    const auto &buttonMapButtons = plugin->buttonMeta;
+    const auto &buttonMapData = plugin->buttonMaps;
+    const auto &buttonMapForModelId = plugin->buttonProductMap;
+
+    const auto *buttonData = BM_ButtonMapForProduct(productHash(r), buttonMapData, buttonMapForModelId);
+    const ButtonMeta *buttonsMeta = nullptr;
+
+    if (buttonData)
+    {
+        const auto i = std::find_if(buttonMapButtons.cbegin(), buttonMapButtons.cend(),
+                                    [buttonData](const auto &meta){ return meta.buttonMapRef.hash == buttonData->buttonMapRef.hash; });
+
+        if (i != buttonMapButtons.cend())
+        {
+            buttonsMeta = &*i;
+        }
+    }
+
     {  // 1) if the DDF provides buttons and button event descriptions take it from there
         const DeviceDescription &ddf = DeviceDescriptions::instance()->get(r);
         if (ddf.isValid())
@@ -932,19 +1004,40 @@ QVariantMap RIS_IntrospectButtonEventItem(const ResourceItemDescriptor &rid, con
 
                     for (unsigned btn: subd.buttonEvents)
                     {
+                        const unsigned button = btn / 1000;
+
                         {
                             QVariantMap m;
-                            m[QLatin1String("button")] = int(btn / 1000);
+                            m[QLatin1String("button")] = int(button);
                             m[QLatin1String("action")] = RIS_ButtonEventActionToString(btn);
                             values[QString::number(btn)] = m;
                         }
 
-                        QString btnNum = QString::number(btn/1000);
+                        QString btnNum = QString::number(button);
 
                         if (!buttons.contains(btnNum))
                         {
                             QVariantMap m;
-                            m[QLatin1String("name")] = QString("Button %1").arg(btn/1000);
+
+                            QString name;
+
+                            const auto ddfName = subd.buttonNameAtomIndices.find(button);
+                            if (ddfName != subd.buttonNameAtomIndices.cend())
+                            {
+                                name = RIS_ButtonNameFromAtomIndex(ddfName->second);
+                            }
+
+                            if (name.isEmpty())
+                            {
+                                name = RIS_ButtonNameFromButtonMeta(buttonsMeta, int(button));
+                            }
+
+                            if (name.isEmpty())
+                            {
+                                name = QString("Button %1").arg(button);
+                            }
+
+                            m[QLatin1String("name")] = name;
                             buttons[btnNum] = m;
                         }
 
@@ -967,13 +1060,6 @@ QVariantMap RIS_IntrospectButtonEventItem(const ResourceItemDescriptor &rid, con
     {
         return result;
     }
-
-    // TODO dependency on plugin needs to be removed to make this testable
-    const auto &buttonMapButtons = plugin->buttonMeta;
-    const auto &buttonMapData = plugin->buttonMaps;
-    const auto &buttonMapForModelId = plugin->buttonProductMap;
-
-    const auto *buttonData = BM_ButtonMapForProduct(productHash(r), buttonMapData, buttonMapForModelId);
 
     if (!buttonData)
     {
@@ -1006,23 +1092,20 @@ QVariantMap RIS_IntrospectButtonEventItem(const ResourceItemDescriptor &rid, con
         result[QLatin1String("values")] = values;
     }
 
-    const auto buttonsMeta = std::find_if(buttonMapButtons.cbegin(), buttonMapButtons.cend(),
-                                          [buttonData](const auto &meta){ return meta.buttonMapRef.hash == buttonData->buttonMapRef.hash; });
-
     QVariantMap buttons;
 
-    if (buttonsMeta != buttonMapButtons.cend())
+    if (buttonsMeta)
     {
         for (const auto &button : buttonsMeta->buttons)
         {
             if (buttonBits & (1 << button.button))
             {
                 QVariantMap m;
-                AT_Atom nameAtom = AT_GetAtomByIndex({button.nameAtomeIndex});
+                const QString name = RIS_ButtonNameFromAtomIndex(button.nameAtomeIndex);
 
-                if (nameAtom.data)
+                if (!name.isEmpty())
                 {
-                    m[QLatin1String("name")] = QString::fromUtf8((const char*)nameAtom.data, nameAtom.len);
+                    m[QLatin1String("name")] = name;
                     buttons[QString::number(button.button)] = m;
                 }
             }


### PR DESCRIPTION
Devices with `buttonevents` in their DDF always showed generic names ("Button 1", "Button 2") in `state/buttonevent/introspect`. The `buttons` object in the DDF wasn't parsed, and the button map names were never checked.

The changes done now:
- Parse subdevice `buttons` in DDFs and store the names as atoms.
- Introspection now takes names from the DDF, then from the button map, and only falls back to "Button N" if neither has one.
- `putItemParameter()` can now serialize list parameters as well as objects.

Tested with a BJ RM01, which exposes the following:

```
{
  "buttons": {
    "1": {
      "name": "But1"
    },
    "2": {
      "name": "But2"
    },
    "3": {
      "name": "But3"
    },
    "4": {
      "name": "But4"
    },
    "5": {
      "name": "But5"
    },
    "6": {
      "name": "But6"
    },
    "7": {
      "name": "But7"
    },
    "8": {
      "name": "But18"
    }
  },
  "type": "int32",
  "values": {
    "1001": {
      "action": "HOLD",
      "button": 1
    },
    "1002": {
      "action": "SHORT_RELEASE",
      "button": 1
    },
    "1003": {
      "action": "LONG_RELEASE",
      "button": 1
    },
    "2001": {
      "action": "HOLD",
      "button": 2
    },
    "2002": {
      "action": "SHORT_RELEASE",
      "button": 2
    },
    "2003": {
      "action": "LONG_RELEASE",
      "button": 2
    },
    "3001": {
      "action": "HOLD",
      "button": 3
    },
    "3002": {
      "action": "SHORT_RELEASE",
      "button": 3
    },
    "3003": {
      "action": "LONG_RELEASE",
      "button": 3
    },
    "4001": {
      "action": "HOLD",
      "button": 4
    },
    "4002": {
      "action": "SHORT_RELEASE",
      "button": 4
    },
    "4003": {
      "action": "LONG_RELEASE",
      "button": 4
    },
    "5001": {
      "action": "HOLD",
      "button": 5
    },
    "5002": {
      "action": "SHORT_RELEASE",
      "button": 5
    },
    "5003": {
      "action": "LONG_RELEASE",
      "button": 5
    },
    "6001": {
      "action": "HOLD",
      "button": 6
    },
    "6002": {
      "action": "SHORT_RELEASE",
      "button": 6
    },
    "6003": {
      "action": "LONG_RELEASE",
      "button": 6
    },
    "7001": {
      "action": "HOLD",
      "button": 7
    },
    "7002": {
      "action": "SHORT_RELEASE",
      "button": 7
    },
    "7003": {
      "action": "LONG_RELEASE",
      "button": 7
    },
    "8001": {
      "action": "HOLD",
      "button": 8
    },
    "8002": {
      "action": "SHORT_RELEASE",
      "button": 8
    },
    "8003": {
      "action": "LONG_RELEASE",
      "button": 8
    }
  }
}
```

Closes #8613